### PR TITLE
MF-345: Disabling future dates on the onSetDate field on the conditions form

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
@@ -144,6 +144,7 @@ const ConditionsForm: React.FC<ConditionsFormProps> = ({
                     id="onsetDate"
                     type="date"
                     name="onsetDate"
+                    max={dayjs(new Date().toUTCString()).format("YYYY-MM-DD")}
                     onChange={event => setOnsetDateTime(event.target.value)}
                   />
                   <svg className="omrs-icon" role="img">


### PR DESCRIPTION
- This is to solve the issue [mf-345.](https://issues.openmrs.org/browse/MF-345) Previously the conditions form allowed the user to set a date in the future as the onset date for a particular condition.
- What i did was to add validation to the date input that allows one to only enter today's date or older.
![conditions](https://user-images.githubusercontent.com/47120265/114195022-c1a63880-9958-11eb-98c8-19173315fc2e.png)
