### PR TITLE
Manage form view states with useReducer

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/visit-note.util.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-note.util.tsx
@@ -35,7 +35,7 @@ export interface VisitNotePayload {
   visit?: string; // when creating an encounter for a specific visit, this specifies the visit
 }
 
-export function convertToObsPayLoad(diagnosisArray: Array<Diagnosis>): Array<ObsData> {
+export function convertToObsPayload(diagnosisArray: Array<Diagnosis>): Array<ObsData> {
   return diagnosisArray.map((diagnosis) => {
     if (diagnosis.confirmed === true && diagnosis.primary === true) {
       // confirmed and primary diagnosis


### PR DESCRIPTION
Use `useReducer` hooks to manage view states in forms. I think these implementations are easier to reason about than their equivalent `useState` hook based implementations.

Other changes:
- Increase timeouts for debounced searches to 500ms.
- Set the default onset date in the `Conditions` form to the current date (`new Date())`.
- Render an error notification when the user tries to enrol a patient in a program using the Programs form but the patient is already enrolled in all of the available programs. Previously, we were rendering this error in a `Tile` that would appear under the `Select program` field.
- Rename `convertToObsPayLoad` to `convertToObsPayload`.