### PR TITLE
Fix forms rendering bug

### DIFF
--- a/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
@@ -135,7 +135,7 @@ const FormView: React.FC<FormViewProps> = ({ forms, patientUuid, patient, pageSi
             {allForms.length} {t('matchFound', 'match found')}
           </p>
         )}
-        {allForms.length && (
+        {allForms?.length > 0 && (
           <>
             <TableContainer className={styles.tableContainer}>
               <DataTable rows={tableRows} headers={tableHeaders} isSortable={true} size="short">


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Fixes a bug in the forms widget where a `0` is being rendered when the `allForms` array is empty.

## Screenshots

<img width="945" alt="Screenshot 2021-09-13 at 23 16 05" src="https://user-images.githubusercontent.com/8509731/133151776-9a814491-bb88-45a1-a576-fe90162e97ed.png">
