### PR TITLE
Reorganize core views

### DIFF
--- a/src/view-components/core-views.tsx
+++ b/src/view-components/core-views.tsx
@@ -104,6 +104,18 @@ export const coreDashboardDefinitions: DashboardConfig[] = [
     },
     widgets: [
       {
+        name: "VitalsOverview",
+        extensionSlotName: "vitals-widget",
+        layout: { columnSpan: 2 },
+        basePath: "results/vitals"
+      },
+      {
+        name: "HeightAndWeightOverview",
+        extensionSlotName: "biometrics-widget",
+        layout: { columnSpan: 2 },
+        basePath: "results/heightAndWeight"
+      },
+      {
         name: "ConditionsOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 2 },
@@ -132,18 +144,6 @@ export const coreDashboardDefinitions: DashboardConfig[] = [
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 4 },
         basePath: "encounters/notes"
-      },
-      {
-        name: "VitalsOverview",
-        extensionSlotName: "vitals-widget",
-        layout: { columnSpan: 2 },
-        basePath: "results/vitals"
-      },
-      {
-        name: "HeightAndWeightOverview",
-        extensionSlotName: "biometrics-widget",
-        layout: { columnSpan: 2 },
-        basePath: "results/heightAndWeight"
       },
       {
         name: "MedicationsOverview",


### PR DESCRIPTION
Moves the vitals and biometrics widgets to the top of the dashboard. These two are the widgets that receive the most focus in the designs. I think it makes sense that they are located higher up at least in the interim before we get to v1.0.

![Screenshot 2021-02-05 at 14 47 45](https://user-images.githubusercontent.com/8509731/107030486-c831fb80-67c1-11eb-8a8c-fde2233b6c14.png)

Tangentially, I think it's worth looking into why the vitals widget takes so long to load.