### PR TITLE
Amend i18n string for attachment upload

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -22,7 +22,7 @@
   "appointmentsForm": "Appointments form",
   "endVisitPrompt": "Are you sure you wish to end this visit?",
   "attachmentCaptionInstruction": "Enter a caption for the image",
-  "attachmentUpload": "Attach files by dragging &amp; dropping, selecting or pasting them.",
+  "attachmentUploadText": "Attach files by dragging & dropping, selecting or pasting them.",
   "author": "Author",
   "birthDate": "Birth date",
   "bloodPressure": "Blood pressure",


### PR DESCRIPTION
Amends the translation string for the attachment upload text in the `AttachmentOverview` widget.

Relates to: https://github.com/openmrs/openmrs-esm-patient-chart-widgets/pull/175