### PR TITLE
Wrap patient chart in SWRConfig context

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,7 @@
     "webpack": "^5.36.2",
     "webpack-cli": "^4.7.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "swr": "^1.0.1"
+  }
 }

--- a/packages/esm-patient-chart-app/src/root.component.tsx
+++ b/packages/esm-patient-chart-app/src/root.component.tsx
@@ -6,6 +6,12 @@ import { BrowserRouter, Route } from 'react-router-dom';
 import { basePath, dashboardPath, spaRoot } from './constants';
 import styles from './root.scss';
 import { ContextWindowSizeProvider } from './hooks/useContextWindowSize';
+import { SWRConfig } from 'swr';
+
+const swrConfiguration = {
+  // Maximum number of retries when the backend returns an error
+  errorRetryCount: 3,
+};
 
 export default function Root() {
   return (
@@ -13,7 +19,9 @@ export default function Root() {
       <ContextWindowSizeProvider>
         <div className={styles.patientChartWrapper}>
           <SideMenu />
-          <Route path={dashboardPath} component={PatientChart} />
+          <SWRConfig value={{ ...swrConfiguration }}>
+            <Route path={dashboardPath} component={PatientChart} />
+          </SWRConfig>
           <Route path={basePath} component={ContextWorkspace} />
         </div>
       </ContextWindowSizeProvider>

--- a/packages/esm-patient-chart-app/src/root.component.tsx
+++ b/packages/esm-patient-chart-app/src/root.component.tsx
@@ -15,16 +15,16 @@ const swrConfiguration = {
 
 export default function Root() {
   return (
-    <BrowserRouter basename={spaRoot}>
-      <ContextWindowSizeProvider>
-        <div className={styles.patientChartWrapper}>
-          <SideMenu />
-          <SWRConfig value={{ ...swrConfiguration }}>
+    <SWRConfig value={swrConfiguration}>
+      <BrowserRouter basename={spaRoot}>
+        <ContextWindowSizeProvider>
+          <div className={styles.patientChartWrapper}>
+            <SideMenu />
             <Route path={dashboardPath} component={PatientChart} />
-          </SWRConfig>
-          <Route path={basePath} component={ContextWorkspace} />
-        </div>
-      </ContextWindowSizeProvider>
-    </BrowserRouter>
+            <Route path={basePath} component={ContextWorkspace} />
+          </div>
+        </ContextWindowSizeProvider>
+      </BrowserRouter>
+    </SWRConfig>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7368,6 +7368,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -16594,6 +16599,13 @@ svgo@^2.3.0:
     css-tree "^1.1.3"
     csso "^4.2.0"
     stable "^0.1.8"
+
+swr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.0.1.tgz#15f62846b87ee000e52fa07812bb65eb62d79483"
+  integrity sha512-EPQAxSjoD4IaM49rpRHK0q+/NzcwoT8c0/Ylu/u3/6mFj/CWnQVjNJ0MV2Iuw/U+EJSd2TX5czdAwKPYZIG0YA==
+  dependencies:
+    dequal "2.0.2"
 
 symbol-observable@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR adds the [SWR](https://swr.vercel.app/) dependency to the patient chart and wraps the `PatientChart` component in a [SWRConfig context](https://swr.vercel.app/docs/global-configuration) that specifies some sensible global configuration default options for all SWR hooks.