### PR TITLE
MF-685: Red dot for in-progress item when workspace item is closed

### DIFF
--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.scss
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.scss
@@ -1,3 +1,7 @@
+@import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
+@import "../root.scss";
+
 $icon-button-size: 48px;
 $actionPanelOffset: 48px;
 
@@ -33,7 +37,7 @@ $actionPanelOffset: 48px;
   padding: 0.625rem;
   border-radius: 24px;
   border-radius: 50%;
-  border: solid 6px #007d79;
+  border: solid 4px #007d79;
   background-color: #ffffff;
 }
 
@@ -45,9 +49,10 @@ $actionPanelOffset: 48px;
   bottom: 3rem;
   right: 2rem;
 
-  width: 3rem;
+  width: fit-content;
+  padding: 0.625rem;
   height: 3rem;
-  border-radius: 50%;
+  border-radius: 1.75rem;
   border-color: transparent;
 
   color: #fff;
@@ -57,4 +62,42 @@ $actionPanelOffset: 48px;
   padding-top: 0.325rem;
   cursor: pointer;
   position: fixed;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  
+}
+
+.actionBtn > div {
+  margin-right: 0.25rem;
+  height: 40px;
+  width: 36px;
+  padding: 0.625rem;
+  position: relative;
+}
+
+.actionBtn > span {
+  @extend .productiveHeading01;
+}
+
+:global(.omrs-breakpoint-gt-tablet) .warningButton {
+  position: absolute;
+  top: 0;
+  right: 0;
+  fill: $danger !important;
+}
+
+
+:global(.omrs-breakpoint-lt-desktop) .warningButton {
+  position: absolute;
+  top: 0;
+  right: 0;
+  fill: $danger !important;
+}
+
+:global(.omrs-breakpoint-lt-desktop) .warningButton [data-icon-path="inner-path"] {
+  fill: white !important;
+  opacity: 1;
 }

--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
@@ -3,11 +3,13 @@ import { ExtensionSlot, useLayoutType } from '@openmrs/esm-framework';
 import { HeaderPanel } from 'carbon-components-react/es/components/UIShell';
 import { isDesktop } from '../utils';
 import Edit20 from '@carbon/icons-react/es/edit/20';
-import Document20 from '@carbon/icons-react/es/document/20';
+import DocumentBlank20 from '@carbon/icons-react/es/document--blank/20';
+import WarningFilled16 from '@carbon/icons-react/es/warning--filled/16';
 import styles from './action-menu.component.scss';
 import Button from 'carbon-components-react/es/components/Button';
 import { useContextWorkspace } from '../hooks/useContextWindowSize';
 import { useWorkspace } from '../hooks/useWorkspace';
+import { useTranslation } from 'react-i18next';
 
 interface ActionMenuInterface {
   open: boolean;
@@ -17,9 +19,10 @@ export const CHARTS_DRAWER_SLOT = 'drawer-slot';
 export const CHARTS_ACTION_MENU_ITEMS_SLOT = 'action-menu-items-slot';
 
 export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
+  const { t } = useTranslation();
   const layout = useLayoutType();
   const { screenMode } = useWorkspace();
-  const { openWindows, updateWindowSize } = useContextWorkspace();
+  const { openWindows, updateWindowSize, windowSize } = useContextWorkspace();
 
   const checkViewMode = () => {
     if (screenMode === 'maximize') {
@@ -38,13 +41,19 @@ export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
         className={`${styles.iconButton} ${openWindows > 0 && styles.activeIconButton} `}
         kind="ghost"
         hasIconOnly>
-        <Document20 />
+        <div>
+          <DocumentBlank20 /> {windowSize.size === 'hide' && <WarningFilled16 className={styles.warningButton} />}
+        </div>
       </Button>
     </aside>
   ) : (
-    <button className={styles.actionBtn}>
-      <Edit20 />
-    </button>
+    <Button className={styles.actionBtn}>
+      <div>
+        <Edit20 />
+        {windowSize.size === 'hide' && <WarningFilled16 className={styles.warningButton} />}
+      </div>
+      <span>{t('careActivities', 'Care Activities')}</span>
+    </Button>
   );
 
   return (


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Add Red dot for in-progress item when workspace item is closed


## Screenshots
![MF-685](https://user-images.githubusercontent.com/28008754/131402797-f96b77a7-f8ee-434c-811a-a116372bbfd3.gif)



## Related Issue

*None.*
<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
