### PR TITLE
Fixed broken links on patient-summary page

### DIFF
--- a/src/view-components/core-views.tsx
+++ b/src/view-components/core-views.tsx
@@ -107,70 +107,55 @@ export const coreDashboardDefinitions: DashboardConfig[] = [
         name: "ConditionsOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 2 },
-        props: {
-          basePath: "conditions"
-        }
+        basePath: "conditions"
       },
       {
         name: "ImmunizationsOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 2 },
-        props: {
-          basePath: "immunizations"
-        }
+        basePath: "immunizations"
       },
       {
         name: "ProgramsOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
-        layout: { columnSpan: 2 }
+        layout: { columnSpan: 2 },
+        basePath: "programs"
       },
       {
         name: "NotesOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 4 },
-        props: {
-          basePath: "encounters/notes"
-        }
+        basePath: "encounters/notes"
       },
       {
         name: "VitalsOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 2 },
-        props: {
-          basePath: "results/vitals"
-        }
+        basePath: "results/vitals"
       },
       {
         name: "HeightAndWeightOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 2 },
-        props: {
-          basePath: "results/heightAndWeight"
-        }
+        basePath: "results/heightAndWeight"
       },
       {
         name: "MedicationsOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 3 },
-        props: {
-          basePath: "orders/medication-orders"
-        }
+        basePath: "orders/medication-orders"
       },
       {
         name: "AllergiesOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 1 },
-        props: {
-          basePath: "allergies"
-        }
+        basePath: "allergies"
       },
       {
         name: "AppointmentsOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 4 },
-        props: {
-          basePath: "appointments"
-        }
+        basePath: "appointments"
       }
     ]
   },
@@ -182,16 +167,12 @@ export const coreDashboardDefinitions: DashboardConfig[] = [
       {
         name: "VitalsOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
-        props: {
-          basePath: "results/vitals"
-        }
+        basePath: "results/vitals"
       },
       {
         name: "HeightAndWeightOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
-        props: {
-          basePath: "results/heightAndWeight"
-        }
+        basePath: "results/heightAndWeight"
       }
     ]
   },
@@ -204,9 +185,7 @@ export const coreDashboardDefinitions: DashboardConfig[] = [
       {
         name: "MedicationsOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
-        props: {
-          basePath: "orders/medication-orders"
-        }
+        basePath: "orders/medication-orders"
       }
     ]
   },

--- a/src/view-components/widget/widget.component.tsx
+++ b/src/view-components/widget/widget.component.tsx
@@ -24,7 +24,12 @@ export default function Widget(props: WidgetProps) {
               if (props.widgetConfig.usesSingleSpaContext) {
                 widgetProps["mountParcel"] = mountParcel;
               }
-              setComponent(() => <Component props={widgetProps} />);
+              setComponent(() => (
+                <Component
+                  props={widgetProps}
+                  basePath={widgetConfig.basePath}
+                />
+              ));
             } else {
               const message = `${widgetConfig.name} does not exist in module ${widgetConfig.esModule}`;
               reportError(message);
@@ -64,8 +69,10 @@ export type WidgetConfig = {
   };
   props?: object;
   config?: object;
+  basePath?: string;
 };
 
 type ComponentProps = {
   props: any;
+  basePath?: string;
 };


### PR DESCRIPTION
This PR is related to [Link Fix](https://github.com/openmrs/openmrs-esm-patient-chart-widgets/pull/130).

Currently basePath on patient-widgets-chart receives `undefined` basePath. This PR fixes the error.