### PR TITLE
MF-739: Test Results widget empty state has two titles

### DIFF
--- a/packages/esm-patient-test-results-app/src/loadPatientTestData/helpers.ts
+++ b/packages/esm-patient-test-results-app/src/loadPatientTestData/helpers.ts
@@ -15,7 +15,7 @@ const retrieveFromIterator = <T>(iteratorOrIterable: IterableIterator<T>, length
   return Array.from({ length }, () => iterator.next().value);
 };
 
-const PATIEN_DATA_CACHE_SIZE = 5;
+const PATIENT_DATA_CACHE_SIZE = 5;
 let patientResultsDataCache: Record<string, [PatientData, number, string]> = {};
 
 /**
@@ -29,10 +29,10 @@ export function addUserDataToCache(patientUuid: string, data: PatientData, indic
   patientResultsDataCache[patientUuid] = [data, Date.now(), indicator];
   const currentStateEntries = Object.entries(patientResultsDataCache);
 
-  if (currentStateEntries.length > PATIEN_DATA_CACHE_SIZE) {
+  if (currentStateEntries.length > PATIENT_DATA_CACHE_SIZE) {
     currentStateEntries.sort(([, [, dateA]], [, [, dateB]]) => dateB - dateA);
 
-    patientResultsDataCache = Object.fromEntries(currentStateEntries.slice(0, PATIEN_DATA_CACHE_SIZE));
+    patientResultsDataCache = Object.fromEntries(currentStateEntries.slice(0, PATIENT_DATA_CACHE_SIZE));
   }
 }
 

--- a/packages/esm-patient-test-results-app/src/loadPatientTestData/loadPatientData.ts
+++ b/packages/esm-patient-test-results-app/src/loadPatientTestData/loadPatientData.ts
@@ -23,7 +23,7 @@ function parseSingleObsData(
         memberRefs[memb.reference.split('/')[1]] = [entry.members, i];
       });
     } else {
-      // is a singe test
+      // is a single test
       entry.meta = metaInfomation[entry.conceptClass];
     }
 
@@ -49,7 +49,7 @@ async function reloadData(patientUuid: string) {
   const metaInfomation = extractMetaInformation(testConcepts);
 
   // obs that are not panels
-  const singeEntries: ObsRecord[] = [];
+  const singleEntries: ObsRecord[] = [];
 
   // a record of observation uuids that are members of panels, mapped to the place where to put them
   const memberRefs: Record<ObsUuid, [ObsRecord[], number]> = {};
@@ -66,11 +66,11 @@ async function reloadData(patientUuid: string) {
     if (entry.members) {
       obsByClass[entry.conceptClass].push(entry);
     } else {
-      singeEntries.push(entry);
+      singleEntries.push(entry);
     }
   });
 
-  singeEntries.forEach((entry) => {
+  singleEntries.forEach((entry) => {
     const { id } = entry;
     const memRef = memberRefs[id];
 

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { ExternalOverviewProps, PanelFilterProps } from '@openmrs/esm-patient-common-lib';
+import { EmptyState, ExternalOverviewProps, PanelFilterProps } from '@openmrs/esm-patient-common-lib';
 import DataTableSkeleton from 'carbon-components-react/es/components/DataTableSkeleton';
 import { parseSingleEntry, OverviewPanelEntry } from './useOverviewData';
 import { RecentResultsGrid, Card } from './helpers';
@@ -34,6 +34,7 @@ function useFilteredOverviewData(patientUuid: string, filter: (filterProps: Pane
 
 const RecentOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }) => {
   const { t } = useTranslation();
+  const cardTitle = t('recentResults', 'Recent Results');
   const { overviewData, loaded, error } = useFilteredOverviewData(patientUuid, filter);
 
   const overViewDataResult = useMemo(() => overviewData?.splice(0, 2), [overviewData]);
@@ -45,22 +46,36 @@ const RecentOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }
   return (
     <RecentResultsGrid>
       {loaded ? (
-        <div>
-          <div className={styles.externalOverviewHeader}>
-            <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{t('recentResults', 'Recent Results')}</h4>
-            <Button kind="ghost" renderIcon={ArrowRight16} iconDescription="Add conditions" onClick={handleSeeAll}>
-              {t('seeAllResults', 'See all results')}
-            </Button>
-          </div>
-          <CommonOverview
-            {...{
-              patientUuid,
-              overviewData,
-              insertSeparator: true,
-              deactivateToolbar: true,
-            }}
-          />
-        </div>
+        <>
+          {(() => {
+            if (overviewData.length) {
+              return (
+                <div>
+                  <div className={styles.externalOverviewHeader}>
+                    <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{cardTitle}</h4>
+                    <Button
+                      kind="ghost"
+                      renderIcon={ArrowRight16}
+                      iconDescription="Add conditions"
+                      onClick={handleSeeAll}>
+                      {t('seeAllResults', 'See all results')}
+                    </Button>
+                  </div>
+                  <CommonOverview
+                    {...{
+                      patientUuid,
+                      overviewData,
+                      insertSeparator: true,
+                      deactivateToolbar: true,
+                    }}
+                  />
+                </div>
+              );
+            } else {
+              return <EmptyState headerTitle={cardTitle} displayText={t('recentTestResults', 'recent test results')} />;
+            }
+          })()}
+        </>
       ) : (
         <Card>
           <DataTableSkeleton columnCount={3} />

--- a/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 
 import Button from 'carbon-components-react/es/components/Button';
 import DataTableSkeleton from 'carbon-components-react/es/components/DataTableSkeleton';
+import { EmptyState } from '@openmrs/esm-patient-common-lib';
+import { useTranslation } from 'react-i18next';
 
 import useOverviewData from './useOverviewData';
 import { RecentResultsGrid, Card } from './helpers';
 import styles from './lab-results.scss';
 import CommonOverview from './common-overview';
 import { navigateToResults, navigateToTimeline, navigateToTrendline } from '../helpers';
-import { useTranslation } from 'react-i18next';
 
 const RECENT_COUNT = 2;
 
@@ -19,29 +20,40 @@ interface RecentOverviewProps {
 
 const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, basePath }) => {
   const { t } = useTranslation();
+  const cardTitle = t('recentResults', 'Recent Results');
   const { overviewData, loaded, error } = useOverviewData(patientUuid);
 
   return (
     <RecentResultsGrid>
       {loaded ? (
         <>
-          <div className={styles['recent-overview-header-container']}>
-            <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
-              {t('recent_results', 'Recent Results')} ({Math.min(RECENT_COUNT, overviewData.length)})
-            </h4>
-            <Button kind="ghost" onClick={() => navigateToResults(basePath)}>
-              {t('all_results', 'All results')}
-            </Button>
-          </div>
-          <CommonOverview
-            {...{
-              patientUuid,
-              overviewData: overviewData.slice(0, RECENT_COUNT),
-              insertSeparator: true,
-              openTimeline: (panelUuid) => navigateToTimeline(basePath, panelUuid),
-              openTrendline: (panelUuid, testUuid) => navigateToTrendline(basePath, panelUuid, testUuid),
-            }}
-          />
+          {(() => {
+            if (overviewData.length) {
+              return (
+                <div>
+                  <div className={styles['recent-overview-header-container']}>
+                    <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
+                      {cardTitle} ({Math.min(RECENT_COUNT, overviewData.length)})
+                    </h4>
+                    <Button kind="ghost" onClick={() => navigateToResults(basePath)}>
+                      {t('all_results', 'All results')}
+                    </Button>
+                  </div>
+                  <CommonOverview
+                    {...{
+                      patientUuid,
+                      overviewData: overviewData.slice(0, RECENT_COUNT),
+                      insertSeparator: true,
+                      openTimeline: (panelUuid) => navigateToTimeline(basePath, panelUuid),
+                      openTrendline: (panelUuid, testUuid) => navigateToTrendline(basePath, panelUuid, testUuid),
+                    }}
+                  />
+                </div>
+              );
+            } else {
+              return <EmptyState headerTitle={cardTitle} displayText={t('recentTestResults', 'recent test results')} />;
+            }
+          })()}
         </>
       ) : (
         <Card>


### PR DESCRIPTION
Recent work on the empty state for the Test Results widget led to a situation where the widget card has two header titles (screenshot below).

![image-2021-08-20-11-50-47-850](https://user-images.githubusercontent.com/8509731/130780133-f4042c6a-ab46-4946-b9c5-3a1a670f8fb7.png)

This PR modifies the widget so that it has just one title that reads:

- `Recent Results` for the Recent Results overview.
- `Test Results` for the Test Results overview.

<img width="795" alt="Screenshot 2021-08-25 at 13 57 18" src="https://user-images.githubusercontent.com/8509731/130779461-02f3bead-f98e-40ef-a6bb-51df84578e9a.png">

<img width="631" alt="Screenshot 2021-08-25 at 13 57 04" src="https://user-images.githubusercontent.com/8509731/130779445-bc6bdded-7c3e-4ce0-a769-2b4f218ee6bc.png">

It also adds some grammatical fixes to related bits of code.



