### PR TITLE
Conditions form enhancements

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
@@ -3,16 +3,17 @@
 @import "~carbon-components/src/globals/scss/mixins";
 
 .condition {
-  padding: 0.625rem;
+  padding: 0.875rem;
 }
 
 .conditionsList {
   background-color: $ui-02;
+  max-height: 14rem;
+  overflow-y: scroll;
 }
 
 .conditionsList li:hover {
-  background-color: $hover-primary;
-  color: $ui-01;
+  background-color: $ui-03;
 }
 
 .emptyResults {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
@@ -9,7 +9,7 @@
 .conditionsList {
   background-color: $ui-02;
   max-height: 14rem;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .conditionsList li:hover {


### PR DESCRIPTION
This PR improves the conditions form as follows:

- Set the padding of items in the search results panel to `0.875rem`.
- Set the `max-height` of the search results panel to 14rem.
- Set the background color of a condition in the search results panel to `$ui-03` on hover.

These changes tie in the UI of this form together with that of the visit notes form for an overall consistent UX.