### PR TITLE
MF-637 : Fix design issue 1: SideBar nav-items height

### DIFF
--- a/packages/esm-patient-chart-app/src/view-components/side-menu.component.scss
+++ b/packages/esm-patient-chart-app/src/view-components/side-menu.component.scss
@@ -8,7 +8,17 @@
   border-left: 0.25rem solid transparent;
 }
 
-.link > div a:nth-child(1):hover {
+:global(.omrs-breakpoint-gt-tablet) .link > div {
+  padding-top: 1rem;
+}
+
+:global(.omrs-breakpoint-gt-tablet) .link > div a:nth-child(1) {
+  height: 2rem;
+  color: $ui-04;
+  padding: 0 0 0 1rem;
+}
+
+.link>div a:nth-child(1):hover {
   background-color: $ui-03;
   color: $ui-05;
   border-left-color: $brand-01;


### PR DESCRIPTION
### Description

Fixed the height of the side-nav link to `2rem` on desktop and `3rem` on tablet mode

### Screenshoot

![Screenshot 2021-06-29 at 12 09 31](https://user-images.githubusercontent.com/28008754/123770362-ea442b80-d8d2-11eb-845c-5b62db5b60f2.png)
