### PR TITLE
Improving support for translations by using i18next babel extract icu option

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,8 @@
       "@babel/plugin-proposal-class-properties",
       ["i18next-extract", {
         "outputPath": "translations/{{locale}}.json",
-        "discardOldKeys": true
+        "discardOldKeys": true,
+        "enableExperimentalIcu": true
       }]
     ]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3191,9 +3191,9 @@
       }
     },
     "babel-plugin-i18next-extract": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-i18next-extract/-/babel-plugin-i18next-extract-0.4.0.tgz",
-      "integrity": "sha512-RdSJx5E/AfpYL28DUvQob0jfA8+YnLSVtfYUK5ChEv3JRMV+NRymjU3ikoLmez3qGd+d+o2Q7mct0vA0hDooNg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-i18next-extract/-/babel-plugin-i18next-extract-0.5.0.tgz",
+      "integrity": "sha512-HTb6GVqW6z4KWc3GoZjnj6zLwoaEXoxlo5MkOQs6MC3NxqCt/qORVD3hdWX23dfDa/MlfPHQHTVseoR94xPz3Q==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.4.5",
@@ -5702,7 +5702,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5723,12 +5724,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5743,17 +5746,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5870,7 +5876,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5882,6 +5889,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5896,6 +5904,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5903,12 +5912,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5927,6 +5938,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6007,7 +6019,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6019,6 +6032,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6104,7 +6118,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6140,6 +6155,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6159,6 +6175,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6202,12 +6219,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
-    "babel-plugin-i18next-extract": "^0.4.0",
+    "babel-plugin-i18next-extract": "^0.5.0",
     "browserslist-config-openmrs": "^1.0.0",
     "clean-webpack-plugin": "^3.0.0",
     "concurrently": "^5.0.0",


### PR DESCRIPTION
See related https://github.com/gilbsgilbs/babel-plugin-i18next-extract/releases, https://github.com/gilbsgilbs/babel-plugin-i18next-extract/pull/112, and https://github.com/gilbsgilbs/babel-plugin-i18next-extract/issues/98

This enables the translations extractor babel plugin to support plural words and accurately translating the plural words. To do so, it uses an [ICU format for plurals](https://docs.transifex.com/formats/json/) that is supported by Transifex.

To actually use the functionality, you use the `t()` function with a `count` option:
```js
const { t } = useTranslation()

t("something", {count: 2, defaultValue: "There are {{count}} items"})
```

This will be automatically extracted into the following string in en.json:

```
{count, plural, one {There are {count} items} other {There are {count} items}
```

To make the English translation correct, you then need to manually modify that translation to say `item` instead of `items` for the singular case:

```
{count, plural, one {There is {count} item} other {There are {count} items}
```

^ This practice should be employed wherever you have plurals in a translated string.

Note that this PR should be replicated in all other repos that are doing translations, but that I'm just putting together this one as a first example of how to do it.