### PR TITLE
O3-922: Make active card highlight viewport-dependent

### DIFF
--- a/packages/esm-patient-test-results-app/src/desktop-view/desktop-view.component.tsx
+++ b/packages/esm-patient-test-results-app/src/desktop-view/desktop-view.component.tsx
@@ -40,7 +40,15 @@ const deduceViewState = ({ panelUuid, testUuid, type = 'none' }): ViewState => {
   }
 };
 
-const DesktopView: React.FC<Record<string, any>> = ({ patientUuid, panelUuid, testUuid, type, basePath }) => {
+interface DesktopViewProps {
+  basePath: string;
+  patientUuid: string;
+  panelUuid: string;
+  testUuid: string;
+  type: string;
+}
+
+const DesktopView: React.FC<DesktopViewProps> = ({ patientUuid, panelUuid, testUuid, type, basePath }) => {
   const [viewState, setViewState] = React.useState<ViewState>(deduceViewState({ panelUuid, testUuid, type }));
 
   React.useEffect(() => {
@@ -58,7 +66,7 @@ const DesktopView: React.FC<Record<string, any>> = ({ patientUuid, panelUuid, te
     <Grid>
       <OverflowBorder>
         <div className={styles.overview}>
-          <Overview patientUuid={patientUuid} openTimeline={openTimeline} openTrendline={openTrendline}></Overview>
+          <Overview patientUuid={patientUuid} openTimeline={openTimeline} openTrendline={openTrendline} />
         </div>
       </OverflowBorder>
       <OverflowBorder>

--- a/packages/esm-patient-test-results-app/src/overview/common-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.component.tsx
@@ -7,7 +7,7 @@ import { Button, TableToolbarContent, TableToolbar } from 'carbon-components-rea
 import { EmptyState } from '@openmrs/esm-patient-common-lib';
 import { OverviewPanelEntry } from './useOverviewData';
 import { useTranslation } from 'react-i18next';
-import { navigate } from '@openmrs/esm-framework';
+import { navigate, useLayoutType } from '@openmrs/esm-framework';
 import CommonDataTable from './common-datatable.component';
 import styles from './common-overview.scss';
 
@@ -48,6 +48,7 @@ const CommonOverview: React.FC<CommonOverviewProps> = ({
   patientUuid,
 }) => {
   const { t } = useTranslation();
+  const isDesktop = useLayoutType() === 'desktop';
   const [activeCardUuid, setActiveCardUuid] = React.useState('');
 
   const headers = [
@@ -57,9 +58,12 @@ const CommonOverview: React.FC<CommonOverviewProps> = ({
   ];
 
   const isActiveCard = useCallback(
-    (uuid: string) =>
-      activeCardUuid === uuid || (!activeCardUuid && uuid === overviewData[0][overviewData[0].length - 1]),
-    [activeCardUuid, overviewData],
+    (uuid: string) => {
+      const isFirstCard = uuid === overviewData[0][overviewData[0].length - 1];
+
+      return isDesktop && (activeCardUuid === uuid || (!activeCardUuid && isFirstCard));
+    },
+    [activeCardUuid, isDesktop, overviewData],
   );
 
   const handleSeeAvailableResults = useCallback(() => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

https://github.com/openmrs/openmrs-esm-patient-chart/pull/455 added a teal border to the active card in the test results overview. One omission from that PR was that this highlight should only appear in the desktop viewport. This PR adds a check that enforces that condition. 

## Issue

https://issues.openmrs.org/projects/MF/issues/O3-922