### PR TITLE
More overflow menu fixes

### DIFF
--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -74,7 +74,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
                           currentVisit.visitType.name}
                       </h6>
                       <span>
-                        <span className={styles.tooltipSmalltext}>
+                        <span className={styles.tooltipSmallText}>
                           Started:{" "}
                         </span>
                         <span>
@@ -94,7 +94,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
               <CustomOverflowMenuComponent
                 menuTitle={
                   <>
-                    Actions{" "}
+                    <span className={styles.actionsButtonText}>Actions</span>{" "}
                     <OverflowMenuVertical16 style={{ marginLeft: "0.5rem" }} />
                   </>
                 }

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.scss
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.scss
@@ -55,6 +55,11 @@
   padding: 0.25rem;
 }
 
-.tooltipSmalltext {
+.tooltipSmallText {
   font-size: 80%;
+}
+
+.actionsButtonText {
+  @include carbon--type-style("body-short-01");
+  color: $interactive-01;
 }

--- a/packages/esm-patient-banner-app/src/ui-components/overflow-menu.component.tsx
+++ b/packages/esm-patient-banner-app/src/ui-components/overflow-menu.component.tsx
@@ -69,7 +69,7 @@ const CustomOverflowMenuComponent: React.FC<CustomOverflowMenuComponentProps> = 
         id="custom-actions-overflow-menu"
         style={{
           display: showMenu ? "block" : "none",
-          top: "3.5rem",
+          top: "3.125rem",
           minWidth: "initial",
           left: "auto",
           right: "0",


### PR DESCRIPTION
- Adjust the font style of the `Actions` button to match the designs.
- Tweak the top margin edge of the overflow menu so it sits flush below the `Actions` button.

![Screenshot 2021-05-03 at 09 18 03](https://user-images.githubusercontent.com/8509731/116846302-b0b3b480-abf0-11eb-8d79-fdc160473f28.png)
