### PR TITLE
Enable widgets as extensions and host the medications/drugorder widget via this mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ## What is this?
 
-openmrs-esm-patient-chart is a patient dashboard microfrontend for the 
-OpenMRS SPA. It provides a simple dashboard with cards detailing the 
+openmrs-esm-patient-chart is a patient dashboard microfrontend for the
+OpenMRS SPA. It provides a simple dashboard with cards detailing the
 patient's information, such as vitals, demographic and relationships.
 
 ## How do I install this?
@@ -13,7 +13,7 @@ patient's information, such as vitals, demographic and relationships.
 Requirements: Node, Git, and OpenMRS with the
 [SPA Module](https://github.com/openmrs/openmrs-module-spa) installed
 
-Currently, there are no compiled releases for openmrs-esm-patient-chart. 
+Currently, there are no compiled releases for openmrs-esm-patient-chart.
 To obtain this module, use the following steps:
 
 ```bash
@@ -33,51 +33,51 @@ for installing microfrontends for the SPA Module.
 
 openmrs-esm-patient-chart is registered as a
 [core application](https://github.com/openmrs/openmrs-esm-root-config/blob/master/src/single-spa-applications/core-applications.js)
-inside of openmrs-esm-root-config. This means that it will automatically 
-activate whenever you are on one of the frontend routes that it controls. 
+inside of openmrs-esm-root-config. This means that it will automatically
+activate whenever you are on one of the frontend routes that it controls.
 The openmrs-esm-patient-chart module serves the route
 `<spa root>/patient/:uuid/chart`.
 
 ## What is the layout of patient chart?
 
-openmrs-esm-patient-chart consists of four parts: patient banner, primary navigation, chart review and a workspace. 
+openmrs-esm-patient-chart consists of four parts: patient banner, primary navigation, chart review and a workspace.
 
 **Patient banner**: This is always displayed at the top of the screen. It displays the patients name, age, birthdate, gender and the preferred OpenMRS identifier for that patient. Additional demographic data may be displayed by clicking on more. Presently, there are no configuration options for this component.
 
 ![image2020-3-7_14-52-22](https://user-images.githubusercontent.com/1031876/81237394-65060500-8fb4-11ea-8318-39031036303e.png)
 
-**Primary navigation**: This component is presently rendered underneath the patient banner and renders items horizontally. The default setting displays the following items: Summary, Results, Orders, Encounters, Conditions, Programs, Allergies, Appointments. This is a rapidly changing area of the module and the preceding items are frequently changing. The primary nav bar is 100% configurable. An implementation can utilize any of the core widgets (please see openmrs-esm-patient-chart-widgets to learn more) or utilize widgets from an external es6 module. 
+**Primary navigation**: This component is presently rendered underneath the patient banner and renders items horizontally. The default setting displays the following items: Summary, Results, Orders, Encounters, Conditions, Programs, Allergies, Appointments. This is a rapidly changing area of the module and the preceding items are frequently changing. The primary nav bar is 100% configurable. An implementation can utilize any of the core widgets (please see openmrs-esm-patient-chart-widgets to learn more) or utilize widgets from an external es6 module.
 
 ![image2020-3-7_14-56-53](https://user-images.githubusercontent.com/1031876/81237430-82d36a00-8fb4-11ea-94ac-f1c7e1622656.png)
 
-**Chart review**: The chart review section is the primary area of the window for displaying historical patient data. It will use the whole screen under the navigation bar unless the workspace is active (which utilizes the right side of the screen). Click on items in the navigation pane will cause them to render here. 
+**Chart review**: The chart review section is the primary area of the window for displaying historical patient data. It will use the whole screen under the navigation bar unless the workspace is active (which utilizes the right side of the screen). Click on items in the navigation pane will cause them to render here.
 
-**Workspace**: The workspace exists to allow a user to simultaneously be "doing" work, e.g. writing a note, placing an order, etc, while reviewing patient data. 
+**Workspace**: The workspace exists to allow a user to simultaneously be "doing" work, e.g. writing a note, placing an order, etc, while reviewing patient data.
 
 ![image2020-3-7_15-3-27](https://user-images.githubusercontent.com/1031876/81237493-a3032900-8fb4-11ea-8e25-0bac0377f173.png)
 
 ## How do I configure this module?
 
-This module is is designed to be driven by configuration files. 
-*openmrs-esm-patient-chart itself contains no components for displaying 
-patient data*. Instead, the implementation must use either the default 
-configuration (see below) or create its own configuration to drive the 
+This module is is designed to be driven by configuration files.
+_openmrs-esm-patient-chart itself contains no components for displaying
+patient data_. Instead, the implementation must use either the default
+configuration (see below) or create its own configuration to drive the
 patient chart.
 
-Configurations can also be hot-loaded such that different 
-configurations could be used to support different user roles. 
+Configurations can also be hot-loaded such that different
+configurations could be used to support different user roles.
 
-Please see 
+Please see
 [esm-module-config](https://github.com/openmrs/openmrs-esm-module-config#openmrs-esm-config)
 for information about how to configure your implementation.
 
-A patient chart configuration consists of four primary sections: primaryNavbar, 
-widgetDefinitions, dashboardDefinitions, tabbedViewDefinitions. We will discuss 
-each of these in sections and then provide a comprehensive example of a configuration 
-file at the end. 
+A patient chart configuration consists of four primary sections: primaryNavbar,
+widgetDefinitions, dashboardDefinitions, tabbedViewDefinitions. We will discuss
+each of these in sections and then provide a comprehensive example of a configuration
+file at the end.
 
-Routes are mapped to views. We provide three types of views: a *widget*, a *dashboard*,
-and a *tabbedView*. 
+Routes are mapped to views. We provide three types of views: a _widget_, a _dashboard_,
+and a _tabbedView_.
 
 ### Widgets
 
@@ -86,27 +86,37 @@ but widgets can be written in different frameworks.
 A widget might be something like a card displaying conditions, or a set of cards
 for displaying orders.
 
-Widgets are defined using the `widgetDefinitions` configuration option. 
+Widgets are defined using the `widgetDefinitions` configuration option.
 
 ```json
 {
   "widgetDefinitions": [
     {
-      "name": "myWidget",
-      "esModule" : "@my-moodule-with-widgets"
+      "name": "widgetUsingEsModule",
+      "esModule": "@my-module-with-widgets"
+    },
+    {
+      "name": "widgetUsingExtensionSlot",
+      "extensionSlotName": "patient-chart-widget"
     }
   ]
 }
 ```
 
-The chart rendering engine will attempt to load the above module, using SystemJS 
-to dynamically load my-module-with-widgets. Note: this module must be listed in 
-your import map in order for SystemJS to be able to import it. Please see here 
-for more instructions on managing your import map. On import, System.JS provides 
-an es6 module. Based on the above configuration, the rendering engine expects there 
-to be a property within the module called "myWidget".  If you are creating your 
-own module to serve widgets, please be sure to use the exact same name to export 
+In the case of `widgetUsingEsModule`,
+the chart rendering engine will attempt to load the above module, using SystemJS
+to dynamically load my-module-with-widgets. Note: this module must be listed in
+your import map in order for SystemJS to be able to import it. Please see here
+for more instructions on managing your import map. On import, System.JS provides
+an es6 module. Based on the above configuration, the rendering engine expects there
+to be a property within the module called `widgetUsingEsModule`. If you are creating your
+own module to serve widgets, please be sure to use the exact same name to export
 the widget as you use in the widget definition.
+
+In the case of `widgetUsingExtensionSlot`, nothing will directly be imported.
+Instead, the chart rendering engine will create an `ExtensionSlot` with the name specified
+in the `extensionSlotName` field. Other modules can then dynamically inject arbitrary
+widgets via the extension mechanism.
 
 ## Dashboards
 
@@ -136,21 +146,21 @@ A dashboard is a collection of widgets with a layout. We provide a simple layout
 }
 ```
 
-Dashboards display a collection of widgets in a grid layout (see 
+Dashboards display a collection of widgets in a grid layout (see
 [css-grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout), if you're interested).
 The number of columns is configurable.
 
-You can specify the number of columns and rows you want each widget to occupy 
+You can specify the number of columns and rows you want each widget to occupy
 using `layout.columnSpan` and `layout.rowSpan` properties within the widget
 configuration. The widgets are rendered in the order they are listed in the config.
 
-*Example*: Let's set up a dashboard with 4 columns. If `widget1` is set to 3 
-columns, and `widget2` is set to 2 columns, then `widget1` will be displayed on the first 
-row. Because 3 + 2 = 5 > 4, `widget2` will be bumped to the next row and occupy the first 
+_Example_: Let's set up a dashboard with 4 columns. If `widget1` is set to 3
+columns, and `widget2` is set to 2 columns, then `widget1` will be displayed on the first
+row. Because 3 + 2 = 5 > 4, `widget2` will be bumped to the next row and occupy the first
 two columns.
 
-If no layout is specified in the configuration, the dashboard will default 
-to using 1 column and 1 row to display the widget. 
+If no layout is specified in the configuration, the dashboard will default
+to using 1 column and 1 row to display the widget.
 
 ## TabbedViews
 
@@ -208,9 +218,10 @@ The primary navigation bar uses an identical configuration set up as the navbar 
 }
 ```
 
-This will generate a primary navigation bar with three items. Each item has 
+This will generate a primary navigation bar with three items. Each item has
 three required properties: `label`, `view` and `path`.
+
 - `label` is what will be displayed to the user on the navigation bar
 - `view` is a generic term we will use to refer to what will be displayed by clicking on the link
 - `path` assigns the widget a path so that it can be linked to directly. In the example above,
-    the conditionsOverview widget will be served at `/patient/:patientUuuid/chart/conditions`.
+  the conditionsOverview widget will be served at `/patient/:patientUuuid/chart/conditions`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2388,6 +2388,119 @@
         "@openmrs/esm-styleguide": "^1.1.0"
       }
     },
+    "@openmrs/esm-extension-manager": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@openmrs/esm-extension-manager/-/esm-extension-manager-0.1.1.tgz",
+      "integrity": "sha512-XLDf+lcugQi69iGrHQYC6tj/IJcTxd3ifq7+/UVhHxghUK9v4gGajF3Yl2t65yPeQdbtf6SWA3tnRLnbcHR5hw==",
+      "requires": {
+        "@types/jest": "^26.0.10",
+        "@types/react": "^16.9.46",
+        "@types/systemjs": "^6.1.0",
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1",
+        "single-spa": "^5.5.5"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/jest": {
+          "version": "26.0.14",
+          "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.14.tgz",
+          "integrity": "sha512-Hz5q8Vu0D288x3iWXePSn53W7hAjP0H7EQ6QvDO9c7t46mR0lNOLlfuwQ+JkVxuhygHzlzPX+0jKdA3ZgSh+Vg==",
+          "requires": {
+            "jest-diff": "^25.2.1",
+            "pretty-format": "^25.2.1"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.7",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+          "integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "single-spa": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/single-spa/-/single-spa-5.6.0.tgz",
+          "integrity": "sha512-UJ89FkEjW6JqAMoyW9RBA7cfpnQ2N8l8E1PEKqgLaHNyYr90WYB2v9s6iR7h0zm6AL218D+obmwtYVLKwetUzw=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@openmrs/esm-module-config": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@openmrs/esm-module-config/-/esm-module-config-2.2.0.tgz",
@@ -2826,8 +2939,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/events": {
       "version": "3.0.0",
@@ -2868,14 +2980,12 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
-      "dev": true
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
     },
     "@types/istanbul-lib-report": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -2884,7 +2994,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
       "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
@@ -3108,8 +3217,7 @@
     "@types/systemjs": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/systemjs/-/systemjs-6.1.0.tgz",
-      "integrity": "sha512-akhlviqwowzRNiz3ooAbkjvyMO8cikBqap9z/0yfvMAb6vIsp91Rfox67qtgIhZosWP01MVSTwsgSFYWo4SWQA==",
-      "dev": true
+      "integrity": "sha512-akhlviqwowzRNiz3ooAbkjvyMO8cikBqap9z/0yfvMAb6vIsp91Rfox67qtgIhZosWP01MVSTwsgSFYWo4SWQA=="
     },
     "@types/tapable": {
       "version": "1.0.4",
@@ -3319,8 +3427,7 @@
     "@types/yargs-parser": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
-      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
-      "dev": true
+      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -5658,8 +5765,7 @@
     "diff-sequences": {
       "version": "25.2.6",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-      "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
-      "dev": true
+      "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg=="
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -8933,7 +9039,6 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
       "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
-      "dev": true,
       "requires": {
         "chalk": "^3.0.0",
         "diff-sequences": "^25.2.6",
@@ -8945,7 +9050,6 @@
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
           "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-          "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
@@ -8957,7 +9061,6 @@
           "version": "15.0.5",
           "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
           "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-          "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -8965,14 +9068,12 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -8982,7 +9083,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -8992,7 +9092,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -9000,20 +9099,17 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "pretty-format": {
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
           "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-          "dev": true,
           "requires": {
             "@jest/types": "^25.5.0",
             "ansi-regex": "^5.0.0",
@@ -9024,14 +9120,12 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -9371,8 +9465,7 @@
     "jest-get-type": {
       "version": "25.2.6",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-      "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
-      "dev": true
+      "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig=="
     },
     "jest-haste-map": {
       "version": "26.3.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   },
   "dependencies": {
     "@openmrs/esm-api": "^3.0.0",
+    "@openmrs/esm-extension-manager": "^0.1.1",
     "@openmrs/esm-module-config": "^2.2.0",
     "@openmrs/esm-patient-chart-widgets": "^1.0.3",
     "i18next": "^19.7.0",

--- a/src/config-schemas/openmrs-esm-patient-chart-schema.ts
+++ b/src/config-schemas/openmrs-esm-patient-chart-schema.ts
@@ -68,7 +68,11 @@ export const esmPatientChartSchema = {
   widgetDefinitions: {
     arrayElements: {
       name: { validators: [validators.isString] },
-      esModule: { validators: [validators.isString] },
+      esModule: { default: undefined, validators: [validators.isString] },
+      extensionSlotName: {
+        default: undefined,
+        validators: [validators.isString]
+      },
       usesSingleSpaContext: { validators: [validators.isBoolean] },
       props: { default: {}, validators: [validators.isObject] },
       config: { default: {}, validators: [validators.isObject] }

--- a/src/view-components/core-views.tsx
+++ b/src/view-components/core-views.tsx
@@ -23,12 +23,12 @@ export const coreWidgetDefinitions: WidgetConfig[] = [
 
   {
     name: "MedicationsOverview",
-    esModule: "@openmrs/esm-patient-chart-widgets"
+    extensionSlotName: "patient-chart-dashboard-medications"
   },
 
   {
     name: "MedicationsSummary",
-    esModule: "@openmrs/esm-patient-chart-widgets"
+    extensionSlotName: "patient-chart-dashboard-medications"
   },
 
   {
@@ -141,9 +141,9 @@ export const coreDashboardDefinitions: DashboardConfig[] = [
       },
       {
         name: "MedicationsOverview",
-        esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 3 },
-        basePath: "orders/medication-orders"
+        basePath: "orders/medication-orders",
+        extensionSlotName: "patient-chart-dashboard-summary"
       },
       {
         name: "AllergiesOverview",
@@ -184,8 +184,8 @@ export const coreDashboardDefinitions: DashboardConfig[] = [
     widgets: [
       {
         name: "MedicationsOverview",
-        esModule: "@openmrs/esm-patient-chart-widgets",
-        basePath: "orders/medication-orders"
+        basePath: "orders/medication-orders",
+        extensionSlotName: "patient-chart-dashboard-medications"
       }
     ]
   },

--- a/src/view-components/widget/widget.component.tsx
+++ b/src/view-components/widget/widget.component.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, useContext } from "react";
 //@ts-ignore The present types for single-spa-react are not updated yet for 2.9 which has SingleSpaContext
 import { SingleSpaContext } from "single-spa-react";
 import { reportError } from "@openmrs/esm-error-handling";
+import { ExtensionSlotReact } from "@openmrs/esm-extension-manager";
 
 export default function Widget(props: WidgetProps) {
   const [component, setComponent] = React.useState<JSX.Element>(null);
@@ -41,6 +42,12 @@ export default function Widget(props: WidgetProps) {
             reportError(`${message}:\n` + error);
             setComponent(() => <div>${message}</div>);
           });
+      } else if (widgetConfig.extensionSlotName) {
+        setComponent(() => (
+          <ExtensionSlotReact
+            extensionSlotName={widgetConfig.extensionSlotName}
+          />
+        ));
       } else {
         // config schema should be fixed so that this is caught in validation
         reportError(
@@ -62,6 +69,7 @@ export type WidgetProps = {
 export type WidgetConfig = {
   name: string;
   esModule?: string;
+  extensionSlotName?: string;
   usesSingleSpaContext?: boolean;
   layout?: {
     rowSpan?: number;


### PR DESCRIPTION
Enables the patient chart to alternatively render widgets via the extension system. This is an alternative to the current way and does *not* inhibit existing functionality.

For now, the configuration is kept rather simple. Instead of specifying an `esModule` in the widget configuration, one can instead define an `extensionSlotName`. If done, the patient chart will render an extension slot with that name into which other modules can then place the widget itself.

This PR also makes the medication widget use this extension system. For the moment, nothing will be displayed, but that will change as soon as the [drugorder widget](https://github.com/openmrs/openmrs-esm-drugorder) is deployed.