### PR TITLE
Change "Quantity dispensed" to just "Quantity"

### DIFF
--- a/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
@@ -337,13 +337,13 @@ export default function MedicationOrderForm({
                   light={isTablet}
                   id="quantity"
                   helperText={t('pillsToDispense', 'Pills to dispense')}
-                  value={orderBasketItem.pillsDispensed}
+                  value={orderBasketItem.pillsToDispense}
                   min={0}
                   onChange={(e) => {
                     setOrderBasketItem({
                       ...orderBasketItem,
                       // @ts-ignore
-                      pillstoDispense: +e.imaginaryTarget.value,
+                      pillsToDispense: +e.imaginaryTarget.value,
                     });
                   }}
                 />

--- a/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
@@ -336,7 +336,7 @@ export default function MedicationOrderForm({
                 <NumberInput
                   light={isTablet}
                   id="quantity"
-                  helperText={t('pillstoDispense', 'Pills to dispense')}
+                  helperText={t('pillsToDispense', 'Pills to dispense')}
                   value={orderBasketItem.pillsDispensed}
                   min={0}
                   onChange={(e) => {

--- a/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
@@ -332,18 +332,18 @@ export default function MedicationOrderForm({
           </Row>
           <Row style={{ marginTop: '1rem' }}>
             <Column md={2}>
-              <FormGroup legendText={t('quantityDispensed', 'Quantity Dispensed')}>
+              <FormGroup legendText={t('quantity', 'Quantity')}>
                 <NumberInput
                   light={isTablet}
-                  id="quantityDispensed"
-                  helperText={t('pillsDispensed', 'Pills dispensed')}
+                  id="quantity"
+                  helperText={t('pillstoDispense', 'Pills to dispense')}
                   value={orderBasketItem.pillsDispensed}
                   min={0}
                   onChange={(e) => {
                     setOrderBasketItem({
                       ...orderBasketItem,
                       // @ts-ignore
-                      pillsDispensed: +e.imaginaryTarget.value,
+                      pillstoDispense: +e.imaginaryTarget.value,
                     });
                   }}
                 />


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/MF-810

The clinician's order should help explain "Quantity *to be* dispensed" (hasn't happened yet), but the current text makes it sound like a quantity *being* dispensed in that moment. 
Current: 
![image](https://user-images.githubusercontent.com/67400059/134568425-3f1ad908-c451-43eb-b3d4-a93aa443c7eb.png)

Changes:
"Quantity Dispensed" --> "Quantity" 
"Pills dispensed" --> "Pills to dispense"

Also updating in translation file here: https://github.com/openmrs/openmrs-esm-patient-chart/pull/395

NOTE: Question to resolve before merging this is: Is there any code elsewhere that depended on "quantityDispensed" or "pillsDispensed"? I am not sure how to check for this. 