### PR TITLE
MF-745: Tablet mode - Unwrap breadcrumbs in patient chart widgets

### DIFF
--- a/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.scss
+++ b/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.scss
@@ -64,3 +64,7 @@ $actionPanelExpandedOffset: $actionNavOffset+$actionPanelOffset;
 .activeWorkspace {
   padding-right: $actionNavOffset;
 }
+
+.breadcrumbs nav ol li{
+  display: inline-flex;
+}

--- a/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.tsx
@@ -37,7 +37,7 @@ const PatientChart: React.FC<RouteComponentProps<PatientChartParams>> = ({ match
             className={`${styles.innerChartContainer} ${
               windowSize.size === 'normal' && openWindows > 0 ? styles.closeWorkspace : styles.activeWorkspace
             }`}>
-            <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
+            <ExtensionSlot className={styles.breadcrumbs} extensionSlotName="breadcrumbs-slot" />
             <aside>
               <ExtensionSlot extensionSlotName="patient-header-slot" state={state} />
               <ExtensionSlot extensionSlotName="patient-info-slot" state={state} />


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d5e84db8dbd2bd64035bf6).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Tablet mode - Unwrap breadcrumbs in patient chart widgets


## Screenshots

![MF-745](https://user-images.githubusercontent.com/40205991/131505318-6de704f1-bbcd-4599-907d-04702b94addf.png)


## Related Issue

Issue: [MF-745](https://issues.openmrs.org/browse/MF-745)


## Other

*None.*

