### PR TITLE
MF-763 Enhance vitals and biometrics chart to match designs

### DIFF
--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-chart.component.scss
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-chart.component.scss
@@ -58,9 +58,9 @@
   text-indent: 5rem;
 }
 
-.tab>button,
-.tab>button:focus,
-.tab>button:active {
+.tab > button,
+.tab > button:focus,
+.tab >  button:active {
   outline: 0 !important;
   outline-offset: 0 !important;
 }

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-chart.component.scss
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-chart.component.scss
@@ -41,8 +41,47 @@
   width: 7.063rem;
 }
 
-.biometricSignsRadioButton {
-  @extend .bodyShort01;
-  color: $ui-05;
-  padding: $spacing-03 0;
+.verticalTabs {
+  margin: 1rem 0;
+  scroll-behavior: smooth;
+}
+
+.verticalTabs > ul {
+  flex-direction: column !important;
+}
+
+.tab:hover {
+  border-bottom: none !important;
+}
+
+.tab > button:first {
+  text-indent: 5rem;
+}
+
+.tab>button,
+.tab>button:focus,
+.tab>button:active {
+  outline: 0 !important;
+  outline-offset: 0 !important;
+}
+
+.selectedTab > button {
+  border-left: 2px solid $brand-teal-01 !important;
+  border-bottom: 0 !important;
+  font-weight: 600 !important;
+}
+
+.tabContent {
+  border-top: 1px solid $ui-03;
+  padding: 1rem 0;
+  width: 10rem;
+}
+
+:global(.bx--tabs--scrollable .bx--tabs--scrollable__nav-item+.bx--tabs--scrollable__nav-item) {
+  margin-left: 0rem;
+}
+
+:global(.bx--tabs--scrollable .bx--tabs--scrollable__nav-link) {
+  border-bottom: 0 !important;
+  border-left: 2px solid $color-gray-30;
 }

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-chart.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import dayjs from 'dayjs';
-import RadioButton from 'carbon-components-react/es/components/RadioButton';
-import RadioButtonGroup from 'carbon-components-react/es/components/RadioButtonGroup';
+import Tab from 'carbon-components-react/es/components/Tab';
+import Tabs from 'carbon-components-react/es/components/Tabs';
 import styles from './biometrics-chart.component.scss';
 import { LineChart } from '@carbon/charts-react';
 import { LineChartOptions } from '@carbon/charts/interfaces/charts';
@@ -75,23 +75,16 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
         <label className={styles.biometricSign} htmlFor="biometrics-chart-radio-group">
           Biometric Displayed
         </label>
-        <RadioButtonGroup
-          defaultSelected="weight"
-          name="biometrics-chart-radio-group"
-          valueSelected="weight"
-          orientation="vertical"
-          labelPosition="right">
+        <Tabs className={styles.verticalTabs} type="default">
           {[
             { id: 'weight', label: `Weight (${weightUnit})` },
             { id: 'height', label: `Height (${heightUnit})` },
             { id: 'bmi', label: `BMI (${bmiUnit})` },
           ].map(({ id, label }) => (
-            <RadioButton
-              key={id}
-              id={id}
-              labelText={label}
-              value={id}
-              className={styles.biometricSignsRadioButton}
+            <Tab
+              className={`${styles.tab} ${styles.bodyLong01} ${
+                selectedBiometrics.title === label && styles.selectedTab
+              }`}
               onClick={() =>
                 setSelectedBiometrics({
                   title: label,
@@ -99,9 +92,10 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
                   groupName: id,
                 })
               }
+              label={label}
             />
           ))}
-        </RadioButtonGroup>
+        </Tabs>
       </div>
       <div className={styles.biometricChartArea}>
         <LineChart data={chartData} options={chartOptions} />

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.scss
@@ -30,7 +30,7 @@
 .vitalsChartArea {
   padding: $spacing-03 $spacing-05;
   width: 100%;
-  height: 13.875rem;
+  height: 17.875rem;
 }
 
 .vitalsSign {
@@ -39,8 +39,47 @@
   width: 7.063rem;
 }
 
-.vitalsSignsRadioButton {
-  @extend .bodyShort01;
-  color: $ui-05;
-  padding: $spacing-03 0;
+.verticalTabs {
+  margin: 1rem 0;
+  scroll-behavior: smooth;
+}
+
+.verticalTabs > ul {
+  flex-direction: column !important;
+}
+
+.tab:hover {
+  border-bottom: none !important;
+}
+
+.tab > button:first {
+  text-indent: 5rem;
+}
+
+.tab > button, 
+.tab > button:focus, 
+.tab > button:active {
+  outline: 0 !important;
+  outline-offset: 0 !important;
+}
+
+.selectedTab > button {
+  border-left: 2px solid $brand-teal-01 !important;
+  border-bottom: 0 !important;
+  font-weight: 600 !important;
+}
+
+.tabContent {
+  border-top: 1px solid $ui-03;
+  padding: 1rem 0;
+  width: 10rem;
+}
+
+:global(.bx--tabs--scrollable .bx--tabs--scrollable__nav-item+.bx--tabs--scrollable__nav-item) {
+  margin-left: 0rem;
+}
+
+:global(.bx--tabs--scrollable .bx--tabs--scrollable__nav-link) {
+  border-bottom: 0 !important;
+  border-left: 2px solid $color-gray-30;
 }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import styles from './vitals-chart.component.scss';
-import RadioButton from 'carbon-components-react/es/components/RadioButton';
-import RadioButtonGroup from 'carbon-components-react/es/components/RadioButtonGroup';
+import Tab from 'carbon-components-react/es/components/Tab';
+import Tabs from 'carbon-components-react/es/components/Tabs';
 import { withUnit } from './vitals-biometrics-form/use-vitalsigns';
 import { PatientVitals } from './vitals-biometrics.resource';
 import { LineChart } from '@carbon/charts-react';
@@ -26,7 +26,7 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptsUnits 
   const [chartData, setChartData] = React.useState([]);
   const [bloodPressureUnit, , temperatureUnit, , , pulseUnit, oxygenSaturationUnit, , respiratoryRateUnit] =
     conceptsUnits;
-  const [selectedVitalSign, setSelecteVitalsSign] = React.useState<vitalsChartData>({
+  const [selectedVitalSign, setSelectedVitalsSign] = React.useState<vitalsChartData>({
     title: `BP (${bloodPressureUnit})`,
     value: 'systolic',
   });
@@ -105,31 +105,28 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptsUnits 
   return (
     <div className={styles.vitalsChartContainer}>
       <div className={styles.vitalSignsArea} style={{ flex: 1 }}>
-        <label className={styles.vitalsSign} htmlFor="radio-button-group">
+        <label className={styles.vitalsSign} htmlFor="vitals-chart-tab-group">
           {t('vitalSignDisplayed', 'Vital Sign Displayed')}
         </label>
-        <RadioButtonGroup
-          defaultSelected="bloodPressure"
-          name="radio-button-group"
-          valueSelected="systolic"
-          orientation="vertical"
-          labelPosition="right">
-          {vitalSigns.map(({ id, title, value }) => (
-            <RadioButton
-              key={id}
-              id={id}
-              labelText={title}
-              value={value}
-              className={styles.vitalsSignsRadioButton}
-              onClick={() =>
-                setSelecteVitalsSign({
-                  title: title,
-                  value: value,
-                })
-              }
-            />
-          ))}
-        </RadioButtonGroup>
+        <Tabs className={styles.verticalTabs} type="default">
+          {vitalSigns.map(({ id, title, value }) => {
+            return (
+              <Tab
+                key={id}
+                className={`${styles.tab} ${styles.bodyLong01} ${
+                  selectedVitalSign.title === title && styles.selectedTab
+                }`}
+                onClick={() =>
+                  setSelectedVitalsSign({
+                    title: title,
+                    value: value,
+                  })
+                }
+                label={title}
+              />
+            );
+          })}
+        </Tabs>
       </div>
       <div className={styles.vitalsChartArea} style={{ flex: 4 }}>
         <LineChart data={chartData} options={chartOptions} />


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

- This PR updates radio buttons found under vitals and biometrics to vertical tabs to match the designs

## Screenshots

![Vitals and Biometrics Tabs](https://user-images.githubusercontent.com/67265839/131845603-def4231e-d494-4d95-9aea-cbad22e543d7.gif)


## Related Issue
Issue [MF-763](https://issues.openmrs.org/browse/MF-763)