### PR TITLE
O3-943: Recent Results overview header style fixes

### DIFF
--- a/packages/esm-patient-test-results-app/src/overview/common-datatable.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-datatable.component.tsx
@@ -9,6 +9,7 @@ import {
   TableCell,
   TableBody,
 } from 'carbon-components-react';
+import { useLayoutType } from '@openmrs/esm-framework';
 import { OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import { OverviewPanelData } from '../overview/useOverviewData';
 import styles from './common-datatable.scss';
@@ -24,45 +25,49 @@ interface CommonDataTableProps {
   description?: React.ReactNode;
 }
 
-const CommonDataTable: React.FC<CommonDataTableProps> = ({ title, data, description, toolbar, tableHeaders }) => (
-  <DataTable rows={data} headers={tableHeaders} size="short">
-    {({ rows, headers, getHeaderProps, getRowProps, getTableProps, getTableContainerProps }) => (
-      <TableContainer
-        className={styles.tableContainer}
-        title={title}
-        description={description}
-        {...getTableContainerProps()}
-      >
-        {toolbar}
-        <Table {...getTableProps()} isSortable useZebraStyles>
-          <colgroup className={styles.columns}>
-            <col span={1} />
-            <col span={1} />
-            <col span={1} />
-          </colgroup>
-          <TableHead>
-            <TableRow>
-              {headers.map((header) => (
-                <TableHeader key={header.key} {...getHeaderProps({ header })} isSortable>
-                  {header.header}
-                </TableHeader>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {rows.map((row, i) => (
-              <TypedTableRow key={row.id} interpretation={data[i]?.interpretation} {...getRowProps({ row })}>
-                {row.cells.map((cell) => (
-                  <TableCell key={cell.id}>{cell.value}</TableCell>
+const CommonDataTable: React.FC<CommonDataTableProps> = ({ title, data, description, toolbar, tableHeaders }) => {
+  const isTablet = useLayoutType() === 'tablet';
+
+  return (
+    <DataTable rows={data} headers={tableHeaders} size="short">
+      {({ rows, headers, getHeaderProps, getRowProps, getTableProps, getTableContainerProps }) => (
+        <TableContainer
+          className={`${styles.tableContainer} ${isTablet ? `${styles.tablet}` : `${styles.desktop}`}`}
+          title={title}
+          description={description}
+          {...getTableContainerProps()}
+        >
+          {toolbar}
+          <Table {...getTableProps()} isSortable useZebraStyles>
+            <colgroup className={styles.columns}>
+              <col span={1} />
+              <col span={1} />
+              <col span={1} />
+            </colgroup>
+            <TableHead>
+              <TableRow>
+                {headers.map((header) => (
+                  <TableHeader key={header.key} {...getHeaderProps({ header })} isSortable>
+                    {header.header}
+                  </TableHeader>
                 ))}
-              </TypedTableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    )}
-  </DataTable>
-);
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row, i) => (
+                <TypedTableRow key={row.id} interpretation={data[i]?.interpretation} {...getRowProps({ row })}>
+                  {row.cells.map((cell) => (
+                    <TableCell key={cell.id}>{cell.value}</TableCell>
+                  ))}
+                </TypedTableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </DataTable>
+  );
+};
 
 const TypedTableRow: React.FC<{
   interpretation: OBSERVATION_INTERPRETATION;

--- a/packages/esm-patient-test-results-app/src/overview/common-datatable.scss
+++ b/packages/esm-patient-test-results-app/src/overview/common-datatable.scss
@@ -8,6 +8,25 @@
   *:not(:first-child) {
     margin: 0.25rem 0rem;
   }
+
+  h4 {
+    @include carbon--type-style("productive-heading-02");
+    max-width: 50%;
+  }
+}
+
+.tableContainer {
+  &.tablet {
+    h4 {
+      color: $text-01;
+    }
+  }
+
+  &.desktop {
+    h4 {
+      color: $text-02;
+    }
+  }
 }
 
 tr {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Fix the Recent Results overview header so that:

- The test/panel title has a darker shade of grey (`$text-01`) in the tablet viewport versus a lighter one (`$text-02`) in the desktop viewport.
- The test/panel title uses the `productive-heading-02` Carbon type style.
- The test/panel title is constrained to a max-width of 50% so that long names overflow.

## Screenshots

(Don't mind that the names of the test title and the actual test don't tally)

Desktop:

<img width="1679" alt="Screenshot 2021-11-24 at 15 24 13" src="https://user-images.githubusercontent.com/8509731/143239729-d794f3ce-5d6f-4c94-98a7-53f51e7e0ee3.png">

Tablet:

<img width="1147" alt="Screenshot 2021-11-24 at 15 24 31" src="https://user-images.githubusercontent.com/8509731/143239753-ff39a3d6-a173-4f7b-95d8-c8ef1556188c.png">

## Issue

https://issues.openmrs.org/browse/O3-943