### PR TITLE
Fixing color of summary card arrow

### DIFF
--- a/src/summary/cards/summary-card.component.tsx
+++ b/src/summary/cards/summary-card.component.tsx
@@ -7,7 +7,7 @@ export default function SummaryCard(props: SummaryCardProps) {
     <div className={`omrs-card ${styles.card}`}>
       <div className={styles.header}>
         <h2 className={`omrs-margin-0`}>{props.name}</h2>
-        <svg className="omrs-icon" fill="var(--omrs-color-inactive-grey)">
+        <svg className="omrs-icon" fill="rgba(0, 0, 0, 0.54)">
           <use xlinkHref="#omrs-icon-chevron-right" />
         </svg>
       </div>


### PR DESCRIPTION
See https://github.com/openmrs/openmrs-esm-styleguide/pull/48 and https://www.figma.com/file/YyVhWTNp89bNiOGadYrHBk/Patient-Chart---Master-(current-file)?node-id=1695%3A290

The inactive-grey color is going away, and it also doesn't match what's in the designs.