### PR TITLE
Cache visits of the selected patient

### DIFF
--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -26,6 +26,11 @@ function setupOpenMRS() {
     pattern: '.+/openmrs/ws/fhir2/R4/Patient/.+',
   });
 
+  messageOmrsServiceWorker({
+    type: 'registerDynamicRoute',
+    pattern: '.+/ws/rest/v1/visit.+',
+  });
+
   defineConfigSchema(moduleName, esmPatientChartSchema);
 
   registerBreadcrumbs([


### PR DESCRIPTION
This is required because otherwise certain actions are not possible while offline (e.g. launching a form would otherwise prompt for a visit creation which is not possible atm).

Will probably be changed later on when we tackle visits in their entirety.