### PR TITLE
MF-751 Closing workspace using Forms Icon

### DIFF
--- a/packages/esm-patient-chart-app/src/hooks/useContextWindowSize.tsx
+++ b/packages/esm-patient-chart-app/src/hooks/useContextWindowSize.tsx
@@ -2,19 +2,19 @@ import { useAssignedExtensionIds } from '@openmrs/esm-framework';
 import React, { createContext, useContext, useMemo, useEffect, useCallback } from 'react';
 import { patientChartWorkspaceSlot } from '../constants';
 import { useWorkspace } from '../hooks/useWorkspace';
+import { ScreenModeTypes } from '../types';
 
 interface WindowSize {
   size: string;
 }
-type ActionTypes = 'minimize' | 'maximize' | 'hide' | 'reopen' | string;
 
 interface ContextWindowSizeContextShape {
   windowSize: WindowSize;
-  updateWindowSize?(value: ActionTypes): any;
+  updateWindowSize?(value: ScreenModeTypes): any;
   openWindows: number;
 }
 
-const reducer = (state: WindowSize, action: ActionTypes) => {
+const reducer = (state: WindowSize, action: ScreenModeTypes) => {
   switch (action) {
     case 'maximize':
       return { size: 'maximize' };
@@ -51,7 +51,7 @@ export const ContextWindowSizeProvider: React.FC = ({ children }) => {
     }
   }, [extensions.length, screenMode]);
 
-  const updateWindowSize = useCallback((action: ActionTypes) => {
+  const updateWindowSize = useCallback((action: ScreenModeTypes) => {
     updateContextWorkspaceWindowSize(action);
   }, []);
 

--- a/packages/esm-patient-chart-app/src/hooks/useContextWindowSize.tsx
+++ b/packages/esm-patient-chart-app/src/hooks/useContextWindowSize.tsx
@@ -6,7 +6,7 @@ import { useWorkspace } from '../hooks/useWorkspace';
 interface WindowSize {
   size: string;
 }
-type ActionTypes = 'minimize' | 'maximize' | 'hide' | 'reopen';
+type ActionTypes = 'minimize' | 'maximize' | 'hide' | 'reopen' | string;
 
 interface ContextWindowSizeContextShape {
   windowSize: WindowSize;

--- a/packages/esm-patient-chart-app/src/hooks/useWorkspace.tsx
+++ b/packages/esm-patient-chart-app/src/hooks/useWorkspace.tsx
@@ -2,11 +2,12 @@ import { useCallback, useMemo } from 'react';
 import { detachAll, extensionStore, useAssignedExtensionIds } from '@openmrs/esm-framework';
 import { patientChartWorkspaceSlot } from '../constants';
 import { getTitle, checkScreenMode } from '../utils';
+import { ScreenModeTypes } from '../types';
 
 export interface WorkspaceState {
   title: string;
   active: boolean;
-  screenMode: string;
+  screenMode: ScreenModeTypes;
 }
 
 export interface WorkspaceDetails extends WorkspaceState {
@@ -30,12 +31,10 @@ export function useWorkspace(): WorkspaceDetails {
 
   const screenMode = useMemo(() => {
     if (extensions.length === 0) {
-      return '';
+      return 'hide';
     } else if (extensions.length === 1) {
       const state = extensionStore.getState();
       return checkScreenMode(state.extensions[extensions[0]]);
-    } else {
-      return `Workspaces (${extensions.length})`;
     }
   }, [extensions]);
 

--- a/packages/esm-patient-chart-app/src/types/index.ts
+++ b/packages/esm-patient-chart-app/src/types/index.ts
@@ -1,0 +1,1 @@
+export type ScreenModeTypes = 'minimize' | 'maximize' | 'hide' | 'reopen';

--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
@@ -25,11 +25,11 @@ export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
   const { openWindows, updateWindowSize, windowSize } = useContextWorkspace();
 
   const checkViewMode = () => {
-    if (screenMode === 'maximize') {
-      updateWindowSize('maximize');
-    } else {
-      updateWindowSize('reopen');
-    }
+    if (windowSize.size === 'maximize') {
+      updateWindowSize('hide');
+    } else if (windowSize.size === 'normal') {
+      updateWindowSize('hide');
+    } else updateWindowSize(screenMode ?? 'reopen');
   };
 
   const menu = isDesktop(layout) ? (

--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
@@ -32,7 +32,7 @@ export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
       } else if (windowSize.size === 'normal') {
         updateWindowSize('hide');
       } else {
-        updateWindowSize((screenMode as ScreenModeTypes) ?? 'reopen');
+        updateWindowSize(screenMode);
       }
     }
   };

--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
@@ -10,6 +10,7 @@ import Button from 'carbon-components-react/es/components/Button';
 import { useContextWorkspace } from '../hooks/useContextWindowSize';
 import { useWorkspace } from '../hooks/useWorkspace';
 import { useTranslation } from 'react-i18next';
+import { ScreenModeTypes } from '../types';
 
 interface ActionMenuInterface {
   open: boolean;
@@ -21,15 +22,19 @@ export const CHARTS_ACTION_MENU_ITEMS_SLOT = 'action-menu-items-slot';
 export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
   const { t } = useTranslation();
   const layout = useLayoutType();
-  const { screenMode } = useWorkspace();
+  const { screenMode, active } = useWorkspace();
   const { openWindows, updateWindowSize, windowSize } = useContextWorkspace();
 
   const checkViewMode = () => {
-    if (windowSize.size === 'maximize') {
-      updateWindowSize('hide');
-    } else if (windowSize.size === 'normal') {
-      updateWindowSize('hide');
-    } else updateWindowSize(screenMode ?? 'reopen');
+    if (active) {
+      if (windowSize.size === 'maximize') {
+        updateWindowSize('hide');
+      } else if (windowSize.size === 'normal') {
+        updateWindowSize('hide');
+      } else {
+        updateWindowSize((screenMode as ScreenModeTypes) ?? 'reopen');
+      }
+    }
   };
 
   const menu = isDesktop(layout) ? (

--- a/packages/esm-patient-chart-app/src/utils.ts
+++ b/packages/esm-patient-chart-app/src/utils.ts
@@ -1,4 +1,5 @@
 import { ExtensionInfo, LayoutType, translateFrom } from '@openmrs/esm-framework';
+import { ScreenModeTypes } from './types';
 
 export function isDesktop(layout: LayoutType) {
   return layout === 'desktop';
@@ -16,14 +17,11 @@ export function getTitle(ext: ExtensionInfo) {
   return ext.name;
 }
 
-export function checkScreenMode(ext: ExtensionInfo) {
-  const screenMode = ext.meta?.screenSize;
+export function checkScreenMode(ext: ExtensionInfo): ScreenModeTypes {
+  const screenMode: ScreenModeTypes = ext.meta?.screenSize;
 
   if (typeof screenMode === 'string') {
     return screenMode;
-  } else if (screenMode && typeof screenMode === 'object') {
-    return translateFrom(ext.moduleName, screenMode.key, screenMode.default);
   }
-
   return 'minimize';
 }


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).
## Summary

- On clicking the Forms icon when the workspace is open collapses the workspace.
