### PR TITLE
Prevent hitting the api on multiple time for the same resource (Observations endpoint)

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vital-header-state.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vital-header-state.component.tsx
@@ -22,6 +22,7 @@ interface VitalHeaderProps {
 const VitalHeader: React.FC<VitalHeaderProps> = ({ patientUuid, showRecordVitals }) => {
   const { t } = useTranslation();
   const config = useConfig();
+  const { concepts } = React.useMemo(() => config, [config]);
   const [vital, setVital] = useState<PatientVitals>();
   const [displayState, setDisplayState] = useState<ViewState>({
     view: 'Default',
@@ -44,14 +45,14 @@ const VitalHeader: React.FC<VitalHeaderProps> = ({ patientUuid, showRecordVitals
   ] = conceptsUnits;
 
   useEffect(() => {
-    if (patientUuid) {
-      const subscription = performPatientsVitalsSearch(config.concepts, patientUuid, 10).subscribe((vitals) => {
+    if (patientUuid && concepts) {
+      const subscription = performPatientsVitalsSearch(concepts, patientUuid, 10).subscribe((vitals) => {
         setVital(vitals[0]);
         setIsLoading(false);
       }, createErrorHandler);
       return () => subscription.unsubscribe();
     }
-  }, [patientUuid, config.concepts]);
+  }, [patientUuid]);
 
   useEffect(() => {
     if (vital && !dayjs(vital.date).isToday()) {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -176,18 +176,19 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
   const [error, setError] = React.useState(null);
   const [showAllVitals, setShowAllVitals] = React.useState(false);
   const headerTitle = t('vitals', 'Vitals');
+  const { concepts } = React.useMemo(() => config, [config]);
 
   const toggleShowAllVitals = React.useCallback(() => setShowAllVitals((value) => !value), []);
 
   React.useEffect(() => {
-    if (patientUuid) {
-      const subscription = performPatientsVitalsSearch(config.concepts, patientUuid, 100).subscribe(
+    if (patientUuid && concepts) {
+      const subscription = performPatientsVitalsSearch(concepts, patientUuid, 100).subscribe(
         (vitals) => setVitals(vitals),
         (err) => setError(err),
       );
       return () => subscription.unsubscribe();
     }
-  }, [patientUuid, config.concepts]);
+  }, [patientUuid]);
 
   const tableRows = React.useMemo(
     () =>


### PR DESCRIPTION
### Description

1. At the moment the vitals-header state component makes three API requests on every page navigation action, which is not ideal. Not sure if this is the best approach to fix this, but I have removed the config object as a dependency on fetch hitting the observation endpoint. Below is a gif on the network tab of before and after this change.

###. Screenshots

before

![before-1](https://user-images.githubusercontent.com/28008754/123542862-83006d00-d754-11eb-82c1-907f16961058.gif)

after

![after](https://user-images.githubusercontent.com/28008754/123542903-acb99400-d754-11eb-8729-b9625dc49586.gif)

