### PR TITLE
O3-956: Workspace should auto-scroll to top

### DIFF
--- a/packages/esm-patient-chart-app/src/workspace/context-workspace.component.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/context-workspace.component.tsx
@@ -35,6 +35,11 @@ const ContextWorkspace: React.FC<RouteComponentProps<ContextWorkspaceParams>> = 
   useEffect(() => {
     if (extensions.length > 0 && (size === ScreenModeTypes.maximize || size === ScreenModeTypes.normal)) {
       setOpenContextWorkspace(true);
+      window.scrollTo({
+        top: 0,
+        left: 0,
+        behavior: 'smooth',
+      });
     } else if (extensions.length > 0 && size === ScreenModeTypes.hide) {
       setOpenContextWorkspace(false);
     } else {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

The workspace should smoothly scroll to the top of the container when launched, obviating the need for the user to do so manually.

## Video

https://user-images.githubusercontent.com/8509731/144903839-a06474b5-f826-42df-9f99-48a34bdd72d1.mp4


