### PR TITLE
Add type definitions for jest-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/react": "^16.14.5",
     "@types/react-dom": "^16.9.12",
     "@types/react-router-dom": "^5.1.7",
+    "@types/testing-library__jest-dom": "^5.14.1",
     "@types/webpack-env": "^1.16.0",
     "@typescript-eslint/eslint-plugin": "^4.15.1",
     "@typescript-eslint/parser": "^4.15.1",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR adds type definitions for jest-dom. 

This fixes an issue in my VS Code where the Typescript compiler complains about missing type definitions for jest-dom extend-expect matchers. 


## Screenshots

<img width="481" alt="Screenshot 2021-10-29 at 23 34 53" src="https://user-images.githubusercontent.com/8509731/139498572-9450376a-1719-4354-8ef2-c88117ea0e91.png">