### PR TITLE
MF-521: Re-order function does not move past medications to active medications

### DIFF
--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -5,6 +5,7 @@ import styles from './medications-summary.scss';
 import MedicationsDetailsTable from '../components/medications-details-table.component';
 import { useTranslation } from 'react-i18next';
 import { usePatientOrders } from '../utils/use-current-patient-orders.hook';
+import { useEffect } from 'react';
 
 export interface MedicationsSummaryProps {
   patientUuid: string;
@@ -12,9 +13,11 @@ export interface MedicationsSummaryProps {
 
 export default function MedicationsSummary({ patientUuid }: MedicationsSummaryProps) {
   const { t } = useTranslation();
-  const [activePatientOrders] = usePatientOrders(patientUuid, 'ACTIVE');
+  const [activePatientOrders,fetchActivePatientOrders] = usePatientOrders(patientUuid, 'ACTIVE');
   const [pastPatientOrders] = usePatientOrders(patientUuid, 'any');
-
+  useEffect(() => {
+    fetchActivePatientOrders();
+  });
   return (
     <>
       <h1 className={styles.productiveHeading03}>{t('medications', 'Medications')}</h1>

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -16,7 +16,7 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
   const [pastPatientOrders] = usePatientOrders(patientUuid, 'any');
   useEffect(() => {
     fetchActivePatientOrders();
-  });
+  },[activePatientOrders]);
   return (
     <>
       <h1 className={styles.productiveHeading03}>{t('medications', 'Medications')}</h1>

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -16,7 +16,7 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
   const [pastPatientOrders] = usePatientOrders(patientUuid, 'any');
   useEffect(() => {
     fetchActivePatientOrders();
-  },[activePatientOrders]);
+  }, [activePatientOrders]);
   return (
     <>
       <h1 className={styles.productiveHeading03}>{t('medications', 'Medications')}</h1>

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import DataTableSkeleton from 'carbon-components-react/es/components/DataTableSkeleton';
 import FloatingOrderBasketButton from './floating-order-basket-button.component';
 import styles from './medications-summary.scss';
 import MedicationsDetailsTable from '../components/medications-details-table.component';
 import { useTranslation } from 'react-i18next';
 import { usePatientOrders } from '../utils/use-current-patient-orders.hook';
-import { useEffect } from 'react';
 
 export interface MedicationsSummaryProps {
   patientUuid: string;
@@ -13,7 +12,7 @@ export interface MedicationsSummaryProps {
 
 export default function MedicationsSummary({ patientUuid }: MedicationsSummaryProps) {
   const { t } = useTranslation();
-  const [activePatientOrders,fetchActivePatientOrders] = usePatientOrders(patientUuid, 'ACTIVE');
+  const [activePatientOrders, fetchActivePatientOrders] = usePatientOrders(patientUuid, 'ACTIVE');
   const [pastPatientOrders] = usePatientOrders(patientUuid, 'any');
   useEffect(() => {
     fetchActivePatientOrders();


### PR DESCRIPTION
### Description
Re-order function to move past medications to active medications and display without user having to refresh the page [MF-521](https://issues.openmrs.org/browse/MF-521)