### PR TITLE
MF-700: Empty state for test results widget

### DIFF
--- a/packages/esm-patient-common-lib/src/empty-state/empty-state.component.tsx
+++ b/packages/esm-patient-common-lib/src/empty-state/empty-state.component.tsx
@@ -24,10 +24,14 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
         </Trans>
       </p>
       <p className={styles.action}>
-        {' '}
-        <Link onClick={() => props.launchForm()}>
-          {t('record', 'Record')} {props.displayText.toLowerCase()}
-        </Link>
+        {props.launchForm && (
+          <span>
+            {' '}
+            <Link onClick={() => props.launchForm()}>
+              {t('record', 'Record')} {props.displayText.toLowerCase()}
+            </Link>
+          </span>
+        )}
       </p>
     </Tile>
   );

--- a/packages/esm-patient-test-results-app/src/overview/common-overview.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.tsx
@@ -12,6 +12,7 @@ import TableCell from 'carbon-components-react/es/components/DataTable/TableCell
 import TableBody from 'carbon-components-react/es/components/DataTable/TableBody';
 import TableToolbarContent from 'carbon-components-react/es/components/DataTable/TableToolbarContent';
 import TableToolbar from 'carbon-components-react/es/components/DataTable/TableToolbar';
+import { EmptyState } from '@openmrs/esm-patient-common-lib';
 import { Card, headers, formatDate, InfoButton, Separator, TypedTableRow } from './helpers';
 import { OverviewPanelEntry, OverviewPanelData } from './useOverviewData';
 import { useTranslation } from 'react-i18next';
@@ -62,7 +63,7 @@ export const CommonDataTable: React.FC<{
 
 interface CommonOverviewPropsBase {
   overviewData: Array<OverviewPanelEntry>;
-  insertSeperator?: boolean;
+  insertSeparator?: boolean;
 }
 
 interface CommonOverviewPropsWithToolbar {
@@ -88,14 +89,15 @@ type CommonOverviewProps = CommonOverviewPropsBase &
 
 const CommonOverview: React.FC<CommonOverviewProps> = ({
   overviewData = [],
-  insertSeperator = false,
+  insertSeparator = false,
   openTimeline,
   openTrendline,
   deactivateToolbar = false,
 }) => {
   const { t } = useTranslation();
 
-  if (!overviewData.length) return <p>{t('no_tests', 'No tests found')}</p>;
+  if (!overviewData.length)
+    return <EmptyState headerTitle={t('testResults', 'Test Results')} displayText={t('testResults', 'test results')} />;
 
   return (
     <>
@@ -132,7 +134,7 @@ const CommonOverview: React.FC<CommonOverviewProps> = ({
           </Card>
         ));
 
-        if (insertSeperator)
+        if (insertSeparator)
           return cards.reduce((acc, val, i, { length }) => {
             acc.push(val);
 

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
@@ -55,8 +55,8 @@ const RecentOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }
           <CommonOverview
             {...{
               patientUuid,
-              overviewData: overViewDataResult,
-              insertSeperator: true,
+              overviewData,
+              insertSeparator: true,
               deactivateToolbar: true,
             }}
           />

--- a/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
@@ -37,7 +37,7 @@ const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, basePath }
             {...{
               patientUuid,
               overviewData: overviewData.slice(0, RECENT_COUNT),
-              insertSeperator: true,
+              insertSeparator: true,
               openTimeline: (panelUuid) => navigateToTimeline(basePath, panelUuid),
               openTrendline: (panelUuid, testUuid) => navigateToTrendline(basePath, panelUuid, testUuid),
             }}


### PR DESCRIPTION
[Ticket](https://issues.openmrs.org/browse/MF-700)

Currently, the test results widget empty state looks pretty barebones (screenshot linked).

<img width="1050" alt="Screenshot 2021-08-11 at 13 43 54" src="https://user-images.githubusercontent.com/8509731/130236279-8c5a00c6-e793-4ba9-92a2-7f99814bf5a7.png">

It can be visually enhanced and made consistent with the rest of the widgets in the patient chart by reusing the EmptyState component.

<img width="992" alt="Screenshot 2021-08-11 at 13 42 42" src="https://user-images.githubusercontent.com/8509731/130236322-6aa4ddbb-2c42-466c-a117-ea413cc5127b.png">

