### PR TITLE
Remove appui dependencies

### DIFF
--- a/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
@@ -46,9 +46,3 @@ export function getAppointmentService(abortController: AbortController, uuid) {
 export function getTimeSlots(abortController: AbortController) {
   //https://openmrs-spa.org/openmrs/ws/rest/v1/appointment/all?forDate=2020-03-02T21:00:00.000Z
 }
-
-export function getSession(abortController: AbortController) {
-  return openmrsFetch(`/ws/rest/v1/appui/session`, {
-    signal: abortController.signal,
-  });
-}

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.outdated.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.outdated.tsx
@@ -5,13 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { screen, render } from '@testing-library/react';
 import { of } from 'rxjs/internal/observable/of';
 import { ConfigMock } from '../../../../__mocks__/chart-widgets-config.mock';
-import {
-  fetchCurrentSessionData,
-  fetchDiagnosisByName,
-  fetchLocationByUuid,
-  fetchProviderByUuid,
-  saveVisitNote,
-} from './visit-notes.resource';
+import { fetchDiagnosisByName, fetchLocationByUuid, fetchProviderByUuid, saveVisitNote } from './visit-notes.resource';
 import {
   currentSessionResponse,
   diagnosisSearchResponse,
@@ -20,14 +14,12 @@ import {
 } from '../../../../__mocks__/visit-note.mock';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 
-const mockFetchCurrentSessionData = fetchCurrentSessionData as jest.Mock;
 const mockFetchDiagnosisByName = fetchDiagnosisByName as jest.Mock;
 const mockFetchLocationByUuid = fetchLocationByUuid as jest.Mock;
 const mockFetchProviderByUuid = fetchProviderByUuid as jest.Mock;
 const mockSaveVisitNote = saveVisitNote as jest.Mock;
 
 jest.mock('./visit-notes.resource', () => ({
-  fetchCurrentSessionData: jest.fn(),
   fetchDiagnosisByName: jest.fn(),
   fetchLocationByUuid: jest.fn(),
   fetchProviderByUuid: jest.fn(),
@@ -38,14 +30,12 @@ describe('Visit notes form', () => {
   let mockConfig = ConfigMock;
 
   beforeEach(() => {
-    mockFetchCurrentSessionData.mockResolvedValue(currentSessionResponse);
     mockFetchLocationByUuid.mockResolvedValue(mockFetchLocationByUuidResponse);
     mockFetchProviderByUuid.mockResolvedValue(mockFetchProviderByUuidResponse);
     mockFetchDiagnosisByName.mockReturnValue(of(diagnosisSearchResponse.results));
   });
 
   afterEach(() => {
-    mockFetchCurrentSessionData.mockReset();
     mockFetchLocationByUuid.mockReset();
     mockFetchProviderByUuid.mockReset();
     mockFetchDiagnosisByName.mockReset();

--- a/packages/esm-patient-notes-app/src/notes/visit-notes.resource.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes.resource.tsx
@@ -3,12 +3,6 @@ import { map } from 'rxjs/operators';
 import { Diagnosis, VisitNotePayload } from './visit-note.util';
 import { ConceptMapping, DiagnosisData, Location, Provider, SessionData } from '../types';
 
-export function fetchCurrentSessionData(abortController: AbortController) {
-  return openmrsFetch<SessionData>(`/ws/rest/v1/appui/session`, {
-    signal: abortController.signal,
-  });
-}
-
 export function fetchLocationByUuid(abortController: AbortController, locationUuid: string) {
   return openmrsFetch<Location>(`/ws/rest/v1/location/${locationUuid}`, {
     signal: abortController.signal,

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -64,7 +64,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
       patientVitalAndBiometrics,
       new Date(),
       ac,
-      session.sessionLocation.uuid,
+      session?.sessionLocation?.uuid,
     ).then((response) => {
       response.status === 201 && closeWorkspace();
       response.status !== 201 && createErrorHandler();


### PR DESCRIPTION
Previously, we made calls to an appui endpoint (`/ws/rest/v1/appui/session`) for fetching session data. 

Following @corneliouzbett's [work](https://github.com/openmrs/openmrs-module-webservices.rest/pull/418), we can now leverage the `useSessionUser` hook and reliably expect it to provide both the `currentProvider` and the `sessionLocation`.

This PR removes all of the existing appui-reliant implementations and refactors the components that used them to make use of the useSessionUser hook instead.