### PR TITLE
MF-635: Add a border to individual patient chart widgets

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -100,7 +100,7 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
     if (allergies.length) {
       const rows = getRowItems(allergies);
       return (
-        <div>
+        <div className={styles.widgetCard}>
           <div className={styles.allergiesHeader}>
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
             {showAddAllergy && (

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.scss
@@ -2,6 +2,10 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .allergiesHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
@@ -78,7 +78,7 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = ({ patient, showAddA
     if (allergies.length) {
       const rows = getRowItems(allergies);
       return (
-        <div>
+        <div className={styles.widgetCard}>
           <div className={styles.allergiesHeader}>
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
             {showAddAllergy && (

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.scss
@@ -2,6 +2,10 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .allergiesHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-overview.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-overview.component.tsx
@@ -79,7 +79,7 @@ const AppointmentsOverview: React.FC<AppointmentOverviewProps> = ({ patientUuid 
     if (appointments.length) {
       const rows = getRowItems(appointments);
       return (
-        <div>
+        <div className={styles.widgetCard}>
           <div className={styles.appointmentsHeader}>
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
             <Button kind="ghost" renderIcon={Add16} iconDescription="Add appointments" onClick={launchAppointmentsForm}>

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-overview.scss
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-overview.scss
@@ -2,6 +2,10 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .appointmentsHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
@@ -4,6 +4,7 @@
 
 .biometricsWidgetContainer {
   background-color: $ui-background;
+  border: 1px solid $ui-03;
   position: relative;
 }
 

--- a/packages/esm-patient-clinical-view-app/src/clinical-view-overview/clinical-view-overview.component.scss
+++ b/packages/esm-patient-clinical-view-app/src/clinical-view-overview/clinical-view-overview.component.scss
@@ -6,7 +6,9 @@
 }
 .clinicalViewContainer {
   background-color: $ui-02;
+  border: 1px solid $ui-03;
 }
+
 .clinicalViewHeaderContainer {
   display: flex;
   align-items: center;

--- a/packages/esm-patient-common-lib/src/empty-state/empty-state.scss
+++ b/packages/esm-patient-common-lib/src/empty-state/empty-state.scss
@@ -31,4 +31,5 @@
 
 .tile {
   text-align: center;
+  border: 1px solid $ui-03;
 }

--- a/packages/esm-patient-common-lib/src/error-state/error-state.scss
+++ b/packages/esm-patient-common-lib/src/error-state/error-state.scss
@@ -33,4 +33,5 @@
 
 .tile {
   text-align: center;
+  border: 1px solid $ui-03;
 }

--- a/packages/esm-patient-common-lib/src/pagination/pagination.component.scss
+++ b/packages/esm-patient-common-lib/src/pagination/pagination.component.scss
@@ -16,7 +16,6 @@
   width: 100%;
   min-height: 3rem;
   overflow: hidden;
-  border-top: 0.063rem solid $ui-03;
 }
 
 .paginationLink {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -74,7 +74,7 @@ const ConditionsDetailedSummary: React.FC = () => {
   const RenderConditionsSummary: React.FC = () => {
     if (conditions.length) {
       return (
-        <div>
+        <div className={styles.widgetCard}>
           <div className={styles.conditionsHeader}>
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
             <Button kind="ghost" renderIcon={Add16} iconDescription="Add conditions" onClick={launchConditionsForm}>

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.scss
@@ -2,6 +2,10 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .conditionsHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
@@ -74,16 +74,16 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patient }) => {
       const rows = getRowItems(conditions);
       const totalRows = conditions.length;
       return (
-        <div>
+        <div className={styles.widgetCard}>
           <div className={styles.conditionsHeader}>
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
             <Button kind="ghost" renderIcon={Add16} iconDescription="Add conditions" onClick={launchConditionsForm}>
               {t('add', 'Add')}
             </Button>
           </div>
-          <TableContainer>
-            <DataTable rows={rows} headers={headers} isSortable={true} size="short">
-              {({ rows, headers, getHeaderProps, getTableProps }) => (
+          <DataTable rows={rows} headers={headers} isSortable={true} size="short">
+            {({ rows, headers, getHeaderProps, getTableProps }) => (
+              <TableContainer>
                 <Table {...getTableProps()} useZebraStyles>
                   <TableHead>
                     <TableRow>
@@ -109,25 +109,25 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patient }) => {
                     ))}
                   </TableBody>
                 </Table>
-              )}
-            </DataTable>
-          </TableContainer>
-          {totalRows > conditionsToShowCount && (
-            <Pagination
-              totalItems={conditions.length}
-              backwardText={previousPage}
-              forwardText={nextPage}
-              pageSize={currentPageSize}
-              pageSizes={[5, 10, 15, 25]}
-              itemsPerPageText={itemPerPage}
-              onChange={({ page, pageSize }) => {
-                if (pageSize !== currentPageSize) {
-                  setCurrentPageSize(pageSize);
-                }
-                setFirstRowIndex(pageSize * (page - 1));
-              }}
-            />
-          )}
+                {totalRows > conditionsToShowCount && (
+                  <Pagination
+                    totalItems={conditions.length}
+                    backwardText={previousPage}
+                    forwardText={nextPage}
+                    pageSize={currentPageSize}
+                    pageSizes={[5, 10, 15, 25]}
+                    itemsPerPageText={itemPerPage}
+                    onChange={({ page, pageSize }) => {
+                      if (pageSize !== currentPageSize) {
+                        setCurrentPageSize(pageSize);
+                      }
+                      setFirstRowIndex(pageSize * (page - 1));
+                    }}
+                  />
+                )}
+              </TableContainer>
+            )}
+          </DataTable>
         </div>
       );
     }

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.scss
@@ -2,6 +2,10 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .conditionsHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-forms-app/src/forms/forms.component.scss
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.scss
@@ -8,6 +8,7 @@
 
 .formsWidgetContainer {
   background-color: $ui-background;
+  border: 1px solid $ui-03;
   position: relative;
   min-height: 22.525rem;
 }

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
@@ -148,11 +148,10 @@ const ImmunizationsDetailedSummary: React.FC<ImmunizationsDetailedSummaryProps> 
     <>
       {status === StateTypes.PENDING && <DataTableSkeleton />}
       {status === StateTypes.RESOLVED && (
-        <div>
+        <div className={styles.widgetCard}>
           <div className={styles.immunizationsHeader}>
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{t('immunizations', 'Immunizations')}</h4>
           </div>
-
           <DataTable rows={results} headers={tableHeader}>
             {({ rows, headers, getHeaderProps, getRowProps, getTableProps }) => (
               <Table {...getTableProps()} useZebraStyles>

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.scss
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.scss
@@ -2,6 +2,10 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .immunizationsHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.component.tsx
@@ -66,7 +66,7 @@ const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = ({ patient, 
     if (immunizations.length) {
       const rows = getRowItems(immunizations);
       return (
-        <div>
+        <div className={styles.widgetCard}>
           <div className={styles.immunizationsHeader}>
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
             <Button

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.scss
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.scss
@@ -2,6 +2,10 @@
 @import "~carbon-components/src/globals/scss/mixins";
 @import "~@openmrs/esm-styleguide/src/vars";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .immunizationsHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -149,7 +149,7 @@ const MedicationsDetailsTable = connect<
     };
 
     return (
-      <>
+      <div className={styles.widgetCard}>
         <div className={styles.cardHeader}>
           <h4>{title}</h4>
           {showAddNewButton && (
@@ -209,7 +209,7 @@ const MedicationsDetailsTable = connect<
             </TableContainer>
           )}
         </DataTable>
-      </>
+      </div>
     );
   },
 );

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.scss
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.scss
@@ -1,5 +1,9 @@
 @import "../root";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .cardHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
@@ -6,6 +6,7 @@ import MedicationsDetailsTable from '../components/medications-details-table.com
 import { Provider } from 'unistore/react';
 import { orderBasketStore } from './order-basket-store';
 import DataTableSkeleton from 'carbon-components-react/es/components/DataTableSkeleton';
+import { EmptyState } from '@openmrs/esm-patient-common-lib';
 
 interface ActiveMedicationsProps {
   patientUuid: string;
@@ -18,20 +19,30 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, show
 
   return (
     <Provider store={orderBasketStore}>
-      {activePatientOrders ? (
-        <div className={styles.activeMedicationContainer}>
-          <MedicationsDetailsTable
-            title={t('activeMedications', 'Active Medications')}
-            medications={activePatientOrders}
-            showDiscontinueButton={true}
-            showModifyButton={true}
-            showReorderButton={false}
-            showAddNewButton={true}
-          />
-        </div>
-      ) : (
-        <DataTableSkeleton role="progressbar" />
-      )}
+      {(() => {
+        if (activePatientOrders && !activePatientOrders?.length)
+          return (
+            <EmptyState
+              displayText={t('activeMedications', 'Active medications')}
+              headerTitle={t('activeMedications', 'active medications')}
+            />
+          );
+        if (activePatientOrders?.length) {
+          return (
+            <div className={styles.activeMedicationContainer}>
+              <MedicationsDetailsTable
+                title={t('activeMedications', 'Active Medications')}
+                medications={activePatientOrders}
+                showDiscontinueButton={true}
+                showModifyButton={true}
+                showReorderButton={false}
+                showAddNewButton={false}
+              />
+            </div>
+          );
+        }
+        return <DataTableSkeleton role="progressbar" />;
+      })()}
     </Provider>
   );
 };

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -56,7 +56,7 @@ const NotesMain: React.FC<NotesOverviewProps> = ({
         if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
         if (notes?.length)
           return (
-            <div>
+            <div className={styles.widgetCard}>
               <div className={styles.notesHeader}>
                 <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
                 {showAddNote && (

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.scss
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.scss
@@ -2,6 +2,10 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .notesHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -82,7 +82,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = () => {
     return (
       <>
         {enrolledPrograms?.length ? (
-          <>
+          <div className={styles.widgetCard}>
             <div className={styles.programsHeader}>
               <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
               <Button kind="ghost" renderIcon={Add16} iconDescription="Add programs" onClick={launchProgramsForm}>
@@ -121,7 +121,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = () => {
                 )}
               </DataTable>
             </TableContainer>
-          </>
+          </div>
         ) : (
           <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchProgramsForm} />
         )}

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.scss
@@ -3,6 +3,10 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .programsHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
@@ -75,7 +75,7 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ patientUuid }) => {
     if (programs.length) {
       const rows = getRowItems(programs);
       return (
-        <div>
+        <div className={styles.widgetCard}>
           <div className={styles.programsHeader}>
             <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
             <Button kind="ghost" renderIcon={Add16} iconDescription="Add programs" onClick={launchProgramsForm}>

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.scss
@@ -2,6 +2,10 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .programsHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.scss
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.scss
@@ -2,6 +2,10 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .externalOverviewHeader {
   display: flex;
   justify-content: space-between;

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
@@ -50,7 +50,7 @@ const RecentOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }
           {(() => {
             if (overviewData.length) {
               return (
-                <div>
+                <div className={styles.widgetCard}>
                   <div className={styles.externalOverviewHeader}>
                     <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{cardTitle}</h4>
                     <Button

--- a/packages/esm-patient-test-results-app/src/overview/lab-results.scss
+++ b/packages/esm-patient-test-results-app/src/overview/lab-results.scss
@@ -2,6 +2,10 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
 .separator {
   height: 1.5rem;
   border-bottom: #e0e0e0 solid 1px;

--- a/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
@@ -30,7 +30,7 @@ const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, basePath }
           {(() => {
             if (overviewData.length) {
               return (
-                <div>
+                <div className={styles.widgetCard}>
                   <div className={styles['recent-overview-header-container']}>
                     <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
                       {cardTitle} ({Math.min(RECENT_COUNT, overviewData.length)})

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.scss
@@ -11,6 +11,7 @@
 }
 
 .vitalsChartContainer {
+  border: 1px solid $ui-03;
   display: flex;
   text-align: left;
   margin: 0 $spacing-03;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
@@ -4,6 +4,7 @@
 
 .vitalsWidgetContainer {
   background-color: $ui-background;
+  border: 1px solid $ui-03;
 }
 
 .vitalsHeaderContainer {


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Adds a border of `1px border $ui-03` to each widget card (including EmptyState and ErrorState widgets) as stipulated in the [designs](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d59c8c1ff239bbe989d7d5).

## Screenshots

<img width="961" alt="Screenshot 2021-09-13 at 11 13 23" src="https://user-images.githubusercontent.com/8509731/133048505-1cdfe513-5108-4bdf-92be-126c3a808eb5.png">
<img width="960" alt="Screenshot 2021-09-13 at 11 14 05" src="https://user-images.githubusercontent.com/8509731/133048558-d246ba1d-0c07-40f0-a1ce-a85416b72374.png">
<img width="960" alt="Screenshot 2021-09-13 at 11 15 44" src="https://user-images.githubusercontent.com/8509731/133048572-ed90fd53-dec1-44f9-8ace-35a5d1efca07.png">
