### PR TITLE
Loop call to fetch appointments fixed

### DIFF
--- a/packages/esm-patient-appointments-app/src/appointments/appointments-overview.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-overview.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import dayjs from 'dayjs';
 import styles from './appointments-overview.scss';
 import Add16 from '@carbon/icons-react/es/add/16';
@@ -23,12 +23,16 @@ interface AppointmentOverviewProps {
   patientUuid: string;
 }
 
+function getStartDate() {
+  return dayjs().format();
+}
+
 const AppointmentsOverview: React.FC<AppointmentOverviewProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const appointmentsToShowCount = 5;
   const [appointments, setAppointments] = React.useState(null);
   const [error, setError] = React.useState(null);
-  const startDate = dayjs().format();
+  const startDate = useMemo(getStartDate, []);
   const displayText = t('appointments', 'appointments');
   const headerTitle = t('appointments', 'Appointments');
 


### PR DESCRIPTION
**What does this PR do?**

This PR has a fix for clearing out the loop call to fetch appointments from **ws/rest/v1/appointments/search** for a patient.
In the code snippet below for appointments overview widget,
![image](https://user-images.githubusercontent.com/51502471/117565979-c4b85400-b0d1-11eb-9f0a-6b2595ebcb1c.png)
 
 Whenever useEffect (line35) runs the API call to fetch the appointments(line 39), which then saves the data in the `appointments` state using `setAppointments`(line 40), the re-rendering happens and the startDate variable is updated to the new Date-Time. When the `startDate` value updates with the latest time, the useEffect re-runs, due to startDate as one of its dependencies and this never-ending loop calls the endpoint again and again.(you can check the network tab in the dev tools on the patient-chart summary page to verify this.)
 
 I have removed the `startDate` from the dependencies of the useEffect function in this PR.