### PR TITLE
Pluralize allergy to allergies

### DIFF
--- a/src/summaries/level-two-routes.component.tsx
+++ b/src/summaries/level-two-routes.component.tsx
@@ -14,17 +14,17 @@ import ConditionsDetailedSummary from "../widgets/conditions/conditions-detailed
 
 export const levelTwoRoutes: PatientChartRoute[] = [
   {
-    url: "/patient/:patientUuid/chart/allergy",
+    url: "/patient/:patientUuid/chart/allergies",
     component: AllergyOverviewLevelTwo,
-    name: "Allergy"
+    name: "Allergies"
   },
   {
-    url: "/patient/:patientUuid/chart/allergy/form/:allergyUuid?",
+    url: "/patient/:patientUuid/chart/allergies/add/:allergyUuid?",
     component: AllergyForm,
     name: "Allergy Form"
   },
   {
-    url: "/patient/:patientUuid/chart/allergy/:allergyUuid",
+    url: "/patient/:patientUuid/chart/allergies/:allergyUuid",
     component: AllergyCardLevelThree,
     name: "Allergy"
   },

--- a/src/widgets/allergies/allergy-card-level-three.component.tsx
+++ b/src/widgets/allergies/allergy-card-level-three.component.tsx
@@ -33,7 +33,7 @@ export function AllergyCardLevelThree(props: AllergyCardLevelThreeProps) {
         name="Allergy"
         match={props.match}
         styles={{ width: "100%" }}
-        editBtnUrl={`/patient/${patientUuid}/chart/allergy/${props.match.params["allergyUuid"]}/edit`}
+        editBtnUrl={`/patient/${patientUuid}/chart/allergies/add/${props.match.params["allergyUuid"]}`}
       >
         <div
           className={`${styles.allergyCard} ${

--- a/src/widgets/allergies/allergy-card-level-two.component.tsx
+++ b/src/widgets/allergies/allergy-card-level-two.component.tsx
@@ -32,10 +32,10 @@ export function AllergyOverviewLevelTwo(props: AllergyOverviewLevelTwoProps) {
   function displayAllergy() {
     return (
       <SummaryCard
-        name="Allergy"
+        name="Allergies"
         match={props.match}
         styles={{ width: "100%" }}
-        addBtnUrl={`/patient/${patientUuid}/chart/allergy/add`}
+        addBtnUrl={`/patient/${patientUuid}/chart/allergies/add`}
       >
         <table className={styles.allergyTable}>
           <thead>
@@ -105,7 +105,7 @@ export function AllergyOverviewLevelTwo(props: AllergyOverviewLevelTwoProps) {
                           </span>
 
                           <Link
-                            to={`/patient/${patientUuid}/chart/allergy/${allergy.resource.id}`}
+                            to={`/patient/${patientUuid}/chart/allergies/${allergy.resource.id}`}
                           >
                             <svg
                               className="omrs-icon"
@@ -154,7 +154,7 @@ export function AllergyOverviewLevelTwo(props: AllergyOverviewLevelTwoProps) {
   function displayNoAllergenHistory() {
     return (
       <SummaryCard
-        name="Allergy"
+        name="Allergies"
         match={props.match}
         styles={{ width: "100%" }}
       >

--- a/src/widgets/allergies/allergy-form.component.tsx
+++ b/src/widgets/allergies/allergy-form.component.tsx
@@ -214,7 +214,7 @@ export function AllergyForm(props: AllergyFormProps) {
   };
 
   function navigate() {
-    window.location.href = `https://openmrs-spa.org/openmrs/spa/patient/${patientUuid}/chart/allergy`;
+    window.location.href = `https://openmrs-spa.org/openmrs/spa/patient/${patientUuid}/chart/allergies`;
   }
 
   const setCheckedValue = uuid => {

--- a/src/widgets/allergies/allergy-overview.component.tsx
+++ b/src/widgets/allergies/allergy-overview.component.tsx
@@ -31,10 +31,10 @@ export default function AllergyOverview(props: AllergyOverviewProps) {
 
   return (
     <SummaryCard
-      name="Allergy"
+      name="Allergies"
       match={props.match}
       styles={{ margin: "1.25rem, 1.5rem" }}
-      link={`/patient/${patientUuid}/chart/allergy`}
+      link={`/patient/${patientUuid}/chart/allergies`}
     >
       {patientAllergy &&
         patientAllergy.total > 0 &&
@@ -42,7 +42,7 @@ export default function AllergyOverview(props: AllergyOverviewProps) {
           return (
             <SummaryCardRow
               key={allergy.resource.id}
-              linkTo={`/patient/${patientUuid}/chart/allergy`}
+              linkTo={`/patient/${patientUuid}/chart/allergies`}
             >
               <HorizontalLabelValue
                 label={allergy.resource.code.text}


### PR DESCRIPTION
This PR pluralizes `allergy` to `allergies` in the overview, level two and level three summary card headers and routing for the allergies widget to make it more consistent with the nomenclature used for the other widgets i.e. pluralized widget names. 

Link to the discussion about this with Greg in the Figma file https://www.figma.com/file/YyVhWTNp89bNiOGadYrHBk#17086460