### PR TITLE
MF-772: Widen patient chart widgets to match designs in tablet mode

### DIFF
--- a/packages/esm-patient-chart-app/src/view-components/grid-view.css
+++ b/packages/esm-patient-chart-app/src/view-components/grid-view.css
@@ -19,6 +19,7 @@
 
 :global(.omrs-breakpoint-lt-tablet) .dashboard {
   display: flex;
+  flex-direction: column;
   flex-wrap: wrap;
 }
 


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d59c8931f6ac12c4675c2d).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Widen patient chart widgets to match designs in tablet mode


## Screenshots

![MF-772](https://user-images.githubusercontent.com/40205991/132820241-42e05d16-4b7d-425b-a55e-7b31990a04ac.png)



## Related Issue

Issue: [MF-772](https://issues.openmrs.org/browse/MF-772) 


## Other

*None.*

