### PR TITLE
O3-942: Tweak the Recent Results overview action button

### DIFF
--- a/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/recent-overview.component.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import useOverviewData from './useOverviewData';
 import CommonOverview from './common-overview.component';
+import ArrowRight24 from '@carbon/icons-react/es/arrow--right/24';
 import { Button, DataTableSkeleton } from 'carbon-components-react';
 import { EmptyState } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
@@ -32,8 +33,13 @@ const RecentOverview: React.FC<RecentOverviewProps> = ({ patientUuid, basePath }
                 <div className={styles.widgetCard}>
                   <div className={isTablet ? styles.tabletHeader : styles.desktopHeader}>
                     <h4>{`${cardTitle} (${resultsCount})`}</h4>
-                    <Button kind="ghost" onClick={() => navigateToResults(basePath)}>
-                      {t('allResults', 'All results')}
+                    <Button
+                      kind="ghost"
+                      onClick={() => navigateToResults(basePath)}
+                      iconDescription="See all results"
+                      renderIcon={ArrowRight24}
+                    >
+                      {t('seeAllResults', 'See all results')}
                     </Button>
                   </div>
                   <CommonOverview

--- a/packages/esm-patient-test-results-app/translations/en.json
+++ b/packages/esm-patient-test-results-app/translations/en.json
@@ -1,10 +1,10 @@
 {
-  "allResults": "All results",
   "backToTimeline": "Back to timeline",
   "date": "Date",
   "moreResultsAvailable": "More results available",
   "recentResults": "Recent Results",
   "recentTestResults": "recent test results",
+  "seeAllResults": "See all results",
   "testResults": "test results",
   "timeline": "Timeline",
   "timeOfTest": "Time of Test",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

There should be a button to the left of the test/panel title in the Recent Results overview header. This button should be labelled `See all results` with an `Arrow24` icon. It should navigate to the Test Results dashboard when clicked.

## Screenshots

<img width="1050" alt="Screenshot 2021-11-24 at 13 59 01" src="https://user-images.githubusercontent.com/8509731/143226089-bac77105-09e1-4d67-8bde-11a0b9e409f0.png">

## Issue

https://issues.openmrs.org/projects/MF/issues/O3-942
