### PR TITLE
Set patient chart dashboard title color

### DIFF
--- a/packages/esm-patient-chart-app/src/view-components/chart-review.scss
+++ b/packages/esm-patient-chart-app/src/view-components/chart-review.scss
@@ -5,4 +5,5 @@
 .dashboardTitle {
   @include carbon--type-style("productive-heading-03");
   margin: 1rem 0rem 1rem 1.3125rem;
+  color: $text-01;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Dashboard titles should have color `$text-01` (#161616). See the Typeface section on the right sidebar here https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d5e12ebc329c17022caf7e.

## Screenshots

<img width="729" alt="Screenshot 2021-11-11 at 16 36 19" src="https://user-images.githubusercontent.com/8509731/141307327-da54c300-1ee2-40ba-8748-4c7ca77e3244.png">
