### PR TITLE
Fixed the patientUuid not being passed to extensions all the time

### DIFF
--- a/src/view-components/widget/widget.component.tsx
+++ b/src/view-components/widget/widget.component.tsx
@@ -60,7 +60,7 @@ export default function Widget(props: WidgetProps) {
       }
     };
     loadWidgetFromConfig(props.widgetConfig);
-  }, [props.widgetConfig, mountParcel]);
+  }, [patientUuid, props.widgetConfig, mountParcel]);
 
   return <>{component || <div>Loading</div>}</>;
 }


### PR DESCRIPTION
As mentioned by @jonathandick on Slack, the drugorder had an issue fetching the patient data on certain steps. That's due to a missing dependency in a `useEffect` hook. This fixes the problem.