### PR TITLE
MF-827: Start Visit Form should require a visit type before a visit can an be started

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -74,32 +74,41 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({ isTablet, patientUuid }
         location: selectedLocation,
       };
 
-      saveVisit(visitPayload, new AbortController())
-        .pipe(first())
-        .subscribe(
-          (response) => {
-            if (response.status === 201) {
-              getStartedVisit.next({
-                mode: VisitMode?.NEWVISIT,
-                visitData: response.data,
-                status: VisitStatus?.ONGOING,
+      if (visitPayload.visitType !== undefined) {
+        saveVisit(visitPayload, new AbortController())
+          .pipe(first())
+          .subscribe(
+            (response) => {
+              if (response.status === 201) {
+                getStartedVisit.next({
+                  mode: VisitMode?.NEWVISIT,
+                  visitData: response.data,
+                  status: VisitStatus?.ONGOING,
+                });
+                handleCloseForm();
+                showToast({
+                  kind: 'success',
+                  description: t('startVisitSuccessfully', 'Visit has been started successfully'),
+                });
+              }
+            },
+            (error) => {
+              showNotification({
+                title: t('startVisitError', 'Error starting current visit'),
+                kind: 'error',
+                critical: true,
+                description: error?.message,
               });
-              handleCloseForm();
-              showToast({
-                kind: 'success',
-                description: t('startVisitSuccessfully', 'Visit has been started successfully'),
-              });
-            }
-          },
-          (error) => {
-            showNotification({
-              title: t('startVisitError', 'Error starting current visit'),
-              kind: 'error',
-              critical: true,
-              description: error?.message,
-            });
-          },
-        );
+            },
+          );
+      } else {
+        showNotification({
+          title: t('startVisitTypeError', 'No Visit Type selected'),
+          kind: 'error',
+          critical: true,
+          description: 'Please select a Vist Type',
+        });
+      }
     },
     [handleCloseForm, patientUuid, selectedLocation, t, timeFormat, visitDate, visitTime, visitType],
   );

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -106,7 +106,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({ isTablet, patientUuid }
           title: t('startVisitTypeError', 'No Visit Type selected'),
           kind: 'error',
           critical: true,
-          description: 'Please select a Vist Type',
+          description: 'Please select a Visit Type',
         });
       }
     },


### PR DESCRIPTION


## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Changed the notification error message gotten while trying to save without selecting a visit type.
<!--
Required.
400 error request when starting a visit with undefined visit type 
-->


## Screenshots

https://user-images.githubusercontent.com/58003327/135734983-b8194ca0-277e-4925-94ec-5b2e6d4b2703.mp4


<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue
https://issues.openmrs.org/browse/MF-827

<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
