### PR TITLE
Visit notes form enhancements

### DIFF
--- a/packages/esm-patient-common-lib/src/index.ts
+++ b/packages/esm-patient-common-lib/src/index.ts
@@ -4,3 +4,4 @@ export * from './error-state';
 export * from './createDashboardLink';
 export * from './openWorkspaceTab';
 export * from './types';
+export * from './launchStartVisitPrompt';

--- a/packages/esm-patient-common-lib/src/launchStartVisitPrompt.tsx
+++ b/packages/esm-patient-common-lib/src/launchStartVisitPrompt.tsx
@@ -1,0 +1,9 @@
+export function launchStartVisitPrompt() {
+  window.dispatchEvent(
+    new CustomEvent('visit-dialog', {
+      detail: {
+        type: 'prompt',
+      },
+    }),
+  );
+}

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.component.tsx
@@ -12,9 +12,9 @@ import DataTable, {
 } from 'carbon-components-react/es/components/DataTable';
 import Add16 from '@carbon/icons-react/es/add/16';
 import styles from './notes-overview.scss';
-import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
+import { EmptyState, ErrorState, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
-import { attach } from '@openmrs/esm-framework';
+import { attach, getStartedVisit, VisitItem } from '@openmrs/esm-framework';
 import { getEncounterObservableRESTAPI, PatientNote } from './encounter.resource';
 import { formatNotesDate } from './notes-helper';
 
@@ -28,6 +28,7 @@ interface NotesOverviewProps {
 const NotesOverview: React.FC<NotesOverviewProps> = ({ patientUuid, patient, showAddNote }) => {
   const notesToShowCount = 5;
   const { t } = useTranslation();
+  const [activeVisit, setActiveVisit] = React.useState<VisitItem>(null);
   const [notes, setNotes] = React.useState<Array<PatientNote>>(null);
   const [error, setError] = React.useState(null);
   const [showAllNotes, setShowAllNotes] = React.useState(false);
@@ -35,8 +36,20 @@ const NotesOverview: React.FC<NotesOverviewProps> = ({ patientUuid, patient, sho
   const headerTitle = t('notes', 'Notes');
 
   React.useEffect(() => {
+    const sub = getStartedVisit.subscribe((visit) => {
+      if (visit && visit.status === 'ongoing') {
+        setActiveVisit(visit);
+      }
+    });
+    return () => sub.unsubscribe();
+  }, []);
+
+  React.useEffect(() => {
     if (patient && patientUuid) {
-      const sub = getEncounterObservableRESTAPI(patientUuid).subscribe((notes) => setNotes(notes), setError);
+      const sub = getEncounterObservableRESTAPI(patientUuid).subscribe(
+        (notes) => setNotes(notes),
+        (err) => setError(err),
+      );
       return () => sub.unsubscribe();
     }
   }, [patient, patientUuid]);
@@ -45,10 +58,13 @@ const NotesOverview: React.FC<NotesOverviewProps> = ({ patientUuid, patient, sho
     setShowAllNotes(!showAllNotes);
   };
 
-  const launchVisitNoteForm = React.useCallback(
-    () => attach('patient-chart-workspace-slot', 'visit-notes-workspace'),
-    [],
-  );
+  const launchVisitNoteForm = React.useCallback(() => {
+    if (activeVisit) {
+      attach('patient-chart-workspace-slot', 'visit-notes-workspace');
+    } else {
+      launchStartVisitPrompt();
+    }
+  }, [activeVisit]);
 
   const headers = [
     {

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.component.tsx
@@ -46,10 +46,7 @@ const NotesOverview: React.FC<NotesOverviewProps> = ({ patientUuid, patient, sho
 
   React.useEffect(() => {
     if (patient && patientUuid) {
-      const sub = getEncounterObservableRESTAPI(patientUuid).subscribe(
-        (notes) => setNotes(notes),
-        (err) => setError(err),
-      );
+      const sub = getEncounterObservableRESTAPI(patientUuid).subscribe(setNotes, setError);
       return () => sub.unsubscribe();
     }
   }, [patient, patientUuid]);

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -19,6 +19,8 @@
 
 .diagnosisList {
   background-color: $ui-02;
+  max-height: 14rem;
+  overflow-y: scroll;
 }
 
 .diagnosisList li:hover {

--- a/packages/esm-patient-notes-app/translations/en.json
+++ b/packages/esm-patient-notes-app/translations/en.json
@@ -30,6 +30,5 @@
   "searchForDiagnosis": "Search for a diagnosis",
   "seeAll": "See all",
   "visitDate": "Visit date",
-  "visitNoteSaved": "Visit note saved successfully",
-  "visitNoteSaveError": "Error saving visit note"
+  "visitNoteSaved": "Visit note saved successfully"
 }

--- a/packages/esm-patient-notes-app/translations/en.json
+++ b/packages/esm-patient-notes-app/translations/en.json
@@ -14,7 +14,6 @@
   "encounterDate": "Encounter date",
   "encounterType": "Encounter type",
   "enterDiagnoses": "Enter diagnoses",
-  "errorSavingVisitNote": "",
   "image": "Image",
   "imageUploadHelperText": "Upload an image or use this device's camera to capture an image",
   "items": "Items",
@@ -31,5 +30,6 @@
   "searchForDiagnosis": "Search for a diagnosis",
   "seeAll": "See all",
   "visitDate": "Visit date",
-  "visitNoteSaved": "Visit note saved successfully"
+  "visitNoteSaved": "Visit note saved successfully",
+  "visitNoteSaveError": "Error saving visit note"
 }

--- a/packages/esm-patient-notes-app/translations/en.json
+++ b/packages/esm-patient-notes-app/translations/en.json
@@ -14,6 +14,7 @@
   "encounterDate": "Encounter date",
   "encounterType": "Encounter type",
   "enterDiagnoses": "Enter diagnoses",
+  "errorSavingVisitNote": "",
   "image": "Image",
   "imageUploadHelperText": "Upload an image or use this device's camera to capture an image",
   "items": "Items",


### PR DESCRIPTION
This PR improves the visit notes form as follows:

- Verify that an active visit is ongoing before launching the form. If there's no active visit, prompt the user to start a visit.
- Use a state machine to more reliably handle the various form states and transitions. This fixes an issue where the user could submit an empty form.
- Show an error toast if there is a problem submitting the form.
- Give the diagnosis search results panel a `max-height` value and make it scrollable.
