### PR TITLE
O3-933: Modifications to the Trendline view header UI

### DIFF
--- a/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
@@ -31,7 +31,7 @@ const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, basePath }
                 <div className={styles.widgetCard}>
                   <CardHeader title={`${cardTitle} ${resultsCount}`}>
                     <Button kind="ghost" onClick={() => navigateToResults(basePath)}>
-                      {t('all_results', 'All results')}
+                      {t('allResults', 'All results')}
                     </Button>
                   </CardHeader>
                   <CommonOverview

--- a/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
+++ b/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
-import LineChart from '@carbon/charts-react/line-chart';
-import ArrowLeft24 from '@carbon/icons-react/es/arrow--left/24';
-import styles from './trendline.scss';
 import RangeSelector from './range-selector.component';
 import usePatientResultsData from '../loadPatientTestData/usePatientResultsData';
+import { Button } from 'carbon-components-react';
+import ArrowLeft24 from '@carbon/icons-react/es/arrow--left/24';
+import LineChart from '@carbon/charts-react/line-chart';
 import { ScaleTypes, LineChartOptions, TickRotations } from '@carbon/charts/interfaces';
 import { toOmrsDateFormat, toOmrsTimeString24 } from '@openmrs/esm-framework';
 import { ObsRecord, OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import { CommonDataTable } from '../overview/common-overview';
 import { exist } from '../loadPatientTestData/helpers';
 import { useTranslation } from 'react-i18next';
+import styles from './trendline.scss';
 import '@carbon/charts/styles.css';
 
 const useTrendlineData = ({
@@ -57,21 +58,29 @@ const withPatientData =
     return <WrappedComponent patientData={patientData} openTimeline={openTimeline} />;
   };
 
-const TrendlineHeader = ({ openTimeline, title }) => {
+const TrendlineHeader = ({ openTimeline, title, referenceRange }) => {
   const { t } = useTranslation();
   return (
     <div className={styles['header']}>
-      <div onClick={openTimeline} role="button" className={styles['back-button']} tabIndex={0}>
-        <ArrowLeft24></ArrowLeft24> {t('back_to_timeline', 'Back to timeline')}
+      <div className={styles['back-button']}>
+        <Button kind="ghost" renderIcon={ArrowLeft24} iconDescription="Return to timeline" onClick={openTimeline}>
+          <span>{t('backToTimeline', 'Back to timeline')}</span>
+        </Button>
       </div>
-      <div className={styles['title']}>{title}</div>
+      <div className={styles['content']}>
+        <span className={styles['title']}>{title}</span>
+        <span className={styles['reference-range']}>{referenceRange}</span>
+      </div>
     </div>
   );
 };
+
 const Trendline: React.FC<{
   patientData: ReturnType<typeof useTrendlineData>;
   openTimeline: () => void;
 }> = ({ patientData, openTimeline }) => {
+  const { t } = useTranslation();
+
   const leftAxisLabel = patientData?.[1]?.[0]?.meta?.units ?? '';
   const [range, setRange] = React.useState<[Date, Date]>();
 
@@ -105,6 +114,7 @@ const Trendline: React.FC<{
     min?: number;
     max?: number;
   }> = [];
+
   const tableData: Array<{
     date: string;
     time: string;
@@ -113,7 +123,8 @@ const Trendline: React.FC<{
     interpretation?: OBSERVATION_INTERPRETATION;
   }> = [];
 
-  let dataset = patientData[0];
+  const dataset = patientData[0];
+  const referenceRange = patientData[1][0]?.meta?.range;
 
   patientData[1].forEach((entry) => {
     const range =
@@ -191,24 +202,24 @@ const Trendline: React.FC<{
   const tableHeaderData = React.useMemo(
     () => [
       {
-        header: 'Date',
+        header: t('date', 'Date'),
         key: 'date',
       },
       {
-        header: `Value (${leftAxisLabel})`,
+        header: t('value', 'Value') + ` (${leftAxisLabel})`,
         key: 'value',
       },
       {
-        header: 'Time',
+        header: t('timeOfTest', 'Time of Test'),
         key: 'time',
       },
     ],
-    [leftAxisLabel],
+    [leftAxisLabel, t],
   );
 
   return (
     <>
-      <TrendlineHeader openTimeline={openTimeline} title={dataset} />
+      <TrendlineHeader openTimeline={openTimeline} title={dataset} referenceRange={referenceRange} />
       <TrendLineBackground>
         <RangeSelector setLowerRange={setLowerRange} upperRange={upperRange} />
         <LineChart data={data} options={options} />

--- a/packages/esm-patient-test-results-app/src/trendline/trendline.scss
+++ b/packages/esm-patient-test-results-app/src/trendline/trendline.scss
@@ -1,6 +1,7 @@
-// trendline.scss
 @import "~@carbon/charts/styles.css";
 @import "~@carbon/colors/scss/index.scss";
+@import "~@openmrs/esm-styleguide/src/vars";
+@import "carbon-components/scss/globals/scss/typography.scss";
 
 .ui-shell-header-modal-bar-default {
   height: 3rem;
@@ -12,17 +13,22 @@
   display: flex;
 }
 
-.title {
-  height: 1.375rem;
-  font-size: 1rem;
-  font-weight: 600;
-  font-stretch: normal;
-  font-style: normal;
-  line-height: 1.38rem;
-  letter-spacing: normal;
-  justify-self: center;
+.content {
+  display: flex;
+  justify-content: center;
+  align-items: baseline;
+  width: calc(100% - 22rem);
+}
 
-  color: #525252;
+.title {
+  @include carbon--type-style('productive-heading-02');
+  color: $text-02;
+  margin-right: 4px;
+}
+
+.reference-range {
+  @include carbon--type-style('helper-text-01');
+  color: $text-05;
 }
 
 :global(.bx--cc--area path.area) {
@@ -31,23 +37,29 @@
 }
 
 .header {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  height: 4rem;
+  display: flex;
   align-items: center;
   background: white;
-  padding: 1.375rem;
-  border-bottom: #e0e0e0 solid 1px;
-  font-family: Roboto, sans-serif !important;
+  border-bottom: 1px solid $ui-03;
 }
 
 .back-button {
-  display: grid;
-  grid-auto-flow: column;
-  justify-content: start;
   align-items: center;
+  display: flex;
+  justify-content: flex-start;
 
-  color: #0f62fe;
+  button {
+    display: flex;
+
+    svg {
+      order: 1;
+      margin-right: 0.5rem;
+    }  
+
+    span {
+      order: 2;
+    }
+  }
 }
 
 .Background {

--- a/packages/esm-patient-test-results-app/translations/en.json
+++ b/packages/esm-patient-test-results-app/translations/en.json
@@ -1,15 +1,18 @@
 {
-  "all_results": "All results",
-  "back_to_timeline": "Back to timeline",
+  "allResults": "All results",
+  "backToTimeline": "Back to timeline",
+  "date": "Date",
   "moreResultsAvailable": "More results available",
   "recentResults": "Recent Results",
   "recentTestResults": "recent test results",
   "seeAllResults": "See all results",
+  "timeOfTest": "Time of Test",
   "trendlineRangeSelector1Day": "1 day",
   "trendlineRangeSelector1Month": "1 month",
   "trendlineRangeSelector1Year": "1 year",
   "trendlineRangeSelector5Days": "5 days",
   "trendlineRangeSelector5Years": "5 years",
   "trendlineRangeSelectorAll": "All",
-  "trendlineRangeSelectorMonths": "6 months"
+  "trendlineRangeSelectorMonths": "6 months",
+  "value": "Value"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Add the following visual tweaks to the test result Trendline view header UI:

- Display the reference range (when available) to the right of the test or panel title.
- Add a button labelled `Back to Timeline` to the left of the test or panel title. The button should have an `ArrowLeft24` icon to the left of the button label.

Unrelated changes:

- Change the format of some translation keys to camel-case. 

## Screenshots

- Before
<img width="1679" alt="Screenshot 2021-11-15 at 16 08 03" src="https://user-images.githubusercontent.com/8509731/141947511-854a7134-fa78-47b3-a13f-21941b819ad6.png">

- After
<img width="1679" alt="Screenshot 2021-11-15 at 22 11 08" src="https://user-images.githubusercontent.com/8509731/141947471-36739793-a79c-427f-b0da-6183a7eac751.png">



## Issue

https://issues.openmrs.org/browse/O3-933
