### PR TITLE
O3-935: Visual tweaks to the test results timeline

### DIFF
--- a/packages/esm-patient-test-results-app/src/timeline/helpers.tsx
+++ b/packages/esm-patient-test-results-app/src/timeline/helpers.tsx
@@ -11,6 +11,7 @@ export const Grid: React.FC<{
     style={{
       ...style,
       gridTemplateColumns: `${padding ? '9em ' : ''} repeat(${dataColumns}, 5em)`,
+      margin: '1px',
     }}
     className={styles['grid']}
     {...props}
@@ -70,7 +71,9 @@ const TimelineCell: React.FC<{
   }
 
   return (
-    <div className={`${styles['timeline-cell']} ${zebra ? styles['timeline-cell-zebra'] : ''} ${additionalClassname}`}>
+    <div
+      className={`${styles['timeline-data-cell']} ${zebra ? styles['timeline-cell-zebra'] : ''} ${additionalClassname}`}
+    >
       <p>{text}</p>
     </div>
   );
@@ -78,32 +81,15 @@ const TimelineCell: React.FC<{
 
 export const RowStartCell = ({ title, range, units, shadow = false, openTrendline }) => (
   <div
-    className={styles['timeline-cell']}
+    className={styles['row-start-cell']}
     style={{
-      position: 'sticky',
-      left: '0px',
       boxShadow: shadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
-      display: 'grid',
-      gridAutoFlow: 'row',
-      justifyItems: 'baseline',
-      alignItems: 'center',
-      gap: '0.5rem',
-      padding: '1rem',
     }}
   >
-    <span
-      onClick={openTrendline}
-      role={'link'}
-      tabIndex={0}
-      style={{
-        color: '#0f62fe',
-        cursor: 'pointer',
-        textTransform: 'capitalize',
-      }}
-    >
-      {title.toLowerCase()}
+    <span className={styles['trendline-link']} onClick={openTrendline} role={'link'} tabIndex={0}>
+      {title}
     </span>
-    <span style={{ color: '#6f6f6f', fontSize: '0.75rem' }}>
+    <span className={styles['range-units']}>
       {range} {units}
     </span>
   </div>

--- a/packages/esm-patient-test-results-app/src/timeline/timeline.component.tsx
+++ b/packages/esm-patient-test-results-app/src/timeline/timeline.component.tsx
@@ -22,21 +22,21 @@ const DateHeaderGrid = ({ timeColumns, yearColumns, dayColumns, displayShadow })
   >
     {yearColumns.map(({ year, size }) => {
       return (
-        <TimeSlots key={year} style={{ gridColumn: `${size} span` }}>
+        <TimeSlots key={year} className={styles['year-column']} style={{ gridColumn: `${size} span` }}>
           {year}
         </TimeSlots>
       );
     })}
     {dayColumns.map(({ day, size }) => {
       return (
-        <TimeSlots key={day} style={{ gridColumn: `${size} span` }}>
+        <TimeSlots key={day} className={styles['day-column']} style={{ gridColumn: `${size} span` }}>
           {day}
         </TimeSlots>
       );
     })}
     {timeColumns.map((time, i) => {
       return (
-        <TimeSlots key={time + i} style={{ scrollSnapAlign: 'start', fontWeight: 400 }}>
+        <TimeSlots key={time + i} className={styles['time-column']}>
           {time}
         </TimeSlots>
       );

--- a/packages/esm-patient-test-results-app/src/timeline/timeline.scss
+++ b/packages/esm-patient-test-results-app/src/timeline/timeline.scss
@@ -1,12 +1,26 @@
-.grid {
-  display: grid;
-  width: fit-content;
-  gap: 1px;
+@import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
+@import "~carbon-components/src/globals/scss/mixins";
 
+.grid {
+  width: fit-content;
+  background-color: $color-gray-30;
+  display: grid;
   grid-auto-rows: auto;
+  gap: 1px;
   justify-items: center;
   align-items: center;
-  background-color: #c6c6c6;
+}
+
+.day-column, .year-column {
+  @include carbon--type-style('productive-heading-01');
+  color: $text-02;
+}
+
+.time-column {
+  @include carbon--type-style('body-short-01');
+  color: $text-02;
+  scroll-snap-align: start;
 }
 
 .padded-main {
@@ -21,12 +35,33 @@
   display: grid;
   justify-items: center;
   align-items: center;
+  padding: 0.5rem;
+}
 
-  padding: 0.5em;
+.timeline-data-cell {
+  @extend .timeline-cell;
+  justify-items: first baseline;
+  
+  p {
+    @include carbon--type-style('body-short-01');
+    color: $text-02;
+  }
+}
+
+.row-start-cell {
+  @extend .timeline-cell;
+  position: sticky;
+  left: 0;
+  display: grid;
+  grid-auto-flow: row;
+  gap: 0.5px;
+  justify-items: baseline;
+  align-items: center;
+  padding: 1rem;
 }
 
 .timeline-cell-zebra {
-  background-color: #ededed;
+  background-color: $ui-03;
 }
 
 .padding-container {
@@ -43,8 +78,9 @@
   scrollbar-width: none;
   display: grid;
   grid-auto-flow: row;
-  gap: 1px;
-  background-color: #c6c6c6;
+  column-gap: 1px;
+  row-gap: 0px;
+  background-color: $color-gray-30;
   grid-template: auto auto / 9em auto;
 }
 
@@ -53,20 +89,16 @@
 }
 
 .time-slot-inner {
-  background-color: #e0e0e0;
-  font-weight: 600;
-
+  background-color: $ui-03;
   padding: 3px 10px;
-
   justify-self: stretch;
   align-self: stretch;
-
   display: grid;
   align-items: center;
 
   div {
     position: sticky;
-    left: calc(9em + 10px);
+    left: calc(10em + 10px);
     width: fit-content;
   }
 }
@@ -77,6 +109,24 @@
   left: 0px;
   top: 0px;
   z-index: 3;
+  padding: 0rem 1rem;
+
+  div {
+    @include carbon--type-style('productive-heading-01');
+    color: $text-01;
+    left: 0;
+  }
+}
+
+.trendline-link {
+  @include carbon--type-style('body-short-01');
+  color: $interactive-01;
+  cursor: pointer;
+}
+
+.range-units {
+  @include carbon--type-style('helper-text-01');
+  color: $text-05;
 }
 
 .off-scale-high,
@@ -85,32 +135,25 @@
 .critically-low,
 .high,
 .low {
-  color: #161616;
   p {
-    font-weight: 600;
-    font-family: "IBM Plex Sans", sans-serif;
-  }
+    @include carbon--type-style('productive-heading-01');
+    color: $text-01;
+  }  
 }
 
 .high,
 .low {
-  box-sizing: content-box;
-  padding: 0;
   box-shadow: 0 0 0 1px #000000;
-
-  td {
-    border: unset !important;
-  }
 }
 
 .critically-high,
 .critically-low {
-  box-sizing: content-box;
-  padding: 0;
-  box-shadow: 0 0 0 1px #da1e28, inset 0 0 0 1px #da1e28;
+  box-shadow: 0 0 0 1px $danger, inset 0 0 0 1px $danger;
+}
 
-  td {
-    border: unset !important;
+.off-scale-low {
+  p::after {
+    content: " ↓↓↓";
   }
 }
 
@@ -119,29 +162,28 @@
     content: " ↑↑↑";
   }
 }
-.critically-high {
-  p::after {
-    content: " ↑↑";
-  }
-}
-.high {
-  p::after {
-    content: " ↑";
-  }
-}
-.off-scale-low {
-  p::after {
-    content: " ↓↓↓";
-  }
-}
+
 .critically-low {
   p::after {
     content: " ↓↓";
   }
 }
+
+.critically-high {
+  p::after {
+    content: " ↑↑";
+  }
+}
+
 .low {
   p::after {
     content: " ↓";
+  }
+}
+
+.high {
+  p::after {
+    content: " ↑";
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Apply some visual enhancements to the Timeline view UI to get it closer in line with the designs. These include:

- Typography fixes - swap custom font styles for their corresponding Carbon type tokens.
- Clean up CSS - move some of the style property definitions into classes in the corresponding SASS file.
- Replace colour hex codes with colour variables from our style guide.

While these fixes help move the needle in the right direction, they still don't fix all the outstanding design issues. Some tweaks to the grid layout are still needed - particularly around the look of grid item borders. Similarly, highlighting abnormal values can be improved. Box shadows are likely not the best solution for this, but they seem to yield better results than borders or outlines.

## Screenshots

Before

<img width="246" alt="Screenshot 2021-11-18 at 11 10 24" src="https://user-images.githubusercontent.com/8509731/142381144-1f8c382f-7e04-4321-92c3-b8ec820bc51a.png">

<img width="737" alt="Screenshot 2021-11-18 at 11 10 46" src="https://user-images.githubusercontent.com/8509731/142381212-f8d4bf1e-8322-4519-ab71-811399153e81.png">

<img width="732" alt="Screenshot 2021-11-18 at 11 11 06" src="https://user-images.githubusercontent.com/8509731/142381320-c3f4f49a-eed1-4394-b63d-b6e8540f7126.png">


After

<img width="257" alt="Screenshot 2021-11-18 at 11 10 30" src="https://user-images.githubusercontent.com/8509731/142381174-9abb7a91-6063-45e2-89bb-2403b0122d8a.png">

<img width="738" alt="Screenshot 2021-11-18 at 11 10 52" src="https://user-images.githubusercontent.com/8509731/142381233-210f601c-5973-4fb9-b818-712fcd3e7697.png">

<img width="734" alt="Screenshot 2021-11-18 at 11 11 18" src="https://user-images.githubusercontent.com/8509731/142381345-3d8392c9-3cbc-4807-ab8f-c43f8982e4b2.png">

## Issue

https://issues.openmrs.org/browse/O3-935