### PR TITLE
add showToast on submitting immunization form

### DIFF
--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styles from './immunizations-form.css';
 import { SummaryCard } from '@openmrs/esm-patient-common-lib';
-import { createErrorHandler, useSessionUser, useVisit } from '@openmrs/esm-framework';
+import { createErrorHandler, showNotification, showToast, useSessionUser, useVisit } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { savePatientImmunization } from './immunizations.resource';
 import { mapToFHIRImmunizationResource } from './immunization-mapper';
@@ -119,9 +119,24 @@ const ImmunizationsForm: React.FC<ImmunizationsFormProps> = ({
       patientUuid,
       formState.immunizationObsUuid,
       abortController,
-    ).then((response) => {
-      response.status === 200 && navigate();
-    }, createErrorHandler());
+    ).then(
+      (response) => {
+        response.status === 201 && navigate();
+        showToast({
+          kind: 'success',
+          description: t('vaccinationSaved', 'Vaccination Saved Successfully'),
+        });
+      },
+      (err) => {
+        createErrorHandler();
+        showNotification({
+          title: t('errorSaving', 'Error Saving Vaccination'),
+          kind: 'error',
+          critical: true,
+          description: err?.message,
+        });
+      },
+    );
     return () => abortController.abort();
   };
 

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
@@ -128,7 +128,6 @@ const ImmunizationsForm: React.FC<ImmunizationsFormProps> = ({
         });
       },
       (err) => {
-        createErrorHandler();
         showNotification({
           title: t('errorSaving', 'Error Saving Vaccination'),
           kind: 'error',


### PR DESCRIPTION
### Description
[MF-677](https://issues.openmrs.org/browse/MF-677)
Fixed immunization form to show message on submitting.

![mf-677-add_showToast_on_immunization_form_submit](https://user-images.githubusercontent.com/48877319/129163287-b8a0c0d3-98dd-4e6b-ae9b-e1e1f8974eb4.gif)
