### PR TITLE
Fix incorrect `useLayoutType` import

### DIFF
--- a/packages/esm-patient-common-lib/src/error-state/error-state.component.tsx
+++ b/packages/esm-patient-common-lib/src/error-state/error-state.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './error-state.scss';
 import { Tile } from 'carbon-components-react';
 import { useTranslation } from 'react-i18next';
-import { useLayoutType } from '@openmrs/esm-react-utils';
+import { useLayoutType } from '@openmrs/esm-framework';
 
 export interface ErrorStateProps {
   error: any;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

`useLayoutType` is being imported from the wrong package in the ErrorState component - a change mistakenly introduced by https://github.com/openmrs/openmrs-esm-patient-chart/pull/446. As a result, an error is displayed instead of the appointments widget (see linked screenshot). This commit fixes the import and thus fixes the error.

## Screenshots

<img width="1265" alt="Screenshot 2021-11-03 at 11 07 20" src="https://user-images.githubusercontent.com/8509731/140026632-6f242594-8b52-4bca-b46a-e8f44cdbe8fb.png">


