### PR TITLE
MF-635: Reusable `CardHeader` component

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
-import { EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { useAllergies } from './allergy-intolerance.resource';
 import Add16 from '@carbon/icons-react/es/add/16';
 import {
@@ -85,15 +85,14 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
   if (allergies?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={styles.allergiesHeader}>
-          <h4>{headerTitle}</h4>
+        <CardHeader title={headerTitle}>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           {showAddAllergy && (
             <Button kind="ghost" renderIcon={Add16} iconDescription="Add allergies" onClick={launchAllergiesForm}>
               {t('add', 'Add')}
             </Button>
           )}
-        </div>
+        </CardHeader>
         <TableContainer>
           <DataTable rows={tableRows} headers={tableHeaders} isSortable={true}>
             {({ rows, headers, getHeaderProps, getTableProps }) => (

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
@@ -15,6 +15,7 @@ import {
 } from 'carbon-components-react';
 import styles from './allergies-overview.scss';
 import {
+  CardHeader,
   EmptyState,
   ErrorState,
   launchPatientWorkspace,
@@ -22,7 +23,7 @@ import {
 } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import { useAllergies } from './allergy-intolerance.resource';
-import { useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { usePagination } from '@openmrs/esm-framework';
 import { allergiesToShowCount, patientAllergiesFormWorkspace } from '../constants';
 
 interface AllergiesOverviewProps {
@@ -37,7 +38,6 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = ({ patient, showAddA
   const headerTitle = t('allergies', 'Allergies');
   const urlLabel = t('seeAll', 'See all');
   const pageUrl = window.spaBase + basePath + '/allergies';
-  const isTablet = useLayoutType() === 'tablet';
 
   const { data: allergies, isError, isLoading, isValidating } = useAllergies(patient.id);
   const { results: paginatedAllergies, goTo, currentPage } = usePagination(allergies ?? [], allergiesToShowCount);
@@ -69,15 +69,14 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = ({ patient, showAddA
   if (allergies?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-          <h4>{headerTitle}</h4>
+        <CardHeader title={headerTitle}>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           {showAddAllergy && (
             <Button kind="ghost" renderIcon={Add16} iconDescription="Add allergies" onClick={launchAllergiesForm}>
               {t('add', 'Add')}
             </Button>
           )}
-        </div>
+        </CardHeader>
         <TableContainer>
           <DataTable rows={tableRows} headers={tableHeaders} isSortable={true} size="short">
             {({ rows, headers, getHeaderProps, getTableProps }) => (

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.scss
@@ -5,35 +5,3 @@
 .widgetCard {
   border: 1px solid $ui-03;
 }
-
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
-  }
-}

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.scss
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.scss
@@ -17,38 +17,6 @@ $color-blue-10: #edf5ff;
   @include carbon--type-style("productive-heading-01");
 }
 
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
-  }
-}
-
 .contentSwitcherWrapper {
   display: flex;
   width: fit-content;

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
 import Add16 from '@carbon/icons-react/es/add/16';
-import { useLayoutType } from '@openmrs/esm-framework';
-import { EmptyDataIllustration, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyDataIllustration, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { Button, DataTableSkeleton, ContentSwitcher, InlineLoading, Switch, Tile } from 'carbon-components-react';
 import { useAppointments } from './appointments.resource';
 import styles from './appointments-base.component.scss';
@@ -22,7 +21,6 @@ enum AppointmentTypes {
 const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const headerTitle = t('appointments', 'Appointments');
-  const isTablet = useLayoutType() === 'tablet';
 
   const [contentSwitcherValue, setContentSwitcherValue] = useState(0);
   const startDate = dayjs(new Date().toISOString()).subtract(6, 'month').toISOString();
@@ -42,8 +40,7 @@ const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
   if (Object.keys(appointmentsData)?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-          <h4>{headerTitle}</h4>
+        <CardHeader title={headerTitle}>
           {isValidating ? (
             <span>
               <InlineLoading />
@@ -59,7 +56,7 @@ const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
               {t('add', 'Add')}
             </Button>
           </div>
-        </div>
+        </CardHeader>
         {(() => {
           if (contentSwitcherValue === AppointmentTypes.UPCOMING) {
             if (appointmentsData.upcomingAppointments?.length) {

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
@@ -6,7 +6,7 @@ import Add16 from '@carbon/icons-react/es/add/16';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'carbon-components-react';
 import { LayoutType, showModal, useLayoutType, usePagination, UserHasAccess } from '@openmrs/esm-framework';
-import { PatientChartPagination, EmptyState } from '@openmrs/esm-patient-common-lib';
+import { PatientChartPagination, EmptyState, CardHeader } from '@openmrs/esm-patient-common-lib';
 import { getAttachments, createAttachment, deleteAttachment, getAttachmentByUuid } from './attachments.resource';
 import { createGalleryEntry, readFileAsString } from './utils';
 
@@ -173,10 +173,11 @@ const AttachmentsOverview: React.FC<{ patientUuid: string }> = ({ patientUuid })
             className={`${styles.galleryContainer} ${layOutType === 'phone' ? styles.mobileLayout : ''}`}
           >
             <div className={styles.attachmentsHeader}>
-              <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{t('attachments', 'Attachments')}</h4>
-              <Button kind="ghost" renderIcon={Add16} iconDescription="Add attachment" onClick={showCam}>
-                {t('add', 'Add')}
-              </Button>
+              <CardHeader title={t('attachments', 'Attachments')}>
+                <Button kind="ghost" renderIcon={Add16} iconDescription="Add attachment" onClick={showCam}>
+                  {t('add', 'Add')}
+                </Button>
+              </CardHeader>
             </div>
             <Gallery
               images={attachments}

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
@@ -7,9 +7,10 @@ import BiometricsChart from './biometrics-chart.component';
 import BiometricsPagination from './biometrics-pagination.component';
 import { Button, DataTableSkeleton, InlineLoading } from 'carbon-components-react';
 import { useTranslation } from 'react-i18next';
-import { useConfig, useLayoutType } from '@openmrs/esm-framework';
+import { useConfig } from '@openmrs/esm-framework';
 import { useBiometrics } from './biometrics.resource';
 import {
+  CardHeader,
   EmptyState,
   ErrorState,
   useVitalsConceptMetadata,
@@ -39,7 +40,6 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
   const displayText = t('biometrics', 'biometrics');
   const headerTitle = t('biometrics', 'Biometrics');
   const [chartView, setChartView] = React.useState(false);
-  const isTablet = useLayoutType() === 'tablet';
 
   const config = useConfig() as ConfigObject;
   const { bmiUnit } = config.biometrics;
@@ -78,8 +78,7 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
   if (biometrics?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-          <h4>{headerTitle}</h4>
+        <CardHeader title={headerTitle}>
           <div className={styles.backgroundDataFetchingIndicator}>
             <span>{isValidating ? <InlineLoading /> : null}</span>
           </div>
@@ -111,7 +110,7 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
               </Button>
             )}
           </div>
-        </div>
+        </CardHeader>
         {chartView ? (
           <BiometricsChart patientBiometrics={biometrics} conceptsUnits={conceptUnits} />
         ) : (

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
@@ -6,38 +6,6 @@
   border: 1px solid $ui-03;
 }
 
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
-  }
-}
-
 .biometricsHeaderActionItems {
   align-items: center;
   display: flex;

--- a/packages/esm-patient-common-lib/src/cards/card-header.component.tsx
+++ b/packages/esm-patient-common-lib/src/cards/card-header.component.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useLayoutType } from '@openmrs/esm-framework';
+import styles from './card-header.scss';
+
+interface CardHeaderProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export function CardHeader({ title, children }: CardHeaderProps) {
+  const isTablet = useLayoutType() === 'tablet';
+
+  return (
+    <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
+      <h4>{title}</h4>
+      {children}
+    </div>
+  );
+}

--- a/packages/esm-patient-common-lib/src/cards/card-header.scss
+++ b/packages/esm-patient-common-lib/src/cards/card-header.scss
@@ -1,0 +1,35 @@
+@import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
+@import "~carbon-components/src/globals/scss/mixins";
+
+.desktopHeader, .tabletHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: $spacing-04 0 $spacing-04 $spacing-05;
+  background-color: $ui-background;
+
+  h4:after {
+    content: "";
+    display: block;
+    width: 2rem;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid $brand-teal-01;
+  }
+}
+
+.desktopHeader {  
+  height: 3rem;
+  h4 {
+    @include carbon--type-style('productive-heading-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeader {  
+  height: 4.5rem;
+  h4 {
+    @include carbon--type-style('productive-heading-03');
+    color: $text-02;
+  }
+}

--- a/packages/esm-patient-common-lib/src/cards/index.ts
+++ b/packages/esm-patient-common-lib/src/cards/index.ts
@@ -1,3 +1,4 @@
 export * from './record-details-card.component';
 export * from './summary-card.component';
 export * from './vertical-label-value.component';
+export * from './card-header.component';

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -18,7 +18,7 @@ import {
   TableRow,
 } from 'carbon-components-react';
 import { Condition, useConditions } from './conditions.resource';
-import { EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { useConditionsContext } from './conditions.context';
 
 const ConditionsDetailedSummary: React.FC = () => {
@@ -65,13 +65,12 @@ const ConditionsDetailedSummary: React.FC = () => {
   if (conditions?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={styles.conditionsHeader}>
-          <h4>{headerTitle}</h4>
+        <CardHeader title={headerTitle}>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           <Button kind="ghost" renderIcon={Add16} iconDescription="Add conditions" onClick={launchConditionsForm}>
             {t('add', 'Add')}
           </Button>
-        </div>
+        </CardHeader>
         <TableContainer>
           <DataTable rows={tableRows} headers={headers} isSortable={true} size="short">
             {({ rows, headers, getHeaderProps, getTableProps }) => (

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
@@ -15,7 +15,7 @@ import {
 } from 'carbon-components-react';
 import Add16 from '@carbon/icons-react/es/add/16';
 import styles from './conditions-overview.scss';
-import { useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { usePagination } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { useConditions } from './conditions.resource';
 import {
@@ -23,6 +23,7 @@ import {
   ErrorState,
   PatientChartPagination,
   launchPatientWorkspace,
+  CardHeader,
 } from '@openmrs/esm-patient-common-lib';
 
 const conditionsToShowCount = 5;
@@ -38,7 +39,6 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patient, basePa
   const headerTitle = t('conditions', 'Conditions');
   const urlLabel = t('seeAll', 'See all');
   const pageUrl = window.spaBase + basePath + '/conditions';
-  const isTablet = useLayoutType() === 'tablet';
 
   const { data: conditions, isError, isLoading, isValidating } = useConditions(patient.id);
   const { results: paginatedConditions, goTo, currentPage } = usePagination(conditions ?? [], conditionsToShowCount);
@@ -67,13 +67,12 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patient, basePa
   if (conditions?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-          <h4>{headerTitle}</h4>
+        <CardHeader title={headerTitle}>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           <Button kind="ghost" renderIcon={Add16} iconDescription="Add conditions" onClick={launchConditionsForm}>
             {t('add', 'Add')}
           </Button>
-        </div>
+        </CardHeader>
         <TableContainer>
           <DataTable rows={tableRows} headers={tableHeaders} isSortable={true} size="short">
             {({ rows, headers, getHeaderProps, getTableProps }) => (

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.scss
@@ -6,39 +6,3 @@
   border: 1px solid $ui-03;
 }
 
-.heading h4 {
-  @include carbon--type-style('productive-heading-02');
-  color: $text-02;
-}
-
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
-  }
-}

--- a/packages/esm-patient-forms-app/src/forms/forms.component.scss
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.scss
@@ -12,38 +12,6 @@
   position: relative;
 }
 
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
-  }
-}
-
 .contextSwitcherContainer {
   width: 60%;
   margin-right: 1rem;

--- a/packages/esm-patient-forms-app/src/forms/forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.tsx
@@ -3,7 +3,7 @@ import FormView from './form-view.component';
 import styles from './forms.component.scss';
 import EmptyFormView from './empty-form.component';
 import { ContentSwitcher, Switch, DataTableSkeleton, InlineLoading } from 'carbon-components-react';
-import { ErrorState } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import { useForms } from '../hooks/useForms';
 import { useLayoutType } from '@openmrs/esm-framework';
@@ -43,8 +43,7 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
 
   return (
     <div className={styles.widgetCard}>
-      <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-        <h4>{headerTitle}</h4>
+      <CardHeader title={headerTitle}>
         {isValidating ? (
           <span>
             <InlineLoading />
@@ -61,7 +60,7 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
             <Switch name={FormsCategory.All} text="All" />
           </ContentSwitcher>
         </div>
-      </div>
+      </CardHeader>
       <div style={{ width: '100%' }}>
         {formsCategory === FormsCategory.Completed && (
           <FormView

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
@@ -7,6 +7,7 @@ import isEmpty from 'lodash-es/isEmpty';
 import orderBy from 'lodash-es/orderBy';
 import styles from './immunizations-detailed-summary.scss';
 import {
+  CardHeader,
   EmptyState,
   ErrorState,
   launchPatientWorkspace,
@@ -125,13 +126,12 @@ const ImmunizationsDetailedSummary: React.FC<ImmunizationsDetailedSummaryProps> 
   if (isError) return <ErrorState error={isError} headerTitle={headerTitle} />;
   if (sortedImmunizations?.length) {
     <div className={styles.widgetCard}>
-      <div className={styles.immunizationsHeader}>
-        <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{t('immunizations', 'Immunizations')}</h4>
+      <CardHeader title={headerTitle}>
         <span>{isValidating ? <InlineLoading /> : null}</span>
         <Button kind="ghost" renderIcon={Add16} iconDescription="Add immunizations" onClick={launchImmunizationsForm}>
           {t('add', 'Add')}
         </Button>
-      </div>
+      </CardHeader>
       <DataTable rows={paginatedImmunizations} headers={tableHeader}>
         {({ rows, headers, getHeaderProps, getRowProps, getTableProps }) => (
           <Table {...getTableProps()} useZebraStyles>

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.component.tsx
@@ -16,6 +16,7 @@ import {
   InlineLoading,
 } from 'carbon-components-react';
 import {
+  CardHeader,
   EmptyState,
   ErrorState,
   launchPatientWorkspace,
@@ -23,7 +24,7 @@ import {
 } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import { useImmunizations } from './immunizations.resource';
-import { useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { usePagination } from '@openmrs/esm-framework';
 
 export interface ImmunizationsOverviewProps {
   basePath: string;
@@ -38,7 +39,6 @@ const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = ({ patient, 
   const headerTitle = t('immunizations', 'Immunizations');
   const urlLabel = t('seeAll', 'See all');
   const pageUrl = window.spaBase + basePath + '/immunizations';
-  const isTablet = useLayoutType() === 'tablet';
 
   const { data: immunizations, isError, isLoading, isValidating } = useImmunizations(patientUuid);
   const {
@@ -74,13 +74,12 @@ const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = ({ patient, 
   if (immunizations?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-          <h4>{headerTitle}</h4>
+        <CardHeader title={headerTitle}>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           <Button kind="ghost" renderIcon={Add16} iconDescription="Add immunizations" onClick={launchImmunizationsForm}>
             {t('add', 'Add')}
           </Button>
-        </div>
+        </CardHeader>
         <TableContainer>
           <DataTable headers={tableHeaders} rows={tableRows} isSortable={true} size="short">
             {({ rows, headers, getHeaderProps, getTableProps }) => (

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.scss
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.scss
@@ -6,38 +6,6 @@
   border: 1px solid $ui-03;
 }
 
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
-  }
-}
-
 .immunizationOverviewSummaryCard {
   margin: 1.25rem 1.5rem;
 }

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -27,8 +27,7 @@ import { connect } from 'unistore/react';
 import { OrderBasketStore, OrderBasketStoreActions, orderBasketStoreActions } from '../medications/order-basket-store';
 import { Order } from '../types/order';
 import { OrderBasketItem } from '../types/order-basket-item';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { useLayoutType } from '@openmrs/esm-framework';
+import { CardHeader, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 
 export interface ActiveMedicationsProps {
   isValidating?: boolean;
@@ -64,7 +63,6 @@ const MedicationsDetailsTable = connect<
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(10);
     const [currentMedicationPage] = paginate(medications, page, pageSize);
-    const isTablet = useLayoutType() === 'tablet';
 
     const openOrderBasket = React.useCallback(() => launchPatientWorkspace('order-basket-workspace'), []);
 
@@ -154,8 +152,7 @@ const MedicationsDetailsTable = connect<
 
     return (
       <div className={styles.widgetCard}>
-        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-          <h4>{title}</h4>
+        <CardHeader title={title}>
           {isValidating ? (
             <span>
               <InlineLoading />
@@ -166,7 +163,7 @@ const MedicationsDetailsTable = connect<
               {t('add', 'Add')}
             </Button>
           )}
-        </div>
+        </CardHeader>
         <DataTable headers={tableHeaders} rows={tableRows} isSortable={true} sortRow={sortRow} useZebraStyles>
           {({ rows, headers, getTableProps, getHeaderProps, getRowProps }) => (
             <TableContainer className={styles.tableHeader}>

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.scss
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.scss
@@ -2,46 +2,9 @@
 
 .widgetCard {
   border: 1px solid $ui-03;
-}
-
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4 {
-    @include carbon--type-style("productive-heading-03");
-    color: $text-02;
-  }
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
 
   span {
     margin: auto;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
   }
 }
 

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -4,9 +4,10 @@ import NotesPagination from './notes-pagination.component';
 import styles from './notes-overview.scss';
 import { useTranslation } from 'react-i18next';
 import { Button, DataTableSkeleton, InlineLoading } from 'carbon-components-react';
-import { useLayoutType, useVisit } from '@openmrs/esm-framework';
+import { useVisit } from '@openmrs/esm-framework';
 import { useEncounters } from './encounter.resource';
 import {
+  CardHeader,
   EmptyState,
   ErrorState,
   launchPatientWorkspace,
@@ -35,7 +36,6 @@ const NotesMain: React.FC<NotesOverviewProps> = ({
   const displayText = t('notes', 'Notes');
   const headerTitle = t('notes', 'Notes');
   const { data: notes, isError, isLoading, isValidating } = useEncounters(patientUuid);
-  const isTablet = useLayoutType() === 'tablet';
 
   const launchVisitNoteForm = React.useCallback(() => {
     if (currentVisit) {
@@ -53,8 +53,7 @@ const NotesMain: React.FC<NotesOverviewProps> = ({
         if (notes?.length)
           return (
             <div className={styles.widgetCard}>
-              <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-                <h4>{headerTitle}</h4>
+              <CardHeader title={headerTitle}>
                 <span>{isValidating ? <InlineLoading /> : null}</span>
                 {showAddNote && (
                   <Button
@@ -66,7 +65,7 @@ const NotesMain: React.FC<NotesOverviewProps> = ({
                     {t('add', 'Add')}
                   </Button>
                 )}
-              </div>
+              </CardHeader>
               <NotesPagination notes={notes} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />
             </div>
           );

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.scss
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.scss
@@ -5,36 +5,3 @@
 .widgetCard {
   border: 1px solid $ui-03;
 }
-
-
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
-  }
-}

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -5,7 +5,7 @@ import filter from 'lodash-es/filter';
 import includes from 'lodash-es/includes';
 import map from 'lodash-es/map';
 import styles from './programs-detailed-summary.scss';
-import { EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import { useAvailablePrograms, useEnrollments } from './programs.resource';
 import { useProgramsContext } from './programs.context';
@@ -79,8 +79,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = () => {
   if (enrolledPrograms?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={styles.programsHeader}>
-          <h4>{headerTitle}</h4>
+        <CardHeader title={headerTitle}>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           <Button
             kind="ghost"
@@ -91,7 +90,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = () => {
           >
             {t('add', 'Add')}
           </Button>
-        </div>
+        </CardHeader>
         <TableContainer>
           {availablePrograms?.length && eligiblePrograms?.length === 0 && (
             <InlineNotification

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import dayjs from 'dayjs';
 import Add16 from '@carbon/icons-react/es/add/16';
 import styles from './programs-overview.scss';
-import { useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { usePagination } from '@openmrs/esm-framework';
 import {
   DataTable,
   DataTableSkeleton,
@@ -21,6 +21,7 @@ import filter from 'lodash-es/filter';
 import includes from 'lodash-es/includes';
 import map from 'lodash-es/map';
 import {
+  CardHeader,
   EmptyState,
   ErrorState,
   PatientChartPagination,
@@ -42,7 +43,6 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ patientUuid, basePa
   const headerTitle = t('carePrograms', 'Care Programs');
   const urlLabel = t('seeAll', 'See all');
   const pageUrl = window.spaBase + basePath + '/programs';
-  const isTablet = useLayoutType() === 'tablet';
 
   const { data: enrollments, isError, isLoading, isValidating } = useEnrollments(patientUuid);
   const activeEnrollments = enrollments?.filter((enrollment) => !enrollment.dateCompleted);
@@ -87,8 +87,7 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ patientUuid, basePa
   if (activeEnrollments?.length) {
     return (
       <div className={styles.widgetCard}>
-        <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-          <h4>{headerTitle}</h4>
+        <CardHeader title={headerTitle}>
           <span>{isValidating ? <InlineLoading /> : null}</span>
           <Button
             kind="ghost"
@@ -99,7 +98,7 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ patientUuid, basePa
           >
             {t('add', 'Add')}
           </Button>
-        </div>
+        </CardHeader>
         <TableContainer>
           {availablePrograms?.length && eligiblePrograms?.length === 0 && (
             <InlineNotification

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.scss
@@ -5,35 +5,3 @@
 .widgetCard {
   border: 1px solid $ui-03;
 }
-
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
-  }
-}

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.scss
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.scss
@@ -5,35 +5,3 @@
 .widgetCard {
   border: 1px solid $ui-03;
 }
-
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
-  }
-}

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
@@ -3,11 +3,11 @@ import ArrowRight16 from '@carbon/icons-react/es/arrow--right/16';
 import CommonOverview from './common-overview';
 import styles from './external-overview.component.scss';
 import useOverviewData from './useOverviewData';
-import { EmptyState, ExternalOverviewProps } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyState, ExternalOverviewProps } from '@openmrs/esm-patient-common-lib';
 import { RecentResultsGrid, Card } from './helpers';
 import { useTranslation } from 'react-i18next';
 import { Button, DataTableSkeleton } from 'carbon-components-react';
-import { navigate, useLayoutType } from '@openmrs/esm-framework';
+import { navigate } from '@openmrs/esm-framework';
 
 const resultsToShow = 5;
 
@@ -15,7 +15,6 @@ const RecentOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }
   const { t } = useTranslation();
   const cardTitle = t('recentResults', 'Recent Results');
   const { overviewData, loaded, error } = useOverviewData(patientUuid);
-  const isTablet = useLayoutType() === 'tablet';
 
   const handleSeeAll = useCallback(() => {
     navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/chart/test-results` });
@@ -29,8 +28,7 @@ const RecentOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }
             if (overviewData.length) {
               return (
                 <div className={styles.widgetCard}>
-                  <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-                    <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{cardTitle}</h4>
+                  <CardHeader title={cardTitle}>
                     <Button
                       kind="ghost"
                       renderIcon={ArrowRight16}
@@ -39,7 +37,7 @@ const RecentOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }
                     >
                       {t('seeAllResults', 'See all results')}
                     </Button>
-                  </div>
+                  </CardHeader>
                   <CommonOverview
                     {...{
                       patientUuid,

--- a/packages/esm-patient-test-results-app/src/overview/lab-results.scss
+++ b/packages/esm-patient-test-results-app/src/overview/lab-results.scss
@@ -30,38 +30,6 @@
   border: 0.125rem solid $brand-01;
 }
 
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
-  }
-}
-
 .info-button {
   margin-left: 10px;
   padding-top: 1px;

--- a/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
@@ -3,11 +3,10 @@ import useOverviewData from './useOverviewData';
 import CommonOverview from './common-overview';
 import styles from './lab-results.scss';
 import { Button, DataTableSkeleton } from 'carbon-components-react';
-import { EmptyState } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyState } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import { RecentResultsGrid, Card } from './helpers';
 import { navigateToResults, navigateToTimeline, navigateToTrendline } from '../helpers';
-import { useLayoutType } from '@openmrs/esm-framework';
 
 const RECENT_COUNT = 2;
 
@@ -20,7 +19,6 @@ const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, basePath }
   const { t } = useTranslation();
   const cardTitle = t('recentResults', 'Recent Results');
   const { overviewData, loaded, error } = useOverviewData(patientUuid);
-  const isTablet = useLayoutType() === 'tablet';
 
   return (
     <RecentResultsGrid>
@@ -28,16 +26,14 @@ const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, basePath }
         <>
           {(() => {
             if (overviewData.length) {
+              const resultsCount = Math.min(RECENT_COUNT, overviewData.length);
               return (
                 <div className={styles.widgetCard}>
-                  <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-                    <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>
-                      {cardTitle} ({Math.min(RECENT_COUNT, overviewData.length)})
-                    </h4>
+                  <CardHeader title={`${cardTitle} ${resultsCount}`}>
                     <Button kind="ghost" onClick={() => navigateToResults(basePath)}>
                       {t('all_results', 'All results')}
                     </Button>
-                  </div>
+                  </CardHeader>
                   <CommonOverview
                     {...{
                       patientUuid,

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -8,6 +8,7 @@ import VitalsChart from './vitals-chart.component';
 import VitalsPagination from './vitals-pagination.component';
 import { DataTableSkeleton, Button, InlineLoading } from 'carbon-components-react';
 import {
+  CardHeader,
   EmptyState,
   ErrorState,
   launchPatientWorkspace,
@@ -15,7 +16,6 @@ import {
   withUnit,
 } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
-import { useLayoutType } from '@openmrs/esm-framework';
 import { patientVitalsBiometricsFormWorkspace } from '../constants';
 import { useVitals } from './vitals.resource';
 
@@ -32,7 +32,6 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
   const displayText = t('vitalSigns', 'Vital signs');
   const headerTitle = t('vitals', 'Vitals');
   const [chartView, setChartView] = React.useState<boolean>();
-  const isTablet = useLayoutType() === 'tablet';
 
   const { data: vitals, isError, isLoading, isValidating } = useVitals(patientUuid);
   const { data: conceptData } = useVitalsConceptMetadata();
@@ -88,8 +87,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
         if (vitals?.length) {
           return (
             <div className={styles.widgetCard}>
-              <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
-                <h4>{headerTitle}</h4>
+              <CardHeader title={headerTitle}>
                 <div className={styles.backgroundDataFetchingIndicator}>
                   <span>{isValidating ? <InlineLoading /> : null}</span>
                 </div>
@@ -126,7 +124,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
                     </Button>
                   )}
                 </div>
-              </div>
+              </CardHeader>
               {chartView ? (
                 <VitalsChart patientVitals={vitals} conceptUnits={conceptUnits} />
               ) : (

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
@@ -7,38 +7,6 @@
   border: 1px solid $ui-03;
 }
 
-.desktopHeader, .tabletHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-
-  h4:after {
-    content: "";
-    display: block;
-    width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
-  }
-}
-
-.desktopHeader {  
-  height: 3rem;
-  h4 {
-    @include carbon--type-style('productive-heading-02');
-    color: $text-02;
-  }
-}
-
-.tabletHeader {  
-  height: 4.5rem;
-  h4 {
-    @include carbon--type-style('productive-heading-03');
-    color: $text-02;
-  }
-}
-
 .divider {
   width: 1px;
   height: 1rem;

--- a/packages/esm-patient-vitals-app/translations/en.json
+++ b/packages/esm-patient-vitals-app/translations/en.json
@@ -17,6 +17,7 @@
   "muac": "MUAC",
   "noDataRecorded": "No data has been recorded for this patient",
   "notes": "Notes",
+  "numericInputError": "Must be a number",
   "oxygenSaturation": "Oxygen Saturation",
   "pulse": "Pulse",
   "recordVitals": "Record Vitals",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

A follow-up to #446. This PR factors out the patient chart widget card headers into a reusable `CardHeader` component. This component is defined in `esm-patient-common-lib` and can be reused anywhere across the patient chart. This PR also removes duplicate styles and refactors the existing widgets to reuse this component.