### PR TITLE
03-902 : : Fix immunization form bug

### DIFF
--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
@@ -59,7 +59,7 @@ const ImmunizationsForm: React.FC<ImmunizationsFormProps> = ({ patientUuid }) =>
   );
 
   useEffect(() => {
-    const sub = immunizationFormSub.subscribe((props) => setFormState(props));
+    const sub = immunizationFormSub.subscribe((props) => props && setFormState(props));
     return () => sub.unsubscribe();
   }, []);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

At the moment loading the immunization form results in an error because we are setting `formState` to null, this PR corrects this issue

## Screenshots

![03-902](https://user-images.githubusercontent.com/28008754/140716652-030fcce6-a768-4a18-933f-acc4d5c84927.gif)



## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
