### PR TITLE
MF-759 Rename Change button on patient photo to Add image if photo is missing

### DIFF
--- a/packages/esm-patient-attachments-app/src/attachments/capture-photo.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/capture-photo.component.tsx
@@ -30,7 +30,7 @@ const CapturePhoto: React.FC<CapturePhotoProps> = ({ initialState, onCapturePhot
         <img src={dataUri || initialState || placeholder} alt="Preview" style={{ width: '100%' }} />
       </div>
       <Button kind="ghost" onClick={showCam} style={{ flex: 1 }}>
-        {t('change', 'Change')}
+        {initialState ? t('changeImage', 'Change image') : t('addImage', 'Add image +')}
       </Button>
     </div>
   );


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).
## Summary

- Renamed change button to "Add image" when image is not added and "change image" when image has been added.

## Screenshots
No image.
![No Image](https://user-images.githubusercontent.com/83347293/131477136-fb1c25c2-360f-488e-8f4b-317d4ef78d9c.png)
When there is an image.
![When there is an image](https://user-images.githubusercontent.com/83347293/131477147-30b216f2-2bfc-4f8a-8950-c0cdba35adda.png)

