### PR TITLE
Decentralized Activation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3997,6 +3997,16 @@
         }
       }
     },
+    "@openmrs/esm-root-config": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@openmrs/esm-root-config/-/esm-root-config-1.3.0.tgz",
+      "integrity": "sha512-lCEOennEyRh7dnuJtq0N1rnpmHJ3+98yZhb10Yg06ahxns5fwgrIdo8NgfxvjWwUoYBQ8Bw83KWgyQSjiI39Ug==",
+      "requires": {
+        "i18next": "^19.0.0",
+        "react-i18next": "^11.2.1",
+        "single-spa": "^4.4.1"
+      }
+    },
     "@openmrs/esm-styleguide": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@openmrs/esm-styleguide/-/esm-styleguide-1.2.0.tgz",
@@ -4645,6 +4655,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.4.tgz",
       "integrity": "sha512-PZtnBuyfL07sqCJvGg3z+0+kt6fobc/xmle08jBiezLS8FrmGeiGkJnuxL/8Zgy9L83ypUhniV5atZn/L8n9MQ==",
+      "dev": true,
       "requires": {
         "@types/history": "*",
         "@types/react": "*"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Patient dashboard microfrontend for the OpenMRS SPA",
   "main": "dist/openmrs-esm-patient-chart.js",
+  "types": "src/index.ts",
+  "license": "MPL-2.0",
+  "homepage": "https://github.com/openmrs/openmrs-esm-patient-chart#readme",
   "scripts": {
     "start": "webpack-dev-server --host 0.0.0.0",
     "start-https": "webpack-dev-server --https",
@@ -31,7 +34,6 @@
       "pre-commit": "pretty-quick --staged && concurrently npm:lint npm:typescript npm:coverage"
     }
   },
-  "types": "src/openmrs-esm-patient-chart.tsx",
   "devDependencies": {
     "@babel/compat-data": "~7.9.0",
     "@babel/core": "^7.8.7",
@@ -50,6 +52,8 @@
     "@types/single-spa-react": "^2.8.3",
     "@types/systemjs": "^6.1.0",
     "@types/webpack-env": "^1.15.1",
+    "@types/lodash-es": "^4.17.3",
+    "@types/react-router": "^5.1.4",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.0.1",
     "babel-loader": "^8.0.6",
@@ -86,18 +90,11 @@
     "@openmrs/esm-api": "^1.3.0",
     "@openmrs/esm-module-config": "^1.2.0",
     "@openmrs/esm-patient-chart-widgets": "^1.0.2",
-    "@types/lodash-es": "^4.17.3",
-    "@types/react-router": "^5.1.4",
+    "@openmrs/esm-root-config": "^1.2.0",
     "i18next": "^19.3.2",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-i18next": "^11.3.3",
     "rxjs": "^6.5.4"
-  },
-  "author": "",
-  "license": "MPL-2.0",
-  "bugs": {
-    "url": "https://github.com/openmrs/openmrs-esm-patient-chart/issues"
-  },
-  "homepage": "https://github.com/openmrs/openmrs-esm-patient-chart#readme"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openmrs-esm-patient-chart",
+  "name": "openmrs-esm-patient-chart-app",
   "version": "1.0.0",
   "description": "Patient dashboard microfrontend for the OpenMRS SPA",
   "main": "dist/openmrs-esm-patient-chart.js",
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "homepage": "https://github.com/openmrs/openmrs-esm-patient-chart#readme",
   "scripts": {
-    "start": "webpack-dev-server --host 0.0.0.0",
+    "start": "webpack-dev-server",
     "start-https": "webpack-dev-server --https",
     "build": "webpack --mode production",
     "analyze": "webpack --mode=production --env.analyze=true",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,19 @@
+import "./set-public-path";
+import { routeRegex } from "@openmrs/esm-root-config";
+import { backendDependencies } from "./openmrs-backend-dependencies";
+
+const importTranslation = require.context(
+  "../translations",
+  false,
+  /.json$/,
+  "lazy"
+);
+
+function setupOpenMRS() {
+  return {
+    lifecycle: () => import("./openmrs-esm-patient-chart"),
+    activate: location => routeRegex(/^patient\/.+\/chart/, location)
+  };
+}
+
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/src/openmrs-esm-patient-chart.tsx
+++ b/src/openmrs-esm-patient-chart.tsx
@@ -1,22 +1,12 @@
-import "./set-public-path";
 import React from "react";
 import ReactDOM from "react-dom";
 import singleSpaReact from "single-spa-react";
 import Root from "./root.component";
 
-const lifecycles = singleSpaReact({
+const { bootstrap, mount, unmount } = singleSpaReact({
   React,
   ReactDOM,
   rootComponent: Root
 });
 
-export const bootstrap = lifecycles.bootstrap;
-export const mount = lifecycles.mount;
-export const unmount = lifecycles.unmount;
-export { backendDependencies } from "./openmrs-backend-dependencies";
-export const importTranslation = require.context(
-  "../translations",
-  false,
-  /.json$/,
-  "lazy"
-);
+export { bootstrap, mount, unmount };

--- a/src/set-public-path.ts
+++ b/src/set-public-path.ts
@@ -1,3 +1,3 @@
 import { setPublicPath } from "systemjs-webpack-interop";
 
-setPublicPath("@openmrs/esm-patient-chart");
+setPublicPath("@openmrs/esm-patient-chart-app");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,27 +3,27 @@ const CleanWebpackPlugin = require("clean-webpack-plugin").CleanWebpackPlugin;
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 
-module.exports = env => ({
-  entry: path.resolve(__dirname, "src/openmrs-esm-patient-chart.tsx"),
+module.exports = (env) => ({
+  entry: path.resolve(__dirname, "src/index.ts"),
   output: {
     filename: "openmrs-esm-patient-chart.js",
     libraryTarget: "system",
     path: path.resolve(__dirname, "dist"),
-    jsonpFunction: "webpackJsonp_openmrs_esm_patient_chart"
+    jsonpFunction: "webpackJsonp_openmrs_esm_patient_chart",
   },
   module: {
     rules: [
       {
         parser: {
-          system: false
-        }
+          system: false,
+        },
       },
       {
         test: /\.m?(js|ts|tsx)$/,
         exclude: /(node_modules|bower_components)/,
         use: {
-          loader: "babel-loader"
-        }
+          loader: "babel-loader",
+        },
       },
       {
         test: /\.css$/,
@@ -34,37 +34,38 @@ module.exports = env => ({
             options: {
               modules: {
                 localIdentName:
-                  "esm-patient-chart__[name]__[local]___[hash:base64:5]"
-              }
-            }
-          }
-        ]
-      }
-    ]
+                  "esm-patient-chart__[name]__[local]___[hash:base64:5]",
+              },
+            },
+          },
+        ],
+      },
+    ],
   },
   devtool: "sourcemap",
   devServer: {
     headers: {
-      "Access-Control-Allow-Origin": "*"
+      "Access-Control-Allow-Origin": "*",
     },
-    disableHostCheck: true
+    disableHostCheck: true,
   },
   externals: [
+    /^@openmrs\/esm.*/,
+    "i18next",
+    "single-spa",
     "react",
     "react-dom",
+    "react-i18next",
     "react-router-dom",
-    /^@openmrs\/esm/,
-    "i18next",
-    "react-i18next"
   ],
   plugins: [
     new ForkTsCheckerWebpackPlugin(),
     new CleanWebpackPlugin(),
     new BundleAnalyzerPlugin({
-      analyzerMode: env && env.analyze ? "server" : "disabled"
-    })
+      analyzerMode: env && env.analyze ? "server" : "disabled",
+    }),
   ],
   resolve: {
-    extensions: [".tsx", ".ts", ".jsx", ".js"]
-  }
+    extensions: [".tsx", ".ts", ".jsx", ".js"],
+  },
 });


### PR DESCRIPTION
Refactored to use `decentralized-activation`.

**Important**:
The module name has to be renamed with a suffix of `-app`. As outlined last week we should also rename the repository then.