### PR TITLE
MF-800: Fix Side Rail border appearing in tablet mode 

### DIFF
--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.scss
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.scss
@@ -15,16 +15,11 @@ $actionPanelOffset: 48px;
   right: 0;
 }
 
-.actionPanel {
+:global(.omrs-breakpoint-gt-tablet) .actionPanel {
   right: $actionPanelOffset;
   background: #fff;
   z-index: auto;
   border: 1px solid #a8a8a8;
-}
-
-.actionPanel :global(.omrs-breakpoint-lt-desktop) {
-  border: 0;
-  right: 0;
 }
 
 .iconButton {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

At the moment, when in tablet mode the side-rail border is appearing, this is a bug. This PR attempts to solve the issue


## Screenshots

![MF-800](https://user-images.githubusercontent.com/28008754/134551612-a3833e7d-cd22-45a8-a856-9250b0076c21.gif)



## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
