### PR TITLE
MF-737: validate biometrics and vitals form inputs to only allow numerals

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.scss
@@ -14,3 +14,6 @@
     margin: $spacing-07 0 0 0;
     width: 17.75rem;
 }
+.danger {
+    color: $danger;
+}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.test.tsx
@@ -45,27 +45,27 @@ describe('VitalsBiometricsForm: ', () => {
     expect(screen.getByText(/vitals/i)).toBeInTheDocument();
     expect(screen.getByText(/biometrics/i)).toBeInTheDocument();
     expect(screen.getByText(/blood pressure/i)).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /systolic/i })).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /diastolic/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /systolic/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /diastolic/i })).toBeInTheDocument();
     expect(screen.getByText(/mmHg/i)).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /pulse/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /pulse/i })).toBeInTheDocument();
     expect(screen.getByText(/beats\/min/i)).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /oxygen saturation/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /oxygen saturation/i })).toBeInTheDocument();
     expect(screen.getByText(/spO2/i)).toBeInTheDocument();
     expect(screen.getByText(/%/i)).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /respiration rate/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /respiration rate/i })).toBeInTheDocument();
     expect(screen.getByText(/breaths\/min/i)).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /temperature/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /temperature/i })).toBeInTheDocument();
     expect(screen.getByText(/temp/i)).toBeInTheDocument();
     expect(screen.getByText(/deg c/i)).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /notes/i })).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/type any additional notes here/i)).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /weight/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /weight/i })).toBeInTheDocument();
     expect(screen.getByText(/^kg$/i)).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /height/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /height/i })).toBeInTheDocument();
     expect(screen.getByText(/bmi \(calc.\)/i)).toBeInTheDocument();
     expect(screen.getByText(/kg \/ m²/i)).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /muac/i })).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /muac/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /sign & save/i })).toBeInTheDocument();
   });
@@ -73,14 +73,14 @@ describe('VitalsBiometricsForm: ', () => {
   it('computes BMI from the given height and weight values', async () => {
     renderForm();
 
-    const heightInput = screen.getByRole('textbox', { name: /height/i });
-    const weightInput = screen.getByRole('textbox', { name: /weight/i });
-    const bmiInput = screen.getByRole('textbox', { name: /bmi/i });
+    const heightInput = screen.getByRole('spinbutton', { name: /height/i });
+    const weightInput = screen.getByRole('spinbutton', { name: /weight/i });
+    const bmiInput = screen.getByRole('spinbutton', { name: /bmi/i });
 
     userEvent.type(heightInput, '180');
     userEvent.type(weightInput, '62');
 
-    expect(bmiInput).toHaveValue('19.1');
+    expect(bmiInput).toHaveValue(19.1);
   });
 });
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -159,12 +159,12 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
               {
                 name: t('systolic', 'systolic'),
                 separator: '/',
-                type: 'text',
+                type: 'number',
                 value: patientVitalAndBiometrics?.systolicBloodPressure || '',
               },
               {
                 name: t('diastolic', 'diastolic'),
-                type: 'text',
+                type: 'number',
                 value: patientVitalAndBiometrics?.diastolicBloodPressure || '',
               },
             ]}
@@ -196,7 +196,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             textFields={[
               {
                 name: t('pulse', 'Pulse'),
-                type: 'text',
+                type: 'number',
                 value: patientVitalAndBiometrics?.pulse || '',
               },
             ]}
@@ -221,7 +221,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             textFields={[
               {
                 name: t('oxygenSaturation', 'Oxygen Saturation'),
-                type: 'text',
+                type: 'number',
                 value: patientVitalAndBiometrics?.oxygenSaturation || '',
               },
             ]}
@@ -246,7 +246,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             textFields={[
               {
                 name: t('respirationRate', 'Respiration Rate'),
-                type: 'text',
+                type: 'number',
                 value: patientVitalAndBiometrics?.respiratoryRate || '',
               },
             ]}
@@ -273,7 +273,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             textFields={[
               {
                 name: t('temperature', 'Temperature'),
-                type: 'text',
+                type: 'number',
                 value: patientVitalAndBiometrics?.temperature || '',
               },
             ]}
@@ -330,7 +330,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             textFields={[
               {
                 name: t('weight', 'Weight'),
-                type: 'text',
+                type: 'number',
                 value: patientVitalAndBiometrics?.weight || '',
               },
             ]}
@@ -351,7 +351,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             textFields={[
               {
                 name: t('height', 'Height'),
-                type: 'text',
+                type: 'number',
                 value: patientVitalAndBiometrics?.height || '',
               },
             ]}
@@ -367,7 +367,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             textFields={[
               {
                 name: t('bmi', 'BMI'),
-                type: 'text',
+                type: 'number',
                 value: patientBMI || '',
               },
             ]}
@@ -389,7 +389,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
             textFields={[
               {
                 name: t('muac', 'MUAC'),
-                type: 'text',
+                type: 'number',
                 value: patientVitalAndBiometrics?.midUpperArmCircumference || '',
               },
             ]}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.test.tsx
@@ -10,7 +10,7 @@ describe('<VitalsBiometricsInput/>', () => {
     textFields: [
       {
         name: 'heartRate',
-        type: 'text',
+        type: 'number',
         value: 120,
       },
     ],
@@ -28,9 +28,9 @@ describe('<VitalsBiometricsInput/>', () => {
     );
     expect(screen.getByText(/Heart Rate/i)).toBeInTheDocument();
     expect(screen.getByText(/bpm/i)).toBeInTheDocument();
-    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
 
-    const inputTextBox = await screen.findByRole('textbox');
+    const inputTextBox = await screen.findByRole('spinbutton');
     userEvent.type(inputTextBox, '75');
     expect(mockOnChange).toHaveBeenCalledTimes(2);
   });
@@ -65,9 +65,9 @@ describe('<VitalsBiometricsInput/>', () => {
     );
     expect(screen.getByText(/Heart Rate/i)).toBeInTheDocument();
     expect(screen.getByText(/bpm/i)).toBeInTheDocument();
-    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
 
-    const inputTextBox = await screen.findByRole('textbox');
+    const inputTextBox = await screen.findByRole('spinbutton');
     userEvent.type(inputTextBox, '7');
     expect(inputTextBox).toHaveProperty('disabled');
     expect(inputTextBox).toHaveClass('danger');

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -41,16 +41,6 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
   function check(value) {
     setInvalid(!(Number(value) || value === ''));
   }
-  const error = () => {
-    return <FormLabel className={styles.danger}>{t('numericInputError', 'Must be a number')}</FormLabel>;
-  };
-  function preventNonNumericalInput(e) {
-    e = e || window.event;
-    let charCode = typeof e.which == 'undefined' ? e.keyCode : e.which;
-    let charStr = String.fromCharCode(charCode);
-
-    if (!charStr.match(/^[0-9]+$/)) e.preventDefault();
-  }
 
   return (
     <div className={styles.inputContainer} style={{ width: textFieldWidth }}>
@@ -74,7 +64,6 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
                   name={val.name}
                   onChange={(e) => check(e.target.value)}
                   onInput={onInputChange}
-                  onKeyPress={(e) => preventNonNumericalInput(e)}
                   labelText={''}
                   value={val.value}
                   title={val.name}
@@ -102,7 +91,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
         </div>
         <p className={styles.unitName}>{unitSymbol}</p>
       </div>
-      {invalid ? error() : null}
+      {invalid ? <FormLabel className={styles.danger}>{t('numericInputError', 'Must be a number')}</FormLabel> : null}
     </div>
   );
 };

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -49,6 +49,8 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
                     !inputIsNormal && styles.danger
                   }`}
                   id={val.name}
+                  type="number"
+                  min={0}
                   name={val.name}
                   onChange={onInputChange}
                   labelText={''}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -37,12 +37,21 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
 }) => {
   const { t } = useTranslation();
   const [invalid, setInvalid] = useState<boolean>(false);
-  const check = (value) => {
-    Number(value) || value === '' ? setInvalid(false) : setInvalid(true);
-  };
+
+  function check(value) {
+    setInvalid(!(Number(value) || value === ''));
+  }
   const error = () => {
     return <FormLabel className={styles.danger}>{t('numericInputError', 'Must be a number')}</FormLabel>;
   };
+  function preventNonNumericalInput(e) {
+    e = e || window.event;
+    let charCode = typeof e.which == 'undefined' ? e.keyCode : e.which;
+    let charStr = String.fromCharCode(charCode);
+
+    if (!charStr.match(/^[0-9]+$/)) e.preventDefault();
+  }
+
   return (
     <div className={styles.inputContainer} style={{ width: textFieldWidth }}>
       <p className={styles.vitalsBiometricInputLabel01}>{title}</p>
@@ -51,7 +60,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
         style={{ ...textFieldStyles }}>
         <div className={styles.centerDiv}>
           {textFields.map((val) => {
-            return val.type === 'text' ? (
+            return val.type === 'number' ? (
               <Fragment key={val.name}>
                 <TextInput
                   style={{ ...textFieldStyles }}
@@ -60,9 +69,12 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
                   }`}
                   id={val.name}
                   invalid={invalid}
+                  type={val.type}
+                  min={0}
                   name={val.name}
                   onChange={(e) => check(e.target.value)}
                   onInput={onInputChange}
+                  onKeyPress={(e) => preventNonNumericalInput(e)}
                   labelText={''}
                   value={val.value}
                   title={val.name}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -1,6 +1,7 @@
-import React, { Fragment } from 'react';
-import { TextArea, TextInput } from 'carbon-components-react';
+import React, { Fragment, useState } from 'react';
+import { FormLabel, TextArea, TextInput } from 'carbon-components-react';
 import styles from './vitals-biometrics-input.component.scss';
+import { useTranslation } from 'react-i18next';
 
 interface VitalsBiometricInputProps {
   title: string;
@@ -11,6 +12,7 @@ interface VitalsBiometricInputProps {
     type?: string | 'text';
     value: number | string;
     className?: string;
+    invalid?: boolean;
   }>;
   unitSymbol?: string;
   textFieldWidth?: string;
@@ -33,6 +35,14 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
   inputIsNormal,
   isTablet,
 }) => {
+  const { t } = useTranslation();
+  const [invalid, setInvalid] = useState<boolean>(false);
+  const check = (value) => {
+    Number(value) || value === '' ? setInvalid(false) : setInvalid(true);
+  };
+  const error = () => {
+    return <FormLabel className={styles.danger}>{t('numericInputError', 'Must be a number')}</FormLabel>;
+  };
   return (
     <div className={styles.inputContainer} style={{ width: textFieldWidth }}>
       <p className={styles.vitalsBiometricInputLabel01}>{title}</p>
@@ -49,10 +59,10 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
                     !inputIsNormal && styles.danger
                   }`}
                   id={val.name}
-                  type="number"
-                  min={0}
+                  invalid={invalid}
                   name={val.name}
-                  onChange={onInputChange}
+                  onChange={(e) => check(e.target.value)}
+                  onInput={onInputChange}
                   labelText={''}
                   value={val.value}
                   title={val.name}
@@ -80,6 +90,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
         </div>
         <p className={styles.unitName}>{unitSymbol}</p>
       </div>
+      {invalid ? error() : null}
     </div>
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d5df2840a9c1136401d7c7).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

-validate biometrics and vitals form inputs to only allow numerals


## Screenshots


![MF-737](https://user-images.githubusercontent.com/40205991/139641610-b7dfb421-1670-4a89-93cc-b7c48a4838c3.gif)


## Issue

[MF-737](https://issues.openmrs.org/browse/MF-737)


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
