### PR TITLE
O3-930: Improve highlighting for abnormal test results

### DIFF
--- a/packages/esm-patient-test-results-app/src/overview/common-overview.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.tsx
@@ -53,7 +53,7 @@ export const CommonDataTable: React.FC<{
           </TableHead>
           <TableBody>
             {rows.map((row, i) => (
-              <TypedTableRow key={row.id} interpretation={data[i].interpretation} {...getRowProps({ row })}>
+              <TypedTableRow key={row.id} interpretation={data[i]?.interpretation} {...getRowProps({ row })}>
                 {row.cells.map((cell) => (
                   <TableCell key={cell.id}>{cell.value}</TableCell>
                 ))}

--- a/packages/esm-patient-test-results-app/src/overview/lab-results.scss
+++ b/packages/esm-patient-test-results-app/src/overview/lab-results.scss
@@ -8,7 +8,7 @@
 
 .separator {
   height: 1.5rem;
-  border-bottom: #e0e0e0 solid 1px;
+  border-bottom: 1px solid $ui-03;
   width: calc(100% - 1.5rem);
   margin-left: 0.75rem;
 }
@@ -26,70 +26,65 @@
   }
 }
 
-.normal-results {
-  border: 0.125rem solid $brand-01;
-}
-
 .info-button {
   margin-left: 10px;
   padding-top: 1px;
   box-sizing: content-box;
   position: absolute;
+  color: black;
 }
 
-.off-scale-high,
-.off-scale-low,
-.critically-high,
-.critically-low,
-.high,
-.low {
-  background-color: #fff1f1;
-  color: #161616;
-  td:nth-child(2) {
-    font-weight: 600;
-    font-family: "IBM Plex Sans", sans-serif;
+tr {
+  &.critically-low, &.critically-high, &.low, &.high {
+    td:nth-child(2) {
+      @include carbon--type-style("productive-heading-01");
+      color: $ui-05;
+    }
   }
-  outline: 0.063rem solid $ui-05;
-  outline-offset: -0.130rem;
-}
 
-.critically-high,
-.critically-low {
-  outline: 0.063rem solid $danger;
-  outline-offset: -0.130rem;
+  &.critically-low, &.critically-high, &.off-scale-high, &.off-scale-low {
+    outline: 2px solid $danger;
+    outline-offset: -1px;
+  }
 
-  td {
-    border: unset !important;
+  &.low, &.high {
+    outline: 1px solid black;
+    outline-offset: -1px;
   }
-}
 
-.off-scale-high {
-  td:nth-child(2)::after {
-    content: " ↑↑↑";
+  &.critically-low {
+    td:nth-child(2)::after {
+      content: " ↓↓";
+    }
   }
-}
-.critically-high {
-  td:nth-child(2)::after {
-    content: " ↑↑";
+  
+  &.critically-high {
+    td:nth-child(2)::after {
+      content: " ↑↑";
+    }
   }
-}
-.high {
-  td:nth-child(2)::after {
-    content: " ↑";
+
+  &.low {
+    td:nth-child(2)::after {
+      content: " ↓";
+    }
   }
-}
-.off-scale-low {
-  td:nth-child(2)::after {
-    content: " ↓↓↓";
+
+  &.high {
+    td:nth-child(2)::after {
+      content: " ↑";
+    }
   }
-}
-.critically-low {
-  td:nth-child(2)::after {
-    content: " ↓↓";
+
+  &.off-scale-low {
+    td:nth-child(2)::after {
+      content: " ↓↓↓";
+    }
   }
-}
-.low {
-  td:nth-child(2)::after {
-    content: " ↓";
+
+  &.off-scale-high {
+    td:nth-child(2)::after {
+      content: " ↑↑↑";
+    }
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Change the `outline` and `outline-offset` properties applied to table rows containing abnormal test results in the Results Overview as follows:

- Change the `outline` applied to `low` and `high` test result table rows from `1px solid $ui-05` to `1px solid black`.
- Change the `outline` applied to `critically-low` and `critically-high` test result table rows from `1px solid $danger` to `2px solid $danger`.
- Change the `outline-offset` applied to `critically-low`, `critically-high`, `off-scale-low` and `off-scale-high` test result table rows from `-2.08px` to `-1px`.
- Change the `outline-offset` applied to `low` and `high` test result table rows from `-2px` to `-1px`;

Additionally, this commit:

- Adds a check that ensures that a table is rendered for a panel of tests even when a test within that panel might not contain an `interpretation` value.
- Refactors the existing styles so that they are more easily readable.

## Screenshots

- Screenshot showing some `low` and `high` test results
<img width="1681" alt="Screenshot 2021-11-15 at 16 07 07" src="https://user-images.githubusercontent.com/8509731/141788967-37488386-7350-45da-a695-f3dd2ddf6c8d.png">
 

- Screenshot showing some `critically-high` test results 
<img width="1679" alt="Screenshot 2021-11-15 at 16 08 03" src="https://user-images.githubusercontent.com/8509731/141788951-e5acd59e-bab1-430a-acb6-a1803e36f275.png">
