### PR TITLE
Patient chart summary UI enhancements

### DIFF
--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -17,7 +17,7 @@ const dashboardMeta = {
   name: 'summary',
   slot: 'patient-chart-summary-dashboard-slot',
   config: { columns: 4, type: 'grid' },
-  title: 'Summary',
+  title: 'Patient Summary',
 };
 
 function setupOpenMRS() {

--- a/packages/esm-patient-chart-app/src/view-components/chart-review.component.tsx
+++ b/packages/esm-patient-chart-app/src/view-components/chart-review.component.tsx
@@ -6,6 +6,7 @@ import { Redirect } from 'react-router-dom';
 import { useExtensionSlotMeta } from '@openmrs/esm-framework';
 import { DashboardConfig } from '../config-schemas';
 import { basePath } from '../constants';
+import styles from './chart-review.scss';
 
 function makePath(target: DashboardConfig, params: Record<string, string> = {}) {
   const parts = `${basePath}/${target.name}/:subview?`.split('/');
@@ -47,13 +48,16 @@ const ChartReview: React.FC<ChartReviewProps> = ({ patientUuid, patient, view, s
     );
   } else if (dashboard.config.type === 'grid') {
     return (
-      <GridView
-        slot={dashboard.slot}
-        layout={dashboard.config}
-        name={dashboard.name}
-        patient={patient}
-        patientUuid={patientUuid}
-      />
+      <>
+        {dashboard.title && <h1 className={styles.dashboardTitle}>{dashboard.title}</h1>}
+        <GridView
+          slot={dashboard.slot}
+          layout={dashboard.config}
+          name={dashboard.name}
+          patient={patient}
+          patientUuid={patientUuid}
+        />
+      </>
     );
   } else if (dashboard.config.type === 'tabs') {
     return (

--- a/packages/esm-patient-chart-app/src/view-components/chart-review.scss
+++ b/packages/esm-patient-chart-app/src/view-components/chart-review.scss
@@ -1,0 +1,8 @@
+@import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
+@import "../root.scss";
+
+.dashboardTitle {
+  @include carbon--type-style("productive-heading-03");
+  margin: 1rem 0rem 1rem 1.3125rem;
+}

--- a/packages/esm-patient-chart-app/src/view-components/chart-review.test.tsx
+++ b/packages/esm-patient-chart-app/src/view-components/chart-review.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import { mockPatient } from '../../../../__mocks__/patient.mock';
+import { extensionStore, useAssignedExtensionIds, useExtensionSlotMeta } from '@openmrs/esm-framework';
+import ChartReview from './chart-review.component';
+
+const mockUseAssignedExtensionIds = useAssignedExtensionIds as jest.Mock;
+const mockUseExtensionSlotMeta = useExtensionSlotMeta as jest.Mock;
+
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+
+  return {
+    ...originalModule,
+    useAssignedExtensionIds: jest.fn(),
+    useExtensionSlotMeta: jest.fn(),
+  };
+});
+
+jest.mock('react-router-dom', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+
+  return {
+    ...originalModule,
+    Redirect: jest.fn(),
+    useRouteMatch: jest.fn().mockReturnValue({
+      url: '/patient/8673ee4f-e2ab-4077-ba55-4980f408773e/chart',
+    }),
+  };
+});
+
+const tabBasedDashboards = {
+  'results-summary-dashboard': {
+    name: 'vitalsAndBiometrics',
+    slot: 'patient-chart-results-dashboard-slot',
+    config: {
+      type: 'tabs',
+    },
+    title: 'Vitals & Biometrics',
+  },
+};
+
+const gridBasedDashboards = {
+  'charts-summary-dashboard': {
+    name: 'summary',
+    slot: 'patient-chart-summary-dashboard-slot',
+    config: {
+      columns: 4,
+      type: 'grid',
+    },
+    title: 'Patient Summary',
+  },
+  'test-results-summary-dashboard': {
+    name: 'test-results',
+    slot: 'patient-chart-test-results-dashboard-slot',
+    config: {
+      columns: 1,
+      type: 'grid',
+    },
+    title: 'Test Results',
+  },
+};
+
+const testProps = {
+  patient: mockPatient,
+  patientUuid: mockPatient.id,
+  subview: undefined,
+  view: 'summary',
+};
+
+describe('ChartReview: ', () => {
+  test(`renders a grid-based layout if the provided config's layout type value is 'grid'`, () => {
+    mockUseExtensionSlotMeta.mockReturnValue(gridBasedDashboards);
+
+    renderChartReview();
+
+    expect(screen.getByRole('heading').textContent).toMatch(/Patient summary/i);
+  });
+
+  test(`renders a tabs-based layout if the provided config's layout type value is 'tabs'`, () => {
+    testProps.subview = 'vitals';
+    testProps.view = 'vitalsAndBiometrics';
+
+    jest.spyOn(extensionStore, 'getState').mockReturnValue({
+      extensions: {
+        'biometrics-details-widget': {
+          instances: {},
+          load: jest.fn(),
+          meta: { view: 'biometrics', title: 'Biometrics' },
+          moduleName: '@openmrs/esm-patient-biometrics-app',
+          name: 'biometrics-details-widget',
+        },
+        'vitals-details-widget': {
+          instances: {},
+          load: jest.fn(),
+          meta: { view: 'vitals', title: 'Vitals' },
+          moduleName: '@openmrs/esm-patient-vitals-app',
+          name: 'vitals-details-widget',
+        },
+      },
+      slots: {
+        'patient-chart-summary-dashboard-slot': {
+          name: 'patient-chart-summary-dashboard-slot',
+          attachedIds: [
+            'biometrics-overview-widget',
+            'appointments-overview-widget',
+            'forms-widget',
+            'vitals-overview-widget',
+            'immunization-overview-widget',
+            'notes-overview-widget',
+            'active-medications-widget',
+            'conditions-overview-widget',
+            'programs-overview-widget',
+            'allergies-overview-widget',
+            'test-results-summary-widget',
+            'patient-clinical-view-overview',
+          ],
+          instances: {},
+        },
+      },
+    });
+    mockUseAssignedExtensionIds.mockReturnValue(['vitals-details-widget', 'biometrics-details-widget']);
+    mockUseExtensionSlotMeta.mockReturnValue(tabBasedDashboards);
+
+    renderChartReview();
+
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem').length).toEqual(2);
+    expect(screen.getByRole('button', { name: /vitals/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /biometrics/i })).toBeInTheDocument();
+  });
+});
+
+function renderChartReview() {
+  render(<ChartReview {...testProps} />);
+}

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.scss
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.scss
@@ -10,6 +10,14 @@
   background-color: $ui-background;
 }
 
+.immunizationsHeader > h4:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}
+
 .immunizationOverviewSummaryCard {
   margin: 1.25rem 1.5rem;
 }

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -118,7 +118,7 @@ const MedicationsDetailsTable = connect<
     return (
       <DataTable headers={tableHeaders} rows={tableRows} isSortable={true} sortRow={sortRow}>
         {({ rows, headers, getTableProps, getHeaderProps, getRowProps }) => (
-          <TableContainer title={title}>
+          <TableContainer className={styles.tableHeader} title={title}>
             {showAddNewButton && (
               <TableToolbar>
                 <TableToolbarContent>

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.scss
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.scss
@@ -1,1 +1,9 @@
 @import "../root";
+
+.tableHeader > :global(.bx--data-table-header) > h4:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import DataTableSkeleton from 'carbon-components-react/es/components/DataTableSkeleton';
 import FloatingOrderBasketButton from './floating-order-basket-button.component';
-import styles from './medications-summary.scss';
 import MedicationsDetailsTable from '../components/medications-details-table.component';
 import { useTranslation } from 'react-i18next';
 import { usePatientOrders } from '../utils/use-current-patient-orders.hook';
@@ -17,7 +16,6 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
 
   return (
     <>
-      <h1 className={styles.productiveHeading03}>{t('medications', 'Medications')}</h1>
       {activePatientOrders ? (
         <MedicationsDetailsTable
           title={t('activeMedications', 'Active Medications')}

--- a/packages/esm-patient-medications-app/src/medications/root-medication-summary.tsx
+++ b/packages/esm-patient-medications-app/src/medications/root-medication-summary.tsx
@@ -10,7 +10,7 @@ export interface RootMedicationSummaryProps {
 
 export default function RootMedicationSummary({ patientUuid }: RootMedicationSummaryProps) {
   return (
-    <div className={styles.resetPatientChartWidgetContainer}>
+    <div>
       <Provider store={orderBasketStore}>
         <MedicationsSummary patientUuid={patientUuid} />
       </Provider>

--- a/packages/esm-patient-medications-app/src/root.scss
+++ b/packages/esm-patient-medications-app/src/root.scss
@@ -2,12 +2,6 @@
 @import "~carbon-components/src/globals/scss/vendor/@carbon/layout/scss/generated/spacing";
 @import "~@openmrs/esm-styleguide/src/vars";
 
-.resetPatientChartWidgetContainer {
-  /* The patient chart's .widgetContainer centers text. We don't want that with Carbon. */
-  text-align: initial;
-  margin: 0 $spacing-05 $spacing-05 $spacing-05;
-}
-
 .productiveHeading01 {
   @include carbon--type-style("productive-heading-01");
   margin-bottom: $spacing-03;

--- a/packages/esm-patient-medications-app/translations/en.json
+++ b/packages/esm-patient-medications-app/translations/en.json
@@ -25,7 +25,6 @@
   "indicationPlaceholder": "e.g. \"Hypertension\"",
   "medicationDurationAndUnit": "for {duration} {durationUnit}",
   "medicationIndefiniteDuration": "Indefinite duration",
-  "medications": "Medications",
   "modify": "Modify",
   "newOrders": "{count} new order(s)",
   "newOrders_plural": "{count} new order(s)",


### PR DESCRIPTION
This PR introduces enhancements to the patient chart summary UI that include:

- Showing header titles for dashboard widgets in the grid-based layout (explanatory screenshot linked below).
- Adding a teal bottom border to the Immunizations and Medications widget header titles (makes them consistent with the rest of the patient chart widgets).
- Removing a superfluous CSS style reset from the Medications widget.

<img width="1584" alt="Screenshot 2021-09-06 at 13 55 41" src="https://user-images.githubusercontent.com/8509731/132207065-01a60454-f834-4ec0-bced-65892437d505.png">
<img width="1582" alt="Screenshot 2021-09-06 at 13 56 13" src="https://user-images.githubusercontent.com/8509731/132207070-23a5f086-7c8e-490b-8415-6a9c25c6036e.png">
<img width="1576" alt="Screenshot 2021-09-06 at 13 56 33" src="https://user-images.githubusercontent.com/8509731/132207087-2aa0ff49-5917-4a66-8857-fb2bb251231f.png">
<img width="705" alt="Screenshot 2021-09-06 at 13 56 49" src="https://user-images.githubusercontent.com/8509731/132207089-6eabdd62-6bf8-49c4-b5fe-8f563350349d.png">
