### PR TITLE
MF-635: Fix patient chart widget pagination

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-type.component.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-type.component.test.tsx
@@ -13,6 +13,7 @@ const mockHandleChange = jest.fn();
 const mockGoToPage = jest.fn();
 
 jest.mock('@openmrs/esm-framework', () => ({
+  ...(jest.requireActual('@openmrs/esm-framework') as any),
   usePagination: jest.fn(),
   useVisitTypes: jest.fn(),
 }));

--- a/packages/esm-patient-common-lib/src/pagination/pagination.component.scss
+++ b/packages/esm-patient-common-lib/src/pagination/pagination.component.scss
@@ -8,28 +8,39 @@
   @include carbon--type-style("body-short-01");
 }
 
-.paginationContainer {
+.desktop, .tablet {
+  @include carbon--type-style('body-short-01');
   display: flex;
-  flex-direction: row;
-  align-items: center;
-  background-color: $ui-02;
-  width: 100%;
-  min-height: 3rem;
-  overflow: hidden;
-}
-
-.paginationLink {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  z-index: 1;
-  position: absolute;
+  border-top: 1px solid #e0e0e0;
+  justify-content: space-between;
+  color: $text-02;
   background-color: $ui-02;
   padding-left: 1rem;
-  color: $color-gray-70;
-  @extend .bodyShort01;
-  height: 3rem;
-  margin: 0;
+  align-items: center;
+}
+
+.desktop :global(.bx--pagination) {
+  min-height: 0rem;
+  height: 2rem;
+  width: auto;
+  border: none;
+
+  & :global(.bx--select-input), :global(.bx--btn), :global(.bx--pagination__right) {
+    min-height: 0rem;
+    height: 2rem;
+  }
+}
+
+.tablet :global(.bx--pagination) {
+  min-height: 0rem;
+  height: 3rem; 
+  width: auto;   
+  border: none;
+
+  & :global(.bx--select-input), :global(.bx--btn), :global(.bx--pagination__right) {
+    min-height: 0rem;
+    height: 3rem;
+  }
 }
 
 .configurableLink {
@@ -39,18 +50,14 @@
 }
 
 .pagination {
-  border: none;
+  @include carbon--type-style('body-short-01');
   background-color: $ui-02;
-  position: absolute;
-  right: 0;
-  max-width: 100%;
-}
-.pagination > :first-child {
-  visibility: hidden;
-  width: 0;
+  color: $text-02;
+  display: flex;
 }
 
-.pagination :nth-child(2),
-.pagination :nth-child(2) > div {
-  display: flex;
+div.pagination {
+  & > :global(.bx--pagination__left) {
+    display: none;
+  }
 }

--- a/packages/esm-patient-common-lib/src/pagination/pagination.component.tsx
+++ b/packages/esm-patient-common-lib/src/pagination/pagination.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './pagination.component.scss';
 import { Pagination } from 'carbon-components-react';
 import { useTranslation } from 'react-i18next';
-import { ConfigurableLink } from '@openmrs/esm-framework';
+import { ConfigurableLink, useLayoutType } from '@openmrs/esm-framework';
 import { usePaginationInfo } from './usePaginationInfo';
 
 interface PatientChartPaginationProps {
@@ -26,12 +26,13 @@ export const PatientChartPagination: React.FC<PatientChartPaginationProps> = ({
 }) => {
   const { t } = useTranslation();
   const { itemsDisplayed, pageSizes } = usePaginationInfo(pageSize, totalItems, pageNumber, currentItems);
+  const isTablet = useLayoutType() === 'tablet';
 
   return (
     <>
       {totalItems > 0 && (
-        <div className={styles.paginationContainer}>
-          <div className={styles.paginationLink}>
+        <div className={isTablet ? styles.tablet : styles.desktop}>
+          <div>
             {itemsDisplayed}
             {pageUrl && (
               <ConfigurableLink to={pageUrl} className={styles.configurableLink}>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Fix the pagination in the patient chart widget cards so that: 

- In the desktop viewport, the pagination container and its children are of height `2rem`.
- In the tablet viewport, the pagination container and its children are of height `3rem`.

## Screenshots

Desktop 

<img width="1267" alt="Screenshot 2021-10-30 at 17 53 20" src="https://user-images.githubusercontent.com/8509731/139538889-8a20125c-1f26-41c7-b67f-4514b69289d5.png">

Tablet 

<img width="958" alt="Screenshot 2021-10-30 at 17 13 51" src="https://user-images.githubusercontent.com/8509731/139538899-76eba5b2-e228-4f0b-85fd-9338d3da6d6f.png">

## Issue

https://issues.openmrs.org/projects/MF/issues/MF-635