### PR TITLE
MF-712: Time stamps and dates for Test Results do not match

### DIFF
--- a/packages/esm-patient-test-results-app/src/timeline/useTimelineData.ts
+++ b/packages/esm-patient-test-results-app/src/timeline/useTimelineData.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import usePatientResultsData from '../loadPatientTestData/usePatientResultsData';
 import { ObsRecord } from '@openmrs/esm-patient-common-lib';
+import dayjs from 'dayjs';
 
 const parseTime = (sortedTimes: string[]) => {
   const yearColumns: Array<{ year: string; size: number }> = [],
@@ -8,9 +9,10 @@ const parseTime = (sortedTimes: string[]) => {
     timeColumns: string[] = [];
 
   sortedTimes.forEach((datetime) => {
-    const [year, month, day, hour, minutes] = datetime.split(/[-,T,:]/);
-    const date = `${month}/${day}`;
-    const time = `${hour}:${minutes}`;
+    const dayJsDate = dayjs(datetime);
+    const year = dayJsDate.year().toString();
+    const date = dayJsDate.format('MM/DD');
+    const time = dayJsDate.format('HH:mm');
 
     const yearColumn = yearColumns.find(({ year: innerYear }) => year === innerYear);
     if (yearColumn) yearColumn.size++;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Fixes [MF-712](https://issues.openmrs.org/browse/MF-712), i.e. makes the dates (-> screenshot) align.


## Screenshots

![grafik](https://user-images.githubusercontent.com/30902964/135418868-f27c7d8b-0a6e-498d-aa59-a9d581ead9d3.png)


## Issue

https://issues.openmrs.org/browse/MF-712


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
