### PR TITLE
Parcel config

### DIFF
--- a/__mocks__/single-spa-react.js
+++ b/__mocks__/single-spa-react.js
@@ -1,0 +1,11 @@
+// In __mocks__/single-spa-react.js
+//import context from "../src/view-components/widget/testHelpers";
+const React = require("react");
+//const context = require("../src/view-components/widget/testHelpers");
+
+const SingleSpaContext = React.createContext({ mountParcel: () => jest.fn() });
+
+//constexport default mock;
+module.exports = {
+  SingleSpaContext: SingleSpaContext
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3569,6 +3569,16 @@
         "@types/react-router": "*"
       }
     },
+    "@types/single-spa-react": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@types/single-spa-react/-/single-spa-react-2.8.3.tgz",
+      "integrity": "sha512-2F2xc0HUzuWAtsrJR3E3vy9dDDQObDv6YqBynPpIz85m5RY6+I4lr3pv93k0uv0nMK2NtHp/cspou4Pj0lEaaQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "@types/react-dom": "*"
+      }
+    },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
     "@types/react-router-dom": "^5.1.3",
+    "@types/single-spa-react": "^2.8.3",
     "@types/systemjs": "^6.1.0",
     "@types/webpack-env": "^1.15.1",
     "babel-eslint": "^10.1.0",

--- a/src/openmrs-esm-patient-chart-config.ts
+++ b/src/openmrs-esm-patient-chart-config.ts
@@ -75,6 +75,7 @@ export const esmPatientChartConfig = {
         arrayElements: {
           name: { validators: [validators.isString] },
           esModule: { validators: [validators.isString] },
+          usesSingleSpaContext: { validators: [validators.isBoolean] },
           layout: {
             rowSpan: {},
             columnSpan: {}

--- a/src/openmrs-esm-patient-chart-config.ts
+++ b/src/openmrs-esm-patient-chart-config.ts
@@ -58,7 +58,8 @@ export const esmPatientChartConfig = {
   widgetDefinitions: {
     arrayElements: {
       name: { validators: [validators.isString] },
-      esModule: { validators: [validators.isString] }
+      esModule: { validators: [validators.isString] },
+      usesSingleSpaContext: { validators: [validators.isBoolean] }
     },
     default: coreWidgetDefinitions
   },

--- a/src/view-components/core-views.tsx
+++ b/src/view-components/core-views.tsx
@@ -94,7 +94,10 @@ export const coreDashboardDefinitions = [
       {
         name: "MedicationsOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
-        layout: { columnSpan: 3 }
+        layout: { columnSpan: 3 },
+        params: {
+          basePath: "orders/medication-orders"
+        }
       },
       {
         name: "AllergiesOverview",
@@ -131,7 +134,10 @@ export const coreDashboardDefinitions = [
     widgets: [
       {
         name: "MedicationsOverview",
-        esModule: "@openmrs/esm-patient-chart-widgets"
+        esModule: "@openmrs/esm-patient-chart-widgets",
+        params: {
+          basePath: "orders/medication-orders"
+        }
       }
     ]
   },

--- a/src/view-components/core-views.tsx
+++ b/src/view-components/core-views.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { DashboardConfig } from "./dashboard/dashboard.component";
 
 export const coreWidgetDefinitions = [
@@ -96,7 +95,7 @@ export const coreDashboardDefinitions = [
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 3 },
         params: {
-          basePath: "orders/medication-orders"
+          basePath: "orders/medications-orders"
         }
       },
       {
@@ -138,6 +137,10 @@ export const coreDashboardDefinitions = [
         params: {
           basePath: "orders/medication-orders"
         }
+      },
+      {
+        name: "MedicationsSummary",
+        esModule: "@openmrs/esm-patient-chart-widgets"
       }
     ]
   },

--- a/src/view-components/widget/testHelpers.js
+++ b/src/view-components/widget/testHelpers.js
@@ -1,0 +1,5 @@
+export const context = {
+  mountParcel: () => jest.fn()
+};
+
+export default context;

--- a/src/view-components/widget/widget.component.tsx
+++ b/src/view-components/widget/widget.component.tsx
@@ -8,7 +8,7 @@ export default function Widget(props) {
 
   React.useEffect(() => {
     loadWidgetFromConfig(props.widgetConfig);
-  }, [props.widgetConfig, loadWidgetFromConfig]);
+  }, [props.widgetConfig]);
 
   function loadWidgetFromConfig(widgetConfig: WidgetConfig) {
     let Component: FunctionComponent<ComponentProps>;

--- a/src/view-components/widget/widget.component.tsx
+++ b/src/view-components/widget/widget.component.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useContext } from "react";
 //@ts-ignore The present types for single-spa-react are not updated yet for 2.9 which has SingleSpaContext
-import s, { SingleSpaContext } from "single-spa-react";
+import { SingleSpaContext } from "single-spa-react";
 
 export default function Widget(props) {
   const [widget, setWidget] = React.useState(null);

--- a/src/view-components/widget/widget.component.tsx
+++ b/src/view-components/widget/widget.component.tsx
@@ -21,13 +21,14 @@ export default function Widget(props) {
             if (widgetConfig.createParcel) {
               <SingleSpaContext.Consumer>
                 {context => {
-                  //create and mount the parcel
+                  widget.component = () => {}; //create and mount the parcel
                 }}
               </SingleSpaContext.Consumer>;
+            } else {
+              widget.component = () => (
+                <Component {...props.widgetConfig.params} {...app.appProps} />
+              );
             }
-            widget.component = () => (
-              <Component {...props.widgetConfig.params} {...app.appProps} />
-            );
           } else {
             widget.component = () => (
               <div>

--- a/src/view-components/widget/widget.component.tsx
+++ b/src/view-components/widget/widget.component.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, useContext } from "react";
 import { AppPropsContext } from "../../app-props-context";
+import singleSpa, { SingleSpaContext } from "single-spa-react";
 
 export default function Widget(props) {
   const [widget, setWidget] = React.useState(null);
@@ -17,7 +18,16 @@ export default function Widget(props) {
         .then(module => {
           if (module[widgetConfig.name]) {
             Component = module[widgetConfig.name];
-            widget.component = () => <Component props={app.appProps} />;
+            if (widgetConfig.createParcel) {
+              <SingleSpaContext.Consumer>
+                {context => {
+                  //create and mount the parcel
+                }}
+              </SingleSpaContext.Consumer>;
+            }
+            widget.component = () => (
+              <Component {...props.widgetConfig.params} {...app.appProps} />
+            );
           } else {
             widget.component = () => (
               <div>
@@ -62,6 +72,7 @@ type GridSize = {
 export type WidgetConfig = {
   name: string;
   esModule?: string;
+  createParcel?: boolean;
   layout?: {
     rowSpan?: number;
     columnSpan?: number;

--- a/src/view-components/widget/widget.component.tsx
+++ b/src/view-components/widget/widget.component.tsx
@@ -54,7 +54,7 @@ export default function Widget(props) {
       }
     };
     loadWidgetFromConfig(props.widgetConfig);
-  }, [props.widgetConfig]);
+  }, [props.widgetConfig, mountParcel]);
 
   return (
     <>

--- a/src/view-components/widget/widget.component.tsx
+++ b/src/view-components/widget/widget.component.tsx
@@ -1,9 +1,11 @@
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useContext } from "react";
 //@ts-ignore The present types for single-spa-react are not updated yet for 2.9 which has SingleSpaContext
-import { SingleSpaContext } from "single-spa-react";
+import s, { SingleSpaContext } from "single-spa-react";
 
 export default function Widget(props) {
   const [widget, setWidget] = React.useState(null);
+
+  const { mountParcel } = useContext(SingleSpaContext);
 
   React.useEffect(() => {
     //This function is moved inside of the effect to avoid change on every render
@@ -16,16 +18,12 @@ export default function Widget(props) {
             if (module[widgetConfig.name]) {
               Component = module[widgetConfig.name];
               if (widgetConfig.usesSingleSpaContext) {
-                <SingleSpaContext.Consumer>
-                  {context => {
-                    widget.component = () => (
-                      <Component
-                        {...props.widgetConfig.params}
-                        singleSpaContext={context}
-                      />
-                    );
-                  }}
-                </SingleSpaContext.Consumer>;
+                widget.component = () => (
+                  <Component
+                    {...props.widgetConfig.params}
+                    singleSpaContext={{ mountParcel: mountParcel }}
+                  />
+                );
               } else {
                 widget.component = () => (
                   <Component {...props.widgetConfig.params} />

--- a/src/view-components/widget/widget.component.tsx
+++ b/src/view-components/widget/widget.component.tsx
@@ -8,7 +8,7 @@ export default function Widget(props) {
 
   React.useEffect(() => {
     loadWidgetFromConfig(props.widgetConfig);
-  }, [props.widgetConfig]);
+  }, [props.widgetConfig, loadWidgetFromConfig]);
 
   function loadWidgetFromConfig(widgetConfig: WidgetConfig) {
     let Component: FunctionComponent<ComponentProps>;

--- a/src/view-components/widget/widget.component.tsx
+++ b/src/view-components/widget/widget.component.tsx
@@ -4,7 +4,6 @@ import singleSpa, { SingleSpaContext } from "single-spa-react";
 
 export default function Widget(props) {
   const [widget, setWidget] = React.useState(null);
-  const app = useContext(AppPropsContext);
 
   React.useEffect(() => {
     loadWidgetFromConfig(props.widgetConfig);
@@ -18,15 +17,17 @@ export default function Widget(props) {
         .then(module => {
           if (module[widgetConfig.name]) {
             Component = module[widgetConfig.name];
-            if (widgetConfig.createParcel) {
+            if (widgetConfig.usesSingleSpaContext) {
               <SingleSpaContext.Consumer>
                 {context => {
-                  widget.component = () => {}; //create and mount the parcel
+                  widget.component = () => (
+                    <Component {...props.widgetConfig.params} {...context} />
+                  );
                 }}
               </SingleSpaContext.Consumer>;
             } else {
               widget.component = () => (
-                <Component {...props.widgetConfig.params} {...app.appProps} />
+                <Component {...props.widgetConfig.params} />
               );
             }
           } else {
@@ -73,7 +74,7 @@ type GridSize = {
 export type WidgetConfig = {
   name: string;
   esModule?: string;
-  createParcel?: boolean;
+  usesSingleSpaContext?: boolean;
   layout?: {
     rowSpan?: number;
     columnSpan?: number;

--- a/src/view-components/widget/widget.test.tsx
+++ b/src/view-components/widget/widget.test.tsx
@@ -102,7 +102,6 @@ describe(`<Widget />`, () => {
     );
 
     const element = await waitForElement(() => queryByText("Test Widget"));
-    debug();
     expect(element).not.toBeNull();
 
     done();

--- a/src/view-components/widget/widget.test.tsx
+++ b/src/view-components/widget/widget.test.tsx
@@ -1,6 +1,15 @@
+//jest.mock("single-spa-react");
+
 import React from "react";
-import { render, waitForElement, cleanup } from "@testing-library/react";
+import {
+  render,
+  waitForElement,
+  cleanup,
+  queryByText
+} from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
+//@ts-ignore
+import ssr, { SingleSpaContext } from "single-spa-react";
 
 import Widget from "./widget.component";
 
@@ -78,6 +87,24 @@ describe(`<Widget />`, () => {
       queryByText("no module provided", { exact: false })
     );
     expect(element).not.toBeNull();
+    done();
+  });
+
+  it(`should get the SingleSpaContext`, async done => {
+    const { queryByText, debug } = render(
+      <Widget
+        widgetConfig={{
+          name: "test",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          usesSingleSpaContext: true
+        }}
+      />
+    );
+
+    const element = await waitForElement(() => queryByText("Test Widget"));
+    debug();
+    expect(element).not.toBeNull();
+
     done();
   });
 });


### PR DESCRIPTION
We have a requested use case where a widget created in an external library requires the ability to mount a parcel from within that widget. In order to do so, the external library must have access to the mountParcel function from single-spa for the esm-patient-chart application. 

This PR introduces the ability to declare within a config that a widget requires the single-spa mount parcel function via a schema property called "usesSingleSpaContext" . For now, I'm only including the mountParcel function from SingleSpaContext  only because that is only what's required by the use case. Technically, SingleSpaContext also makes available single-spa itself.  

See documentation here about SingleSpaContext: https://single-spa.js.org/docs/ecosystem-react/

