### PR TITLE
Remove Medication Orders as a default clinical view

### DIFF
--- a/packages/esm-patient-clinical-view-app/src/config-schema.ts
+++ b/packages/esm-patient-clinical-view-app/src/config-schema.ts
@@ -7,9 +7,6 @@ export const configSchema = {
       slot: { _type: Type.String },
       slotName: { _type: Type.String },
     },
-    _default: [
-      { slot: 'All', slotName: '' },
-      { slot: 'Medication Orders', slotName: 'patient-chart-orders-dashboard-slot' },
-    ],
+    _default: [{ slot: 'All', slotName: '' }],
   },
 };


### PR DESCRIPTION
### Description

At the moment the medication order is set as a default clinical view, since we shouldn't be specifying this kind of configuration, am removing it.