### PR TITLE
Use a real UUID for offline visits.

### DIFF
--- a/packages/esm-patient-chart-app/package.json
+++ b/packages/esm-patient-chart-app/package.json
@@ -42,7 +42,6 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
-    "@types/uuid": "^8.3.0",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",
@@ -51,5 +50,7 @@
     "react-router-dom": "5.x",
     "rxjs": "6.x"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@types/uuid": "^8.3.0"
+  }
 }

--- a/packages/esm-patient-chart-app/package.json
+++ b/packages/esm-patient-chart-app/package.json
@@ -37,10 +37,12 @@
     "@carbon/icons-react": "^10.18.0",
     "@openmrs/esm-patient-common-lib": "^3.0.0",
     "carbon-components-react": "^7.25.0",
-    "lodash-es": "^4.17.15"
+    "lodash-es": "^4.17.15",
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@types/uuid": "^8.3.0",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-chart-app/src/offline.ts
+++ b/packages/esm-patient-chart-app/src/offline.ts
@@ -8,10 +8,10 @@ import {
   setupOfflineSync,
   VisitMode,
   VisitStatus,
-  generateOfflineUuid,
   subscribeConnectivity,
 } from '@openmrs/esm-framework';
 import { useEffect } from 'react';
+import { v4 } from 'uuid';
 
 interface OfflineVisit extends NewVisitPayload {
   uuid: string;
@@ -32,16 +32,17 @@ export function setupCacheableRoutes() {
 }
 
 export function setupOfflineVisitsSync() {
-  setupOfflineSync<OfflineVisit>(visitSyncType, [], async (item, options) => {
-    const { uuid, ...visitData } = item;
+  setupOfflineSync<OfflineVisit>(visitSyncType, [], async (visit, options) => {
     const visitPayload = {
-      ...visitData,
+      ...visit,
       stopDatetime: new Date(),
     };
 
     const res = await saveVisit(visitPayload, options.abort).toPromise();
     if (!res.ok) {
-      throw new Error(`Failed to synchronize offline visit with the UUID: ${uuid}. Error: ${JSON.stringify(res.data)}`);
+      throw new Error(
+        `Failed to synchronize offline visit with the UUID: ${visit.uuid}. Error: ${JSON.stringify(res.data)}`,
+      );
     }
   });
 }
@@ -70,7 +71,7 @@ async function getOfflineVisitForPatient(patientUuid: string) {
 
 async function createOfflineVisitForPatient(patientUuid: string, location: string) {
   const offlineVisit: OfflineVisit = {
-    uuid: generateOfflineUuid(),
+    uuid: v4(),
     patient: patientUuid,
     startDatetime: new Date(),
     location,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13967,7 +13967,7 @@ uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
For visits it actually is possible to specify a UUID when creating new ones. This doesn't require us to do any offline UUID handling (which is fantastic).