### PR TITLE
MF-755 : Lab Results Showing under wrong Panel in Summary Widget

### DIFF
--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { EmptyState, ExternalOverviewProps, PanelFilterProps } from '@openmrs/esm-patient-common-lib';
 import DataTableSkeleton from 'carbon-components-react/es/components/DataTableSkeleton';
-import { parseSingleEntry, OverviewPanelEntry } from './useOverviewData';
+import useOverviewData, { parseSingleEntry, OverviewPanelEntry } from './useOverviewData';
 import { RecentResultsGrid, Card } from './helpers';
 import CommonOverview from './common-overview';
 import usePatientResultsData from '../loadPatientTestData/usePatientResultsData';
@@ -10,6 +10,8 @@ import { useTranslation } from 'react-i18next';
 import Button from 'carbon-components-react/es/components/Button';
 import ArrowRight16 from '@carbon/icons-react/es/arrow--right/16';
 import { navigate } from '@openmrs/esm-framework';
+
+const resultsToShow = 5;
 
 function useFilteredOverviewData(patientUuid: string, filter: (filterProps: PanelFilterProps) => boolean = () => true) {
   const { sortedObs, loaded, error } = usePatientResultsData(patientUuid);
@@ -35,9 +37,7 @@ function useFilteredOverviewData(patientUuid: string, filter: (filterProps: Pane
 const RecentOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }) => {
   const { t } = useTranslation();
   const cardTitle = t('recentResults', 'Recent Results');
-  const { overviewData, loaded, error } = useFilteredOverviewData(patientUuid, filter);
-
-  const overViewDataResult = useMemo(() => overviewData?.splice(0, 2), [overviewData]);
+  const { overviewData, loaded, error } = useOverviewData(patientUuid);
 
   const handleSeeAll = useCallback(() => {
     navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/chart/test-results` });
@@ -64,11 +64,17 @@ const RecentOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }
                   <CommonOverview
                     {...{
                       patientUuid,
-                      overviewData,
+                      overviewData: overviewData.slice(0, resultsToShow),
                       insertSeparator: true,
                       deactivateToolbar: true,
+                      isPatientSummaryDashboard: true,
                     }}
                   />
+                  {overviewData.length > resultsToShow && (
+                    <Button onClick={handleSeeAll} kind="ghost">
+                      {t('moreResultsAvailable', 'More results available')}
+                    </Button>
+                  )}
                 </div>
               );
             } else {


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

1. Fixes issue where the `external-overview` and `patient-summary-dashboard` test results showed different sets of data.
2. Limit the number of results show on patient-summary-dashboard to top five only and add button to navigate to details on test-results. In addition each test-result panel on patient-summary-dashboard should only display the top five results, and in the event more results are available  display `More results are available` button to test-results


## Screenshots

![MF-755](https://user-images.githubusercontent.com/28008754/131656744-c21f2542-e423-49bd-ac1b-a0b23426cf7d.gif)



## Related Issue

[MF-684 -ticket](https://issues.openmrs.org/projects/MF/issues/MF-684?filter=myopenissues)


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->