### PR TITLE
Move `extract-translations` task to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+set -e  # die on error
+
+yarn run extract-translations

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,4 +7,3 @@ npx pretty-quick --staged
 npx lerna run lint
 npx lerna run test
 npx lerna run typescript
-yarn run extract-translations


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

`yarn run extract-translations` should run pre-commit so that the updated translation files get committed. 

Occasionally, after updating your local branch, you'll see uncommitted translation files show up in your IDE git diff. Moving this task to the pre-commit hook affords the committer a chance to include any potentially updated translations without having to amend their commits or push subsequent commits just for that purpose.