### PR TITLE
Exlude Sass files from formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 dist/
 node_modules/
 **/*.css
+**/*.scss
 **/*.md
 **/*.json


### PR DESCRIPTION
Sass files should not be formatted by Prettier.

Thanks to @nmalyschkin for figuring out that this was what was screwing up Prettier locally.