### PR TITLE
03-938: Add ability to navigate to patient registration in edit mode

### DIFF
--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -15,12 +15,21 @@ interface PatientBannerProps {
   patient: Pick<fhir.Patient, 'id' | 'name' | 'gender' | 'birthDate' | 'identifier' | 'address' | 'telecom'>;
   patientUuid: string;
   onClick?: (patientUuid: string) => void;
+  closePatientSearchResultsPanel?: () => void;
 }
 
-const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, onClick }) => {
+const PatientBanner: React.FC<PatientBannerProps> = ({
+  patient,
+  patientUuid,
+  onClick,
+  closePatientSearchResultsPanel,
+}) => {
   const { t } = useTranslation();
   const overFlowMenuRef = React.useRef(null);
-  const state = React.useMemo(() => ({ patientUuid, onClick }), [patientUuid, onClick]);
+  const state = React.useMemo(
+    () => ({ patientUuid, onClick, closePatientSearchResultsPanel }),
+    [patientUuid, onClick, closePatientSearchResultsPanel],
+  );
   const [showContactDetails, setShowContactDetails] = React.useState(false);
   const toggleContactDetails = React.useCallback((event: MouseEvent) => {
     event.stopPropagation();

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -15,21 +15,18 @@ interface PatientBannerProps {
   patient: Pick<fhir.Patient, 'id' | 'name' | 'gender' | 'birthDate' | 'identifier' | 'address' | 'telecom'>;
   patientUuid: string;
   onClick?: (patientUuid: string) => void;
-  closePatientSearchResultsPanel?: () => void;
+  onTransition?: () => void;
 }
 
-const PatientBanner: React.FC<PatientBannerProps> = ({
-  patient,
-  patientUuid,
-  onClick,
-  closePatientSearchResultsPanel,
-}) => {
+const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, onClick, onTransition }) => {
   const { t } = useTranslation();
   const overFlowMenuRef = React.useRef(null);
-  const state = React.useMemo(
-    () => ({ patientUuid, onClick, closePatientSearchResultsPanel }),
-    [patientUuid, onClick, closePatientSearchResultsPanel],
+  const patientActionsSlotState = React.useMemo(
+    () => ({ patientUuid, onClick, onTransition }),
+    [patientUuid, onClick, onTransition],
   );
+
+  const patientPhotoSlotState = React.useMemo(() => ({ patientUuid }), [patientUuid]);
   const [showContactDetails, setShowContactDetails] = React.useState(false);
   const toggleContactDetails = React.useCallback((event: MouseEvent) => {
     event.stopPropagation();
@@ -38,7 +35,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
 
   const patientAvatar = (
     <div className={styles.patientAvatar} role="img">
-      <ExtensionSlot extensionSlotName="patient-photo-slot" state={state} />
+      <ExtensionSlot extensionSlotName="patient-photo-slot" state={patientPhotoSlotState} />
     </div>
   );
 
@@ -82,7 +79,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
                   extensionSlotName="patient-actions-slot"
                   key="patient-actions-slot"
                   className={styles.overflowMenuItemList}
-                  state={state}
+                  state={patientActionsSlotState}
                 />
               </CustomOverflowMenuComponent>
             </div>

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -26,7 +26,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, onC
     () => ({ patientUuid, onClick, onTransition }),
     [patientUuid, onClick, onTransition],
   );
-  
+
   const patientName = `${patient.name[0].given.join(' ')} ${patient.name[0].family}`;
   const patientPhotoSlotState = React.useMemo(() => ({ patientUuid, patientName }), [patientUuid]);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR is [related to](https://github.com/openmrs/openmrs-esm-patient-management/pull/69), to enable navigation from patient-search-results panel to patient-registration in edit mode.


## Screenshots
![03-938](https://user-images.githubusercontent.com/28008754/143402019-685a27d5-b797-4809-851f-e3dba578e971.gif)



## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
