### PR TITLE
Removes tabs from the medications widget to match the current designs 

### DIFF
--- a/__mocks__/tabbed-view.mock.ts
+++ b/__mocks__/tabbed-view.mock.ts
@@ -2,7 +2,7 @@ export const mockedTabbedViewConfig = {
   primaryNavbar: [
     { label: "Summary", path: "/summary", view: "summaryDashboard" },
     { label: "Results", path: "/results", view: "resultsTabbedView" },
-    { label: "Orders", path: "/orders", view: "ordersTabbedView" },
+    { label: "Orders", path: "/orders", view: "MedicationsOverview" },
     { label: "Encounters", path: "/encounters", view: "encountersTabbedView" },
     { label: "Conditions", path: "/conditions", view: "conditionsDashboard" },
     { label: "Programs", path: "/programs", view: "programsDashboard" },
@@ -244,22 +244,6 @@ export const mockedTabbedViewConfig = {
           label: "Height and Weight",
           path: "/heightAndWeight",
           view: "HeightAndWeightSummary"
-        }
-      ]
-    },
-    {
-      name: "ordersTabbedView",
-      title: "Orders",
-      navbar: [
-        {
-          label: "Overview",
-          path: "/overview",
-          view: "ordersOverviewDashboard"
-        },
-        {
-          label: "Medication Orders",
-          path: "/medication-orders",
-          view: "MedicationsSummary"
         }
       ]
     },

--- a/src/config-schemas/openmrs-esm-patient-chart-schema.ts
+++ b/src/config-schemas/openmrs-esm-patient-chart-schema.ts
@@ -31,7 +31,7 @@ export const esmPatientChartSchema = {
       {
         label: "Orders",
         path: "/orders",
-        view: "ordersTabbedView"
+        view: "MedicationsOverview"
       },
       {
         label: "Encounters",

--- a/src/view-components/core-views.tsx
+++ b/src/view-components/core-views.tsx
@@ -290,25 +290,6 @@ export const coreTabbedViewDefinitions = [
       }
     ]
   },
-
-  {
-    name: "ordersTabbedView",
-    title: "Orders",
-
-    navbar: [
-      {
-        label: "Overview",
-        path: "/overview",
-        view: "ordersOverviewDashboard"
-      },
-      {
-        label: "Medication Orders",
-        path: "/medication-orders",
-        view: "MedicationsSummary"
-      }
-    ]
-  },
-
   {
     name: "encountersTabbedView",
     title: "Encounters",


### PR DESCRIPTION
Removes the tabs for the drugorder widget. This reflects the current design proposed by Ciaran.

![grafik](https://user-images.githubusercontent.com/30902964/97432679-a2709d00-191c-11eb-873c-18ad04e8e3a7.png)
