### PR TITLE
MF-159: Patient profile is displaying in background rather than foreground

### DIFF
--- a/src/root.component.tsx
+++ b/src/root.component.tsx
@@ -23,7 +23,7 @@ function Root(props) {
             flexDirection: "column"
           }}
         >
-          <aside style={{ height: "2.75rem" }}>
+          <aside className={styles.patientBanner}>
             <Route path="/patient/:patientUuid/chart">
               <PatientBanner match={props.match} />
             </Route>

--- a/src/root.css
+++ b/src/root.css
@@ -1,6 +1,6 @@
 .grid {
-  position: fixed;
-  top: 6.25rem;
+  position: relative;
+  top: 2.75rem;
   display: grid;
   grid-template-columns: 1fr min-content;
   grid-template-rows: 1fr;
@@ -8,6 +8,11 @@
   width: 100vw;
   height: 100vh;
   overflow-y: scroll;
+}
+
+.patientBanner {
+  position: relative;
+  z-index: 1;
 }
 
 .chartreview {


### PR DESCRIPTION
Positions the PatientBanner and ChartReview components relatively and applies `z-index: 1` to the PatientBanner so that it is stacked on top https://issues.openmrs.org/browse/MF-159

<img width="1792" alt="Screenshot 2020-04-08 at 19 24 32" src="https://user-images.githubusercontent.com/8509731/78809204-36096d00-79cf-11ea-9a0f-a5a966a79741.png">
