### PR TITLE
MF-635: Fix patient chart widget card headers

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -86,7 +86,7 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
     return (
       <div className={styles.widgetCard}>
         <div className={styles.allergiesHeader}>
-          <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
+          <h4>{headerTitle}</h4>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           {showAddAllergy && (
             <Button kind="ghost" renderIcon={Add16} iconDescription="Add allergies" onClick={launchAllergiesForm}>

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
@@ -22,7 +22,7 @@ import {
 } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import { useAllergies } from './allergy-intolerance.resource';
-import { usePagination } from '@openmrs/esm-framework';
+import { useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { allergiesToShowCount, patientAllergiesFormWorkspace } from '../constants';
 
 interface AllergiesOverviewProps {
@@ -37,6 +37,7 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = ({ patient, showAddA
   const headerTitle = t('allergies', 'Allergies');
   const urlLabel = t('seeAll', 'See all');
   const pageUrl = window.spaBase + basePath + '/allergies';
+  const isTablet = useLayoutType() === 'tablet';
 
   const { data: allergies, isError, isLoading, isValidating } = useAllergies(patient.id);
   const { results: paginatedAllergies, goTo, currentPage } = usePagination(allergies ?? [], allergiesToShowCount);
@@ -68,8 +69,8 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = ({ patient, showAddA
   if (allergies?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={styles.allergiesHeader}>
-          <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
+        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
+          <h4>{headerTitle}</h4>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           {showAddAllergy && (
             <Button kind="ghost" renderIcon={Add16} iconDescription="Add allergies" onClick={launchAllergiesForm}>

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.scss
@@ -6,18 +6,34 @@
   border: 1px solid $ui-03;
 }
 
-.allergiesHeader {
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
 }
 
-.allergiesHeader > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.scss
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.scss
@@ -9,7 +9,7 @@
 $color-blue-30 : #a6c8ff;
 $color-blue-10: #edf5ff;
 
-.card {
+.widgetCard {
   border: 1px solid $ui-03;
 }
 
@@ -17,20 +17,36 @@ $color-blue-10: #edf5ff;
   @include carbon--type-style("productive-heading-01");
 }
 
-.appointmentsHeader {
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
 }
 
-.appointmentsHeader > h4:after {
-  content: "";
-  display: block;
-  width: $spacing-07;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }
 
 .contentSwitcherWrapper {

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
 import Add16 from '@carbon/icons-react/es/add/16';
-import { attach } from '@openmrs/esm-framework';
+import { useLayoutType } from '@openmrs/esm-framework';
 import { EmptyDataIllustration, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { Button, DataTableSkeleton, ContentSwitcher, InlineLoading, Switch, Tile } from 'carbon-components-react';
 import { useAppointments } from './appointments.resource';
@@ -22,6 +22,7 @@ enum AppointmentTypes {
 const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const headerTitle = t('appointments', 'Appointments');
+  const isTablet = useLayoutType() === 'tablet';
 
   const [contentSwitcherValue, setContentSwitcherValue] = useState(0);
   const startDate = dayjs(new Date().toISOString()).subtract(6, 'month').toISOString();
@@ -40,9 +41,9 @@ const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
   }
   if (Object.keys(appointmentsData)?.length) {
     return (
-      <div className={styles.card}>
-        <div className={styles.appointmentsHeader}>
-          <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
+      <div className={styles.widgetCard}>
+        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
+          <h4>{headerTitle}</h4>
           {isValidating ? (
             <span>
               <InlineLoading />

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
@@ -7,7 +7,7 @@ import BiometricsChart from './biometrics-chart.component';
 import BiometricsPagination from './biometrics-pagination.component';
 import { Button, DataTableSkeleton, InlineLoading } from 'carbon-components-react';
 import { useTranslation } from 'react-i18next';
-import { useConfig } from '@openmrs/esm-framework';
+import { useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { useBiometrics } from './biometrics.resource';
 import {
   EmptyState,
@@ -39,6 +39,7 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
   const displayText = t('biometrics', 'biometrics');
   const headerTitle = t('biometrics', 'Biometrics');
   const [chartView, setChartView] = React.useState(false);
+  const isTablet = useLayoutType() === 'tablet';
 
   const config = useConfig() as ConfigObject;
   const { bmiUnit } = config.biometrics;
@@ -76,9 +77,9 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
   if (isError) return <ErrorState error={isError} headerTitle={headerTitle} />;
   if (biometrics?.length) {
     return (
-      <div className={styles.biometricsWidgetContainer}>
-        <div className={styles.biometricsHeaderContainer}>
-          <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
+      <div className={styles.widgetCard}>
+        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
+          <h4>{headerTitle}</h4>
           <div className={styles.backgroundDataFetchingIndicator}>
             <span>{isValidating ? <InlineLoading /> : null}</span>
           </div>

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
@@ -2,18 +2,40 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
-.biometricsWidgetContainer {
-  background-color: $ui-background;
+.widgetCard {
   border: 1px solid $ui-03;
-  position: relative;
 }
 
-.biometricsHeaderContainer {
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
+}
+
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }
 
 .biometricsHeaderActionItems {
@@ -28,14 +50,6 @@
   height: 1rem;
   color: $ui-03;
   margin: 0rem 0.5rem;
-}
-
-.biometricsHeaderContainer > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
 }
 
 .toggleButtons {
@@ -96,10 +110,6 @@
   &:global(.bx--btn--ghost) {
     border-left: 0rem;
   }
-}
-
-.customRow tbody{
-  white-space: nowrap;
 }
 
 .backgroundDataFetchingIndicator {

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-pagination.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-pagination.component.tsx
@@ -36,7 +36,7 @@ const BiometricsPagination: React.FC<BiometricsPaginationProps> = ({
       <TableContainer>
         <DataTable rows={paginatedBiometrics} headers={tableHeaders} isSortable size="short">
           {({ rows, headers, getHeaderProps, getTableProps }) => (
-            <Table {...getTableProps()} className={styles.customRow}>
+            <Table {...getTableProps()} useZebraStyles>
               <TableHead>
                 <TableRow>
                   {headers.map((header) => (

--- a/packages/esm-patient-common-lib/src/empty-state/empty-state.component.tsx
+++ b/packages/esm-patient-common-lib/src/empty-state/empty-state.component.tsx
@@ -3,6 +3,7 @@ import styles from './empty-state.scss';
 import { Link, Tile } from 'carbon-components-react';
 import { Trans, useTranslation } from 'react-i18next';
 import { EmptyDataIllustration } from './empty-data-illustration.component';
+import { useLayoutType } from '@openmrs/esm-framework';
 
 export interface EmptyStateProps {
   headerTitle: string;
@@ -12,10 +13,13 @@ export interface EmptyStateProps {
 
 export const EmptyState: React.FC<EmptyStateProps> = (props) => {
   const { t } = useTranslation();
+  const isTablet = useLayoutType() === 'tablet';
 
   return (
     <Tile light className={styles.tile}>
-      <h1 className={styles.heading}>{props.headerTitle}</h1>
+      <div className={isTablet ? styles.tabletHeading : styles.desktopHeading}>
+        <h4>{props.headerTitle}</h4>
+      </div>
       <EmptyDataIllustration />
       <p className={styles.content}>
         <Trans i18nKey="emptyStateText" values={{ displayText: props.displayText.toLowerCase() }}>

--- a/packages/esm-patient-common-lib/src/empty-state/empty-state.scss
+++ b/packages/esm-patient-common-lib/src/empty-state/empty-state.scss
@@ -13,12 +13,32 @@
   margin-bottom: $spacing-03;
 }
 
-.heading {
+.desktopHeading {
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeading {
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
+}
+
+.desktopHeading, .tabletHeading {
   text-align: left;
   text-transform: capitalize;
-  margin-bottom: 1rem;
-  @include carbon--type-style("productive-heading-03");
-  color: $text-02;
+  margin-bottom: $spacing-05;
+  
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
 }
 
 .heading:after {

--- a/packages/esm-patient-common-lib/src/error-state/error-state.component.tsx
+++ b/packages/esm-patient-common-lib/src/error-state/error-state.component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styles from './error-state.scss';
 import { Tile } from 'carbon-components-react';
 import { useTranslation } from 'react-i18next';
+import { useLayoutType } from '@openmrs/esm-react-utils';
 
 export interface ErrorStateProps {
   error: any;
@@ -10,10 +11,13 @@ export interface ErrorStateProps {
 
 export const ErrorState: React.FC<ErrorStateProps> = ({ error, headerTitle }) => {
   const { t } = useTranslation();
+  const isTablet = useLayoutType() === 'tablet';
 
   return (
     <Tile light className={styles.tile}>
-      <h1 className={styles.heading}>{headerTitle}</h1>
+      <div className={isTablet ? styles.tabletHeading : styles.desktopHeading}>
+        <h4>{headerTitle}</h4>
+      </div>
       <p className={styles.errorMessage}>
         {t('error', 'Error')} {`${error?.response?.status}: `}
         {error?.response?.statusText}

--- a/packages/esm-patient-common-lib/src/error-state/error-state.scss
+++ b/packages/esm-patient-common-lib/src/error-state/error-state.scss
@@ -15,20 +15,32 @@
   color: $text-02;
 }
 
-.heading {
+.desktopHeading {
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeading {
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
+}
+
+.desktopHeading, .tabletHeading {
   text-align: left;
   text-transform: capitalize;
   margin-bottom: $spacing-05;
-  @include carbon--type-style("productive-heading-03");
-  color: $text-02;
-}
 
-.heading:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
 }
 
 .tile {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -66,7 +66,7 @@ const ConditionsDetailedSummary: React.FC = () => {
     return (
       <div className={styles.widgetCard}>
         <div className={styles.conditionsHeader}>
-          <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
+          <h4>{headerTitle}</h4>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           <Button kind="ghost" renderIcon={Add16} iconDescription="Add conditions" onClick={launchConditionsForm}>
             {t('add', 'Add')}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
@@ -15,7 +15,7 @@ import {
 } from 'carbon-components-react';
 import Add16 from '@carbon/icons-react/es/add/16';
 import styles from './conditions-overview.scss';
-import { usePagination } from '@openmrs/esm-framework';
+import { useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { useConditions } from './conditions.resource';
 import {
@@ -38,6 +38,7 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patient, basePa
   const headerTitle = t('conditions', 'Conditions');
   const urlLabel = t('seeAll', 'See all');
   const pageUrl = window.spaBase + basePath + '/conditions';
+  const isTablet = useLayoutType() === 'tablet';
 
   const { data: conditions, isError, isLoading, isValidating } = useConditions(patient.id);
   const { results: paginatedConditions, goTo, currentPage } = usePagination(conditions ?? [], conditionsToShowCount);
@@ -66,8 +67,8 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patient, basePa
   if (conditions?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={styles.conditionsHeader}>
-          <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
+        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
+          <h4>{headerTitle}</h4>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           <Button kind="ghost" renderIcon={Add16} iconDescription="Add conditions" onClick={launchConditionsForm}>
             {t('add', 'Add')}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.scss
@@ -6,18 +6,39 @@
   border: 1px solid $ui-03;
 }
 
-.conditionsHeader {
+.heading h4 {
+  @include carbon--type-style('productive-heading-02');
+  color: $text-02;
+}
+
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
 }
 
-.conditionsHeader > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }

--- a/packages/esm-patient-forms-app/src/forms/forms.component.scss
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.scss
@@ -6,26 +6,42 @@
   @include carbon--type-style("body-short-01");
 }
 
-.formsWidgetContainer {
+.widgetCard {
   background-color: $ui-background;
   border: 1px solid $ui-03;
   position: relative;
 }
 
-.formsHeaderContainer {
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
 }
 
-.formsHeaderContainer > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }
 
 .contextSwitcherContainer {
@@ -33,9 +49,14 @@
   margin-right: 1rem;
 }
 
-.contextSwitcherWidth {
+.desktopContentSwitcher {
   width: 100%;
-  height: 48px;
+  height: 2rem;
+}
+
+.tabletContentSwitcher {
+  width: 100%;
+  height: 2.5rem;
 }
 
 .helperContainer {

--- a/packages/esm-patient-forms-app/src/forms/forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.tsx
@@ -6,6 +6,7 @@ import { ContentSwitcher, Switch, DataTableSkeleton, InlineLoading } from 'carbo
 import { ErrorState } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import { useForms } from '../hooks/useForms';
+import { useLayoutType } from '@openmrs/esm-framework';
 
 const enum FormsCategory {
   Recommended,
@@ -24,6 +25,7 @@ interface FormsProps {
 const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, urlLabel }) => {
   const { t } = useTranslation();
   const headerTitle = t('forms', 'Forms');
+  const isTablet = useLayoutType() === 'tablet';
   const [formsCategory, setFormsCategory] = useState(FormsCategory.All);
   const { isValidating, data, error } = useForms(patientUuid);
 
@@ -40,9 +42,9 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
   }
 
   return (
-    <div className={styles.formsWidgetContainer}>
-      <div className={styles.formsHeaderContainer}>
-        <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
+    <div className={styles.widgetCard}>
+      <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
+        <h4>{headerTitle}</h4>
         {isValidating ? (
           <span>
             <InlineLoading />
@@ -50,7 +52,7 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
         ) : null}
         <div className={styles.contextSwitcherContainer}>
           <ContentSwitcher
-            className={styles.contextSwitcherWidth}
+            className={isTablet ? styles.tabletContentSwitcher : styles.desktopContentSwitcher}
             onChange={(event) => setFormsCategory(event.name as any)}
             selectedIndex={formsCategory}
           >

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.component.tsx
@@ -23,7 +23,7 @@ import {
 } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import { useImmunizations } from './immunizations.resource';
-import { usePagination } from '@openmrs/esm-framework';
+import { useLayoutType, usePagination } from '@openmrs/esm-framework';
 
 export interface ImmunizationsOverviewProps {
   basePath: string;
@@ -38,6 +38,7 @@ const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = ({ patient, 
   const headerTitle = t('immunizations', 'Immunizations');
   const urlLabel = t('seeAll', 'See all');
   const pageUrl = window.spaBase + basePath + '/immunizations';
+  const isTablet = useLayoutType() === 'tablet';
 
   const { data: immunizations, isError, isLoading, isValidating } = useImmunizations(patientUuid);
   const {
@@ -73,8 +74,8 @@ const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = ({ patient, 
   if (immunizations?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={styles.immunizationsHeader}>
-          <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
+        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
+          <h4>{headerTitle}</h4>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           <Button kind="ghost" renderIcon={Add16} iconDescription="Add immunizations" onClick={launchImmunizationsForm}>
             {t('add', 'Add')}

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.scss
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.scss
@@ -6,20 +6,36 @@
   border: 1px solid $ui-03;
 }
 
-.immunizationsHeader {
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
 }
 
-.immunizationsHeader > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }
 
 .immunizationOverviewSummaryCard {

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -28,6 +28,7 @@ import { OrderBasketStore, OrderBasketStoreActions, orderBasketStoreActions } fr
 import { Order } from '../types/order';
 import { OrderBasketItem } from '../types/order-basket-item';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { useLayoutType } from '@openmrs/esm-framework';
 
 export interface ActiveMedicationsProps {
   isValidating?: boolean;
@@ -63,6 +64,7 @@ const MedicationsDetailsTable = connect<
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(10);
     const [currentMedicationPage] = paginate(medications, page, pageSize);
+    const isTablet = useLayoutType() === 'tablet';
 
     const openOrderBasket = React.useCallback(() => launchPatientWorkspace('order-basket-workspace'), []);
 
@@ -152,7 +154,7 @@ const MedicationsDetailsTable = connect<
 
     return (
       <div className={styles.widgetCard}>
-        <div className={styles.cardHeader}>
+        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
           <h4>{title}</h4>
           {isValidating ? (
             <span>

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.scss
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.scss
@@ -4,29 +4,45 @@
   border: 1px solid $ui-03;
 }
 
-.cardHeader {
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
+
+  h4 {
+    @include carbon--type-style("productive-heading-03");
+    color: $text-02;
+  }
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
+
+  span {
+    margin: auto;
+  }
 }
 
-.cardHeader span {
-  margin: auto;
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
 }
 
-.cardHeader h4 {
-  @include carbon--type-style("productive-heading-03");
-  color: $text-02;
-}
-
-.cardHeader > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 3px;
-  border-bottom: 0.375rem solid $brand-teal-01;
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }
 
 .medicationRecord {

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -4,7 +4,7 @@ import NotesPagination from './notes-pagination.component';
 import styles from './notes-overview.scss';
 import { useTranslation } from 'react-i18next';
 import { Button, DataTableSkeleton, InlineLoading } from 'carbon-components-react';
-import { useVisit } from '@openmrs/esm-framework';
+import { useLayoutType, useVisit } from '@openmrs/esm-framework';
 import { useEncounters } from './encounter.resource';
 import {
   EmptyState,
@@ -35,6 +35,7 @@ const NotesMain: React.FC<NotesOverviewProps> = ({
   const displayText = t('notes', 'Notes');
   const headerTitle = t('notes', 'Notes');
   const { data: notes, isError, isLoading, isValidating } = useEncounters(patientUuid);
+  const isTablet = useLayoutType() === 'tablet';
 
   const launchVisitNoteForm = React.useCallback(() => {
     if (currentVisit) {
@@ -52,8 +53,8 @@ const NotesMain: React.FC<NotesOverviewProps> = ({
         if (notes?.length)
           return (
             <div className={styles.widgetCard}>
-              <div className={styles.notesHeader}>
-                <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
+              <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
+                <h4>{headerTitle}</h4>
                 <span>{isValidating ? <InlineLoading /> : null}</span>
                 {showAddNote && (
                   <Button

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.scss
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.scss
@@ -6,18 +6,35 @@
   border: 1px solid $ui-03;
 }
 
-.notesHeader {
+
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
 }
 
-.notesHeader > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -80,7 +80,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = () => {
     return (
       <div className={styles.widgetCard}>
         <div className={styles.programsHeader}>
-          <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
+          <h4>{headerTitle}</h4>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           <Button
             kind="ghost"

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import dayjs from 'dayjs';
 import Add16 from '@carbon/icons-react/es/add/16';
 import styles from './programs-overview.scss';
-import { usePagination } from '@openmrs/esm-framework';
+import { useLayoutType, usePagination } from '@openmrs/esm-framework';
 import {
   DataTable,
   DataTableSkeleton,
@@ -42,6 +42,7 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ patientUuid, basePa
   const headerTitle = t('carePrograms', 'Care Programs');
   const urlLabel = t('seeAll', 'See all');
   const pageUrl = window.spaBase + basePath + '/programs';
+  const isTablet = useLayoutType() === 'tablet';
 
   const { data: enrollments, isError, isLoading, isValidating } = useEnrollments(patientUuid);
   const activeEnrollments = enrollments?.filter((enrollment) => !enrollment.dateCompleted);
@@ -86,8 +87,8 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ patientUuid, basePa
   if (activeEnrollments?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={styles.programsHeader}>
-          <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{headerTitle}</h4>
+        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
+          <h4>{headerTitle}</h4>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           <Button
             kind="ghost"

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.scss
@@ -6,18 +6,34 @@
   border: 1px solid $ui-03;
 }
 
-.programsHeader {
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
 }
 
-.programsHeader > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.scss
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.scss
@@ -6,18 +6,34 @@
   border: 1px solid $ui-03;
 }
 
-.externalOverviewHeader {
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
 }
 
-.externalOverviewHeader > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
@@ -7,7 +7,7 @@ import { EmptyState, ExternalOverviewProps } from '@openmrs/esm-patient-common-l
 import { RecentResultsGrid, Card } from './helpers';
 import { useTranslation } from 'react-i18next';
 import { Button, DataTableSkeleton } from 'carbon-components-react';
-import { navigate } from '@openmrs/esm-framework';
+import { navigate, useLayoutType } from '@openmrs/esm-framework';
 
 const resultsToShow = 5;
 
@@ -15,6 +15,7 @@ const RecentOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }
   const { t } = useTranslation();
   const cardTitle = t('recentResults', 'Recent Results');
   const { overviewData, loaded, error } = useOverviewData(patientUuid);
+  const isTablet = useLayoutType() === 'tablet';
 
   const handleSeeAll = useCallback(() => {
     navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/chart/test-results` });
@@ -28,7 +29,7 @@ const RecentOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }
             if (overviewData.length) {
               return (
                 <div className={styles.widgetCard}>
-                  <div className={styles.externalOverviewHeader}>
+                  <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
                     <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{cardTitle}</h4>
                     <Button
                       kind="ghost"

--- a/packages/esm-patient-test-results-app/src/overview/lab-results.scss
+++ b/packages/esm-patient-test-results-app/src/overview/lab-results.scss
@@ -30,20 +30,36 @@
   border: 0.125rem solid $brand-01;
 }
 
-.recent-overview-header-container {
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
   background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
 }
 
-.recent-overview-header-container > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }
 
 .info-button {

--- a/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import { RecentResultsGrid, Card } from './helpers';
 import { navigateToResults, navigateToTimeline, navigateToTrendline } from '../helpers';
+import { useLayoutType } from '@openmrs/esm-framework';
 
 const RECENT_COUNT = 2;
 
@@ -19,6 +20,7 @@ const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, basePath }
   const { t } = useTranslation();
   const cardTitle = t('recentResults', 'Recent Results');
   const { overviewData, loaded, error } = useOverviewData(patientUuid);
+  const isTablet = useLayoutType() === 'tablet';
 
   return (
     <RecentResultsGrid>
@@ -28,7 +30,7 @@ const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, basePath }
             if (overviewData.length) {
               return (
                 <div className={styles.widgetCard}>
-                  <div className={styles['recent-overview-header-container']}>
+                  <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
                     <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
                       {cardTitle} ({Math.min(RECENT_COUNT, overviewData.length)})
                     </h4>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -15,7 +15,7 @@ import {
   withUnit,
 } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
-import { attach } from '@openmrs/esm-framework';
+import { useLayoutType } from '@openmrs/esm-framework';
 import { patientVitalsBiometricsFormWorkspace } from '../constants';
 import { useVitals } from './vitals.resource';
 
@@ -32,6 +32,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
   const displayText = t('vitalSigns', 'Vital signs');
   const headerTitle = t('vitals', 'Vitals');
   const [chartView, setChartView] = React.useState<boolean>();
+  const isTablet = useLayoutType() === 'tablet';
 
   const { data: vitals, isError, isLoading, isValidating } = useVitals(patientUuid);
   const { data: conceptData } = useVitalsConceptMetadata();
@@ -86,8 +87,8 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
         if (isError) return <ErrorState error={isError} headerTitle={headerTitle} />;
         if (vitals?.length) {
           return (
-            <div className={styles.vitalsWidgetContainer}>
-              <div className={styles.vitalsHeaderContainer}>
+            <div className={styles.widgetCard}>
+              <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
                 <h4>{headerTitle}</h4>
                 <div className={styles.backgroundDataFetchingIndicator}>
                   <span>{isValidating ? <InlineLoading /> : null}</span>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
@@ -2,16 +2,41 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
-.vitalsWidgetContainer {
+.widgetCard {
   background-color: $ui-background;
   border: 1px solid $ui-03;
 }
 
-.vitalsHeaderContainer {
+.desktopHeader, .tabletHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: $spacing-04 0 $spacing-04 $spacing-05;
+  background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
+}
+
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
 }
 
 .divider {
@@ -19,19 +44,6 @@
   height: 1rem;
   color: $ui-03;
   margin: 0rem 0.5rem;
-}
-
-.vitalsHeaderContainer h4 {
-  @include carbon--type-style('productive-heading-03');
-  color: $text-02;
-}
-
-.vitalsHeaderContainer > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
 }
 
 .toggleButtons {
@@ -94,11 +106,6 @@
   }
 }
 
-.vitalsWidgetContainer {
-  background-color: $ui-background;
-  position: relative;
-}
-
 .vitalsHeaderActionItems {
   align-items: center;
   display: flex;
@@ -116,4 +123,3 @@
   flex: 1 1 0%;
   justify-content: end;
 }
-


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR changes the header designs of all the widgets in the patient chart. The card headers should have `3rem` height on the desktop viewport and `4.5rem` on a tablet. Additionally, the widget titles on the card headers change depending on the viewport.

## Screenshots

Desktop

![Screenshot 2021-10-30 at 01 17 35](https://user-images.githubusercontent.com/8509731/139536311-063a3c60-a8aa-4201-84b1-289ab123d98b.png)

Empty / error state

![Screenshot 2021-10-30 at 00 52 58](https://user-images.githubusercontent.com/8509731/139536360-4b5224f3-0d4e-492f-a255-342cad476c60.png)

Tablet 

<img width="960" alt="Screenshot 2021-10-30 at 17 13 34" src="https://user-images.githubusercontent.com/8509731/139536592-44990176-3bb4-4204-89ae-9cbdf21ff1c5.png">

## Issue

https://issues.openmrs.org/projects/MF/issues/MF-635