### PR TITLE
MF-738 : Interchanged table background color for rows to match designs

### DIFF
--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.component.tsx
@@ -97,7 +97,7 @@ const RenderBiometrics: React.FC<RenderBiometricsProps> = ({
           <BiometricsChart patientBiometrics={biometrics} conceptsUnits={conceptsUnits} />
         ) : (
           <TableContainer>
-            <DataTable rows={tableRows} headers={tableHeaders} isSortable={true} size="short">
+            <DataTable rows={tableRows} headers={tableHeaders} isSortable={true} size="short" useZebraStyles>
               {({ rows, headers, getHeaderProps, getTableProps }) => (
                 <Table {...getTableProps()}>
                   <TableHead>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -111,7 +111,7 @@ const RenderVitals: React.FC<RenderVitalsProps> = ({
           <VitalsChart patientVitals={vitals} conceptsUnits={conceptsUnits} />
         ) : (
           <TableContainer>
-            <DataTable rows={tableRows} headers={tableHeaders} isSortable={true} size="short">
+            <DataTable rows={tableRows} headers={tableHeaders} isSortable={true} size="short" useZebraStyles>
               {({ rows, headers, getHeaderProps, getTableProps }) => (
                 <Table {...getTableProps()}>
                   <TableHead>


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d5df25f3058bbcafbcd802).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Issue: [MF-738](https://issues.openmrs.org/browse/MF-738)
- Implemented a stripped table to match designs


## Screenshots

![MF-738 stripped table](https://user-images.githubusercontent.com/40205991/130590028-9ddd2457-a3d1-4a5f-b41a-51187ea149f1.png)


## Related Issue

*None.*

## Other

*None.*

