### PR TITLE
MF-518: Action Menu (with Extension slots)

### DIFF
--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -91,10 +91,10 @@ function setupOpenMRS() {
         }),
       },
       {
-        id: 'notification-buttons-slot',
+        id: 'notification-buttons',
         slot: 'action-menu-items-slot',
         load: getAsyncLifecycle(() => import('./ui-components/notifications-button.component'), {
-          featureName: 'notification-buttons-slot',
+          featureName: 'notification-buttons',
           moduleName,
         }),
       },

--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -91,6 +91,14 @@ function setupOpenMRS() {
         }),
       },
       {
+        id: 'notification-buttons-slot',
+        slot: 'action-menu-items-slot',
+        load: getAsyncLifecycle(() => import('./ui-components/notifications-button.component'), {
+          featureName: 'notification-buttons-slot',
+          moduleName,
+        }),
+      },
+      {
         id: 'add-past-visit-patient-actions-slot',
         slot: 'patient-actions-slot',
         load: getAsyncLifecycle(() => import('./actions-buttons/add-past-visit.component'), {

--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.scss
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.scss
@@ -1,0 +1,49 @@
+$icon-button-size: 48px;
+$actionPanelOffset: 48px;
+
+.rightSideNav {
+  position: fixed;
+  align-self: flex-end;
+  background: #ededed;
+  flex-direction: column;
+  display: flex;
+  height: 100%;
+  z-index: 9000;
+}
+
+.actionPanel {
+  right: $actionPanelOffset;
+  background: #fff;
+
+  border: 1px solid #a8a8a8;
+}
+
+:global(.omrs-breakpoint-lt-desktop) .actionPanel {
+  border: 0;
+  right: 0;
+}
+
+.iconButton {
+  width: $icon-button-size;
+  height: $icon-button-size;
+
+  color: #000;
+}
+
+.actionBtn {
+  bottom: 3rem;
+  right: 2rem;
+
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border-color: transparent;
+
+  color: #fff;
+  background: #005d5d;
+  transition: all 0.11s;
+  z-index: 9000;
+  padding-top: 0.325rem;
+  cursor: pointer;
+  position: fixed;
+}

--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback } from 'react';
+import { ExtensionSlot, useLayoutType } from '@openmrs/esm-framework';
+import Button from 'carbon-components-react/es/components/Button';
+import { HeaderPanel } from 'carbon-components-react';
+
+import { Edit20 } from '@carbon/icons-react';
+import styles from './action-menu.scss';
+import { isDesktop } from '../utils';
+
+interface ActionMenuInterface {
+  open: boolean;
+}
+
+export const CHARTS_DRAWER_SLOT = 'drawer-slot';
+export const CHARTS_ACTION_MENU_ITEMS_SLOT = 'action-menu-items-slot';
+
+export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
+  const layout = useLayoutType();
+
+  const menu = isDesktop(layout) ? (
+    <aside className={styles.rightSideNav}>
+      <ExtensionSlot extensionSlotName={CHARTS_ACTION_MENU_ITEMS_SLOT} />
+    </aside>
+  ) : (
+    <button className={styles.actionBtn}>
+      <Edit20 />
+    </button>
+  );
+
+  return (
+    <>
+      {menu}
+      <HeaderPanel className={styles.actionPanel} expanded={open}>
+        <ExtensionSlot extensionSlotName={CHARTS_DRAWER_SLOT} />
+        {/* Drawer main content goes inside here */}
+      </HeaderPanel>
+    </>
+  );
+};
+
+export default ActionMenu;

--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
@@ -1,10 +1,9 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { ExtensionSlot, useLayoutType } from '@openmrs/esm-framework';
-import Button from 'carbon-components-react/es/components/Button';
 import { HeaderPanel } from 'carbon-components-react';
 
 import { Edit20 } from '@carbon/icons-react';
-import styles from './action-menu.scss';
+import styles from './action-menu.component.scss';
 import { isDesktop } from '../utils';
 
 interface ActionMenuInterface {

--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { ExtensionSlot, useLayoutType } from '@openmrs/esm-framework';
-import { HeaderPanel } from 'carbon-components-react';
+import { HeaderPanel } from 'carbon-components-react/es/components/UIShell';
 
-import { Edit20 } from '@carbon/icons-react';
+import Edit20 from '@carbon/icons-react/es/edit/20';
 import styles from './action-menu.component.scss';
 import { isDesktop } from '../utils';
 

--- a/packages/esm-patient-chart-app/src/ui-components/notifications-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/notifications-button.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from 'carbon-components-react/es/components/Button';
-import { Notification20 } from '@carbon/icons-react';
+import Notification20 from '@carbon/icons-react/es/notification/20';
 import styles from './action-menu.component.scss';
 
 interface NotificationsButtonInterface {

--- a/packages/esm-patient-chart-app/src/ui-components/notifications-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/notifications-button.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Button from 'carbon-components-react/es/components/Button';
 import { Notification20 } from '@carbon/icons-react';
-import styles from './action-menu.scss';
+import styles from './action-menu.component.scss';
 
 interface NotificationsButtonInterface {
   onClick: Function;

--- a/packages/esm-patient-chart-app/src/ui-components/notifications-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/notifications-button.component.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Button from 'carbon-components-react/es/components/Button';
+import { Notification20 } from '@carbon/icons-react';
+import styles from './action-menu.scss';
+
+interface NotificationsButtonInterface {
+  onClick: Function;
+}
+
+const NotificationsButton: React.FC<NotificationsButtonInterface> = ({ onClick }) => {
+  return (
+    <Button onClick={onClick} iconDescription="Notifications" className={styles.iconButton} kind="ghost" hasIconOnly>
+      <Notification20 aria-label="Notifications" />
+    </Button>
+  );
+};
+
+export default NotificationsButton;

--- a/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.scss
+++ b/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.scss
@@ -1,3 +1,7 @@
+$actionNavOffset: 45px;
+$actionPanelOffset: 256px;
+$actionPanelExpandedOffset: $actionNavOffset + $actionPanelOffset;
+
 .grid {
   display: grid;
   grid-template-columns: 1fr min-content;

--- a/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.scss
+++ b/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.scss
@@ -39,6 +39,17 @@
   margin-left: var(--omrs-sidenav-width);
 }
 
+:global(.omrs-breakpoint-lt-desktop) .innerChartContainer {
+  padding-right: 0;
+}
+
+:global(.action-menu-expanded) .innerChartContainer {
+  padding-right: $actionPanelExpandedOffset;
+}
+
 .innerChartContainer {
+  display: flex;
   width: 100%;
+  padding-right: $actionNavOffset;
+  flex-direction: column;
 }

--- a/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.tsx
@@ -7,6 +7,7 @@ import VisitDialog from '../visit/visit-dialog.component';
 import { useVisitDialog } from '../hooks/useVisitDialog';
 import { RouteComponentProps } from 'react-router-dom';
 import { ExtensionSlot, useCurrentPatient } from '@openmrs/esm-framework';
+import ActionMenu from './action-menu.component';
 
 interface PatientChartParams {
   patientUuid: string;
@@ -19,29 +20,37 @@ const PatientChart: React.FC<RouteComponentProps<PatientChartParams>> = ({ match
   const [loading, patient] = useCurrentPatient(patientUuid);
   const state = useMemo(() => ({ patient, patientUuid }), [patient, patientUuid]);
 
+  const mainClassName = `
+    omrs-main-content 
+    ${styles.chartContainer} 
+  `;
+
   useVisitDialog(patientUuid);
 
   return (
-    <main className={`omrs-main-content ${styles.chartContainer}`}>
+    <main className={mainClassName}>
       {loading ? (
         <Loader />
       ) : (
-        <div className={styles.innerChartContainer}>
-          <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
-          <aside className={styles.patientBanner}>
-            <ExtensionSlot extensionSlotName="patient-header-slot" state={state} />
-            <ExtensionSlot extensionSlotName="patient-info-slot" state={state} />
-          </aside>
-          <div className={styles.grid}>
-            <div className={styles.chartreview}>
-              <ChartReview {...state} view={view} subview={subview} />
-              <VisitDialog />
-            </div>
-            <div className={styles.workspace}>
-              <WorkspaceWrapper {...state} />
+        <>
+          <div className={styles.innerChartContainer}>
+            <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
+            <aside className={styles.patientBanner}>
+              <ExtensionSlot extensionSlotName="patient-header-slot" state={state} />
+              <ExtensionSlot extensionSlotName="patient-info-slot" state={state} />
+            </aside>
+            <div className={styles.grid}>
+              <div className={styles.chartreview}>
+                <ChartReview {...state} view={view} subview={subview} />
+                <VisitDialog />
+              </div>
+              <div className={styles.workspace}>
+                <WorkspaceWrapper {...state} />
+              </div>
             </div>
           </div>
-        </div>
+          <ActionMenu open={false} />
+        </>
       )}
     </main>
   );


### PR DESCRIPTION
# Description

Adding the action menu again because the merge conflicts were way too much to handle again;

<img width="1166" alt="Screen Shot 2021-05-18 at 9 53 20 PM" src="https://user-images.githubusercontent.com/2448569/118745118-8d5d4c00-b823-11eb-96b0-7a342eaa0421.png">
