### PR TITLE
Programs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,9 @@
     ],
     "plugins": [
       "@babel/plugin-proposal-class-properties",
+      ["i18next-extract", {
+        "outputPath": "translations/{{locale}}.json",
+        "discardOldKeys": true
+      }]
     ]
   }

--- a/__mocks__/programs.mocks.ts
+++ b/__mocks__/programs.mocks.ts
@@ -1,0 +1,52 @@
+export const mockProgramsResponse = {
+  headers: null,
+  ok: true,
+  redirected: true,
+  status: 200,
+  statusText: "ok",
+  trailer: null,
+  type: null,
+  url: "",
+  clone: null,
+  body: null,
+  bodyUsed: null,
+  arrayBuffer: null,
+  blob: null,
+  formData: null,
+  json: null,
+  text: null,
+  data: {
+    results: [
+      {
+        uuid: "b033f8c3-7e0b-4118-aa1d-76c550f2978d",
+        program: {
+          uuid: "64f950e6-1b07-4ac0-8e7e-f3e148f3463f",
+          name: "HIV Care and Treatment",
+          allWorkflows: [],
+          links: [
+            {
+              rel: "self",
+              uri:
+                "http://localhost:8090/openmrs/ws/rest/v1/program/64f950e6-1b07-4ac0-8e7e-f3e148f3463f"
+            }
+          ]
+        },
+        display: "HIV Care and Treatment",
+        dateEnrolled: "2019-11-01T00:00:00.000+0000",
+        dateCompleted: null,
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/programenrollment/b033f8c3-7e0b-4118-aa1d-76c550f2978d"
+          },
+          {
+            rel: "full",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/programenrollment/b033f8c3-7e0b-4118-aa1d-76c550f2978d?v=full"
+          }
+        ]
+      }
+    ]
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3190,6 +3190,17 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-i18next-extract": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-i18next-extract/-/babel-plugin-i18next-extract-0.4.0.tgz",
+      "integrity": "sha512-RdSJx5E/AfpYL28DUvQob0jfA8+YnLSVtfYUK5ChEv3JRMV+NRymjU3ikoLmez3qGd+d+o2Q7mct0vA0hDooNg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.4.5",
+        "i18next": "^19.0.0",
+        "json-stable-stringify": "^1.0.1"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
@@ -8039,6 +8050,15 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8065,6 +8085,12 @@
       "requires": {
         "minimist": "^1.2.0"
       }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
+    "babel-plugin-i18next-extract": "^0.4.0",
     "browserslist-config-openmrs": "^1.0.0",
     "clean-webpack-plugin": "^3.0.0",
     "concurrently": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prettier": "prettier",
     "typescript": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "jest --config jest.config.json",
+    "test": "jest --config jest.config.json --verbose false",
     "coverage": "npm test -- --coverage"
   },
   "repository": {

--- a/src/summary/cards/summary-card.component.tsx
+++ b/src/summary/cards/summary-card.component.tsx
@@ -1,8 +1,10 @@
 import React, { ReactChildren } from "react";
 import styles from "./summary-card.css";
 import { match } from "react-router";
+import { Trans, useTranslation } from "react-i18next";
 
 export default function SummaryCard(props: SummaryCardProps) {
+  const { t } = useTranslation();
   return (
     <div style={props.styles} className={`omrs-card ${styles.card}`}>
       <div className={styles.header}>

--- a/src/summary/documentation/vitals-card-level-two.test.tsx
+++ b/src/summary/documentation/vitals-card-level-two.test.tsx
@@ -12,6 +12,7 @@ import {
 import { useCurrentPatient, openmrsObservableFetch } from "@openmrs/esm-api";
 import * as openmrsApi from "./vitals-card.resource";
 import { act } from "react-dom/test-utils";
+import dayjs from "dayjs";
 
 const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
 const mockOpenmrsObservableFetch = openmrsObservableFetch as jest.Mock;
@@ -57,12 +58,21 @@ describe("<VitalsLevelTwo/>", () => {
       const tableBody = wrapper.container.querySelector("tbody");
       const firstTableRow = tableBody.children[0];
       const secondTableRow = tableBody.children[1];
-      expect(firstTableRow.children[0].textContent).toBe("2016 16-May");
+
+      const testDate = dayjs("2016-05-16T06:13:36.000+00:00");
+      const testDate2 = dayjs("2015-08-25T06:30:35.000+00:00");
+
+      expect(firstTableRow.children[0].textContent).toBe(
+        testDate.format("YYYY DD-MMM")
+      );
       expect(firstTableRow.children[1].textContent).toBe("161 / 72 mmHg ");
       expect(firstTableRow.children[2].textContent).toBe("22 bpm");
       expect(firstTableRow.children[3].textContent).toBe("30 %");
       expect(firstTableRow.children[4].textContent).toBe("37 ℃ ");
-      expect(secondTableRow.children[0].textContent).toBe("2015 25-Aug");
+
+      expect(secondTableRow.children[0].textContent).toBe(
+        testDate2.format("YYYY DD-MMM")
+      );
       expect(secondTableRow.children[1].textContent).toBe("156 / 64");
       expect(secondTableRow.children[2].textContent).toBe("173 ");
       expect(secondTableRow.children[3].textContent).toBe("41 ");

--- a/src/summary/history/conditions-card.component.tsx
+++ b/src/summary/history/conditions-card.component.tsx
@@ -10,6 +10,7 @@ import { createErrorHandler } from "@openmrs/esm-error-handling";
 import HorizontalLabelValue from "../cards/horizontal-label-value.component";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import SummaryCardFooter from "../cards/summary-card-footer.component";
+import { useTranslation } from "react-i18next";
 
 export default function ConditionsCard(props: ConditionsCardProps) {
   const [patientConditions, setPatientConditions] = React.useState(null);
@@ -19,6 +20,7 @@ export default function ConditionsCard(props: ConditionsCardProps) {
     patientUuid,
     patientErr
   ] = useCurrentPatient();
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     if (patient) {
@@ -35,7 +37,7 @@ export default function ConditionsCard(props: ConditionsCardProps) {
   }, [patient]);
 
   return (
-    <SummaryCard name="Conditions" match={props.match}>
+    <SummaryCard name={t("conditions", "Conditions")} match={props.match}>
       <SummaryCardRow>
         <SummaryCardRowContent>
           <HorizontalLabelValue

--- a/src/summary/history/history-section.component.tsx
+++ b/src/summary/history/history-section.component.tsx
@@ -11,7 +11,7 @@ export default function HistorySection(props: HistorySectionProps) {
     <div>
       <SummarySectionCards match={props.match}>
         <ConditionsCard match={props.match} />
-        <ProgramsCard match={props.match}/>
+        <ProgramsCard match={props.match} />
       </SummarySectionCards>
       <SummarySectionCards>
         <AllergyCard match={props.match} />

--- a/src/summary/history/history-section.component.tsx
+++ b/src/summary/history/history-section.component.tsx
@@ -4,12 +4,16 @@ import SummarySectionCards from "../cards/summary-section-cards.component";
 import AllergyCard from "./allergy-card.component";
 import ConditionsCard from "./conditions-card.component";
 import NotesCard from "./notes-card.component";
+import ProgramsCard from "./programs/programs-card.component";
 
 export default function HistorySection(props: HistorySectionProps) {
   return (
     <div>
       <SummarySectionCards match={props.match}>
         <ConditionsCard match={props.match} />
+        <ProgramsCard match={props.match}/>
+      </SummarySectionCards>
+      <SummarySectionCards>
         <AllergyCard match={props.match} />
       </SummarySectionCards>
       <SummarySectionCards match={props.match}>

--- a/src/summary/history/programs/programs-card-style.css
+++ b/src/summary/history/programs/programs-card-style.css
@@ -1,0 +1,13 @@
+.conditionMore {
+  display: flex;
+  align-items: center;
+  border: none;
+  padding: 0.625rem 1.625rem 0.625rem 1rem;
+  background-color: var(--omrs-color-bg-medium-contrast);
+  color: var(--omrs-color-ink-medium-contrast);
+  cursor: pointer;
+}
+
+.conditionMore p {
+  margin: 0;
+}

--- a/src/summary/history/programs/programs-card.component.tsx
+++ b/src/summary/history/programs/programs-card.component.tsx
@@ -29,7 +29,6 @@ export default function Programs(props: ProgramsCardProps) {
     return () => subscription.unsubscribe();
   }, [patientUuid]);
 
-
   return (
     <SummaryCard name="Care Programs" match={props.match}>
       <SummaryCardRow>
@@ -55,9 +54,7 @@ export default function Programs(props: ProgramsCardProps) {
               <HorizontalLabelValue
                 label={program.display}
                 labelStyles={{ fontWeight: 500 }}
-                value={dayjs(program.dateEnrolled).format(
-                  "MMM-YYYY"
-                )}
+                value={dayjs(program.dateEnrolled).format("MMM-YYYY")}
                 valueStyles={{ fontFamily: "Work Sans" }}
               />
             </SummaryCardRow>

--- a/src/summary/history/programs/programs-card.component.tsx
+++ b/src/summary/history/programs/programs-card.component.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import style from "./conditions-card-style.css";
+import dayjs from "dayjs";
+import SummaryCard from "../../cards/summary-card.component";
+import SummaryCardRow from "../../cards/summary-card-row.component";
+import SummaryCardRowContent from "../../cards/summary-card-row-content.component";
+import { match } from "react-router";
+import { performPatientProgramsSearch } from "./programs.resource";
+import { createErrorHandler } from "@openmrs/esm-error-handling";
+import HorizontalLabelValue from "../../cards/horizontal-label-value.component";
+import { useCurrentPatient } from "@openmrs/esm-api";
+import SummaryCardFooter from "../../cards/summary-card-footer.component";
+
+export default function Programs(props: ProgramsCardProps) {
+  const [patientPrograms, setPatientPrograms] = React.useState(null);
+  const [
+    isLoadingPatient,
+    patient,
+    patientUuid,
+    patientErr
+  ] = useCurrentPatient();
+
+  React.useEffect(() => {
+    const subscription = performPatientProgramsSearch(patientUuid).subscribe(
+      programs => setPatientPrograms(programs),
+      createErrorHandler()
+    );
+
+    return () => subscription.unsubscribe();
+  }, [patientUuid]);
+
+
+  return (
+    <SummaryCard name="Care Programs" match={props.match}>
+      <SummaryCardRow>
+        <SummaryCardRowContent>
+          <HorizontalLabelValue
+            label="Active Programs"
+            labelStyles={{
+              color: "var(--omrs-color-ink-medium-contrast)",
+              fontFamily: "Work Sans"
+            }}
+            value="Since"
+            valueStyles={{
+              color: "var(--omrs-color-ink-medium-contrast)",
+              fontFamily: "Work Sans"
+            }}
+          />
+        </SummaryCardRowContent>
+      </SummaryCardRow>
+      {patientPrograms &&
+        patientPrograms.map(program => {
+          return (
+            <SummaryCardRow key={program.uuid} linkTo="/">
+              <HorizontalLabelValue
+                label={program.display}
+                labelStyles={{ fontWeight: 500 }}
+                value={dayjs(program.dateEnrolled).format(
+                  "MMM-YYYY"
+                )}
+                valueStyles={{ fontFamily: "Work Sans" }}
+              />
+            </SummaryCardRow>
+          );
+        })}
+      <SummaryCardFooter linkTo={`/patient/${patientUuid}/chart/programs`} />
+    </SummaryCard>
+  );
+}
+
+type ProgramsCardProps = {
+  match: match;
+};

--- a/src/summary/history/programs/programs-card.component.tsx
+++ b/src/summary/history/programs/programs-card.component.tsx
@@ -5,7 +5,7 @@ import SummaryCard from "../../cards/summary-card.component";
 import SummaryCardRow from "../../cards/summary-card-row.component";
 import SummaryCardRowContent from "../../cards/summary-card-row-content.component";
 import { match } from "react-router";
-import { performPatientProgramsSearch } from "./programs.resource";
+import { fetchPatientPrograms } from "./programs.resource";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import HorizontalLabelValue from "../../cards/horizontal-label-value.component";
 import { useCurrentPatient } from "@openmrs/esm-api";
@@ -23,7 +23,7 @@ export default function Programs(props: ProgramsCardProps) {
   const { t } = useTranslation();
 
   React.useEffect(() => {
-    const subscription = performPatientProgramsSearch(patientUuid).subscribe(
+    const subscription = fetchPatientPrograms(patientUuid).subscribe(
       programs => setPatientPrograms(programs),
       createErrorHandler()
     );

--- a/src/summary/history/programs/programs-card.component.tsx
+++ b/src/summary/history/programs/programs-card.component.tsx
@@ -10,6 +10,7 @@ import { createErrorHandler } from "@openmrs/esm-error-handling";
 import HorizontalLabelValue from "../../cards/horizontal-label-value.component";
 import { useCurrentPatient } from "@openmrs/esm-api";
 import SummaryCardFooter from "../../cards/summary-card-footer.component";
+import { Trans, useTranslation } from "react-i18next";
 
 export default function Programs(props: ProgramsCardProps) {
   const [patientPrograms, setPatientPrograms] = React.useState(null);
@@ -19,6 +20,7 @@ export default function Programs(props: ProgramsCardProps) {
     patientUuid,
     patientErr
   ] = useCurrentPatient();
+  const { t } = useTranslation();
 
   React.useEffect(() => {
     const subscription = performPatientProgramsSearch(patientUuid).subscribe(
@@ -30,16 +32,16 @@ export default function Programs(props: ProgramsCardProps) {
   }, [patientUuid]);
 
   return (
-    <SummaryCard name="Care Programs" match={props.match}>
+    <SummaryCard name={t("care programs", "Care Programs")} match={props.match}>
       <SummaryCardRow>
         <SummaryCardRowContent>
           <HorizontalLabelValue
-            label="Active Programs"
+            label={t("Active Programs", "Active Programs")}
             labelStyles={{
               color: "var(--omrs-color-ink-medium-contrast)",
               fontFamily: "Work Sans"
             }}
-            value="Since"
+            value={t("Since", "Since")}
             valueStyles={{
               color: "var(--omrs-color-ink-medium-contrast)",
               fontFamily: "Work Sans"

--- a/src/summary/history/programs/programs-card.component.tsx
+++ b/src/summary/history/programs/programs-card.component.tsx
@@ -51,7 +51,7 @@ export default function Programs(props: ProgramsCardProps) {
       {patientPrograms &&
         patientPrograms.map(program => {
           return (
-            <SummaryCardRow key={program.uuid} linkTo="/">
+            <SummaryCardRow key={program.uuid} linkTo="">
               <HorizontalLabelValue
                 label={program.display}
                 labelStyles={{ fontWeight: 500 }}

--- a/src/summary/history/programs/programs-card.test.tsx
+++ b/src/summary/history/programs/programs-card.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { cleanup, render, wait } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
-import { performPatientProgramsSearch } from "./programs.resource";
+import { fetchPatientPrograms } from "./programs.resource";
 import ProgramsCard from "./programs-card.component";
 import { mockPatient } from "../../../../__mocks__/patient.mock";
 import { mockProgramsResponse } from "../../../../__mocks__/programs.mocks";

--- a/src/summary/history/programs/programs-card.test.tsx
+++ b/src/summary/history/programs/programs-card.test.tsx
@@ -39,7 +39,7 @@ describe("<ProgramsCard />", () => {
       </BrowserRouter>
     );
     await wait(() => {
-      console.log(wrapper);
+      expect(wrapper.getByTitle("HIV Care and Treatment")).toBeDefined();
       spy.mockRestore();
     });
   });

--- a/src/summary/history/programs/programs-card.test.tsx
+++ b/src/summary/history/programs/programs-card.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { cleanup, render, wait } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { act } from "react-dom/test-utils";
+import { performPatientProgramsSearch } from "./programs.resource";
+import ConditionsCard from "./programs-card.component";
+import { useCurrentPatient } from "@openmrs/esm-api";
+
+
+jest.mock("@openmrs/esm-api", () => ({
+  useCurrentPatient: jest.fn()
+}));
+
+jest.mock("./conditions.resource", () => ({
+  performPatientProgramsSearch: jest.fn()
+}));
+
+
+let wrapper;
+
+
+describe("<ConditionsCard />", () => {
+  afterEach(() => {
+    cleanup;
+  });
+
+  beforeEach(mockUseCurrentPatient.mockReset);
+
+  it("should render without dying", async () => {
+    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
+
+    mockPerformPatientConditionsSearch.mockResolvedValue(mockPatientConditions);
+
+    wrapper = render(
+      <BrowserRouter>
+        <ConditionsCard match={match} />
+      </BrowserRouter>
+    );
+    await wait(() => {
+      expect(wrapper).toBeTruthy();
+    });
+  });
+
+  it("should display the patient conditions correctly", async () => {
+    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
+    mockPerformPatientConditionsSearch.mockReturnValue(
+      Promise.resolve(mockPatientConditions)
+    );
+
+    wrapper = render(
+      <BrowserRouter>
+        <ConditionsCard match={match} />
+      </BrowserRouter>
+    );
+
+    await wait(() => {
+      expect(wrapper.getByText("Hypothyroidism")).toBeTruthy();
+      expect(wrapper.getByText("Hypertension")).toBeTruthy();
+    });
+  });
+});

--- a/src/summary/history/programs/programs-card.test.tsx
+++ b/src/summary/history/programs/programs-card.test.tsx
@@ -1,34 +1,27 @@
 import React from "react";
 import { cleanup, render, wait } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
-import { act } from "react-dom/test-utils";
 import { performPatientProgramsSearch } from "./programs.resource";
 import ProgramsCard from "./programs-card.component";
-import { useCurrentPatient } from "@openmrs/esm-api";
-
-jest.mock("@openmrs/esm-api", () => ({
-  useCurrentPatient: jest.fn
-}));
-
-jest.mock("./programs.resource", () => ({
-  performPatientProgramsSearch: jest.fn()
-}));
-
-let wrapper;
+import { mockPatient } from "../../../../__mocks__/patient.mock";
+import { mockProgramsResponse } from "../../../../__mocks__/programs.mocks";
+import * as openmrsApi from "@openmrs/esm-api";
+import { of } from "rxjs/internal/observable/of";
 
 describe("<ProgramsCard />", () => {
-  let match, wrapper: any;
+  let match, wrapper: any, patient: fhir.Patient, programs: any;
 
   afterEach(cleanup);
 
   beforeEach(() => {
+    patient = mockPatient;
     match = { params: {}, isExact: false, path: "/", url: "/" };
   });
 
   it("should render without dying", async () => {
     wrapper = render(
       <BrowserRouter>
-        <ProgramsCard match={match} />
+        <ProgramsCard match={match} patient={patient} />
       </BrowserRouter>
     );
     await wait(() => {
@@ -36,4 +29,17 @@ describe("<ProgramsCard />", () => {
     });
   });
 
+  it("should display the patients programs correctly", async () => {
+    const spy = jest.spyOn(openmrsApi, "openmrsObservableFetch");
+    spy.mockReturnValue(of(mockProgramsResponse));
+
+    const wrapper = render(
+      <BrowserRouter>
+        <ProgramsCard match={match} patient={patient} />
+      </BrowserRouter>
+    );
+    await wait(() => {
+      spy.mockRestore();
+    });
+  });
 });

--- a/src/summary/history/programs/programs-card.test.tsx
+++ b/src/summary/history/programs/programs-card.test.tsx
@@ -39,6 +39,7 @@ describe("<ProgramsCard />", () => {
       </BrowserRouter>
     );
     await wait(() => {
+      console.log(wrapper);
       spy.mockRestore();
     });
   });

--- a/src/summary/history/programs/programs-card.test.tsx
+++ b/src/summary/history/programs/programs-card.test.tsx
@@ -6,18 +6,15 @@ import { performPatientProgramsSearch } from "./programs.resource";
 import ProgramsCard from "./programs-card.component";
 import { useCurrentPatient } from "@openmrs/esm-api";
 
-
 jest.mock("@openmrs/esm-api", () => ({
-  useCurrentPatient: jest.fn()
+  useCurrentPatient: jest.fn
 }));
 
 jest.mock("./programs.resource", () => ({
   performPatientProgramsSearch: jest.fn()
 }));
 
-
 let wrapper;
-
 
 describe("<ProgramsCard />", () => {
   let match, wrapper: any;

--- a/src/summary/history/programs/programs-card.test.tsx
+++ b/src/summary/history/programs/programs-card.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render, wait } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import { act } from "react-dom/test-utils";
 import { performPatientProgramsSearch } from "./programs.resource";
-import ConditionsCard from "./programs-card.component";
+import ProgramsCard from "./programs-card.component";
 import { useCurrentPatient } from "@openmrs/esm-api";
 
 
@@ -11,7 +11,7 @@ jest.mock("@openmrs/esm-api", () => ({
   useCurrentPatient: jest.fn()
 }));
 
-jest.mock("./conditions.resource", () => ({
+jest.mock("./programs.resource", () => ({
   performPatientProgramsSearch: jest.fn()
 }));
 
@@ -19,21 +19,19 @@ jest.mock("./conditions.resource", () => ({
 let wrapper;
 
 
-describe("<ConditionsCard />", () => {
-  afterEach(() => {
-    cleanup;
+describe("<ProgramsCard />", () => {
+  let match, wrapper: any;
+
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    match = { params: {}, isExact: false, path: "/", url: "/" };
   });
 
-  beforeEach(mockUseCurrentPatient.mockReset);
-
   it("should render without dying", async () => {
-    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
-
-    mockPerformPatientConditionsSearch.mockResolvedValue(mockPatientConditions);
-
     wrapper = render(
       <BrowserRouter>
-        <ConditionsCard match={match} />
+        <ProgramsCard match={match} />
       </BrowserRouter>
     );
     await wait(() => {
@@ -41,21 +39,4 @@ describe("<ConditionsCard />", () => {
     });
   });
 
-  it("should display the patient conditions correctly", async () => {
-    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
-    mockPerformPatientConditionsSearch.mockReturnValue(
-      Promise.resolve(mockPatientConditions)
-    );
-
-    wrapper = render(
-      <BrowserRouter>
-        <ConditionsCard match={match} />
-      </BrowserRouter>
-    );
-
-    await wait(() => {
-      expect(wrapper.getByText("Hypothyroidism")).toBeTruthy();
-      expect(wrapper.getByText("Hypertension")).toBeTruthy();
-    });
-  });
 });

--- a/src/summary/history/programs/programs.resource.tsx
+++ b/src/summary/history/programs/programs.resource.tsx
@@ -2,7 +2,7 @@ import { openmrsObservableFetch } from "@openmrs/esm-api";
 import { Observable } from "rxjs";
 import { map, take } from "rxjs/operators";
 
-export function performPatientProgramsSearch(
+export function fetchPatientPrograms(
   patientID: string
 ): Observable<PatientPrograms[]> {
   return openmrsObservableFetch(

--- a/src/summary/history/programs/programs.resource.tsx
+++ b/src/summary/history/programs/programs.resource.tsx
@@ -1,0 +1,18 @@
+import { openmrsObservableFetch } from "@openmrs/esm-api";
+import { Observable } from "rxjs";
+import { map, take } from "rxjs/operators";
+
+
+export function performPatientProgramsSearch(
+  patientID: string
+): Observable<PatientPrograms[]> {
+  return openmrsObservableFetch(
+    `/ws/rest/v1/programenrollment?patient=${patientID}`
+  ).pipe(
+    map(({ data }) => data["results"]),
+    take(3)
+  );
+}
+
+type PatientPrograms = {
+};

--- a/src/summary/history/programs/programs.resource.tsx
+++ b/src/summary/history/programs/programs.resource.tsx
@@ -13,4 +13,11 @@ export function performPatientProgramsSearch(
   );
 }
 
-type PatientPrograms = {};
+type PatientPrograms = {
+  uuid: String;
+  program: {};
+  display: String;
+  dateEnrolled: Date;
+  dateCompleted: Date;
+  links: [];
+};

--- a/src/summary/history/programs/programs.resource.tsx
+++ b/src/summary/history/programs/programs.resource.tsx
@@ -2,7 +2,6 @@ import { openmrsObservableFetch } from "@openmrs/esm-api";
 import { Observable } from "rxjs";
 import { map, take } from "rxjs/operators";
 
-
 export function performPatientProgramsSearch(
   patientID: string
 ): Observable<PatientPrograms[]> {
@@ -14,5 +13,4 @@ export function performPatientProgramsSearch(
   );
 }
 
-type PatientPrograms = {
-};
+type PatientPrograms = {};

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,3 +1,5 @@
 {
-  "conditions": "Conditions"
+  "Active Programs": "Active Programs",
+  "Since": "Since",
+  "care programs": "Care Programs"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,1 +1,3 @@
-{}
+{
+  "conditions": "Conditions"
+}


### PR DESCRIPTION
Added a widget to list programs for which a patient has been enrolled. This widget will allow a user to navigate to program specific dashboards. It will not follow same pattern of Level1, Level2,Level 3 used for other widgets. The designs are pending but have discussed this with Greg Schmidt. 

In addition, I have move put programs next to conditions on the dashboard and moved allergies below them. Note that this ordering is somewhat temporary as in the near future, we will be refactoring patient chart to use a configuration which determines the layout of widgets. 

![image](https://user-images.githubusercontent.com/139934/69905649-c40f8000-136b-11ea-86d4-740f569d8e2a.png)
 