### PR TITLE
MF-620 : Add Active Medication Widget Extension to Patient Summary

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -29,7 +29,7 @@ import { OrderBasketItem } from '../types/order-basket-item';
 import { attach } from '@openmrs/esm-framework';
 
 export interface ActiveMedicationsProps {
-  title: string;
+  title?: string;
   medications?: Array<Order> | null;
   showAddNewButton: boolean;
   showDiscontinueButton: boolean;

--- a/packages/esm-patient-medications-app/src/index.ts
+++ b/packages/esm-patient-medications-app/src/index.ts
@@ -26,6 +26,16 @@ function setupOpenMRS() {
         },
       },
       {
+        id: 'active-medications-widget',
+        slot: 'patient-chart-summary-dashboard-slot',
+        load: getAsyncLifecycle(() => import('./medications/active-medications.component'), options),
+        meta: {
+          columnSpan: 4,
+        },
+        online: { showAddMedications: true },
+        offline: { showAddMedications: false },
+      },
+      {
         id: 'order-basket-workspace',
         load: getAsyncLifecycle(() => import('./medications/root-order-basket'), options),
         meta: {

--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.scss
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.scss
@@ -1,0 +1,26 @@
+@import '../root.scss';
+
+.activeMedicationContainer {
+  display: flex;
+  justify-content: space-between;
+  background-color: $ui-background;
+  flex-direction: column;
+}
+
+
+.activeMedicationHeader {
+  display: flex;
+  justify-content: space-between;
+  padding: $spacing-04 0 $spacing-04 $spacing-05;
+}
+.activeMedicationHeader>h4:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}
+
+.title {
+  @extend .productiveHeading03;
+}

--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePatientOrders } from '../utils/use-current-patient-orders.hook';
+import styles from './active-medications.component.scss';
+import MedicationsDetailsTable from '../components/medications-details-table.component';
+import { Provider } from 'unistore/react';
+import { orderBasketStore } from './order-basket-store';
+import Add16 from '@carbon/icons-react/es/add/16';
+import Button from 'carbon-components-react/es/components/Button';
+import { attach } from '@openmrs/esm-framework';
+import DataTableSkeleton from 'carbon-components-react/es/components/DataTableSkeleton';
+
+interface ActiveMedicationsProps {
+  patientUuid: string;
+  showAddMedications: boolean;
+}
+
+const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, showAddMedications }) => {
+  const { t } = useTranslation();
+  const [activePatientOrders] = usePatientOrders(patientUuid, 'ACTIVE');
+
+  const launchOrderBasket = () => attach('patient-chart-workspace-slot', 'order-basket-workspace');
+
+  return (
+    <Provider store={orderBasketStore}>
+      {activePatientOrders ? (
+        <div className={styles.activeMedicationContainer}>
+          <div className={styles.activeMedicationHeader}>
+            <h4 className={styles.title}>{t('activeMedications', 'Active Medications')}</h4>
+            {showAddMedications && (
+              <Button kind="ghost" renderIcon={Add16} iconDescription="Add notes" onClick={launchOrderBasket}>
+                {t('add', 'Add')}
+              </Button>
+            )}
+          </div>
+
+          <MedicationsDetailsTable
+            medications={activePatientOrders}
+            showDiscontinueButton={true}
+            showModifyButton={true}
+            showReorderButton={false}
+            showAddNewButton={false}
+          />
+        </div>
+      ) : (
+        <DataTableSkeleton />
+      )}
+    </Provider>
+  );
+};
+
+export default ActiveMedications;


### PR DESCRIPTION
### Description

At the moment `medications app` provides a medication-summary extension that shows both active and past medication. This PR provides an extension to show only active medications.

jira ticket [MF-620](https://issues.openmrs.org/projects/MF/issues/MF-620)


### Screenshoot

<img width="1389" alt="Screenshot 2021-06-17 at 10 56 24" src="https://user-images.githubusercontent.com/28008754/122355683-c4299d80-cf5a-11eb-83a2-fe8bd3a61982.png">


