### PR TITLE
Adding backend dependencies

### DIFF
--- a/src/openmrs-backend-dependencies.ts
+++ b/src/openmrs-backend-dependencies.ts
@@ -1,1 +1,4 @@
-export const backendDependencies = {};
+export const backendDependencies = {
+  "webservices.rest": "^2.24.0",
+  fhir: "^1.18.0"
+};

--- a/src/openmrs-backend-dependencies.ts
+++ b/src/openmrs-backend-dependencies.ts
@@ -1,4 +1,4 @@
 export const backendDependencies = {
-  "webservices.rest": "^2.24.0",
-  fhir: "^1.18.0"
+  "webservices.rest": "^2.2.0",
+  fhir: "^1.4.2"
 };


### PR DESCRIPTION
Specifying these backend deps helps us communicate to developers why things aren't working. I don't know what the actual minimum version is for the fhir and rest java modules for the patient-chart to work. I know that these versions are a bit high because the version we have installed on openmrs-spa.org is lower than the specified versions here. However, I'm not sure how to calculate the correct version. I just copied these versions from esm-primary-navigation.