### PR TITLE
Change Vitals and Biometrics Detailed page to grid view

### DIFF
--- a/packages/esm-patient-biometrics-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-biometrics-app/src/dashboard.meta.tsx
@@ -1,6 +1,6 @@
 export const dashboardMeta = {
   name: 'vitalsAndBiometrics',
-  slot: 'patient-chart-results-dashboard-slot',
-  config: { type: 'tabs' },
+  slot: 'patient-chart-vitals-biometrics-dashboard-slot',
+  config: { columns: 1, type: 'grid' },
   title: 'Vitals & Biometrics',
 };

--- a/packages/esm-patient-vitals-app/src/index.ts
+++ b/packages/esm-patient-vitals-app/src/index.ts
@@ -43,7 +43,7 @@ function setupOpenMRS() {
       },
       {
         id: 'vitals-details-widget',
-        slot: 'patient-chart-results-dashboard-slot',
+        slot: 'patient-chart-vitals-biometrics-dashboard-slot',
         load: getAsyncLifecycle(() => import('./vitals/vitals-main.component'), options),
         meta: {
           view: 'vitals',


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- This PR changes the `tab` display of vitals and biometrics detailed view to a single `grid`. This is a result of user-feedback preference
- Changed the slot to match the contents on the slot from `patient-chart-results-dashboard-slot` to `patient-chart-vitals-biometrics-dashboard-slot`


## Screenshots

before
<img width="841" alt="Screenshot 2021-12-10 at 11 21 09" src="https://user-images.githubusercontent.com/28008754/145541094-d86ea936-059b-4dd4-a51d-a637be8d0454.png">

after
<img width="1674" alt="Screenshot 2021-12-10 at 11 21 32" src="https://user-images.githubusercontent.com/28008754/145541126-c0674bd3-b7bb-443c-9f15-20edc37d325a.png">



## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
