### PR TITLE
MF-723: changed vitals signs  and biometric views color to match designs

### DIFF
--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
@@ -26,6 +26,12 @@
 .toggleButtons {
   width: fit-content;
   margin: 0 $spacing-03;
+  border: $spacing-01 solid $inverse-support-04;
+  border-radius: $spacing-03 $spacing-03  $spacing-03  $spacing-03;
+}
+
+.toggle:focus{
+  background-color: $focus;
 }
 
 .toggle:first-of-type {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
@@ -24,8 +24,12 @@
 .toggleButtons {
   width: fit-content;
   margin: 0 $spacing-03;
+  border: $spacing-01 solid $inverse-support-04;
+  border-radius: $spacing-03 $spacing-03  $spacing-03  $spacing-03;
 }
-
+.toggle:focus{
+  background-color: $focus;
+}
 .toggle:first-of-type {
   border-radius: $spacing-02 0 0 $spacing-02;
 }


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d5df25f3058bbcafbcd802).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Changed vitals signs and biometric views color to match designs

When you are on active view, the color is blue and not black as it is on the current view.
The inactive view is black and both views are within a blue border.

## Screenshots

![MF-723](https://user-images.githubusercontent.com/40205991/130576283-72dad855-c502-4d52-833c-f3ccee0f4b6e.png)

![MF-723-chartview](https://user-images.githubusercontent.com/40205991/130576346-c6ff98bf-86e8-4ada-8c18-438d87719b9d.png)


## Related Issue

[MF-723](https://issues.openmrs.org/browse/MF-723)



## Other

*None.*

