### PR TITLE
Patient banner to be used in the patient search

### DIFF
--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -9,7 +9,7 @@ import CustomOverflowMenuComponent from '../ui-components/overflow-menu.componen
 import styles from './patient-banner.scss';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'carbon-components-react';
-import { ExtensionSlot, age, navigate } from '@openmrs/esm-framework';
+import { ExtensionSlot, age } from '@openmrs/esm-framework';
 
 interface PatientBannerProps {
   patient: fhir.Patient;

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -14,11 +14,10 @@ import { ExtensionSlot, age } from '@openmrs/esm-framework';
 interface PatientBannerProps {
   patient: fhir.Patient;
   patientUuid: string;
-  patientUrl?: string;
-  onClick?: (patientUrl: string) => void;
+  onClick?: (patientUuid: string) => void;
 }
 
-const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, patientUrl, onClick }) => {
+const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, onClick }) => {
   const { t } = useTranslation();
   const state = React.useMemo(() => ({ patientUuid }), [patientUuid]);
   const [showContactDetails, setShowContactDetails] = React.useState(false);
@@ -32,8 +31,8 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, pat
   return (
     <div className={styles.container} role="banner">
       <div className={styles.patientBanner}>
-        {patientUrl ? (
-          <button className={styles.patientAvatarButton} onClick={() => onClick(patientUrl)}>
+        {onClick ? (
+          <button className={styles.patientAvatarButton} onClick={() => onClick(patientUuid)}>
             {patientAvatar}
           </button>
         ) : (

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -15,10 +15,10 @@ interface PatientBannerProps {
   patient: fhir.Patient;
   patientUuid: string;
   patientUrl?: string;
-  hidePatientSearchPanel?: () => void;
+  onClick?: (patientUrl: string) => void;
 }
 
-const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, patientUrl, hidePatientSearchPanel }) => {
+const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, patientUrl, onClick }) => {
   const { t } = useTranslation();
   const state = React.useMemo(() => ({ patientUuid }), [patientUuid]);
   const [showContactDetails, setShowContactDetails] = React.useState(false);
@@ -33,16 +33,9 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, pat
     <div className={styles.container} role="banner">
       <div className={styles.patientBanner}>
         {patientUrl ? (
-          <div
-            role="button"
-            tabIndex={0}
-            className={styles.patientAvatarButton}
-            onClick={() => {
-              navigate({ to: patientUrl });
-              hidePatientSearchPanel && hidePatientSearchPanel();
-            }}>
+          <button className={styles.patientAvatarButton} onClick={() => onClick(patientUrl)}>
             {patientAvatar}
-          </div>
+          </button>
         ) : (
           patientAvatar
         )}

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -9,7 +9,7 @@ import CustomOverflowMenuComponent from '../ui-components/overflow-menu.componen
 import styles from './patient-banner.scss';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'carbon-components-react';
-import { ExtensionSlot, age, ConfigurableLink, navigate } from '@openmrs/esm-framework';
+import { ExtensionSlot, age, navigate } from '@openmrs/esm-framework';
 
 interface PatientBannerProps {
   patient: fhir.Patient;

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -9,25 +9,43 @@ import CustomOverflowMenuComponent from '../ui-components/overflow-menu.componen
 import styles from './patient-banner.scss';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'carbon-components-react';
-import { ExtensionSlot, age } from '@openmrs/esm-framework';
+import { ExtensionSlot, age, ConfigurableLink, navigate } from '@openmrs/esm-framework';
 
 interface PatientBannerProps {
   patient: fhir.Patient;
   patientUuid: string;
+  patientUrl?: string;
+  hidePatientSearchPanel?: () => void;
 }
 
-const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid }) => {
+const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, patientUrl, hidePatientSearchPanel }) => {
   const { t } = useTranslation();
   const state = React.useMemo(() => ({ patientUuid }), [patientUuid]);
   const [showContactDetails, setShowContactDetails] = React.useState(false);
   const toggleContactDetails = React.useCallback(() => setShowContactDetails((value) => !value), []);
 
+  const patientAvatar = (
+    <div className={styles.patientAvatar} role="img">
+      <ExtensionSlot extensionSlotName="patient-photo-slot" state={state} />
+    </div>
+  );
   return (
     <div className={styles.container} role="banner">
       <div className={styles.patientBanner}>
-        <div className={styles.patientAvatar} role="img">
-          <ExtensionSlot extensionSlotName="patient-photo-slot" state={state} />
-        </div>
+        {patientUrl ? (
+          <div
+            role="button"
+            tabIndex={0}
+            className={styles.patientAvatarButton}
+            onClick={() => {
+              navigate({ to: patientUrl });
+              hidePatientSearchPanel && hidePatientSearchPanel();
+            }}>
+            {patientAvatar}
+          </div>
+        ) : (
+          patientAvatar
+        )}
         <div className={styles.patientInfo}>
           <div className={`${styles.row} ${styles.patientNameRow}`}>
             <div className={styles.flexRow}>

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.scss
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.scss
@@ -24,6 +24,9 @@
 
 .patientAvatarButton {
   cursor: pointer;
+  border: none;
+  padding: 0px;
+  background: none;
 }
 
 .patientInfo {

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.scss
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.scss
@@ -22,6 +22,10 @@
   border-radius: 1px;
 }
 
+.patientAvatarButton {
+  cursor: pointer;
+}
+
 .patientInfo {
   width: 100%;
 }

--- a/packages/esm-patient-test-results-app/src/overview/common-overview.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.tsx
@@ -84,10 +84,9 @@ interface CommonOverviewPropsWithoutToolbar {
 
 type Only<T, U> = {
   [P in keyof T]: T[P];
-} &
-  {
-    [P in keyof U]?: never;
-  };
+} & {
+  [P in keyof U]?: never;
+};
 
 type Either<T, U> = Only<T, U> | Only<U, T>;
 

--- a/packages/esm-patient-test-results-app/src/overview/common-overview.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.tsx
@@ -84,9 +84,10 @@ interface CommonOverviewPropsWithoutToolbar {
 
 type Only<T, U> = {
   [P in keyof T]: T[P];
-} & {
-  [P in keyof U]?: never;
-};
+} &
+  {
+    [P in keyof U]?: never;
+  };
 
 type Either<T, U> = Only<T, U> | Only<U, T>;
 


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
In order to make using the patient banner in the search results possible, we need an ad-hoc option of supporting navigation to the patient's dashboard. This is configured through the `patientUrl` prop. 


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

- https://issues.openmrs.org/browse/MF-462


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
