### PR TITLE
O3-940: Redesign patient avatars

### DIFF
--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -20,7 +20,8 @@ interface PatientBannerProps {
 const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, onClick }) => {
   const { t } = useTranslation();
   const overFlowMenuRef = React.useRef(null);
-  const state = React.useMemo(() => ({ patientUuid, onClick }), [patientUuid, onClick]);
+  const patientName = `${patient.name[0].given.join(' ')} ${patient.name[0].family}`;
+  const state = React.useMemo(() => ({ patientUuid, patientName, onClick }), [patientUuid, patientName, onClick]);
   const [showContactDetails, setShowContactDetails] = React.useState(false);
   const toggleContactDetails = React.useCallback((event: MouseEvent) => {
     event.stopPropagation();
@@ -51,9 +52,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, onC
         <div className={styles.patientInfo}>
           <div className={`${styles.row} ${styles.patientNameRow}`}>
             <div className={styles.flexRow}>
-              <span className={styles.patientName}>
-                {patient.name[0].given.join(' ')} {patient.name[0].family}
-              </span>
+              <span className={styles.patientName}>{patientName}</span>
               <ExtensionSlot
                 extensionSlotName="patient-banner-tags-slot"
                 state={{ patientUuid }}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR relates to https://github.com/openmrs/openmrs-esm-patient-management/pull/68.

Redesign patient avatars to match the designs outlined in https://app.zeplin.io/project/61434fa756474d5545f65cf4/screen/614362b21dd66d20a276d8b8.

This commit passes the patient's name downstream to the `patient-photo-widget` extension. This data gets used by the Avatar component to generate the patient's initials. In the absence of an image `src`, these initials get displayed inside a placeholder SVG as a fallback. When there's a problem rendering the avatar, the Avatar component uses the patient's name to construct the alt text. So you get `John Wilson's avatar` instead of the more generic `Patient avatar`.

## Screenshots
<img width="1686" alt="Screenshot 2021-11-23 at 13 24 56" src="https://user-images.githubusercontent.com/8509731/143008165-7a34fb2d-2417-4d11-aee1-6402bc1e32ed.png">

<img width="1685" alt="Screenshot 2021-11-23 at 13 25 12" src="https://user-images.githubusercontent.com/8509731/143008173-63e5e381-9f44-4522-aa03-a09f2fe33b78.png">

<img width="1686" alt="Screenshot 2021-11-23 at 13 27 33" src="https://user-images.githubusercontent.com/8509731/143008058-7d1243fa-6f1c-402d-890e-b05bd0dc1594.png">

## Issue

https://issues.openmrs.org/projects/MF/issues/O3-940
