### PR TITLE
Add swr to relationships widget

### DIFF
--- a/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.component.tsx
@@ -16,7 +16,7 @@ function ActiveVisitBannerTag({ patientUuid }) {
           <div className={styles.tooltipPadding}>
             <h6 style={{ marginBottom: '0.5rem' }}>{currentVisit?.visitType?.name}</h6>
             <span>
-              <span className={styles.tooltipSmallText}>Started: </span>
+              <span className={styles.tooltipSmallText}>{t('started', 'Started')}: </span>
               <span>{dayjs(currentVisit?.startDatetime).format('DD - MMM - YYYY @ HH:mm')}</span>
             </span>
           </div>

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.test.tsx
@@ -4,9 +4,10 @@ import userEvent from '@testing-library/user-event';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import PatientBanner from './patient-banner.component';
 
-jest.unmock('lodash');
-const lodash = jest.requireActual('lodash');
-lodash.capitalize = jest.fn().mockImplementation((s) => s.charAt(0).toUpperCase() + s.slice(1));
+const testProps = {
+  patient: mockPatient,
+  patientUuid: mockPatient.id,
+};
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...(jest.requireActual('@openmrs/esm-framework') as any),
@@ -50,5 +51,5 @@ describe('PatientBanner: ', () => {
 });
 
 function renderPatientBanner() {
-  render(<PatientBanner patient={mockPatient} patientUuid={mockPatient.id} />);
+  render(<PatientBanner {...testProps} />);
 }

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { fetchPatientRelationships } from './relationships.resource';
+import { screen } from '@testing-library/react';
+import { openmrsFetch } from '@openmrs/esm-framework';
+import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import ContactDetails from './contact-details.component';
-import { waitForLoadingToFinish } from '../../../../tools/test-helpers';
 
 const testProps = {
   address: [
@@ -21,39 +21,39 @@ const testProps = {
 
 const mockRelationships = [
   {
-    uuid: 1111,
-    display: 'Amanda Testerson',
-    relativeAge: 30,
-    relativeUuid: 2222,
-    relationshipType: 'Cousin',
+    display: 'Amanda is the Sibling of John',
+    uuid: '993bc79d-5ca5-4c76-b4b3-adf49e25bd0b',
+    personA: {
+      uuid: '07006bcb-91d4-4c57-a5f7-49751899d9b5',
+      display: '100ADT - Amanda Robinson',
+      person: {
+        age: 24,
+        display: 'Amanda Robinson',
+      },
+    },
+    personB: {
+      uuid: '8673ee4f-e2ab-4077-ba55-4980f408773e',
+      display: '100GEJ - John Wilson',
+      person: {
+        age: 49,
+        display: 'John Wilson',
+      },
+    },
+    relationshipType: {
+      uuid: '8d91a01c-c2cc-11de-8d13-0010c6dffd0f',
+      display: 'Sibling/Sibling',
+      description: 'Relationship between brother/sister, brother/brother, and sister/sister',
+      aIsToB: 'Sibling',
+      bIsToA: 'Sibling',
+    },
   },
 ];
 
-const mockFetchPatientRelationships = fetchPatientRelationships as jest.Mock;
-
-jest.mock('./relationships.resource', () => ({
-  fetchPatientRelationships: jest.fn(),
-}));
+const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
 describe('ContactDetails: ', () => {
-  it("shows the patient's contact details and relationships when available", async () => {
-    mockFetchPatientRelationships.mockResolvedValue(mockRelationships);
-
-    renderContactDetails();
-
-    await waitForLoadingToFinish();
-
-    screen.findByText('Relationships');
-    expect(screen.getByText('Address')).toBeInTheDocument();
-    expect(screen.getByText('Contact Details')).toBeInTheDocument();
-    expect(screen.getByText('Relationships')).toBeInTheDocument();
-    expect(screen.getByText('Amanda Testerson')).toBeInTheDocument();
-    expect(screen.getByText(/Cousin/i)).toBeInTheDocument();
-    expect(screen.getByText(/30 yrs/i)).toBeInTheDocument();
-  });
-
-  it('shows an empty state when relationships data is not available', async () => {
-    mockFetchPatientRelationships.mockResolvedValue([]);
+  it('renders an empty state view when relationships data is not available', async () => {
+    mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
 
     renderContactDetails();
 
@@ -63,8 +63,23 @@ describe('ContactDetails: ', () => {
     expect(screen.getByText('Relationships')).toBeInTheDocument();
     expect(screen.getByText('-')).toBeInTheDocument();
   });
+
+  it("renders the patient's address, contact details and relationships when available", async () => {
+    mockOpenmrsFetch.mockReturnValueOnce({ data: { results: mockRelationships } });
+
+    renderContactDetails();
+
+    await waitForLoadingToFinish();
+
+    expect(screen.getByText('Address')).toBeInTheDocument();
+    expect(screen.getByText('Contact Details')).toBeInTheDocument();
+    expect(screen.getByText('Relationships')).toBeInTheDocument();
+    expect(screen.getByText(/Amanda Robinson/)).toBeInTheDocument();
+    expect(screen.getByText(/Sibling/i)).toBeInTheDocument();
+    expect(screen.getByText(/24 yrs/i)).toBeInTheDocument();
+  });
 });
 
 function renderContactDetails() {
-  render(<ContactDetails {...testProps} />);
+  swrRender(<ContactDetails {...testProps} />);
 }

--- a/packages/esm-patient-banner-app/translations/en.json
+++ b/packages/esm-patient-banner-app/translations/en.json
@@ -3,6 +3,8 @@
   "activeVisit": "Active Visit",
   "address": "Address",
   "contactDetails": "Contact Details",
+  "relationships": "Relationships",
   "showAllDetails": "Show all details",
-  "showLess": "Show less"
+  "showLess": "Show less",
+  "started": "Started"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR:

1. Add a `useRelationships` hook that handles fetching the relationships data from the backend. This is the data that gets displayed in the patient banner when you expand the ContactDetails panel.
2. Refactor the `ContactDetails` component to reuse this hook. Similarly, refactor existing tests so that they use the SWR paradigm.

## Videos 

https://user-images.githubusercontent.com/8509731/135156807-02ac01c3-b280-4eb5-bdee-05488d154b16.mp4

## Issue

https://issues.openmrs.org/browse/MF-824