### PR TITLE
MF-868: Add providerUuid to valueProcessingInfo for AMPATH Forms engine.

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -305,6 +305,7 @@ export class FeWrapperComponent implements OnInit {
     this.form.valueProcessingInfo.personUuid = this.patient.id;
     this.form.valueProcessingInfo.patientUuid = this.patient.id;
     this.form.valueProcessingInfo.formUuid = this.formSchema.uuid;
+    this.form.valueProcessingInfo.providerUuid = this.loggedInUser.currentProvider.uuid;
     if (this.formSchema.encounterType) {
       this.form.valueProcessingInfo.encounterTypeUuid = this.formSchema.encounterType.uuid;
     } else {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This adds the providerUuid in form engine valueProcessingInfo which is required for some features like making test orders via the engine to work properly. Without this the `orderer` property won't be set and  you can't save the form.


## Screenshots

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue
https://issues.openmrs.org/browse/MF-868

## Other
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
