### PR TITLE
MF-624: Improve Workspace visual formatting (tablet and desktop mode)

### DIFF
--- a/packages/esm-patient-chart-app/src/workspace/context-workspace.component.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/context-workspace.component.tsx
@@ -19,7 +19,11 @@ const ContextWorkspace: React.FC<RouteComponentProps<ContextWorkspaceParams>> = 
   const { patientUuid } = match.params;
   const { active, title, closeWorkspace } = useWorkspace();
   const { t } = useTranslation();
-  const props = React.useMemo(() => ({ closeWorkspace, patientUuid }), [closeWorkspace, patientUuid]);
+  const isTablet = layout === 'tablet';
+  const props = React.useMemo(
+    () => ({ closeWorkspace, patientUuid, isTablet }),
+    [closeWorkspace, isTablet, patientUuid],
+  );
 
   useBodyScrollLock(active && !isDesktop(layout));
 

--- a/packages/esm-patient-clinical-view-app/src/clinical-view-form/clinical-view-form.component.scss
+++ b/packages/esm-patient-clinical-view-app/src/clinical-view-form/clinical-view-form.component.scss
@@ -1,31 +1,33 @@
 @import "../root.scss";
+@import "~@openmrs/esm-styleguide/src/vars";
 
 .formContainer {
-  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
 }
+
 .checkboxContainer {
   display: flex;
-  height: 30rem;
-  flex-direction: column;
+  flex-direction: row;
   flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: flex-start;
-  margin: $spacing-05;
+  margin: 1rem 0rem 0rem 1rem;
 }
-.checkboxContainer div {
-  flex: none;
-  display: flex;
-  align-items: center;
-}
+
 .checkBox {
   height: $spacing-09;
   width: 16rem;
 }
 
 .buttonContainer {
-  margin: $spacing-05;
+  display: flex;
+  width: 100%;
+  flex-direction: row;
+  padding: $spacing-05;
 }
 
 .buttonContainer button {
-  width: 50%;
+  flex: 1;
+  margin: 0.125rem;
 }

--- a/packages/esm-patient-clinical-view-app/src/clinical-view-form/clinical-view-form.component.tsx
+++ b/packages/esm-patient-clinical-view-app/src/clinical-view-form/clinical-view-form.component.tsx
@@ -11,13 +11,15 @@ import isEmpty from 'lodash-es/isEmpty';
 import cloneDeep from 'lodash-es/cloneDeep';
 import set from 'lodash-es/set';
 
-interface ClinicalViewFormProps {}
+interface ClinicalViewFormProps {
+  isTablet: boolean;
+}
 interface View {
   slotName: string;
   slot: string;
 }
 
-const ClinicalViewForm: React.FC<ClinicalViewFormProps> = () => {
+const ClinicalViewForm: React.FC<ClinicalViewFormProps> = ({ isTablet }) => {
   const { t } = useTranslation();
   const { clinicalViews } = useConfig();
   const moduleName = '@openmrs/esm-patient-clinical-view-app';
@@ -89,8 +91,10 @@ const ClinicalViewForm: React.FC<ClinicalViewFormProps> = () => {
         id="search"
         onChange={(event) => handleSearch(event.target.value)}
         labelText=""
+        light={isTablet}
+        size="xl"
       />
-      <div className={styles.checkboxContainer}>
+      <section className={styles.checkboxContainer}>
         {searchResults.map((view) => (
           <Checkbox
             key={view.slot}
@@ -101,7 +105,7 @@ const ClinicalViewForm: React.FC<ClinicalViewFormProps> = () => {
             onChange={(checked) => handleChange(view.slotName, view.slot, checked)}
           />
         ))}
-      </div>
+      </section>
       <div className={styles.buttonContainer}>
         <Button kind="secondary" onClick={closeClinicalViewForm}>
           {t('cancel', 'Cancel')}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
@@ -1,8 +1,15 @@
-import React, { SyntheticEvent } from 'react';
+import React, { SyntheticEvent, useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 import debounce from 'lodash-es/debounce';
 import { useTranslation } from 'react-i18next';
-import { createErrorHandler, detach, showNotification, showToast, useSessionUser } from '@openmrs/esm-framework';
+import {
+  createErrorHandler,
+  detach,
+  showNotification,
+  showToast,
+  useLayoutType,
+  useSessionUser,
+} from '@openmrs/esm-framework';
 import Button from 'carbon-components-react/es/components/Button';
 import DatePicker from 'carbon-components-react/es/components/DatePicker';
 import DatePickerInput from 'carbon-components-react/es/components/DatePickerInput';
@@ -53,12 +60,18 @@ type ViewState = IdleState | SearchState | ConditionState | SubmitState;
 const ConditionsForm: React.FC<ConditionsFormProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const session = useSessionUser();
+  const layout = useLayoutType();
   const [clinicalStatus, setClinicalStatus] = React.useState('active');
   const [endDate, setEndDate] = React.useState(null);
   const [onsetDate, setOnsetDate] = React.useState(null);
   const [viewState, setViewState] = React.useState<ViewState>({
     type: StateTypes.IDLE,
   });
+  const [lightMode, setLightMode] = useState<boolean>();
+
+  useEffect(() => {
+    layout === 'desktop' ? setLightMode(false) : setLightMode(true);
+  }, [layout]);
 
   const closeWorkspace = React.useCallback(
     () => detach('patient-chart-workspace-slot', 'conditions-form-workspace'),
@@ -169,7 +182,8 @@ const ConditionsForm: React.FC<ConditionsFormProps> = ({ patientUuid }) => {
     <Form style={{ margin: '2rem' }} onSubmit={handleSubmit}>
       <FormGroup style={{ width: '50%' }} legendText={t('condition', 'Condition')}>
         <Search
-          light
+          light={lightMode}
+          size="xl"
           id="conditionsSearch"
           labelText={t('enterCondition', 'Enter condition')}
           placeholder={t('searchConditions', 'Search conditions')}
@@ -234,7 +248,7 @@ const ConditionsForm: React.FC<ConditionsFormProps> = ({ patientUuid }) => {
           placeholder="dd/mm/yyyy"
           onChange={([date]) => setOnsetDate(date)}
           value={onsetDate}
-          light>
+          light={lightMode}>
           <DatePickerInput id="onsetDateInput" labelText="" />
         </DatePicker>
       </FormGroup>
@@ -260,7 +274,7 @@ const ConditionsForm: React.FC<ConditionsFormProps> = ({ patientUuid }) => {
           placeholder="dd/mm/yyyy"
           onChange={([date]) => setEndDate(date)}
           value={endDate}
-          light>
+          light={lightMode}>
           <DatePickerInput id="endDateInput" labelText={t('endDate', 'End date')} />
         </DatePicker>
       )}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
@@ -1,15 +1,8 @@
-import React, { SyntheticEvent, useEffect, useState } from 'react';
+import React, { SyntheticEvent } from 'react';
 import dayjs from 'dayjs';
 import debounce from 'lodash-es/debounce';
 import { useTranslation } from 'react-i18next';
-import {
-  createErrorHandler,
-  detach,
-  showNotification,
-  showToast,
-  useLayoutType,
-  useSessionUser,
-} from '@openmrs/esm-framework';
+import { createErrorHandler, detach, showNotification, showToast, useSessionUser } from '@openmrs/esm-framework';
 import Button from 'carbon-components-react/es/components/Button';
 import DatePicker from 'carbon-components-react/es/components/DatePicker';
 import DatePickerInput from 'carbon-components-react/es/components/DatePickerInput';
@@ -33,6 +26,7 @@ enum StateTypes {
 
 interface ConditionsFormProps {
   patientUuid: string;
+  isTablet: boolean;
 }
 
 interface IdleState {
@@ -57,21 +51,15 @@ interface SubmitState {
 
 type ViewState = IdleState | SearchState | ConditionState | SubmitState;
 
-const ConditionsForm: React.FC<ConditionsFormProps> = ({ patientUuid }) => {
+const ConditionsForm: React.FC<ConditionsFormProps> = ({ patientUuid, isTablet }) => {
   const { t } = useTranslation();
   const session = useSessionUser();
-  const layout = useLayoutType();
   const [clinicalStatus, setClinicalStatus] = React.useState('active');
   const [endDate, setEndDate] = React.useState(null);
   const [onsetDate, setOnsetDate] = React.useState(null);
   const [viewState, setViewState] = React.useState<ViewState>({
     type: StateTypes.IDLE,
   });
-  const [lightMode, setLightMode] = useState<boolean>();
-
-  useEffect(() => {
-    layout === 'desktop' ? setLightMode(false) : setLightMode(true);
-  }, [layout]);
 
   const closeWorkspace = React.useCallback(
     () => detach('patient-chart-workspace-slot', 'conditions-form-workspace'),
@@ -182,7 +170,7 @@ const ConditionsForm: React.FC<ConditionsFormProps> = ({ patientUuid }) => {
     <Form style={{ margin: '2rem' }} onSubmit={handleSubmit}>
       <FormGroup style={{ width: '50%' }} legendText={t('condition', 'Condition')}>
         <Search
-          light={lightMode}
+          light={isTablet}
           size="xl"
           id="conditionsSearch"
           labelText={t('enterCondition', 'Enter condition')}
@@ -248,7 +236,7 @@ const ConditionsForm: React.FC<ConditionsFormProps> = ({ patientUuid }) => {
           placeholder="dd/mm/yyyy"
           onChange={([date]) => setOnsetDate(date)}
           value={onsetDate}
-          light={lightMode}>
+          light={isTablet}>
           <DatePickerInput id="onsetDateInput" labelText="" />
         </DatePicker>
       </FormGroup>
@@ -274,7 +262,7 @@ const ConditionsForm: React.FC<ConditionsFormProps> = ({ patientUuid }) => {
           placeholder="dd/mm/yyyy"
           onChange={([date]) => setEndDate(date)}
           value={endDate}
-          light={lightMode}>
+          light={isTablet}>
           <DatePickerInput id="endDateInput" labelText={t('endDate', 'End date')} />
         </DatePicker>
       )}

--- a/packages/esm-patient-medications-app/src/medications/root-order-basket.tsx
+++ b/packages/esm-patient-medications-app/src/medications/root-order-basket.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import OrderBasket from '../order-basket/order-basket.component';
 import { Provider } from 'unistore/react';
 import { orderBasketStore } from './order-basket-store';
+import { useLayoutType } from '@openmrs/esm-framework';
 
 export interface RootOrderBasketProps {
   patientUuid: string;
@@ -9,9 +10,11 @@ export interface RootOrderBasketProps {
 }
 
 export default function RootOrderBasket({ patientUuid, closeWorkspace }: RootOrderBasketProps) {
+  const layout = useLayoutType();
+  const isTablet = React.useMemo(() => layout === 'tablet', [layout]);
   return (
     <Provider store={orderBasketStore}>
-      <OrderBasket patientUuid={patientUuid} closeWorkspace={closeWorkspace} />
+      <OrderBasket patientUuid={patientUuid} closeWorkspace={closeWorkspace} isTablet={isTablet} />
     </Provider>
   );
 }

--- a/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from './medication-order-form.scss';
 import capitalize from 'lodash-es/capitalize';
 import Button from 'carbon-components-react/es/components/Button';
@@ -20,6 +20,7 @@ import { OrderBasketItem } from '../types/order-basket-item';
 import { daysDurationUnit } from '../constants';
 import { getCommonMedicationByUuid } from '../api/common-medication';
 import { OpenmrsResource } from '../types/openmrs-resource';
+import { useLayoutType } from '@openmrs/esm-framework';
 
 export interface MedicationOrderFormProps {
   initialOrderBasketItem: OrderBasketItem;
@@ -35,8 +36,14 @@ export default function MedicationOrderForm({
   onCancel,
 }: MedicationOrderFormProps) {
   const { t } = useTranslation();
+  const layout = useLayoutType();
   const [orderBasketItem, setOrderBasketItem] = useState(initialOrderBasketItem);
   const commonMedication = getCommonMedicationByUuid(orderBasketItem.drug.uuid);
+  const [lightMode, setLightMode] = useState<boolean>();
+
+  useEffect(() => {
+    layout === 'desktop' ? setLightMode(false) : setLightMode(true);
+  }, [layout]);
 
   return (
     <>
@@ -84,6 +91,7 @@ export default function MedicationOrderForm({
             <Row style={{ marginTop: '0.5rem' }}>
               <Column md={8}>
                 <TextArea
+                  light={lightMode}
                   labelText={t('freeTextDosage', 'Free Text Dosage')}
                   placeholder={t('freeTextDosage', 'Free Text Dosage')}
                   value={orderBasketItem.freeTextDosage}
@@ -103,6 +111,7 @@ export default function MedicationOrderForm({
                 <Column md={4}>
                   <ComboBox
                     id="doseSelection"
+                    light={lightMode}
                     items={commonMedication.commonDosages.map((x) => ({
                       id: x.dosage,
                       text: x.dosage,
@@ -129,6 +138,7 @@ export default function MedicationOrderForm({
                 <Column md={4}>
                   <ComboBox
                     id="editFrequency"
+                    light={lightMode}
                     items={commonMedication.commonFrequencies.map((x) => ({
                       id: x.conceptUuid,
                       text: x.name,
@@ -157,6 +167,7 @@ export default function MedicationOrderForm({
                 <Column md={4}>
                   <ComboBox
                     id="editRoute"
+                    light={lightMode}
                     items={commonMedication.route.map((x) => ({
                       id: x.conceptUuid,
                       text: x.name,
@@ -184,6 +195,7 @@ export default function MedicationOrderForm({
               <Row style={{ marginTop: '1rem' }}>
                 <Column className={styles.fullHeightTextAreaContainer}>
                   <TextArea
+                    light={lightMode}
                     labelText={t('patientInstructions', 'Patient Instructions')}
                     placeholder={t(
                       'patientInstructionsPlaceholder',
@@ -202,6 +214,7 @@ export default function MedicationOrderForm({
                 <Column>
                   <FormGroup legendText={t('prn', 'P.R.N.')}>
                     <Checkbox
+                      light={lightMode}
                       id="prn"
                       labelText={t('takeAsNeeded', 'Take As Needed')}
                       checked={orderBasketItem.asNeeded}
@@ -217,6 +230,7 @@ export default function MedicationOrderForm({
                     className={styles.fullHeightTextAreaContainer}
                     style={orderBasketItem.asNeeded ? {} : { visibility: 'hidden' }}>
                     <TextArea
+                      light={lightMode}
                       labelText={t('prnReason', 'P.R.N. Reason')}
                       placeholder={t('prnReasonPlaceholder', 'Reason to take medicine')}
                       rows={3}
@@ -242,6 +256,7 @@ export default function MedicationOrderForm({
           <Row style={{ marginTop: '1rem' }}>
             <Column md={4} className={styles.fullWidthDatePickerContainer}>
               <DatePicker
+                light={lightMode}
                 datePickerType="single"
                 maxDate={new Date()}
                 value={[orderBasketItem.startDate]}
@@ -260,6 +275,7 @@ export default function MedicationOrderForm({
             </Column>
             <Column md={2}>
               <NumberInput
+                light={lightMode}
                 id="durationInput"
                 label={t('duration', 'Duration')}
                 min={1}
@@ -280,6 +296,7 @@ export default function MedicationOrderForm({
             <Column md={2}>
               <FormGroup legendText={t('durationUnit', 'Duration Unit')}>
                 <ComboBox
+                  light={lightMode}
                   id="durationUnitPlaceholder"
                   selectedItem={{
                     id: orderBasketItem.durationUnit.uuid,
@@ -318,6 +335,7 @@ export default function MedicationOrderForm({
             <Column md={2}>
               <FormGroup legendText={t('quantityDispensed', 'Quantity Dispensed')}>
                 <NumberInput
+                  light={lightMode}
                   id="quantityDispensed"
                   helperText={t('pillsDispensed', 'Pills dispensed')}
                   value={orderBasketItem.pillsDispensed}
@@ -335,6 +353,7 @@ export default function MedicationOrderForm({
             <Column md={2}>
               <FormGroup legendText={t('prescriptionRefills', 'Prescription Refills')}>
                 <NumberInput
+                  light={lightMode}
                   id="prescriptionRefills"
                   min={0}
                   value={orderBasketItem.numRefills}
@@ -352,6 +371,7 @@ export default function MedicationOrderForm({
           <Row>
             <Column md={8}>
               <TextInput
+                light={lightMode}
                 id="indication"
                 labelText={t('indication', 'Indication')}
                 placeholder={t('indicationPlaceholder', 'e.g. "Hypertension"')}

--- a/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import styles from './medication-order-form.scss';
 import capitalize from 'lodash-es/capitalize';
 import Button from 'carbon-components-react/es/components/Button';
@@ -20,13 +20,13 @@ import { OrderBasketItem } from '../types/order-basket-item';
 import { daysDurationUnit } from '../constants';
 import { getCommonMedicationByUuid } from '../api/common-medication';
 import { OpenmrsResource } from '../types/openmrs-resource';
-import { useLayoutType } from '@openmrs/esm-framework';
 
 export interface MedicationOrderFormProps {
   initialOrderBasketItem: OrderBasketItem;
   durationUnits: Array<OpenmrsResource>;
   onSign: (finalizedOrder: OrderBasketItem) => void;
   onCancel: () => void;
+  isTablet: boolean;
 }
 
 export default function MedicationOrderForm({
@@ -34,16 +34,11 @@ export default function MedicationOrderForm({
   durationUnits,
   onSign,
   onCancel,
+  isTablet,
 }: MedicationOrderFormProps) {
   const { t } = useTranslation();
-  const layout = useLayoutType();
   const [orderBasketItem, setOrderBasketItem] = useState(initialOrderBasketItem);
   const commonMedication = getCommonMedicationByUuid(orderBasketItem.drug.uuid);
-  const [lightMode, setLightMode] = useState<boolean>();
-
-  useEffect(() => {
-    layout === 'desktop' ? setLightMode(false) : setLightMode(true);
-  }, [layout]);
 
   return (
     <>
@@ -91,7 +86,7 @@ export default function MedicationOrderForm({
             <Row style={{ marginTop: '0.5rem' }}>
               <Column md={8}>
                 <TextArea
-                  light={lightMode}
+                  light={isTablet}
                   labelText={t('freeTextDosage', 'Free Text Dosage')}
                   placeholder={t('freeTextDosage', 'Free Text Dosage')}
                   value={orderBasketItem.freeTextDosage}
@@ -111,7 +106,7 @@ export default function MedicationOrderForm({
                 <Column md={4}>
                   <ComboBox
                     id="doseSelection"
-                    light={lightMode}
+                    light={isTablet}
                     items={commonMedication.commonDosages.map((x) => ({
                       id: x.dosage,
                       text: x.dosage,
@@ -138,7 +133,7 @@ export default function MedicationOrderForm({
                 <Column md={4}>
                   <ComboBox
                     id="editFrequency"
-                    light={lightMode}
+                    light={isTablet}
                     items={commonMedication.commonFrequencies.map((x) => ({
                       id: x.conceptUuid,
                       text: x.name,
@@ -167,7 +162,7 @@ export default function MedicationOrderForm({
                 <Column md={4}>
                   <ComboBox
                     id="editRoute"
-                    light={lightMode}
+                    light={isTablet}
                     items={commonMedication.route.map((x) => ({
                       id: x.conceptUuid,
                       text: x.name,
@@ -195,7 +190,7 @@ export default function MedicationOrderForm({
               <Row style={{ marginTop: '1rem' }}>
                 <Column className={styles.fullHeightTextAreaContainer}>
                   <TextArea
-                    light={lightMode}
+                    light={isTablet}
                     labelText={t('patientInstructions', 'Patient Instructions')}
                     placeholder={t(
                       'patientInstructionsPlaceholder',
@@ -214,7 +209,7 @@ export default function MedicationOrderForm({
                 <Column>
                   <FormGroup legendText={t('prn', 'P.R.N.')}>
                     <Checkbox
-                      light={lightMode}
+                      light={isTablet}
                       id="prn"
                       labelText={t('takeAsNeeded', 'Take As Needed')}
                       checked={orderBasketItem.asNeeded}
@@ -230,7 +225,7 @@ export default function MedicationOrderForm({
                     className={styles.fullHeightTextAreaContainer}
                     style={orderBasketItem.asNeeded ? {} : { visibility: 'hidden' }}>
                     <TextArea
-                      light={lightMode}
+                      light={isTablet}
                       labelText={t('prnReason', 'P.R.N. Reason')}
                       placeholder={t('prnReasonPlaceholder', 'Reason to take medicine')}
                       rows={3}
@@ -256,7 +251,7 @@ export default function MedicationOrderForm({
           <Row style={{ marginTop: '1rem' }}>
             <Column md={4} className={styles.fullWidthDatePickerContainer}>
               <DatePicker
-                light={lightMode}
+                light={isTablet}
                 datePickerType="single"
                 maxDate={new Date()}
                 value={[orderBasketItem.startDate]}
@@ -275,7 +270,7 @@ export default function MedicationOrderForm({
             </Column>
             <Column md={2}>
               <NumberInput
-                light={lightMode}
+                light={isTablet}
                 id="durationInput"
                 label={t('duration', 'Duration')}
                 min={1}
@@ -296,7 +291,7 @@ export default function MedicationOrderForm({
             <Column md={2}>
               <FormGroup legendText={t('durationUnit', 'Duration Unit')}>
                 <ComboBox
-                  light={lightMode}
+                  light={isTablet}
                   id="durationUnitPlaceholder"
                   selectedItem={{
                     id: orderBasketItem.durationUnit.uuid,
@@ -335,7 +330,7 @@ export default function MedicationOrderForm({
             <Column md={2}>
               <FormGroup legendText={t('quantityDispensed', 'Quantity Dispensed')}>
                 <NumberInput
-                  light={lightMode}
+                  light={isTablet}
                   id="quantityDispensed"
                   helperText={t('pillsDispensed', 'Pills dispensed')}
                   value={orderBasketItem.pillsDispensed}
@@ -353,7 +348,7 @@ export default function MedicationOrderForm({
             <Column md={2}>
               <FormGroup legendText={t('prescriptionRefills', 'Prescription Refills')}>
                 <NumberInput
-                  light={lightMode}
+                  light={isTablet}
                   id="prescriptionRefills"
                   min={0}
                   value={orderBasketItem.numRefills}
@@ -371,7 +366,7 @@ export default function MedicationOrderForm({
           <Row>
             <Column md={8}>
               <TextInput
-                light={lightMode}
+                light={isTablet}
                 id="indication"
                 labelText={t('indication', 'Indication')}
                 placeholder={t('indicationPlaceholder', 'e.g. "Hypertension"')}

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search.component.tsx
@@ -1,32 +1,26 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Search from 'carbon-components-react/es/components/Search';
 import styles from './order-basket-search.scss';
 import OrderBasketSearchResults from './order-basket-search-results';
 import { useTranslation } from 'react-i18next';
 import { OrderBasketItem } from '../types/order-basket-item';
-import { useLayoutType } from '@openmrs/esm-framework';
 
 export interface OrderBasketSearchProps {
   encounterUuid: string;
   onSearchResultClicked: (searchResult: OrderBasketItem, directlyAddToBasket: boolean) => void;
+  isTablet: boolean;
 }
 
-export default function OrderBasketSearch({ encounterUuid, onSearchResultClicked }: OrderBasketSearchProps) {
+export default function OrderBasketSearch({ encounterUuid, onSearchResultClicked, isTablet }: OrderBasketSearchProps) {
   const { t } = useTranslation();
-  const layout = useLayoutType();
   const [searchTerm, setSearchTerm] = useState('');
-  const [lightMode, setLightMode] = useState<boolean>();
-
-  useEffect(() => {
-    layout === 'desktop' ? setLightMode(false) : setLightMode(true);
-  }, [layout]);
 
   return (
     <>
       <div className={styles.searchPopupContainer}>
         <Search
           size="xl"
-          light={lightMode}
+          light={isTablet}
           value={searchTerm}
           placeholder={t('searchFieldPlaceholder', 'Search for an order (e.g. "Aspirin")')}
           labelText={t('searchFieldPlaceholder', 'Search for an order (e.g. "Aspirin")')}

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search.component.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Search from 'carbon-components-react/es/components/Search';
 import styles from './order-basket-search.scss';
 import OrderBasketSearchResults from './order-basket-search-results';
 import { useTranslation } from 'react-i18next';
 import { OrderBasketItem } from '../types/order-basket-item';
+import { useLayoutType } from '@openmrs/esm-framework';
 
 export interface OrderBasketSearchProps {
   encounterUuid: string;
@@ -12,12 +13,20 @@ export interface OrderBasketSearchProps {
 
 export default function OrderBasketSearch({ encounterUuid, onSearchResultClicked }: OrderBasketSearchProps) {
   const { t } = useTranslation();
+  const layout = useLayoutType();
   const [searchTerm, setSearchTerm] = useState('');
+  const [lightMode, setLightMode] = useState<boolean>();
+
+  useEffect(() => {
+    layout === 'desktop' ? setLightMode(false) : setLightMode(true);
+  }, [layout]);
 
   return (
     <>
       <div className={styles.searchPopupContainer}>
         <Search
+          size="xl"
+          light={lightMode}
           value={searchTerm}
           placeholder={t('searchFieldPlaceholder', 'Search for an order (e.g. "Aspirin")')}
           labelText={t('searchFieldPlaceholder', 'Search for an order (e.g. "Aspirin")')}

--- a/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
@@ -1,10 +1,10 @@
-import React, { SyntheticEvent, useEffect, useState } from 'react';
+import React, { SyntheticEvent } from 'react';
 import dayjs from 'dayjs';
 import filter from 'lodash-es/filter';
 import includes from 'lodash-es/includes';
 import map from 'lodash-es/map';
 import { useTranslation } from 'react-i18next';
-import { createErrorHandler, showNotification, showToast, useLayoutType, useSessionUser } from '@openmrs/esm-framework';
+import { createErrorHandler, showNotification, showToast, useSessionUser } from '@openmrs/esm-framework';
 import Button from 'carbon-components-react/es/components/Button';
 import DatePicker from 'carbon-components-react/es/components/DatePicker';
 import DatePickerInput from 'carbon-components-react/es/components/DatePickerInput';
@@ -26,6 +26,7 @@ import styles from './programs-form.scss';
 interface ProgramsFormProps {
   closeWorkspace(): void;
   patientUuid: string;
+  isTablet: boolean;
 }
 
 enum StateTypes {
@@ -51,10 +52,9 @@ interface SubmittingState {
 
 type ViewState = IdleState | ResolvedState | SubmittingState;
 
-const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace }) => {
+const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace, isTablet }) => {
   const { t } = useTranslation();
   const session = useSessionUser();
-  const layout = useLayoutType();
   const [availableLocations, setAvailableLocations] = React.useState(null);
   const [completionDate, setCompletionDate] = React.useState(null);
   const [enrollmentDate, setEnrollmentDate] = React.useState(new Date());
@@ -62,11 +62,6 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace
   const [viewState, setViewState] = React.useState<ViewState>({
     type: StateTypes.IDLE,
   });
-  const [lightMode, setLightMode] = useState<boolean>();
-
-  useEffect(() => {
-    layout === 'desktop' ? setLightMode(false) : setLightMode(true);
-  }, [layout]);
 
   if (!userLocation && session?.sessionLocation?.uuid) {
     setUserLocation(session?.sessionLocation?.uuid);
@@ -170,7 +165,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace
             id="program"
             invalidText={t('required', 'Required')}
             labelText=""
-            light={lightMode}
+            light={isTablet}
             onChange={(event) => {
               setViewState({
                 availablePrograms: (viewState as ResolvedState)?.availablePrograms,
@@ -202,7 +197,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace
           id="enrollmentDate"
           datePickerType="single"
           dateFormat="d/m/Y"
-          light={lightMode}
+          light={isTablet}
           maxDate={new Date().toISOString()}
           placeholder="dd/mm/yyyy"
           onChange={([date]) => setEnrollmentDate(date)}
@@ -215,7 +210,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace
           id="completionDate"
           datePickerType="single"
           dateFormat="d/m/Y"
-          light={lightMode}
+          light={isTablet}
           minDate={new Date(enrollmentDate).toISOString()}
           maxDate={new Date().toISOString()}
           placeholder="dd/mm/yyyy"
@@ -229,7 +224,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace
           id="location"
           invalidText="Required"
           labelText=""
-          light={lightMode}
+          light={isTablet}
           onChange={(event) => setUserLocation(event.target.value)}
           value={userLocation}>
           {!userLocation ? <SelectItem text={t('chooseLocation', 'Choose a location')} value="" /> : null}

--- a/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
@@ -1,10 +1,10 @@
-import React, { SyntheticEvent } from 'react';
+import React, { SyntheticEvent, useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 import filter from 'lodash-es/filter';
 import includes from 'lodash-es/includes';
 import map from 'lodash-es/map';
 import { useTranslation } from 'react-i18next';
-import { createErrorHandler, showNotification, showToast, useSessionUser } from '@openmrs/esm-framework';
+import { createErrorHandler, showNotification, showToast, useLayoutType, useSessionUser } from '@openmrs/esm-framework';
 import Button from 'carbon-components-react/es/components/Button';
 import DatePicker from 'carbon-components-react/es/components/DatePicker';
 import DatePickerInput from 'carbon-components-react/es/components/DatePickerInput';
@@ -54,6 +54,7 @@ type ViewState = IdleState | ResolvedState | SubmittingState;
 const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace }) => {
   const { t } = useTranslation();
   const session = useSessionUser();
+  const layout = useLayoutType();
   const [availableLocations, setAvailableLocations] = React.useState(null);
   const [completionDate, setCompletionDate] = React.useState(null);
   const [enrollmentDate, setEnrollmentDate] = React.useState(new Date());
@@ -61,6 +62,11 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace
   const [viewState, setViewState] = React.useState<ViewState>({
     type: StateTypes.IDLE,
   });
+  const [lightMode, setLightMode] = useState<boolean>();
+
+  useEffect(() => {
+    layout === 'desktop' ? setLightMode(false) : setLightMode(true);
+  }, [layout]);
 
   if (!userLocation && session?.sessionLocation?.uuid) {
     setUserLocation(session?.sessionLocation?.uuid);
@@ -164,7 +170,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace
             id="program"
             invalidText={t('required', 'Required')}
             labelText=""
-            light
+            light={lightMode}
             onChange={(event) => {
               setViewState({
                 availablePrograms: (viewState as ResolvedState)?.availablePrograms,
@@ -196,7 +202,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace
           id="enrollmentDate"
           datePickerType="single"
           dateFormat="d/m/Y"
-          light
+          light={lightMode}
           maxDate={new Date().toISOString()}
           placeholder="dd/mm/yyyy"
           onChange={([date]) => setEnrollmentDate(date)}
@@ -209,7 +215,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace
           id="completionDate"
           datePickerType="single"
           dateFormat="d/m/Y"
-          light
+          light={lightMode}
           minDate={new Date(enrollmentDate).toISOString()}
           maxDate={new Date().toISOString()}
           placeholder="dd/mm/yyyy"
@@ -223,7 +229,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, closeWorkspace
           id="location"
           invalidText="Required"
           labelText=""
-          light
+          light={lightMode}
           onChange={(event) => setUserLocation(event.target.value)}
           value={userLocation}>
           {!userLocation ? <SelectItem text={t('chooseLocation', 'Choose a location')} value="" /> : null}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.scss
@@ -6,11 +6,6 @@
   @include carbon--type-style("productive-heading-03");
 }
 
-.vitalsBiometricContainer {
-  background-color: $ui-01;
-  margin-left: $spacing-05;
-}
-
 .vitalsTitle {
   @extend .productiveHeading03;
   margin: 0 $spacing-03 $spacing-05 0;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -3,7 +3,14 @@ import VitalsBiometricInput from './vitals-biometrics-input.component';
 import Button from 'carbon-components-react/es/components/Button';
 import styles from './vitals-biometrics-form.component.scss';
 import { useTranslation } from 'react-i18next';
-import { useConfig, createErrorHandler, useSessionUser, showToast, showNotification } from '@openmrs/esm-framework';
+import {
+  useConfig,
+  createErrorHandler,
+  useSessionUser,
+  showToast,
+  showNotification,
+  useLayoutType,
+} from '@openmrs/esm-framework';
 import { Column, Grid, Row } from 'carbon-components-react/es/components/Grid';
 import { calculateBMI, isInNormalRange } from './vitals-biometrics-form.utils';
 import { savePatientVitals } from '../vitals-biometrics.resource';
@@ -32,11 +39,13 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
   const session = useSessionUser();
   const config = useConfig() as ConfigObject;
   const { t } = useTranslation();
+  const layout = useLayoutType();
   const { vitalsSignsConceptMetadata, conceptsUnits } = useVitalsSignsConceptMetaData();
   const biometricsUnitsSymbols = config.biometrics;
   const [patientVitalAndBiometrics, setPatientVitalAndBiometrics] = useState<PatientVitalAndBiometric>();
   const [patientBMI, setPatientBMI] = useState<number>();
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [lightMode, setLightMode] = useState<boolean>();
 
   const [
     bloodPressureUnit,
@@ -103,8 +112,12 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
     }
   }, [patientVitalAndBiometrics?.weight, patientVitalAndBiometrics?.height]);
 
+  useEffect(() => {
+    layout === 'desktop' ? setLightMode(false) : setLightMode(true);
+  }, [layout]);
+
   return (
-    <Grid condensed className={styles.vitalsBiometricContainer}>
+    <Grid condensed>
       <Row>
         <Column>
           <p className={styles.vitalsTitle}>{t('vitals', 'Vitals')}</p>
@@ -151,6 +164,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
                 patientVitalAndBiometrics?.diastolicBloodPressure,
               )
             }
+            lightMode={lightMode}
           />
         </Column>
         <Column>
@@ -175,6 +189,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
               config.concepts['pulseUuid'],
               patientVitalAndBiometrics?.pulse,
             )}
+            lightMode={lightMode}
           />
         </Column>
         <Column>
@@ -199,6 +214,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
               config.concepts['oxygenSaturationUuid'],
               patientVitalAndBiometrics?.oxygenSaturation,
             )}
+            lightMode={lightMode}
           />
         </Column>
         <Column>
@@ -223,6 +239,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
               config.concepts['respiratoryRateUuid'],
               patientVitalAndBiometrics?.respiratoryRate,
             )}
+            lightMode={lightMode}
           />
         </Column>
       </Row>
@@ -249,6 +266,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
               config.concepts['temperatureUuid'],
               patientVitalAndBiometrics?.temperature,
             )}
+            lightMode={lightMode}
           />
         </Column>
       </Row>
@@ -272,6 +290,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             textFieldWidth="26.375rem"
             placeholder={t('additionalNoteText', 'Type any additional notes here')}
             inputIsNormal={true}
+            lightMode={lightMode}
           />
         </Column>
       </Row>
@@ -300,6 +319,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             ]}
             unitSymbol={weightUnit}
             inputIsNormal={true}
+            lightMode={lightMode}
           />
         </Column>
         <Column>
@@ -320,6 +340,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             ]}
             unitSymbol={heightUnit}
             inputIsNormal={true}
+            lightMode={lightMode}
           />
         </Column>
         <Column>
@@ -336,6 +357,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             unitSymbol={biometricsUnitsSymbols['bmiUnit']}
             disabled={true}
             inputIsNormal={isBMIInNormalRange(patientBMI)}
+            lightMode={lightMode}
           />
         </Column>
         <Column>
@@ -360,6 +382,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
               config.concepts['midUpperArmCircumferenceUuid'],
               patientVitalAndBiometrics?.midUpperArmCircumference,
             )}
+            lightMode={lightMode}
           />
         </Column>
       </Row>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -3,14 +3,7 @@ import VitalsBiometricInput from './vitals-biometrics-input.component';
 import Button from 'carbon-components-react/es/components/Button';
 import styles from './vitals-biometrics-form.component.scss';
 import { useTranslation } from 'react-i18next';
-import {
-  useConfig,
-  createErrorHandler,
-  useSessionUser,
-  showToast,
-  showNotification,
-  useLayoutType,
-} from '@openmrs/esm-framework';
+import { useConfig, createErrorHandler, useSessionUser, showToast, showNotification } from '@openmrs/esm-framework';
 import { Column, Grid, Row } from 'carbon-components-react/es/components/Grid';
 import { calculateBMI, isInNormalRange } from './vitals-biometrics-form.utils';
 import { savePatientVitals } from '../vitals-biometrics.resource';
@@ -20,6 +13,7 @@ import { ConfigObject } from '../../config-schema';
 interface VitalsAndBiometricFormProps {
   patientUuid: string;
   closeWorkspace(): void;
+  isTablet: boolean;
 }
 
 export interface PatientVitalAndBiometric {
@@ -35,17 +29,15 @@ export interface PatientVitalAndBiometric {
   midUpperArmCircumference?: string;
 }
 
-const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patientUuid, closeWorkspace }) => {
+const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patientUuid, closeWorkspace, isTablet }) => {
   const session = useSessionUser();
   const config = useConfig() as ConfigObject;
   const { t } = useTranslation();
-  const layout = useLayoutType();
   const { vitalsSignsConceptMetadata, conceptsUnits } = useVitalsSignsConceptMetaData();
   const biometricsUnitsSymbols = config.biometrics;
   const [patientVitalAndBiometrics, setPatientVitalAndBiometrics] = useState<PatientVitalAndBiometric>();
   const [patientBMI, setPatientBMI] = useState<number>();
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const [lightMode, setLightMode] = useState<boolean>();
 
   const [
     bloodPressureUnit,
@@ -112,10 +104,6 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
     }
   }, [patientVitalAndBiometrics?.weight, patientVitalAndBiometrics?.height]);
 
-  useEffect(() => {
-    layout === 'desktop' ? setLightMode(false) : setLightMode(true);
-  }, [layout]);
-
   return (
     <Grid condensed>
       <Row>
@@ -164,7 +152,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
                 patientVitalAndBiometrics?.diastolicBloodPressure,
               )
             }
-            lightMode={lightMode}
+            isTablet={isTablet}
           />
         </Column>
         <Column>
@@ -189,7 +177,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
               config.concepts['pulseUuid'],
               patientVitalAndBiometrics?.pulse,
             )}
-            lightMode={lightMode}
+            isTablet={isTablet}
           />
         </Column>
         <Column>
@@ -214,7 +202,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
               config.concepts['oxygenSaturationUuid'],
               patientVitalAndBiometrics?.oxygenSaturation,
             )}
-            lightMode={lightMode}
+            isTablet={isTablet}
           />
         </Column>
         <Column>
@@ -239,7 +227,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
               config.concepts['respiratoryRateUuid'],
               patientVitalAndBiometrics?.respiratoryRate,
             )}
-            lightMode={lightMode}
+            isTablet={isTablet}
           />
         </Column>
       </Row>
@@ -266,7 +254,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
               config.concepts['temperatureUuid'],
               patientVitalAndBiometrics?.temperature,
             )}
-            lightMode={lightMode}
+            isTablet={isTablet}
           />
         </Column>
       </Row>
@@ -290,7 +278,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             textFieldWidth="26.375rem"
             placeholder={t('additionalNoteText', 'Type any additional notes here')}
             inputIsNormal={true}
-            lightMode={lightMode}
+            isTablet={isTablet}
           />
         </Column>
       </Row>
@@ -319,7 +307,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             ]}
             unitSymbol={weightUnit}
             inputIsNormal={true}
-            lightMode={lightMode}
+            isTablet={isTablet}
           />
         </Column>
         <Column>
@@ -340,7 +328,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             ]}
             unitSymbol={heightUnit}
             inputIsNormal={true}
-            lightMode={lightMode}
+            isTablet={isTablet}
           />
         </Column>
         <Column>
@@ -357,7 +345,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             unitSymbol={biometricsUnitsSymbols['bmiUnit']}
             disabled={true}
             inputIsNormal={isBMIInNormalRange(patientBMI)}
-            lightMode={lightMode}
+            isTablet={isTablet}
           />
         </Column>
         <Column>
@@ -382,7 +370,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
               config.concepts['midUpperArmCircumferenceUuid'],
               patientVitalAndBiometrics?.midUpperArmCircumference,
             )}
-            lightMode={lightMode}
+            isTablet={isTablet}
           />
         </Column>
       </Row>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.scss
@@ -28,7 +28,6 @@
 
 .textInput {
   border: none;
-  background-color: white;
   @extend .productiveHeading04;
   text-align: center;
   padding: 0;
@@ -37,7 +36,6 @@
 
 .textInputContainer {
   @extend .productiveHeading04;
-  background-color: #ffffff;
   height: 4.875rem;
   display: flex;
   justify-content: center;
@@ -45,11 +43,15 @@
   text-align: center;
   padding: $spacing-03;
   color: $text-02;
+  background-color: $ui-02;
+}
+
+:global(.omrs-breakpoint-gt-tablet) .textInputContainer {
+background-color: $ui-01;
 }
 
 .textArea {
   border: none;
-  background-color: white;
   @extend .bodyLong01;
   text-align: left;
 }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -19,6 +19,7 @@ interface VitalsBiometricInputProps {
   placeholder?: string;
   disabled?: boolean;
   inputIsNormal: boolean;
+  lightMode?: boolean;
 }
 
 const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
@@ -31,6 +32,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
   placeholder,
   disabled,
   inputIsNormal,
+  lightMode,
 }) => {
   return (
     <div className={styles.inputContainer} style={{ width: textFieldWidth }}>
@@ -53,6 +55,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
                   labelText={''}
                   value={val.value}
                   title={val.name}
+                  light={lightMode}
                 />
                 {val?.separator}
               </Fragment>
@@ -69,6 +72,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
                 placeholder={placeholder}
                 value={val.value}
                 title={val.name}
+                light={lightMode}
               />
             );
           })}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -19,7 +19,7 @@ interface VitalsBiometricInputProps {
   placeholder?: string;
   disabled?: boolean;
   inputIsNormal: boolean;
-  lightMode?: boolean;
+  isTablet: boolean;
 }
 
 const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
@@ -32,7 +32,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
   placeholder,
   disabled,
   inputIsNormal,
-  lightMode,
+  isTablet,
 }) => {
   return (
     <div className={styles.inputContainer} style={{ width: textFieldWidth }}>
@@ -55,7 +55,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
                   labelText={''}
                   value={val.value}
                   title={val.name}
-                  light={lightMode}
+                  light={isTablet}
                 />
                 {val?.separator}
               </Fragment>
@@ -72,7 +72,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
                 placeholder={placeholder}
                 value={val.value}
                 title={val.name}
-                light={lightMode}
+                light={isTablet}
               />
             );
           })}


### PR DESCRIPTION
### Description
This is a follow up on the first ticket on improving workspace formatting [MF-624](https://github.com/openmrs/openmrs-esm-patient-chart/pull/291)

1. According to the designs, workspace styling is different from tablet styling on `input` elements, in desktop mode input elements have a light grey background while in tablet mode the inputs have a white background. This PR attempts to correct this issue on the following 
- vitals
- conditions
- programs 
- medication orders
- visit notes

### Screenshoot

![workspace](https://user-images.githubusercontent.com/28008754/122562160-6d4fc100-d04b-11eb-81ba-12a43680c0ff.gif)

