### PR TITLE
MF-605 Rename results widget to vitals on the left nav

### DIFF
--- a/packages/esm-patient-biometrics-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-biometrics-app/src/dashboard.meta.tsx
@@ -1,6 +1,6 @@
 export const dashboardMeta = {
-  name: 'results',
+  name: 'vitalsAndBiometrics',
   slot: 'patient-chart-results-dashboard-slot',
   config: { type: 'tabs' },
-  title: 'Results',
+  title: 'Vitals & Biometrics',
 };


### PR DESCRIPTION
### Description

At the moment vitals and biometrics are named as results on the left side menu, this PR updates its name to `Vitals & Biometrics` to match designs

### Screenshoot

<img width="831" alt="Screenshot 2021-06-18 at 16 17 42" src="https://user-images.githubusercontent.com/28008754/122566968-d2f27c00-d050-11eb-842c-cfd25c48bd03.png">
