### PR TITLE
Reorganize core views

### DIFF
--- a/src/view-components/core-views.tsx
+++ b/src/view-components/core-views.tsx
@@ -122,6 +122,12 @@ export const coreDashboardDefinitions: DashboardConfig[] = [
         basePath: "programs"
       },
       {
+        name: "AllergiesOverview",
+        esModule: "@openmrs/esm-patient-chart-widgets",
+        layout: { columnSpan: 2 },
+        basePath: "allergies"
+      },
+      {
         name: "NotesOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 4 },
@@ -144,12 +150,6 @@ export const coreDashboardDefinitions: DashboardConfig[] = [
         layout: { columnSpan: 3 },
         basePath: "orders/medication-orders",
         extensionSlotName: "patient-chart-dashboard-summary"
-      },
-      {
-        name: "AllergiesOverview",
-        esModule: "@openmrs/esm-patient-chart-widgets",
-        layout: { columnSpan: 1 },
-        basePath: "allergies"
       },
       {
         name: "AppointmentsOverview",


### PR DESCRIPTION
This PR: 

- Moves the `Allergies` widget up higher in the UI so it sits alongside the `Care Programs` widget and underneath the `Conditions` and `Immunizations` widget. It also assigns it `columnSpan: 2` so it fills up half of the page width. 

The rationale for this is that each of the widgets mentioned above takes up half of the available page width. With the current widget order, there's an empty space next to the `Care Programs` widget. The `Allergies` widget is placed at the bottom where the surrounding widgets are full-width. This makes the UI look jarring and inconsistent.

Before:

![Screenshot 2020-11-10 at 09 28 36](https://user-images.githubusercontent.com/8509731/98636894-bbc01300-2338-11eb-8e7c-78ba2b883109.png)

After:

![Screenshot 2020-11-10 at 09 27 40](https://user-images.githubusercontent.com/8509731/98636901-c11d5d80-2338-11eb-806e-f93606b8c44c.png)
