### PR TITLE
MF-818: Adjusted Recent Results widget to be sized like other Patient Summary widgets

### DIFF
--- a/packages/esm-patient-test-results-app/src/index.ts
+++ b/packages/esm-patient-test-results-app/src/index.ts
@@ -42,7 +42,7 @@ function setupOpenMRS() {
         slot: 'patient-chart-summary-dashboard-slot',
         load: getAsyncLifecycle(() => import('./overview/recent-overview.component'), options),
         meta: {
-          columnSpan: 2,
+          columnSpan: 4,
         },
         online: true,
         offline: true,
@@ -52,7 +52,7 @@ function setupOpenMRS() {
         slot: 'test-results-filtered-overview',
         load: getAsyncLifecycle(() => import('./overview/external-overview.component'), options),
         meta: {
-          columnSpan: 2,
+          columnSpan: 4,
         },
         online: true,
         offline: true,


### PR DESCRIPTION
… Widgets
-Recent Results widget 

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d59c8c2ad2f809f62880ec ).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Adjusted Recent Results widget to be sized like other Patient Summary widgets


## Screenshots

![Screenshot from 2021-10-01 11-09-31](https://user-images.githubusercontent.com/40205991/135587753-1a7dc991-b0a2-47f2-acc1-21fb1977d41a.png)



## Issue

[MF-818](https://issues.openmrs.org/projects/MF/issues/MF-818?filter=allopenissues)


## Other

*None.*

