### PR TITLE
DE-31: Design Edit 31, Fixed font work-sans application to only dates

### DIFF
--- a/src/summary/history/allergy-card-level-two.css
+++ b/src/summary/history/allergy-card-level-two.css
@@ -10,7 +10,6 @@
 
 .allergyTable {
   width: 100%;
-  font-family: "Work Sans";
 }
 
 .allergyTable thead {
@@ -39,10 +38,12 @@
 
 .allergyTable tbody td:nth-child(3) {
   text-align: right;
+  font-family: "Work Sans";
 }
 
 .allergyTable tbody td:nth-child(4) {
   text-align: right;
+  font-family: "Work Sans";
 }
 
 .allergyTable tbody tr:nth-child(3n) {


### PR DESCRIPTION
Fixed Allergy Level Two Components having worksan font applied everywhere to only the dates that is the SINCE and UPDATED columns: Working on top of PR #32 
![Screenshot from 2019-11-25 14-52-35](https://user-images.githubusercontent.com/28008754/69538395-45919780-0f93-11ea-9659-3bbf4fcbb04a.png)
