### PR TITLE
MF-810: Change texts in order workspace

### DIFF
--- a/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
@@ -332,11 +332,11 @@ export default function MedicationOrderForm({
           </Row>
           <Row style={{ marginTop: '1rem' }}>
             <Column md={2}>
-              <FormGroup legendText={t('quantityDispensed', 'Quantity Dispensed')}>
+              <FormGroup legendText={t('quantity', 'Quantity')}>
                 <NumberInput
                   light={isTablet}
                   id="quantityDispensed"
-                  helperText={t('pillsDispensed', 'Pills dispensed')}
+                  helperText={t('pillsToDispense', 'Pills to dispense')}
                   value={orderBasketItem.pillsDispensed}
                   min={0}
                   onChange={(e) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Changed the following texts in the order workspace:
"Quantity dispensed" => "Quantity"
"Pills dispensed" => "Pills to dispense"

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
![Screenshot from 2021-09-24 20-37-58](https://user-images.githubusercontent.com/48877319/134719425-92ce2016-c96c-4532-9bbb-151bf4642df4.png)


<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
