### PR TITLE
Trend and Timeline unresponsive in Tablet mode 

### DIFF
--- a/packages/esm-patient-test-results-app/src/desktopView/desktopView.tsx
+++ b/packages/esm-patient-test-results-app/src/desktopView/desktopView.tsx
@@ -3,6 +3,7 @@ import { Overview } from '../overview/overview.component';
 import { Timeline } from '../timeline/timeline.component';
 import Trendline from '../trendline/trendline.component';
 import { navigateToTimeline, navigateToTrendline } from '../helpers';
+import { useLayoutType } from '@openmrs/esm-framework';
 
 const Grid: React.FC<{}> = ({ children }) => (
   <div
@@ -64,6 +65,7 @@ const deduceViewState = ({ panelUuid, testUuid, type = 'none' }): ViewState => {
 
 const DesktopView: React.FC<Record<string, any>> = ({ patientUuid, panelUuid, testUuid, type, basePath }) => {
   const [viewState, setViewState] = React.useState<ViewState>(deduceViewState({ panelUuid, testUuid, type }));
+  const isTablet = useLayoutType() === 'tablet';
 
   React.useEffect(() => {
     setViewState(deduceViewState({ panelUuid, testUuid, type }));
@@ -76,7 +78,7 @@ const DesktopView: React.FC<Record<string, any>> = ({ patientUuid, panelUuid, te
     [basePath],
   );
 
-  return (
+  return !isTablet ? (
     <Grid>
       <OverflowBorder>
         <div style={{ display: 'grid', gap: '1.5rem' }}>
@@ -111,6 +113,43 @@ const DesktopView: React.FC<Record<string, any>> = ({ patientUuid, panelUuid, te
               return <div></div>;
           }
         })()}
+      </OverflowBorder>
+    </Grid>
+  ) : (
+    <Grid>
+      <OverflowBorder>
+        <div style={{ display: 'grid', gap: '1.5rem' }}>
+          <Overview patientUuid={patientUuid} openTimeline={openTimeline} openTrendline={openTrendline}></Overview>
+        </div>
+        <OverflowBorder>
+          {(() => {
+            switch (viewState.type) {
+              case 'timeline':
+                return (
+                  <Timeline
+                    patientUuid={patientUuid}
+                    panelUuid={viewState.panelUuid}
+                    key={viewState.panelUuid}
+                    openTrendline={openTrendline}
+                  />
+                );
+
+              case 'trendline':
+                return (
+                  <Trendline
+                    patientUuid={patientUuid}
+                    panelUuid={viewState.panelUuid}
+                    testUuid={viewState.testUuid}
+                    openTimeline={openTimeline}
+                  />
+                );
+
+              case 'none':
+              default:
+                return <div></div>;
+            }
+          })()}
+        </OverflowBorder>
       </OverflowBorder>
     </Grid>
   );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Makes Trend an Timeline responsive in tablet mode.



## Screenshots

![Trend and timeline responsive](https://user-images.githubusercontent.com/83347293/140025431-113ba48f-b258-4e80-8d43-cff1b2c1d46d.gif)

## Issue

- Issue  [O3-856](https://issues.openmrs.org/browse/O3-856?filter=-1)

