### PR TITLE
Fix patient photo extension slot name

### DIFF
--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -55,7 +55,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
     <div className={styles.container}>
       <div className={styles.patientBanner}>
         <div className={styles.patientAvatar}>
-          <ExtensionSlot extensionSlotName="patient-photo" state={state} />
+          <ExtensionSlot extensionSlotName="patient-photo-slot" state={state} />
         </div>
         <div className={styles.patientInfo}>
           <div className={(styles.row, styles.nameRow)}>


### PR DESCRIPTION
Fixes an issue where the patient avatar was not being displayed on the patient banner.

![Screenshot 2021-05-03 at 09 28 11](https://user-images.githubusercontent.com/8509731/116846846-edcc7680-abf1-11eb-9c25-f3f4f4f7c5f6.png)
