### PR TITLE
Remove unused styles from CardHeader refactor

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
@@ -5,7 +5,7 @@ import styles from './obs-switchable.scss';
 import ObsGraph from '../obs-graph/obs-graph.component';
 import ObsTable from '../obs-table/obs-table.component';
 import { DataTableSkeleton, Button, InlineLoading } from 'carbon-components-react';
-import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import { useObs } from '../resources/useObs';
 import { useConfig } from '@openmrs/esm-framework';
@@ -29,8 +29,7 @@ const ObsSwitchable: React.FC<ObsSwitchableProps> = ({ patientUuid }) => {
         if (data?.length) {
           return (
             <div className={styles.widgetContainer}>
-              <div className={styles.headerContainer}>
-                <h4>{config.title}</h4>
+              <CardHeader title={config.title}>
                 <div className={styles.backgroundDataFetchingIndicator}>
                   <span>{isValidating ? <InlineLoading /> : null}</span>
                 </div>
@@ -56,7 +55,7 @@ const ObsSwitchable: React.FC<ObsSwitchableProps> = ({ patientUuid }) => {
                     />
                   </div>
                 </div>
-              </div>
+              </CardHeader>
               {chartView ? <ObsGraph patientUuid={patientUuid} /> : <ObsTable patientUuid={patientUuid} />}
             </div>
           );

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.scss
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.scss
@@ -21,19 +21,6 @@
   margin: 0rem 0.5rem;
 }
 
-.headerContainer h4 {
-  @include carbon--type-style('productive-heading-03');
-  color: $text-02;
-}
-
-.headerContainer > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
-}
-
 .toggleButtons {
   width: fit-content;
   margin: 0 $spacing-03;

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.scss
@@ -6,22 +6,6 @@
   border: 1px solid $ui-03;
 }
 
-.allergiesHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-}
-
-.allergiesHeader > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
-}
-
 .allergySeverity {
   margin: 0.5rem 0rem;
   letter-spacing: 0.063rem;

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.scss
@@ -5,19 +5,3 @@
 .widgetCard {
   border: 1px solid $ui-03;
 }
-
-.conditionsHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-}
-
-.conditionsHeader > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
-}

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.scss
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.scss
@@ -5,20 +5,3 @@
 .widgetCard {
   border: 1px solid $ui-03;
 }
-
-.immunizationsHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-}
-
-.immunizationsHeader > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
-}
-

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.scss
@@ -6,19 +6,3 @@
 .widgetCard {
   border: 1px solid $ui-03;
 }
-
-.programsHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: $spacing-04 0 $spacing-04 $spacing-05;
-  background-color: $ui-background;
-}
-
-.programsHeader > h4:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
-}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

The changes introduced here should've been part of https://github.com/openmrs/openmrs-esm-patient-chart/pull/451. 

This PR refactors the ObsSwitchableComponent to reuse the CardHeader component as well as deleting some unused CSS styles.
