### PR TITLE
Remove duplicate `Date enrolled` form label

### DIFF
--- a/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
@@ -247,7 +247,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ patientUuid, isTablet }) =>
           placeholder="dd/mm/yyyy"
           onChange={([date]) => setEnrollmentDate(date)}
           value={enrollmentDate}>
-          <DatePickerInput id="enrollmentDateInput" labelText={t('dateEnrolled', 'Date enrolled')} />
+          <DatePickerInput id="enrollmentDateInput" labelText="" />
         </DatePicker>
       </FormGroup>
       <FormGroup legendText={t('dateCompleted', 'Date completed')}>


### PR DESCRIPTION
A recent change to the ProgramsForm component test suite involved mistakenly adding a superfluous label to
the `Date enrolled` date picker input (see screenshot below). This commit removes that label.

<img width="856" alt="Screenshot 2021-09-04 at 19 00 16" src="https://user-images.githubusercontent.com/8509731/132101102-606ce1c5-156e-4779-a06e-423c2d1cd51e.png">
