### PR TITLE
Set vertical overflow behaviour to auto.

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -20,7 +20,7 @@
 .diagnosisList {
   background-color: $ui-02;
   max-height: 14rem;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .diagnosisList li:hover {


### PR DESCRIPTION
Preferable to `overflow-y: scroll` as we don't want scrollbars to be shown when content is not being clipped.