### PR TITLE
Test results extension

### DIFF
--- a/packages/esm-patient-test-results-app/src/index.ts
+++ b/packages/esm-patient-test-results-app/src/index.ts
@@ -9,6 +9,7 @@ import { createDashboardLink } from '@openmrs/esm-patient-common-lib';
 import { configSchema } from './config-schema';
 import { backendDependencies } from './openmrs-backend-dependencies';
 import { dashboardMeta } from './dashboard.meta';
+export type { RecentOverviewProps } from './overview/external-overview.component';
 
 const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 

--- a/packages/esm-patient-test-results-app/src/index.ts
+++ b/packages/esm-patient-test-results-app/src/index.ts
@@ -40,6 +40,16 @@ function setupOpenMRS() {
         offline: true,
       },
       {
+        id: 'test-results-summary-widget',
+        slot: 'test-results-filtered-overview',
+        load: getAsyncLifecycle(() => import('./overview/external-overview.component'), options),
+        meta: {
+          columnSpan: 2,
+        },
+        online: true,
+        offline: true,
+      },
+      {
         id: 'test-results-dashboard-widget',
         slot: dashboardMeta.slot,
         load: getAsyncLifecycle(() => import('./desktopView/index'), options),

--- a/packages/esm-patient-test-results-app/src/loadPatientTestData/types.ts
+++ b/packages/esm-patient-test-results-app/src/loadPatientTestData/types.ts
@@ -8,6 +8,10 @@ export interface ObsRecord {
   conceptClass: ConceptUuid;
   meta?: ObsMetaInfo;
   effectiveDateTime: string;
+  encounter: {
+    reference: string;
+    type: string;
+  };
   [_: string]: any;
 }
 

--- a/packages/esm-patient-test-results-app/src/overview/common-overview.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.tsx
@@ -60,18 +60,38 @@ export const CommonDataTable: React.FC<{
   </DataTable>
 );
 
-interface CommonOverviewProps {
+interface CommonOverviewPropsBase {
   overviewData: Array<OverviewPanelEntry>;
   insertSeperator?: boolean;
+}
+
+interface CommonOverviewPropsWithToolbar {
   openTimeline: (panelUuid: string) => void;
   openTrendline: (panelUuid: string, testUuid: string) => void;
 }
+
+interface CommonOverviewPropsWithoutToolbar {
+  deactivateToolbar: true;
+}
+
+type Only<T, U> = {
+  [P in keyof T]: T[P];
+} &
+  {
+    [P in keyof U]?: never;
+  };
+
+type Either<T, U> = Only<T, U> | Only<U, T>;
+
+type CommonOverviewProps = CommonOverviewPropsBase &
+  Either<CommonOverviewPropsWithToolbar, CommonOverviewPropsWithoutToolbar>;
 
 const CommonOverview: React.FC<CommonOverviewProps> = ({
   overviewData = [],
   insertSeperator = false,
   openTimeline,
   openTrendline,
+  deactivateToolbar = false,
 }) => {
   return (
     <>
@@ -89,7 +109,7 @@ const CommonOverview: React.FC<CommonOverviewProps> = ({
                     <InfoButton />
                   </div>
                 ),
-                toolbar: (
+                toolbar: deactivateToolbar || (
                   <TableToolbar>
                     <TableToolbarContent>
                       {type === 'Test' && (

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
@@ -10,9 +10,9 @@ import { ObsRecord } from '../loadPatientTestData/types';
 
 const RECENT_COUNT = 2;
 
-interface RecentOverviewProps {
+export interface RecentOverviewProps {
   patientUuid: string;
-  basePath: string;
+  filter: (filterProps: PanelFilterProps) => boolean;
 }
 
 type PanelFilterProps = [entry: ObsRecord, uuid: string, type: string, panelName: string];
@@ -38,8 +38,8 @@ function useFilteredOverviewData(patientUuid: string, filter: (filterProps: Pane
   return { overviewData, loaded, error };
 }
 
-const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, basePath }) => {
-  const { overviewData, loaded, error } = useFilteredOverviewData(patientUuid);
+const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, filter }) => {
+  const { overviewData, loaded, error } = useFilteredOverviewData(patientUuid, filter);
 
   return (
     <RecentResultsGrid>

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import DataTableSkeleton from 'carbon-components-react/lib/components/DataTableSkeleton';
+
+import { parseSingleEntry, OverviewPanelEntry } from './useOverviewData';
+import { RecentResultsGrid, Card } from './helpers';
+import CommonOverview from './common-overview';
+import usePatientResultsData from '../loadPatientTestData/usePatientResultsData';
+import { ObsRecord } from '../loadPatientTestData/types';
+
+const RECENT_COUNT = 2;
+
+interface RecentOverviewProps {
+  patientUuid: string;
+  basePath: string;
+}
+
+type PanelFilterProps = [entry: ObsRecord, uuid: string, type: string, panelName: string];
+
+function useFilteredOverviewData(patientUuid: string, filter: (filterProps: PanelFilterProps) => boolean = () => true) {
+  const { sortedObs, loaded, error } = usePatientResultsData(patientUuid);
+  const [overviewData, setDisplayData] = React.useState<Array<OverviewPanelEntry>>([]);
+
+  React.useEffect(() => {
+    setDisplayData(
+      Object.entries(sortedObs)
+        .flatMap(([panelName, { entries, type, uuid }]) => {
+          return entries.map((e) => [e, uuid, type, panelName] as PanelFilterProps);
+        })
+        .filter(filter)
+        .map(([entry, uuid, type, panelName]: PanelFilterProps): OverviewPanelEntry => {
+          return [panelName, type, parseSingleEntry(entry, type, panelName), new Date(entry.effectiveDateTime), uuid];
+        })
+        .sort(([, , , date1], [, , , date2]) => date2.getTime() - date1.getTime()),
+    );
+  }, [sortedObs]);
+
+  return { overviewData, loaded, error };
+}
+
+const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, basePath }) => {
+  const { overviewData, loaded, error } = useFilteredOverviewData(patientUuid);
+
+  return (
+    <RecentResultsGrid>
+      {loaded ? (
+        <>
+          <CommonOverview
+            {...{
+              patientUuid,
+              overviewData: overviewData.slice(0, RECENT_COUNT),
+              insertSeperator: true,
+              deactivateToolbar: true,
+            }}
+          />
+        </>
+      ) : (
+        <Card>
+          <DataTableSkeleton columnCount={3} />
+        </Card>
+      )}
+    </RecentResultsGrid>
+  );
+};
+
+export default RecentOverview;

--- a/packages/esm-patient-test-results-app/src/overview/useOverviewData.ts
+++ b/packages/esm-patient-test-results-app/src/overview/useOverviewData.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { OBSERVATION_INTERPRETATION } from '../loadPatientTestData/helpers';
+import { ObsRecord } from '../loadPatientTestData/types';
 import usePatientResultsData from '../loadPatientTestData/usePatientResultsData';
 
 export interface OverviewPanelData {
@@ -13,6 +14,29 @@ export interface OverviewPanelData {
 
 export type OverviewPanelEntry = [string, string, Array<OverviewPanelData>, Date, string];
 
+export function parseSingleEntry(entry: ObsRecord, type: string, panelName: string): Array<OverviewPanelData> {
+  if (type === 'Test') {
+    return [
+      {
+        id: entry.id,
+        name: panelName,
+        range: entry.meta?.range || '--',
+        interpretation: entry.meta.assessValue(entry.value),
+        value: entry.value,
+      },
+    ];
+  } else {
+    return entry.members.map((gm) => ({
+      id: gm.id,
+      key: gm.id,
+      name: gm.name,
+      range: gm.meta?.range || '--',
+      interpretation: gm.meta.assessValue(gm.value),
+      value: gm.value,
+    }));
+  }
+}
+
 function useOverviewData(patientUuid: string) {
   const { sortedObs, loaded, error } = usePatientResultsData(patientUuid);
   const [overviewData, setDisplayData] = useState<Array<OverviewPanelEntry>>([]);
@@ -20,35 +44,17 @@ function useOverviewData(patientUuid: string) {
   useEffect(() => {
     setDisplayData(
       Object.entries(sortedObs)
-        .map(
-          ([panelName, { entries, type, uuid }]): OverviewPanelEntry => {
-            const newestEntry = entries[0];
-            let data: Array<OverviewPanelData>;
+        .map(([panelName, { entries, type, uuid }]): OverviewPanelEntry => {
+          const newestEntry = entries[0];
 
-            if (type === 'Test') {
-              data = [
-                {
-                  id: newestEntry.id,
-                  name: panelName,
-                  range: newestEntry.meta?.range || '--',
-                  interpretation: newestEntry.meta.assessValue(newestEntry.value),
-                  value: newestEntry.value,
-                },
-              ];
-            } else {
-              data = newestEntry.members.map((gm) => ({
-                id: gm.id,
-                key: gm.id,
-                name: gm.name,
-                range: gm.meta?.range || '--',
-                interpretation: gm.meta.assessValue(gm.value),
-                value: gm.value,
-              }));
-            }
-
-            return [panelName, type, data, new Date(newestEntry.effectiveDateTime), uuid];
-          },
-        )
+          return [
+            panelName,
+            type,
+            parseSingleEntry(newestEntry, type, panelName),
+            new Date(newestEntry.effectiveDateTime),
+            uuid,
+          ];
+        })
         .sort(([, , , date1], [, , , date2]) => date2.getTime() - date1.getTime()),
     );
   }, [sortedObs]);


### PR DESCRIPTION
Providing the test results overview as an extension.
Necessary for https://github.com/openmrs/openmrs-esm-patient-chart/pull/276


![image](https://user-images.githubusercontent.com/44928856/121154060-e4fd3f00-c846-11eb-99e7-e7ebce28904d.png)
