### PR TITLE
MF-829: Allergies page won't show if reaction manifestations are missing

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -73,7 +73,7 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
                 {allergy.criticality}
               </span>
             </p>
-            <p>{allergy.reactionManifestations.join(', ')}</p>
+            <p>{allergy.reactionManifestations?.join(', ')}</p>
             <p className={styles.note}>{allergy?.note}</p>
           </div>
         ),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x]  I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Currently, the `AllergiesDetailedSummary` component won't render when reaction manifestations are missing. This PR adds a check to its rendering logic that allows it to render successfully in those situations.


## Screenshots

<img width="960" alt="Screenshot 2021-10-04 at 09 57 55" src="https://user-images.githubusercontent.com/8509731/135806904-e735fec3-889c-4fbb-ba14-8f080b14b1d9.png">

## Issue

https://issues.openmrs.org/browse/MF-829