### PR TITLE
MF-635: Fix design issues in the patient banner

### DIFF
--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
@@ -15,7 +15,7 @@ const Address: React.FC<{ address: fhir.Address }> = ({ address }) => {
   const { city, country, postalCode, state } = address;
 
   return (
-    <div className={styles.col}>
+    <>
       <p className={styles.heading}>{t('address', 'Address')}</p>
       <ul>
         <li>{postalCode}</li>
@@ -23,7 +23,7 @@ const Address: React.FC<{ address: fhir.Address }> = ({ address }) => {
         <li>{state}</li>
         <li>{country}</li>
       </ul>
-    </div>
+    </>
   );
 };
 
@@ -32,12 +32,12 @@ const Contact: React.FC<{ telecom: Array<fhir.ContactPoint> }> = ({ telecom }) =
   const value = telecom && telecom.length ? telecom[0].value : '-';
 
   return (
-    <div className={styles.col}>
+    <>
       <p className={styles.heading}>{t('contactDetails', 'Contact Details')}</p>
       <ul>
         <li>{value}</li>
       </ul>
-    </div>
+    </>
   );
 };
 
@@ -46,14 +46,14 @@ const Relationships: React.FC<{ patientId: string }> = ({ patientId }) => {
   const { data: relationships, isLoading } = useRelationships(patientId);
 
   return (
-    <div className={styles.col}>
+    <>
       <p className={styles.heading}>{t('relationships', 'Relationships')}</p>
       <>
         {(() => {
           if (isLoading) return <InlineLoading description="Loading..." role="progressbar" />;
           if (relationships?.length) {
             return (
-              <ul style={{ width: '50%' }}>
+              <ul>
                 {relationships.map((r) => (
                   <li key={r.uuid} className={styles.relationship}>
                     <div>{r.display}</div>
@@ -67,7 +67,7 @@ const Relationships: React.FC<{ patientId: string }> = ({ patientId }) => {
           return <p>-</p>;
         })()}
       </>
-    </div>
+    </>
   );
 };
 
@@ -75,19 +75,21 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ address, telecom, patie
   const currentAddress = address.find((a) => a.use === 'home');
 
   return (
-    <div className={styles.verticalLine}>
-      <hr className={styles.hr} />
-      <div className={styles.contactDetails}>
-        <div className={styles.row}>
+    <div className={styles.contactDetails}>
+      <div className={styles.row}>
+        <div className={styles.col}>
           <Address address={currentAddress} />
+        </div>
+        <div className={styles.col}>
           <Contact telecom={telecom} />
         </div>
-        <hr className={styles.hr} />
-        <div className={styles.row}>
+      </div>
+      <div className={styles.row}>
+        <div className={styles.col}>
           <Relationships patientId={patientId} />
         </div>
+        <div className={styles.col}>{/* Patient lists go here */}</div>
       </div>
-      <hr className={styles.hr} />
     </div>
   );
 };

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.scss
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.scss
@@ -3,6 +3,7 @@
 .contactDetails {
   color: $text-02;
   width: 100%;
+  border-top: 1px solid $ui-03;
 }
 
 .heading {
@@ -13,13 +14,19 @@
 .row {
   @include carbon--type-style("body-short-01");
   display: flex;
-  margin: 1rem 0;
+
+  &:first-child {
+    border-bottom: 1px solid $ui-03;
+  }
 }
 
-.row .col {
+.row > .col {
   flex: 1;
-  padding: 1.0125rem;
-  padding-top: 0.15rem;
+  padding: 1rem 1rem;
+
+  &:nth-of-type(2n + 1) {
+    border-right: 1px solid $ui-03;
+  }
 }
 
 .row li {
@@ -33,24 +40,5 @@
 
 .relationship div {
   flex: 1 1;
-}
-
-.verticalLine {
-  position: relative;
-}
-
-.verticalLine:after {
-  content: '';
-  position: absolute;
-  border-left: $spacing-01 solid $ui-03;
-  left: 50%;
-  top: 0;
-  bottom: 0;
-}
-
-.hr{
-  height: $spacing-01;
-  background-color: $ui-03;
-  border: none;
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR fixes some design issues in the patient banner. It:

- Fixes incorrect use of a horizontal rule when a 1px border would be better suited.
- Changes the design to use the correct border size and colour.
- Removes the space between the ContactDetails component and the Vitals header (see linked screenshots).
- Removes the bottom border on the ContactDetails component (notice the dark grey border just above the Vitals header).

Before:
<img width="960" alt="Screenshot 2021-10-28 at 22 47 14" src="https://user-images.githubusercontent.com/8509731/139325133-8b22a8d2-649c-42ab-b324-7228d0783d74.png">

After:
<img width="961" alt="Screenshot 2021-10-28 at 22 35 36" src="https://user-images.githubusercontent.com/8509731/139324930-9612bcfc-a1fa-488b-89df-2350fa41587f.png">

## Issue

Part of https://issues.openmrs.org/projects/MF/issues/MF-635.