### PR TITLE
Fix inexhaustive hook deps warning

### DIFF
--- a/src/widgets/allergies/allergy-card-level-three.component.tsx
+++ b/src/widgets/allergies/allergy-card-level-three.component.tsx
@@ -25,7 +25,7 @@ export function AllergyCardLevelThree(props: AllergyCardLevelThreeProps) {
 
       return () => abortController.abort();
     }
-  }, [isLoadingPatient, patient]);
+  }, [isLoadingPatient, patient, patientUuid, props.match.params]);
 
   function displayAllergy() {
     return (


### PR DESCRIPTION
Fixes a React hook exhaustive dependency warning from not including `patientUuid` and `props.match.params` in the dependency array.