### PR TITLE
Add forms extension to summary dashboard

### DIFF
--- a/src/view-components/core-views.tsx
+++ b/src/view-components/core-views.tsx
@@ -110,6 +110,12 @@ export const coreDashboardDefinitions: DashboardConfig[] = [
         basePath: "conditions"
       },
       {
+        name: "forms",
+        extensionSlotName: "forms",
+        layout: { columnSpan: 2 },
+        basePath: "forms"
+      },
+      {
         name: "ImmunizationsOverview",
         esModule: "@openmrs/esm-patient-chart-widgets",
         layout: { columnSpan: 2 },


### PR DESCRIPTION
### What does this PR do?

1. Adds forms extension to the core-views summary dashboard
[MFF-389 Patient Chart Widgets](https://github.com/openmrs/openmrs-esm-patient-chart-widgets/pull/198)