### PR TITLE
Removing duplicate test run in pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged && concurrently npm:test npm:lint npm:typescript npm:coverage"
+      "pre-commit": "pretty-quick --staged && concurrently npm:lint npm:typescript npm:coverage"
     }
   },
   "types": "src/openmrs-esm-patient-chart.tsx",


### PR DESCRIPTION
There's no need to run both `npm test` and `npm run coverage`, since running coverage runs the tests.

I discovered this because I copy pasted this package.json into create-single-spa and then saw it  (see related https://github.com/CanopyTax/create-single-spa/pull/10)