### PR TITLE
MF-637: Fix design issues removed active visit underline

### DIFF
--- a/packages/esm-patient-banner-app/src/banner/patient-banner.scss
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.scss
@@ -64,3 +64,7 @@
   @include carbon--type-style("body-short-01");
   color: $interactive-01;
 }
+
+:global(.bx--tooltip--definition .bx--tooltip__trigger){
+  border-bottom: none;
+}

--- a/packages/esm-patient-common-lib/src/empty-state/empty-state.component.tsx
+++ b/packages/esm-patient-common-lib/src/empty-state/empty-state.component.tsx
@@ -24,6 +24,7 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
         </Trans>
       </p>
       <p className={styles.action}>
+        {' '}
         <Link onClick={() => props.launchForm()}>
           {t('record', 'Record')} {props.displayText.toLowerCase()}
         </Link>

--- a/packages/esm-patient-forms-app/src/forms/forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.tsx
@@ -7,7 +7,6 @@ import FormView from './form-view.component';
 import styles from './forms.component.scss';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
-import { navigate } from '@openmrs/esm-framework';
 import { fetchAllForms, fetchPatientEncounters } from './forms.resource';
 import { filterAvailableAndCompletedForms } from './forms-utils';
 import { Encounter, Form } from '../types';
@@ -117,13 +116,7 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient }) => {
       {filledForms.length > 0 ? (
         <RenderForm />
       ) : (
-        <EmptyState
-          displayText={displayText}
-          headerTitle={headerTitle}
-          launchForm={() => {
-            navigate({ to: '/formbuilder/#/forms' });
-          }}
-        />
+        <EmptyState displayText={displayText} headerTitle={t('helpText', 'Contact system Admin to configure form')} />
       )}
       {error && <ErrorState error={error} headerTitle={headerTitle} />}
     </>


### PR DESCRIPTION
### What does this PR do?

1. Remove the underline from the active visit tag
2. Remove ability to redirect to form builder in the event no forms are available and display a meaningful message

### Screenshoot

<img width="514" alt="Screenshot 2021-07-01 at 22 07 32" src="https://user-images.githubusercontent.com/28008754/124177361-cf331080-dab8-11eb-9484-e67138a36fcb.png">

