### PR TITLE
MF-148: Fixed tabbed view not selecting right tab

### DIFF
--- a/__mocks__/tabbed-view.mock.ts
+++ b/__mocks__/tabbed-view.mock.ts
@@ -1,0 +1,289 @@
+export const mockedTabbedViewConfig = {
+  primaryNavbar: [
+    { label: "Summary", path: "/summary", view: "summaryDashboard" },
+    { label: "Results", path: "/results", view: "resultsTabbedView" },
+    { label: "Orders", path: "/orders", view: "ordersTabbedView" },
+    { label: "Encounters", path: "/encounters", view: "encountersTabbedView" },
+    { label: "Conditions", path: "/conditions", view: "conditionsDashboard" },
+    { label: "Programs", path: "/programs", view: "programsDashboard" },
+    { label: "Allergies", path: "/allergies", view: "allergiesDashboard" },
+    {
+      label: "Appointments",
+      path: "/appointments",
+      view: "appointmentsDashboard"
+    }
+  ],
+  widgetDefinitions: [
+    {
+      name: "ProgramsOverview",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "ProgramsSummary",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "Conditions",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "MedicationsOverview",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "MedicationsSummary",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "HeightAndWeightOverview",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "HeightAndWeightSummary",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "VitalsOverview",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "VitalsSummary",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "ConditionsOverview",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "AllergiesOverview",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "AllergiesSummary",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "NotesOverview",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "Notes",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "AppointmentsOverview",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    },
+    {
+      name: "AppointmentsSummary",
+      esModule: "@openmrs/esm-patient-chart-widgets",
+      usesSingleSpaContext: {}
+    }
+  ],
+  dashboardDefinitions: [
+    {
+      name: "summaryDashboard",
+      title: "Overview",
+      layout: { columns: 4 },
+      widgets: [
+        {
+          name: "ConditionsOverview",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          layout: { columnSpan: 2 },
+          params: { basePath: "conditions" }
+        },
+        {
+          name: "ProgramsOverview",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          layout: { columnSpan: 2 }
+        },
+        {
+          name: "NotesOverview",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          layout: { columnSpan: 4 },
+          params: { basePath: "encounters/notes" }
+        },
+        {
+          name: "VitalsOverview",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          layout: { columnSpan: 2 },
+          params: { basePath: "results/vitals" }
+        },
+        {
+          name: "HeightAndWeightOverview",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          layout: { columnSpan: 2 },
+          params: { basePath: "results/heightAndWeight" }
+        },
+        {
+          name: "MedicationsOverview",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          layout: { columnSpan: 3 },
+          params: { basePath: "orders/medication-orders" }
+        },
+        {
+          name: "AllergiesOverview",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          layout: { columnSpan: 1 },
+          params: { basePath: "allergies" }
+        },
+        {
+          name: "AppointmentsOverview",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          layout: { columnSpan: 4 },
+          params: { basePath: "appointments" }
+        }
+      ]
+    },
+    {
+      name: "resultsOverviewDashboard",
+      layout: { columns: 1 },
+      widgets: [
+        {
+          name: "VitalsOverview",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          params: { basePath: "results/vitals" }
+        },
+        {
+          name: "HeightAndWeightOverview",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          params: { basePath: "results/heightAndWeight" }
+        }
+      ],
+      title: {}
+    },
+    {
+      name: "ordersOverviewDashboard",
+      title: "Orders Overview",
+      layout: { columns: 1 },
+      widgets: [
+        {
+          name: "MedicationsOverview",
+          esModule: "@openmrs/esm-patient-chart-widgets",
+          params: { basePath: "orders/medication-orders" }
+        }
+      ]
+    },
+    {
+      name: "notesDashboard",
+      layout: { columns: 1 },
+      widgets: [
+        { name: "Notes", esModule: "@openmrs/esm-patient-chart-widgets" }
+      ],
+      title: {}
+    },
+    {
+      name: "conditionsDashboard",
+      layout: { columns: 1 },
+      widgets: [
+        { name: "Conditions", esModule: "@openmrs/esm-patient-chart-widgets" }
+      ],
+      title: {}
+    },
+    {
+      name: "allergiesDashboard",
+      layout: { columns: 1 },
+      widgets: [
+        {
+          name: "AllergiesSummary",
+          esModule: "@openmrs/esm-patient-chart-widgets"
+        }
+      ],
+      title: {}
+    },
+    {
+      name: "programsDashboard",
+      layout: { columns: 1 },
+      widgets: [
+        {
+          name: "ProgramsSummary",
+          esModule: "@openmrs/esm-patient-chart-widgets"
+        }
+      ],
+      title: {}
+    },
+    {
+      name: "appointmentsDashboard",
+      layout: { columns: 1 },
+      widgets: [
+        {
+          name: "AppointmentsSummary",
+          esModule: "@openmrs/esm-patient-chart-widgets"
+        }
+      ],
+      title: {}
+    }
+  ],
+  tabbedViewDefinitions: [
+    {
+      name: "resultsTabbedView",
+      title: "Results",
+      navbar: [
+        {
+          label: "Overview",
+          path: "/overview",
+          view: "resultsOverviewDashboard"
+        },
+        { label: "Vitals", path: "/vitals", view: "VitalsSummary" },
+        {
+          label: "Height and Weight",
+          path: "/heightAndWeight",
+          view: "HeightAndWeightSummary"
+        }
+      ]
+    },
+    {
+      name: "ordersTabbedView",
+      title: "Orders",
+      navbar: [
+        {
+          label: "Overview",
+          path: "/overview",
+          view: "ordersOverviewDashboard"
+        },
+        {
+          label: "Medication Orders",
+          path: "/medication-orders",
+          view: "MedicationsSummary"
+        }
+      ]
+    },
+    {
+      name: "encountersTabbedView",
+      title: "Encounters",
+      navbar: [{ label: "Notes", path: "/notes", view: "notesDashboard" }]
+    }
+  ]
+};
+
+export const mockConfig = {
+  name: "resultsTabbedView",
+  title: "Results",
+  navbar: [
+    { label: "Overview", path: "/overview", view: "resultsOverviewDashboard" },
+    { label: "Vitals", path: "/vitals", view: "VitalsSummary" },
+    {
+      label: "Height and Weight",
+      path: "/heightAndWeight",
+      view: "HeightAndWeightSummary"
+    }
+  ]
+};
+
+export const mockDefaultPath =
+  "/patient/0b1b7481-704b-440f-a50f-3b7d0abac8c1/chart/results";

--- a/src/view-components/tabbed-view/tabbed-view.component.tsx
+++ b/src/view-components/tabbed-view/tabbed-view.component.tsx
@@ -1,22 +1,9 @@
 import React, { useState } from "react";
-import {
-  Route,
-  Link,
-  Redirect,
-  useHistory,
-  useParams,
-  useLocation,
-  Switch,
-  useRouteMatch
-} from "react-router-dom";
+import { Route, Link, Redirect, Switch, useRouteMatch } from "react-router-dom";
 
 import styles from "./tabbed-view.css";
 import { getView, View } from "../view-utils";
-import { Navbar } from "../../root.component";
 import { useConfig } from "@openmrs/esm-module-config";
-function useQuery() {
-  return new URLSearchParams(useLocation().search);
-}
 
 export default function TabbedView(props: any) {
   const [views, setViews] = useState<View[]>([]);
@@ -25,14 +12,23 @@ export default function TabbedView(props: any) {
 
   const [selected, setSelected] = React.useState(getInitialTab());
 
-  function getInitialTab() {
+  function getInitialTab(): number {
+    let navItemIndex = getNavItemIndex();
+    return navItemIndex === -1 ? 0 : navItemIndex;
+  }
+
+  function getNavItemIndex(): number {
     const viewPath = match.url.substr(match.url.lastIndexOf("/"));
     const navItemIndex = props.config.navbar.findIndex(
       element => element.path === viewPath
     );
-
-    return navItemIndex === -1 ? 0 : navItemIndex;
+    return navItemIndex;
   }
+
+  React.useEffect(() => {
+    if (getNavItemIndex() === -1) setSelected(0);
+    setSelected(getNavItemIndex());
+  }, [match.url]);
 
   React.useEffect(() => {
     setViews(
@@ -92,12 +88,3 @@ export default function TabbedView(props: any) {
     </>
   );
 }
-
-type TabbedViewProps = {
-  config: {
-    name: string;
-    title: string;
-    navbar: Navbar[];
-  };
-  defaultPath?: string;
-};

--- a/src/view-components/tabbed-view/tabbed-view.component.tsx
+++ b/src/view-components/tabbed-view/tabbed-view.component.tsx
@@ -12,12 +12,12 @@ export default function TabbedView(props: any) {
 
   const [selected, setSelected] = React.useState(getInitialTab());
 
-  function getInitialTab(): number {
-    let navItemIndex = getNavItemIndex();
+  function getInitialTab() {
+    const navItemIndex = getNavItemIndex();
     return navItemIndex === -1 ? 0 : navItemIndex;
   }
 
-  function getNavItemIndex(): number {
+  function getNavItemIndex() {
     const viewPath = match.url.substr(match.url.lastIndexOf("/"));
     const navItemIndex = props.config.navbar.findIndex(
       element => element.path === viewPath

--- a/src/view-components/tabbed-view/tabbed-view.test.tsx
+++ b/src/view-components/tabbed-view/tabbed-view.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { BrowserRouter, match, useRouteMatch } from "react-router-dom";
+import TabbedView from "./tabbed-view.component";
+import {
+  render,
+  screen,
+  getByText,
+  fireEvent,
+  wait,
+  findAllByRole,
+  getAllByRole
+} from "@testing-library/react";
+import { useConfig } from "@openmrs/esm-module-config";
+import {
+  mockedTabbedViewConfig,
+  mockConfig,
+  mockDefaultPath
+} from "../../../__mocks__/tabbed-view.mock";
+import "@testing-library/jest-dom";
+
+const mockUseConfig = useConfig as jest.Mock;
+const mockUseRouteMatch = useRouteMatch as jest.Mock;
+
+const mockMatch: match = {
+  isExact: true,
+  params: { subview: "overview" },
+  path: "/patient/0b1b7481-704b-440f-a50f-3b7d0abac8c1/chart/results/:subview?",
+  url: "/patient/0b1b7481-704b-440f-a50f-3b7d0abac8c1/chart/results/overview"
+};
+
+jest.mock("@openmrs/esm-module-config", () => ({
+  useConfig: jest.fn()
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useRouteMatch: jest.fn()
+}));
+
+describe("TabbedView", () => {
+  beforeAll(() => {
+    System.import = jest.fn().mockImplementation(module => {
+      return module === "@openmrs/esm-patient-chart-widgets"
+        ? Promise.resolve({ test: () => <div>Test Widget</div> })
+        : Promise.reject({ reason: "module failed to load" });
+    });
+  });
+
+  beforeEach(() => {
+    mockUseConfig.mockReturnValue(mockedTabbedViewConfig);
+    mockUseRouteMatch.mockReturnValue(mockMatch);
+  });
+
+  afterEach(() => {
+    mockUseConfig.mockReset();
+    mockUseRouteMatch.mockReset();
+  });
+
+  it("should render the tabs", () => {
+    render(
+      <BrowserRouter>
+        <TabbedView config={mockConfig} defaultPath={mockDefaultPath} />
+      </BrowserRouter>
+    );
+  });
+
+  it("should select the overview tab by default", async () => {
+    render(
+      <BrowserRouter>
+        <TabbedView config={mockConfig} defaultPath={mockDefaultPath} />
+      </BrowserRouter>
+    );
+    const listItemArray = screen.getAllByRole("listitem");
+    expect(listItemArray[0].firstChild).toHaveClass("selected");
+    expect(listItemArray[1].firstChild).toHaveClass("unselected");
+    expect(listItemArray[2].firstChild).toHaveClass("unselected");
+  });
+
+  it("should select the correct tab when tab label is clicked", async () => {
+    render(
+      <BrowserRouter>
+        <TabbedView config={mockConfig} defaultPath={mockDefaultPath} />
+      </BrowserRouter>
+    );
+
+    const vitalsButton = screen.getByText(/Vitals/);
+    expect(screen.getAllByRole("listitem")[0].firstChild).toHaveClass(
+      "selected"
+    );
+    fireEvent.click(vitalsButton);
+    const listItemArray: Array<HTMLElement> = await screen.findAllByRole(
+      "listitem"
+    );
+    expect(listItemArray[0].firstChild).toHaveClass("unselected");
+    expect(listItemArray[1].firstChild).toHaveClass("selected");
+    expect(listItemArray[2].firstChild).toHaveClass("unselected");
+  });
+});


### PR DESCRIPTION
1. This PR fixes a bug where the correct tabbed view isn't select through the correct widget gets displayed.
The error.
![MF-148-error](https://user-images.githubusercontent.com/28008754/84072291-a0428c00-a9d7-11ea-9a76-5abbeb126b6b.gif)
The solution
![MF-148-B](https://user-images.githubusercontent.com/28008754/84072308-a8023080-a9d7-11ea-8130-dcbd377e3a8c.gif)

2. Remove unused imports 