### PR TITLE
MF-738 : interchanged table background color to match design

### DIFF
--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
@@ -35,3 +35,11 @@
 .toggle:last-of-type {
   border-radius: 0 $spacing-02 $spacing-02 0;
 }
+
+.customTable tr:nth-child(odd) td {
+  background-color: #fff;
+}
+
+.customTable  tbody  tr:nth-child(even)  td {
+  background-color: #f4f4f4;
+}

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometricsPagination.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometricsPagination.component.tsx
@@ -26,9 +26,9 @@ const BiometricsPagination: React.FC<FormsProps> = ({ tableRows, pageSize, pageU
   return (
     <div>
       <TableContainer>
-        <DataTable rows={results} headers={tableHeaders} isSortable={true} size="short" useZebraStyles>
+        <DataTable rows={results} headers={tableHeaders} isSortable={true} size="short">
           {({ rows, headers, getHeaderProps, getTableProps }) => (
-            <Table {...getTableProps()}>
+            <Table {...getTableProps()} className={styles.customTable}>
               <TableHead>
                 <TableRow>
                   {headers.map((header) => (

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
@@ -38,3 +38,11 @@
   background-color: $ui-background;
   position: relative;
 }
+
+.customTable tr:nth-child(odd) td {
+  background-color: #fff;
+}
+
+.customTable  tbody  tr:nth-child(even)  td {
+  background-color: #f4f4f4;
+}

--- a/packages/esm-patient-vitals-app/src/vitals/vitalsPagination.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitalsPagination.component.tsx
@@ -32,9 +32,9 @@ const VitalsPagination: React.FC<VitalsPaginationProps> = ({
   return (
     <div>
       <TableContainer>
-        <DataTable rows={results} headers={tableHeaders} isSortable={true} size="short" useZebraStyles>
+        <DataTable rows={results} headers={tableHeaders} isSortable={true} size="short">
           {({ rows, headers, getHeaderProps, getTableProps }) => (
-            <Table {...getTableProps()}>
+            <Table {...getTableProps()} className={styles.customTable}>
               <TableHead>
                 <TableRow>
                   {headers.map((header) => (


### PR DESCRIPTION
## Requirements

- [X] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d5df25f3058bbcafbcd802).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Interchanged table background color to match design


## Screenshots
![MF-738 stripped table](https://user-images.githubusercontent.com/40205991/130839034-a2b3b73a-b2e5-4fc9-a943-f69113683ac5.png)



## Related Issue

Issue : [MF-738](https://issues.openmrs.org/browse/MF-738)


## Other

*None.*
