### PR TITLE
Remove overflow-y from workspace container

### DIFF
--- a/packages/esm-patient-chart-app/src/workspace/context-workspace.scss
+++ b/packages/esm-patient-chart-app/src/workspace/context-workspace.scss
@@ -17,7 +17,6 @@
   bottom: 0;
   z-index: 10;
   background-color: $ui-01;
-  overflow-y: auto;
 }
 
 /* Desktop view */
@@ -26,7 +25,6 @@
   background-color: $ui-02;
   margin-right: 50px;
   flex: 1;
-  overflow-y: auto;
 }
 
 :global(.omrs-breakpoint-gt-tablet) .contextWorkspaceContainer>header {


### PR DESCRIPTION
## Summary

This PR addresses a scroll issue with the forms because of an overflow-y attribute. It makes the sidenav scrollable as seen in the videos

## Screenshots

BEFORE:

https://user-images.githubusercontent.com/15266028/136370708-1dbee5e7-ff61-424f-96fe-3a744e3ca355.mov


AFTER:

https://user-images.githubusercontent.com/15266028/136370662-f52fb97e-b974-4c29-9be2-fc80ab66b3bf.mov
