### PR TITLE
Remove errant semi-colon from markup

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
@@ -153,7 +153,6 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patient }) => {
               }}
             />
           )}
-          ;
         </div>
       );
     }


### PR DESCRIPTION
Removes an errant semicolon from the `ConditionsOverview` markup.