### PR TITLE
Medication order bug fix

### DIFF
--- a/__mocks__/medication.mock.ts
+++ b/__mocks__/medication.mock.ts
@@ -39,3 +39,252 @@ export const mockPatientEncounterIDResults = {
     results: [{ uuid: "0926163e-8a28-43c2-a2cf-9851dc72f39d" }]
   }
 };
+
+export const mockMedicationOrderByUuidResponse = {
+  data: {
+    uuid: "42b8fe2f-8c55-45a2-8e40-cb0b8100de7c",
+    route: {
+      uuid: "160240AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      display: "Oral"
+    },
+    action: "REVISE",
+    urgency: "ROUTINE",
+    display: "(REVISE) sulfadoxine: 2.0 Capsule Oral Once daily 5 Days dosing",
+    drug: {
+      display: "sulfadoxine",
+      strength: "500mg"
+    },
+    frequency: {
+      display: "Once daily"
+    },
+    dose: 2.0,
+    doseUnits: {
+      display: "Capsule"
+    },
+    orderer: {
+      uuid: "e89cae4a-3cb3-40a2-b964-8b20dda2c985",
+      display: "ghvbjnkm-1 - Fifty User",
+      person: {
+        uuid: "e7dd932e-c2ac-4917-bf66-e59793adbd5f",
+        display: "Fifty User",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/person/e7dd932e-c2ac-4917-bf66-e59793adbd5f"
+          }
+        ]
+      },
+      identifier: "ghvbjnkm-1",
+      attributes: [],
+      retired: false,
+      links: [
+        {
+          rel: "self",
+          uri:
+            "http://localhost:8090/openmrs/ws/rest/v1/provider/e89cae4a-3cb3-40a2-b964-8b20dda2c985"
+        },
+        {
+          rel: "full",
+          uri:
+            "http://localhost:8090/openmrs/ws/rest/v1/provider/e89cae4a-3cb3-40a2-b964-8b20dda2c985?v=full"
+        }
+      ],
+      resourceVersion: "1.9"
+    },
+    dateStopped: null,
+    dateActivated: "2020-02-19T14:16:17.000+0000",
+    previousOrder: {
+      uuid: "0d46ad72-9d94-41f7-92cf-0a568cfff357",
+      orderNumber: "ORD-142",
+      accessionNumber: null,
+      patient: {
+        uuid: "8673ee4f-e2ab-4077-ba55-4980f408773e",
+        display: "100GEJ - John Wilson",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/patient/8673ee4f-e2ab-4077-ba55-4980f408773e"
+          }
+        ]
+      },
+      concept: {
+        uuid: "84462AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        display: "SULFADOXINE",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/concept/84462AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        ]
+      },
+      action: "NEW",
+      careSetting: {
+        uuid: "6f0c9a92-6f24-11e3-af88-005056821db0",
+        display: "Outpatient",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/caresetting/6f0c9a92-6f24-11e3-af88-005056821db0"
+          }
+        ]
+      },
+      previousOrder: null,
+      dateActivated: "2020-02-19T14:15:47.000+0000",
+      scheduledDate: null,
+      dateStopped: "2020-02-19T14:16:16.000+0000",
+      autoExpireDate: null,
+      encounter: {
+        uuid: "11c22e25-f9f8-4c79-b384-1da39ee7d5d2",
+        display: "Visit Note 10/11/2016",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/encounter/11c22e25-f9f8-4c79-b384-1da39ee7d5d2"
+          }
+        ]
+      },
+      orderer: {
+        uuid: "e89cae4a-3cb3-40a2-b964-8b20dda2c985",
+        display: "ghvbjnkm-1 - Fifty User",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/provider/e89cae4a-3cb3-40a2-b964-8b20dda2c985"
+          }
+        ]
+      },
+      orderReason: null,
+      orderReasonNonCoded: null,
+      orderType: {
+        uuid: "131168f4-15f5-102d-96e4-000c29c2a5d7",
+        display: "Drug Order",
+        name: "Drug Order",
+        javaClassName: "org.openmrs.DrugOrder",
+        retired: false,
+        description: "An order for a medication to be given to the patient",
+        conceptClasses: [],
+        parent: null,
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/ordertype/131168f4-15f5-102d-96e4-000c29c2a5d7"
+          },
+          {
+            rel: "full",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/ordertype/131168f4-15f5-102d-96e4-000c29c2a5d7?v=full"
+          }
+        ],
+        resourceVersion: "1.10"
+      },
+      urgency: "ROUTINE",
+      instructions: null,
+      commentToFulfiller: null,
+      display: "(NEW) sulfadoxine: 1.0 Capsule Oral Once daily 5 Days dosing",
+      drug: {
+        uuid: "fc92c351-8a85-41b9-95bf-a7dfea46c9cd",
+        display: "sulfadoxine",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/drug/fc92c351-8a85-41b9-95bf-a7dfea46c9cd"
+          }
+        ]
+      },
+      dosingType: "org.openmrs.SimpleDosingInstructions",
+      dose: 1.0,
+      doseUnits: {
+        uuid: "1608AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        display: "Capsule",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/concept/1608AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        ]
+      },
+      frequency: {
+        uuid: "160862OFAAAAAAAAAAAAAAA",
+        display: "Once daily",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/orderfrequency/160862OFAAAAAAAAAAAAAAA"
+          }
+        ]
+      },
+      asNeeded: false,
+      asNeededCondition: null,
+      quantity: 1.0,
+      quantityUnits: {
+        uuid: "162396AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        display: "Box",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/concept/162396AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        ]
+      },
+      numRefills: 5,
+      dosingInstructions: "dosing",
+      duration: 5,
+      durationUnits: {
+        uuid: "1072AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        display: "Days",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/concept/1072AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        ]
+      },
+      route: {
+        uuid: "160240AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        display: "Oral",
+        links: [
+          {
+            rel: "self",
+            uri:
+              "http://localhost:8090/openmrs/ws/rest/v1/concept/160240AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        ]
+      },
+      brandName: null,
+      dispenseAsWritten: false,
+      drugNonCoded: null,
+      links: [
+        {
+          rel: "self",
+          uri:
+            "http://localhost:8090/openmrs/ws/rest/v1/order/0d46ad72-9d94-41f7-92cf-0a568cfff357"
+        },
+        {
+          rel: "full",
+          uri:
+            "http://localhost:8090/openmrs/ws/rest/v1/order/0d46ad72-9d94-41f7-92cf-0a568cfff357?v=full"
+        }
+      ],
+      type: "drugorder",
+      resourceVersion: "1.10"
+    },
+    numRefills: 5,
+    duration: 5,
+    durationUnits: {
+      display: "Days"
+    },
+    type: "drugorder"
+  }
+};

--- a/src/widgets/medications/medication-button.component.tsx
+++ b/src/widgets/medications/medication-button.component.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { newWorkspaceItem } from "../../workspace/workspace.resource";
 import { styles } from "./medication-button.css";
+import { MedicationOrderBasket } from "./medication-order-basket.component";
 
 export function MedicationButton(props: any) {
   return (
@@ -19,7 +20,11 @@ export function MedicationButton(props: any) {
               }
             }
           },
-          inProgress: props.inProgress
+          inProgress: props.inProgress,
+          validations: (workspaceTabs: any[]) =>
+            workspaceTabs.findIndex(
+              tab => tab.component === MedicationOrderBasket
+            )
         })
       }
     >

--- a/src/widgets/medications/medication-level-three/medication-level-three.component.tsx
+++ b/src/widgets/medications/medication-level-three/medication-level-three.component.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { match } from "react-router";
+import { useRouteMatch } from "react-router-dom";
 import dayjs from "dayjs";
 import { createErrorHandler } from "@openmrs/esm-error-handling";
 import { useCurrentPatient } from "@openmrs/esm-api";
@@ -16,26 +16,28 @@ export default function MedicationCardLevelThree(
 ) {
   const [patientMedication, setMedication] = React.useState(null);
   const [isLoadingPatient, patient, patientUuid] = useCurrentPatient();
+  const match = useRouteMatch({
+    path: "/patient/:patientUuid/chart/medications/:medicationUuid"
+  });
 
   React.useEffect(() => {
     if (!isLoadingPatient && patient) {
       const abortController = new AbortController();
-      getMedicationByUuid(
-        abortController,
-        props.match.params["medicationUuid"]
-      ).then(response => {
-        setMedication(response.data);
-      });
+      getMedicationByUuid(abortController, match.params["medicationUuid"]).then(
+        response => {
+          setMedication(response.data);
+        },
+        createErrorHandler()
+      );
       return () => abortController.abort();
     }
-  }, [isLoadingPatient, patient, props.match.params]);
+  }, [isLoadingPatient, patient, match.params]);
 
   function displayMedication() {
     return (
       <>
         <SummaryCard
           name="Medication"
-          match={props.match}
           styles={{ width: "90%" }}
           editBtnUrl={`/patient/${patientUuid}/chart/medication/edit`}
         >
@@ -136,7 +138,6 @@ export default function MedicationCardLevelThree(
     return (
       <SummaryCard
         name="Details"
-        match={props.match}
         styles={{
           width: "90%",
           backgroundColor: "var(--omrs-color-bg-medium-contrast)"
@@ -177,6 +178,4 @@ export default function MedicationCardLevelThree(
     </>
   );
 }
-type MedicationCardLevelThreeProps = {
-  match: match;
-};
+type MedicationCardLevelThreeProps = {};

--- a/src/widgets/medications/medication-level-three/medication-level-three.test.tsx
+++ b/src/widgets/medications/medication-level-three/medication-level-three.test.tsx
@@ -1,19 +1,51 @@
 import React from "react";
-
 import { render, cleanup, wait } from "@testing-library/react";
-import { BrowserRouter, match } from "react-router-dom";
+import { match, useRouteMatch } from "react-router";
 import MedicationCardLevelThree from "./medication-level-three.component";
+import { BrowserRouter } from "react-router-dom";
+import { useCurrentPatient, openmrsFetch } from "@openmrs/esm-api";
+import { mockPatient } from "../../../../__mocks__/patient.mock";
+import { mockMedicationOrderByUuidResponse } from "../../../../__mocks__/medication.mock";
+
+const mockUseRouteMatch = useRouteMatch as jest.Mock;
+const mockUseCurrentPatient = useCurrentPatient as jest.Mock;
+const mockOpenmrsFetch = openmrsFetch as jest.Mock;
+
+jest.mock("@openmrs/esm-api", () => ({
+  useCurrentPatient: jest.fn(),
+  openmrsFetch: jest.fn()
+}));
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useRouteMatch: jest.fn()
+}));
 
 describe("<MedicationCardLevelThree />", () => {
-  let match: match = { params: {}, isExact: false, path: "/", url: "/" };
+  let patient: fhir.Patient = mockPatient;
+  let match: match = {
+    params: { medicationUuid: "bbd27a2f-442a-418a-9952-f2bb0e54df97" },
+    isExact: true,
+    path: "/patient/:patientUuid/chart/medications/:medicationUuid",
+    url: "/"
+  };
   let wrapper: any;
 
   afterEach(cleanup);
 
+  beforeEach(() => {
+    mockUseRouteMatch.mockReset();
+  });
+
   it("renders without dying", async () => {
+    mockUseCurrentPatient.mockReturnValue([false, patient, patient.id, null]);
+    mockUseRouteMatch.mockReturnValue(match);
+    mockOpenmrsFetch.mockReturnValue(
+      Promise.resolve(mockMedicationOrderByUuidResponse)
+    );
     wrapper = render(
       <BrowserRouter>
-        <MedicationCardLevelThree match={match} />
+        <MedicationCardLevelThree />
       </BrowserRouter>
     );
 

--- a/src/widgets/medications/medication-level-two.component.tsx
+++ b/src/widgets/medications/medication-level-two.component.tsx
@@ -137,6 +137,18 @@ export default function MedicationLevelTwo(props: MedicationsOverviewProps) {
                               inProgress={true}
                             />
                           </td>
+                          <td style={{ textAlign: "end" }}>
+                            <Link
+                              to={`/patient/${patientUuid}/chart/medications/${medication.uuid}`}
+                            >
+                              <svg
+                                className="omrs-icon"
+                                fill="rgba(0, 0, 0, 0.54)"
+                              >
+                                <use xlinkHref="#omrs-icon-chevron-right" />
+                              </svg>
+                            </Link>
+                          </td>
                         </tr>
                       </React.Fragment>
                     );

--- a/src/widgets/medications/medication-level-two.component.tsx
+++ b/src/widgets/medications/medication-level-two.component.tsx
@@ -127,29 +127,15 @@ export default function MedicationLevelTwo(props: MedicationsOverviewProps) {
                               action={"REVISE"}
                               inProgress={true}
                             />
-                            <td>
-                              <MedicationButton
-                                component={MedicationOrderBasket}
-                                name={"Medication Order Basket"}
-                                label={"DISCONTINUE"}
-                                orderUuid={medication.uuid}
-                                drugName={medication.drug.name}
-                                action={"DISCONTINUE"}
-                                inProgress={true}
-                              />
-                            </td>
-                            <td style={{ textAlign: "end" }}>
-                              <Link
-                                to={`/patient/${patientUuid}/chart/medications/${medication.uuid}`}
-                              >
-                                <svg
-                                  className="omrs-icon"
-                                  fill="rgba(0, 0, 0, 0.54)"
-                                >
-                                  <use xlinkHref="#omrs-icon-chevron-right" />
-                                </svg>
-                              </Link>
-                            </td>
+                            <MedicationButton
+                              component={MedicationOrderBasket}
+                              name={"Medication Order Basket"}
+                              label={"DISCONTINUE"}
+                              orderUuid={medication.uuid}
+                              drugName={null}
+                              action={"DISCONTINUE"}
+                              inProgress={true}
+                            />
                           </td>
                         </tr>
                       </React.Fragment>

--- a/src/widgets/medications/medication-order-basket.component.tsx
+++ b/src/widgets/medications/medication-order-basket.component.tsx
@@ -13,7 +13,7 @@ import { useCurrentPatient } from "@openmrs/esm-api";
 import SummaryCardRow from "../cards/summary-card-row.component";
 import SummaryCardRowContent from "../cards/summary-card-row-content.component";
 import { getDosage, OrderMedication } from "./medication-orders-utils";
-import { useHistory, useRouteMatch } from "react-router-dom";
+import { useHistory, match } from "react-router-dom";
 
 const NEW_MEDICATION_ACTION: string = "NEW";
 const DISCONTINUE_MEDICATION_ACTION: string = "DISCONTINUE";
@@ -38,7 +38,7 @@ export function MedicationOrderBasket(props: MedicationOrderBasketProps) {
     orderEdit: Boolean;
     order?: OrderMedication;
   }>({ orderEdit: false, order: null });
-  const match = useRouteMatch();
+
   const handleDrugSelected = $event => {
     setDrugName(searchTerm);
     setShowOrderMedication(true);
@@ -71,7 +71,7 @@ export function MedicationOrderBasket(props: MedicationOrderBasketProps) {
   }, [orderBasket]);
 
   useEffect(() => {
-    let params: any = match.params;
+    let params: any = props.match.params;
     if (params.drugName) {
       setShowOrderMedication(true);
       setEditProperty([
@@ -83,10 +83,10 @@ export function MedicationOrderBasket(props: MedicationOrderBasketProps) {
       ]);
       setDrugName(params.drugName);
     }
-  }, [match.params]);
+  }, [props.match.params]);
 
   useEffect(() => {
-    let params: any = match.params;
+    let params: any = props.match.params;
     const DISCONTINUE = "DISCONTINUE";
     if (params.action != undefined && params.action === DISCONTINUE) {
       const abortController = new AbortController();
@@ -121,7 +121,7 @@ export function MedicationOrderBasket(props: MedicationOrderBasketProps) {
       return () => abortController.abort();
     }
     //eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [match.params]);
+  }, [props.match.params]);
 
   const handleSaveOrders = () => {
     const abortController = new AbortController();
@@ -143,7 +143,7 @@ export function MedicationOrderBasket(props: MedicationOrderBasketProps) {
   };
 
   const resetParams = () => {
-    match.params = {};
+    props.match.params = {};
   };
 
   function navigate() {
@@ -224,27 +224,23 @@ export function MedicationOrderBasket(props: MedicationOrderBasketProps) {
         </div>
       </div>
 
-      <div style={{ width: "70%" }}>
+      <div style={{ width: "90%" }}>
         {orderBasket.length > 0 &&
           orderBasket.map((order, index) => {
             return (
               <div
-                className={`${styles.basketStyles} ${
-                  order.action === NEW_MEDICATION_ACTION
-                    ? styles.newOrder
-                    : styles.reviseOrder
-                }`}
+                className={`${styles.basketStyles} ${styles.OrderStyle}`}
                 key={index}
               >
                 <SummaryCardRow>
                   <SummaryCardRowContent justifyContent="space-between">
                     <span>
-                      <b>{order.drugName}</b>
+                      {order.action} <b>{order.drugName}</b>
                       {" \u2014 "}{" "}
                       {String(order.dosageForm).toLocaleLowerCase()}
                       {" \u2014 "} {String(order.routeName).toLocaleLowerCase()}
-                      {" \u2014 "}{" "}
-                      {`DOSE ${getDosage(order.drugStrength, order.dose)}`}{" "}
+                      {" \u2014 "} DOSE{" "}
+                      <b>{`${getDosage(order.drugStrength, order.dose)}`} </b>
                       <b>{String(order.frequencyName).toLocaleLowerCase()}</b>
                     </span>
                     <span>
@@ -254,7 +250,7 @@ export function MedicationOrderBasket(props: MedicationOrderBasketProps) {
                       >
                         <svg>
                           <use
-                            fill={"var(--omrs-color-ink-white)"}
+                            fill={"var(--omrs-color-brand-black)"}
                             xlinkHref="#omrs-icon-close"
                           ></use>
                         </svg>
@@ -270,7 +266,7 @@ export function MedicationOrderBasket(props: MedicationOrderBasketProps) {
                       >
                         <svg>
                           <use
-                            fill={"var(--omrs-color-ink-white)"}
+                            fill={"var(--omrs-color-brand-black)"}
                             xlinkHref="#omrs-icon-menu"
                           ></use>
                         </svg>
@@ -324,4 +320,6 @@ export function MedicationOrderBasket(props: MedicationOrderBasketProps) {
   );
 }
 
-type MedicationOrderBasketProps = {};
+type MedicationOrderBasketProps = {
+  match: match;
+};

--- a/src/widgets/medications/medication-order-basket.css
+++ b/src/widgets/medications/medication-order-basket.css
@@ -144,12 +144,7 @@ th {
   cursor: pointer;
 }
 
-.newOrder {
-  background-color: var(--omrs-color-success);
-  color: var(--omrs-color-ink-white);
-}
-
-.reviseOrder {
-  background-color: var(--omrs-color-brand-orange);
-  color: var(--omrs-color-ink-white);
+.OrderStyle {
+  background-color: var(--omrs-color-success-two);
+  color: var(--omrs-color-brand-black);
 }

--- a/src/widgets/medications/medications.resource.tsx
+++ b/src/widgets/medications/medications.resource.tsx
@@ -28,7 +28,7 @@ export function fetchPatientMedications(
   patientID: string
 ): Observable<PatientMedications[]> {
   return openmrsObservableFetch(
-    `/ws/rest/v1/order?patient=${patientID}&careSetting=${CARE_SETTING}&status=any&v=custom:(uuid,orderNumber,accessionNumber,patient:ref,action,careSetting:ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,orderType:ref,encounter:ref,orderer:ref,orderReason,orderType,urgency,instructions,commentToFulfiller,drug:(name,strength,concept),dose,doseUnits:ref,frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)`
+    `/ws/rest/v1/order?patient=${patientID}&careSetting=${CARE_SETTING}&status=ACTIVE&v=custom:(uuid,orderNumber,accessionNumber,patient:ref,action,careSetting:ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,orderType:ref,encounter:ref,orderer:ref,orderReason,orderType,urgency,instructions,commentToFulfiller,drug:(name,strength,concept),dose,doseUnits:ref,frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,numRefills,dosingInstructions,duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)`
   ).pipe(
     map(({ data }) => {
       const meds = [];


### PR DESCRIPTION
1. Fixes bug where an already discontinued order was displayed as still active. 
2. Fixes Medication Level Three Failing test.
3. Removes colors on the medication order basket and adds the action prefixed on the order item. 

![Screenshot from 2020-02-20 10-22-17](https://user-images.githubusercontent.com/28008754/74910149-e5ac6080-53ca-11ea-95b4-3bec273de781.png)
