### PR TITLE
03-936 :  Fix error on clicking show all details on patient banner

### DIFF
--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
@@ -72,16 +72,33 @@ const Relationships: React.FC<{ patientId: string }> = ({ patientId }) => {
 };
 
 const ContactDetails: React.FC<ContactDetailsProps> = ({ address, telecom, patientId }) => {
-  const currentAddress = address.find((a) => a.use === 'home');
+  const { t } = useTranslation();
+  const currentAddress = address ? address.find((a) => a.use === 'home') : null;
 
   return (
     <div className={styles.contactDetails}>
       <div className={styles.row}>
         <div className={styles.col}>
-          <Address address={currentAddress} />
+          {address ? (
+            <Address address={currentAddress} />
+          ) : (
+            <>
+              <p className={styles.heading}>{t('address', 'Address')}</p>
+              <p className={styles.label}>{t('noAddress', 'There is no address to display for this patient')}</p>
+            </>
+          )}
         </div>
         <div className={styles.col}>
-          <Contact telecom={telecom} />
+          {telecom ? (
+            <Contact telecom={telecom} />
+          ) : (
+            <>
+              <p className={styles.heading}>{t('contactDetails', 'Contact Details')}</p>
+              <p className={styles.label}>
+                {t('noContactDetails', 'There are no contact details to display for this patient')}
+              </p>
+            </>
+          )}
         </div>
       </div>
       <div className={styles.row}>

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
@@ -12,16 +12,25 @@ interface ContactDetailsProps {
 
 const Address: React.FC<{ address: fhir.Address }> = ({ address }) => {
   const { t } = useTranslation();
-  const { city, country, postalCode, state } = address;
 
   return (
     <>
       <p className={styles.heading}>{t('address', 'Address')}</p>
       <ul>
-        <li>{postalCode}</li>
-        <li>{city}</li>
-        <li>{state}</li>
-        <li>{country}</li>
+        {(() => {
+          if (address) {
+            const { city, country, postalCode, state } = address;
+            return (
+              <>
+                <li>{postalCode}</li>
+                <li>{city}</li>
+                <li>{state}</li>
+                <li>{country}</li>
+              </>
+            );
+          }
+          return '--';
+        })()}
       </ul>
     </>
   );
@@ -29,7 +38,7 @@ const Address: React.FC<{ address: fhir.Address }> = ({ address }) => {
 
 const Contact: React.FC<{ telecom: Array<fhir.ContactPoint> }> = ({ telecom }) => {
   const { t } = useTranslation();
-  const value = telecom && telecom.length ? telecom[0].value : '-';
+  const value = telecom && telecom.length ? telecom[0].value : '--';
 
   return (
     <>
@@ -64,7 +73,7 @@ const Relationships: React.FC<{ patientId: string }> = ({ patientId }) => {
               </ul>
             );
           }
-          return <p>-</p>;
+          return <p>--</p>;
         })()}
       </>
     </>
@@ -79,26 +88,10 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ address, telecom, patie
     <div className={styles.contactDetails}>
       <div className={styles.row}>
         <div className={styles.col}>
-          {address ? (
-            <Address address={currentAddress} />
-          ) : (
-            <>
-              <p className={styles.heading}>{t('address', 'Address')}</p>
-              <p className={styles.label}>{t('noAddress', 'There is no address to display for this patient')}</p>
-            </>
-          )}
+          <Address address={currentAddress} />
         </div>
         <div className={styles.col}>
-          {telecom ? (
-            <Contact telecom={telecom} />
-          ) : (
-            <>
-              <p className={styles.heading}>{t('contactDetails', 'Contact Details')}</p>
-              <p className={styles.label}>
-                {t('noContactDetails', 'There are no contact details to display for this patient')}
-              </p>
-            </>
-          )}
+          <Contact telecom={telecom} />
         </div>
       </div>
       <div className={styles.row}>

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.scss
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.scss
@@ -44,8 +44,4 @@
   flex: 1 1;
 }
 
-.label {
-  @include carbon--type-style("body-short-02");
-  margin: $spacing-03 0;
-}
 

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.scss
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.scss
@@ -1,4 +1,6 @@
-@import "carbon-components/scss/globals/scss/typography.scss";
+@import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
+@import "~carbon-components/src/globals/scss/mixins";
 
 .contactDetails {
   color: $text-02;
@@ -40,5 +42,10 @@
 
 .relationship div {
   flex: 1 1;
+}
+
+.label {
+  @include carbon--type-style("body-short-02");
+  margin: $spacing-03 0;
 }
 

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
@@ -78,6 +78,14 @@ describe('ContactDetails: ', () => {
     expect(screen.getByText(/Sibling/i)).toBeInTheDocument();
     expect(screen.getByText(/24 yrs/i)).toBeInTheDocument();
   });
+
+  it('renders an empty state view when address and contact details is not available', () => {
+    swrRender(<ContactDetails address={null} telecom={null} patientId={'some-uuid'} />);
+    mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
+
+    expect(screen.getByText('There is no address to display for this patient')).toBeInTheDocument();
+    expect(screen.getByText('There are no contact details to display for this patient')).toBeInTheDocument();
+  });
 });
 
 function renderContactDetails() {

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
@@ -61,7 +61,7 @@ describe('ContactDetails: ', () => {
 
     screen.findByText('Relationships');
     expect(screen.getByText('Relationships')).toBeInTheDocument();
-    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(screen.getByText('--')).toBeInTheDocument();
   });
 
   it("renders the patient's address, contact details and relationships when available", async () => {
@@ -83,8 +83,9 @@ describe('ContactDetails: ', () => {
     swrRender(<ContactDetails address={null} telecom={null} patientId={'some-uuid'} />);
     mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
 
-    expect(screen.getByText('There is no address to display for this patient')).toBeInTheDocument();
-    expect(screen.getByText('There are no contact details to display for this patient')).toBeInTheDocument();
+    expect(screen.getByText('Address')).toBeInTheDocument();
+    expect(screen.getByText('Contact Details')).toBeInTheDocument();
+    expect(screen.getAllByText('--').length).toBe(2);
   });
 });
 

--- a/packages/esm-patient-banner-app/translations/en.json
+++ b/packages/esm-patient-banner-app/translations/en.json
@@ -3,8 +3,6 @@
   "activeVisit": "Active Visit",
   "address": "Address",
   "contactDetails": "Contact Details",
-  "noAddress": "There is no address to display for this patient",
-  "noContactDetails": "There are no contact details to display for this patient",
   "relationships": "Relationships",
   "showAllDetails": "Show all details",
   "showLess": "Show less",

--- a/packages/esm-patient-banner-app/translations/en.json
+++ b/packages/esm-patient-banner-app/translations/en.json
@@ -3,6 +3,8 @@
   "activeVisit": "Active Visit",
   "address": "Address",
   "contactDetails": "Contact Details",
+  "noAddress": "There is no address to display for this patient",
+  "noContactDetails": "There are no contact details to display for this patient",
   "relationships": "Relationships",
   "showAllDetails": "Show all details",
   "showLess": "Show less",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This fixes issue on clicking show more details crashing `contact` component


## Screenshots

<img width="1252" alt="Screenshot 2021-11-24 at 20 42 38" src="https://user-images.githubusercontent.com/28008754/143288746-1ec8c467-cb12-4ae4-902f-9eabe7f0880b.png">


## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
