### PR TITLE
MF-608 start visit button open Start visit Form

### DIFF
--- a/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useVisit } from '@openmrs/esm-framework';
+import { attach, useVisit } from '@openmrs/esm-framework';
 
 interface StartVisitOverflowMenuItemProps {
   patientUuid: string;
@@ -9,18 +9,9 @@ interface StartVisitOverflowMenuItemProps {
 const StartVisitOverflowMenuItem: React.FC<StartVisitOverflowMenuItemProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const { currentVisit } = useVisit(patientUuid);
-  const handleClick = React.useCallback(
-    () =>
-      window.dispatchEvent(
-        new CustomEvent('visit-dialog', {
-          detail: {
-            type: 'prompt',
-            state: { type: 'start' },
-          },
-        }),
-      ),
-    [],
-  );
+  const handleClick = React.useCallback(() => {
+    attach('patient-chart-workspace-slot', 'start-visit-workspace-form');
+  }, []);
 
   return (
     !currentVisit && (


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).
## Summary
- Issue [MF-608](https://issues.openmrs.org/browse/MF-608)
- Made the start Visit to open the Form - It currently opens the modal then the "Start New Visit"  button in the modal opens the Form.
