### PR TITLE
03-977: Workspace warning modal enhancements

### DIFF
--- a/packages/esm-patient-chart-app/src/ui-components/workspace-notification.component.scss
+++ b/packages/esm-patient-chart-app/src/ui-components/workspace-notification.component.scss
@@ -1,20 +1,5 @@
 @import '../root.scss';
 
 .messageBody {
-    @extend .productiveHeading02;
-}
-
-.buttonContainer {
-    display: flex;
-    width: 100%;
-    padding: 0.625rem;
-}
-
-.buttonContainer button {
-    width: 50%;
-    height: 4rem;
-    display: flex;
-    justify-content: flex-start;
-    align-items: flex-start;
-    max-width: 100%;
+ @extend .productiveHeading02;
 }

--- a/packages/esm-patient-chart-app/src/ui-components/workspace-notification.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/workspace-notification.component.tsx
@@ -1,17 +1,16 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import styles from './workspace-notification.component.scss';
-import { Button, ComposedModal, ModalBody, ModalHeader } from 'carbon-components-react';
+import { Button, ComposedModal, ModalBody, ModalFooter, ModalHeader } from 'carbon-components-react';
 import { patientChartWorkspaceSlot } from '../constants';
 import { useAssignedExtensionIds, attach, detachAll, extensionStore } from '@openmrs/esm-framework';
 import { getTitle } from '../utils';
 
 const WorkspaceNotification: React.FC = () => {
   const { t } = useTranslation();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [extensionSlotName, setExtensionSlotName] = useState('');
   const extensions = useAssignedExtensionIds(patientChartWorkspaceSlot);
-
-  const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [extensionSlotName, setExtensionSlotName] = useState<string>('');
 
   const formName = useMemo(() => {
     if (extensions.length === 1) {
@@ -23,7 +22,7 @@ const WorkspaceNotification: React.FC = () => {
   }, [extensions]);
 
   const toggleActive = () => {
-    setIsOpen((prevState) => !prevState);
+    setIsModalOpen((prevState) => !prevState);
   };
 
   useEffect(() => {
@@ -32,11 +31,12 @@ const WorkspaceNotification: React.FC = () => {
       const { extensionSlotName } = state;
       setExtensionSlotName(extensionSlotName);
       if (extensions.length > 0) {
-        setIsOpen(true);
+        setIsModalOpen(true);
       } else {
         attach(patientChartWorkspaceSlot, extensionSlotName);
       }
     };
+
     window.addEventListener('workspace-dialog', handler);
     return () => window.removeEventListener('workspace-dialog', handler);
   }, [extensions.length]);
@@ -48,21 +48,27 @@ const WorkspaceNotification: React.FC = () => {
   };
 
   return (
-    <ComposedModal open={isOpen} onClose={toggleActive}>
-      <ModalHeader>
-        <span className={styles.productiveHeading04}>{t('activeWorkspaceText', { formName })}</span>
-      </ModalHeader>
+    <ComposedModal open={isModalOpen} onClose={toggleActive}>
+      <ModalHeader
+        label={t('workspaceWarning', 'Workspace warning')}
+        title={t('activeFormWarning', 'There is an active form open in the workspace')}
+      ></ModalHeader>
       <ModalBody>
-        <p className={styles.messageBody}>{t('workspaceNotificationHelperText', { formName })}</p>
+        <p className={styles.messageBody}>
+          <Trans i18nKey="workspaceModalText" values={{ formName: formName }}>
+            Launching a new form in the workspace could cause you to lose unsaved work on the{' '}
+            <strong>{formName}</strong> form.
+          </Trans>
+        </p>
       </ModalBody>
-      <div className={styles.buttonContainer}>
-        <Button onClick={toggleActive} kind="secondary">
+      <ModalFooter>
+        <Button kind="secondary" onClick={toggleActive}>
           {t('cancel', 'Cancel')}
         </Button>
-        <Button onClick={handleOpenNewForm} kind="danger">
-          {t('closeCurrent', 'Open new form')}
+        <Button kind="danger" onClick={handleOpenNewForm}>
+          {t('openAnyway', 'Open anyway')}
         </Button>
-      </div>
+      </ModalFooter>
     </ComposedModal>
   );
 };

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -1,12 +1,11 @@
 {
-  "activeWorkspaceText": "{formName} form is active",
+  "activeFormWarning": "There is an active form open in the workspace",
   "addPastVisit": "Add past visit",
   "addPastVisitText": "You can add past visit, update past visit or add new past visit, Click on one of the buttons below",
   "all": "All",
   "allEncounters": "All Encounters",
   "cancel": "Cancel",
   "careActivities": "Care Activities",
-  "closeCurrent": "Open new form",
   "date": "Date",
   "dateAndTimeOfVisit": "Date and time of visit",
   "diagnoses": "Diagnoses",
@@ -34,6 +33,7 @@
   "noNotesFound": "No notes found",
   "noObservationsFound": "No observations found",
   "notes": "Notes",
+  "openAnyway": "Open anyway",
   "orderDurationAndUnit": "for {duration} {durationUnit}",
   "orderIndefiniteDuration": "Indefinite duration",
   "pastVisitErrorText": "Past Visit Error",
@@ -56,5 +56,6 @@
   "visitLocation": "Visit Location",
   "visitSummary": "Visit Summary",
   "visitType": "Visit type",
-  "workspaceNotificationHelperText": "Opening a new form will cause you to loose unsaved work on {formName}."
+  "workspaceModalText": "Launching a new form in the workspace could cause you to lose unsaved work on the <2>{formName}</2> form.",
+  "workspaceWarning": "Workspace warning"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x]  I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Currently, there are a few issues with the workspace warning modal:

- Translations don't work.
- The modal copy can be clearer and concise.
- The design of the modal action buttons doesn't quite tally with the official Modal component guidance https://www.carbondesignsystem.com/components/modal/usage#transactional-modal. The buttons ought to be full bleed to the edge of the modal container. They should each span 50% of the dialog.

## Screenshots

Before

<img width="1080" alt="Screenshot 2021-12-14 at 22 34 46" src="https://user-images.githubusercontent.com/8509731/146156114-7ecc623b-61da-4fc5-b723-0f25c0ad6303.png">


After

<img width="1375" alt="Screenshot 2021-12-15 at 11 54 02" src="https://user-images.githubusercontent.com/8509731/146156152-5b71ea7f-3121-4746-b436-75b827ebe0a9.png">

