### PR TITLE
Update handling of vitals/biometrics concept symbols

### DIFF
--- a/__mocks__/vitals.mock.ts
+++ b/__mocks__/vitals.mock.ts
@@ -393,7 +393,7 @@ export const mockVitalsSignsConcept = {
             lowNormal: null,
             lowAbsolute: 0.0,
             lowCritical: null,
-            units: '/ min',
+            units: 'breaths/min',
           },
         ],
       },

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
@@ -44,8 +44,7 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
   const config = useConfig() as ConfigObject;
   const { bmiUnit } = config.biometrics;
 
-  const { data: conceptData } = useVitalsConceptMetadata();
-  const conceptUnits = conceptData ? conceptData.conceptUnits : null;
+  const { data: conceptUnits } = useVitalsConceptMetadata();
 
   const { data: biometrics, isLoading, isError, isValidating } = useBiometrics(patientUuid);
 
@@ -56,10 +55,10 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
 
   const tableHeaders = [
     { key: 'date', header: 'Date and time' },
-    { key: 'weight', header: withUnit('Weight', conceptUnits?.[4] ?? '') },
-    { key: 'height', header: withUnit('Height', conceptUnits?.[3] ?? '') },
+    { key: 'weight', header: withUnit('Weight', conceptUnits.get(config.concepts.weightUuid) ?? '') },
+    { key: 'height', header: withUnit('Height', conceptUnits.get(config.concepts.heightUuid) ?? '') },
     { key: 'bmi', header: `BMI (${bmiUnit})` },
-    { key: 'muac', header: withUnit('MUAC', conceptUnits?.[7] ?? '') },
+    { key: 'muac', header: withUnit('MUAC', conceptUnits.get(config.concepts.muacUuid) ?? '') },
   ];
   const tableRows = React.useMemo(
     () =>
@@ -112,7 +111,7 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
           </div>
         </CardHeader>
         {chartView ? (
-          <BiometricsChart patientBiometrics={biometrics} conceptsUnits={conceptUnits} />
+          <BiometricsChart patientBiometrics={biometrics} conceptUnits={conceptUnits} config={config} />
         ) : (
           <BiometricsPagination
             tableRows={tableRows}

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-chart.component.tsx
@@ -7,10 +7,12 @@ import { LineChartOptions } from '@carbon/charts/interfaces/charts';
 import { ScaleTypes } from '@carbon/charts/interfaces/enums';
 import { useConfig } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
+import { ConfigObject } from '../config-schema';
 
 interface BiometricsChartProps {
   patientBiometrics: Array<any>;
-  conceptsUnits: Array<string>;
+  conceptUnits: Map<string, string>;
+  config: ConfigObject;
 }
 
 interface BiometricChartData {
@@ -21,13 +23,11 @@ interface BiometricChartData {
 
 const chartColors = { weight: '#6929c4', height: '#6929c4', bmi: '#6929c4' };
 
-const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, conceptsUnits }) => {
-  const config = useConfig();
+const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, conceptUnits, config }) => {
   const { t } = useTranslation();
   const { bmiUnit } = config.biometrics;
-  const [, , , heightUnit, weightUnit] = conceptsUnits;
   const [selectedBiometrics, setSelectedBiometrics] = React.useState<BiometricChartData>({
-    title: `Weight (${weightUnit})`,
+    title: `Weight (${conceptUnits.get(config.concepts.weightUuid) ?? ''})`,
     value: 'weight',
     groupName: 'weight',
   });
@@ -79,8 +79,8 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
         </label>
         <Tabs className={styles.verticalTabs} type="default">
           {[
-            { id: 'weight', label: `Weight (${weightUnit})` },
-            { id: 'height', label: `Height (${heightUnit})` },
+            { id: 'weight', label: `Weight (${conceptUnits.get(config.concepts.weightUuid) ?? ''})` },
+            { id: 'height', label: `Height (${conceptUnits.get(config.concepts.heightUuid) ?? ''})` },
             { id: 'bmi', label: `BMI (${bmiUnit})` },
           ].map(({ id, label }) => (
             <Tab

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.test.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.test.tsx
@@ -6,16 +6,20 @@ import {
   formattedBiometrics,
   mockBiometricsResponse,
   mockConceptMetadata,
-  mockConceptUnits,
 } from '../../../../__mocks__/biometrics.mock';
 import { patientChartBasePath, swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import BiometricsOverview from './biometrics-overview.component';
+import { mockVitalsSignsConcept } from '../../../../__mocks__/vitals.mock';
 
 const testProps = {
   basePath: patientChartBasePath,
   showAddBiometrics: true,
   patientUuid: mockPatient.id,
 };
+
+const mockConceptUnits = new Map<string, string>(
+  mockVitalsSignsConcept.data.results[0].setMembers.map((concept) => [concept.uuid, concept.units]),
+);
 
 const mockBiometricsConfig = {
   biometrics: { bmiUnit: 'kg / m²' },
@@ -45,10 +49,8 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   return {
     ...originalModule,
     useVitalsConceptMetadata: jest.fn().mockImplementation(() => ({
-      data: {
-        conceptUnits: mockConceptUnits,
-        conceptMetadata: mockConceptMetadata,
-      },
+      data: mockConceptUnits,
+      conceptMetadata: mockConceptMetadata,
     })),
   };
 });

--- a/packages/esm-patient-biometrics-app/src/biometrics/weight-tile.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/weight-tile.component.tsx
@@ -4,6 +4,8 @@ import { InlineLoading } from 'carbon-components-react';
 import { useVitalsConceptMetadata } from '@openmrs/esm-patient-common-lib';
 import { useBiometrics } from './biometrics.resource';
 import styles from './weight-tile.component.scss';
+import { ConfigObject } from '../config-schema';
+import { useConfig } from '@openmrs/esm-framework';
 
 interface WeightTileInterface {
   patientUuid: string;
@@ -11,8 +13,9 @@ interface WeightTileInterface {
 
 const WeightTile: React.FC<WeightTileInterface> = ({ patientUuid }) => {
   const { t } = useTranslation();
+  const config = useConfig() as ConfigObject;
   const { data: biometrics, isLoading } = useBiometrics(patientUuid);
-  const { data: conceptData } = useVitalsConceptMetadata();
+  const { data: conceptUnits } = useVitalsConceptMetadata();
   const weightData = biometrics?.filter((result) => result.weight);
 
   if (isLoading) {
@@ -23,7 +26,8 @@ const WeightTile: React.FC<WeightTileInterface> = ({ patientUuid }) => {
       <div>
         <p className={styles.label}>{t('weight', 'Weight')}</p>
         <p className={styles.content}>
-          <span className={styles.value}>{weightData?.[0]?.weight}</span> {conceptData?.conceptUnits?.[4]}
+          <span className={styles.value}>{weightData?.[0]?.weight}</span>{' '}
+          {conceptUnits.get(config.concepts.weightUuid) ?? ''}
         </p>
       </div>
     );

--- a/packages/esm-patient-biometrics-app/src/biometrics/weight-tile.test.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/weight-tile.test.tsx
@@ -3,8 +3,13 @@ import { screen } from '@testing-library/react';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { getByTextWithMarkup, swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
-import { mockBiometricsResponse, mockConceptMetadata, mockConceptUnits } from '../../../../__mocks__/biometrics.mock';
+import { mockBiometricsResponse, mockConceptMetadata } from '../../../../__mocks__/biometrics.mock';
 import WeightTile from './weight-tile.component';
+import { mockVitalsSignsConcept } from '../../../../__mocks__/vitals.mock';
+
+const mockConceptUnits = new Map<string, string>(
+  mockVitalsSignsConcept.data.results[0].setMembers.map((concept) => [concept.uuid, concept.units]),
+);
 
 const testProps = {
   patientUuid: mockPatient.id,
@@ -32,10 +37,8 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   return {
     ...originalModule,
     useVitalsConceptMetadata: jest.fn().mockImplementation(() => ({
-      data: {
-        conceptUnits: mockConceptUnits,
-        conceptMetadata: mockConceptMetadata,
-      },
+      data: mockConceptUnits,
+      conceptMetadata: mockConceptMetadata,
     })),
   };
 });

--- a/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
+++ b/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
@@ -11,12 +11,15 @@ export function useVitalsConceptMetadata() {
   );
 
   const conceptMetadata = data?.data?.results[0]?.setMembers;
-  const conceptUnits = conceptMetadata?.length ? conceptMetadata.map((conceptUnit) => conceptUnit.units) : null;
+  const conceptUnits = conceptMetadata?.length
+    ? new Map<string, string>(conceptMetadata.map((concept) => [concept.uuid, concept.units]))
+    : new Map<string, string>([]);
 
   return {
-    data: conceptMetadata?.length ? { conceptUnits, conceptMetadata } : null,
+    data: conceptUnits,
     isError: error,
     isLoading: !data && !error,
+    conceptMetadata,
   };
 }
 

--- a/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
+++ b/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
@@ -11,10 +11,10 @@ export function useVitalsConceptMetadata() {
   );
 
   const conceptMetadata = data?.data?.results[0]?.setMembers;
+
   const conceptUnits = conceptMetadata?.length
     ? new Map<string, string>(conceptMetadata.map((concept) => [concept.uuid, concept.units]))
     : new Map<string, string>([]);
-
   return {
     data: conceptUnits,
     isError: error,

--- a/packages/esm-patient-vitals-app/src/config-schema.ts
+++ b/packages/esm-patient-vitals-app/src/config-schema.ts
@@ -59,6 +59,7 @@ export interface ConfigObject {
     heightUuid: string;
     weightUuid: string;
     respiratoryRateUuid: string;
+    midUpperArmCircumferenceUuid: string;
   };
   vitals: VitalsConfigObject;
   biometrics: BiometricsConfigObject;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.test.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render } from '@testing-library/react';
-import { mockConceptMetadata, mockConceptUnits, mockVitalsConfig } from '../../../../../__mocks__/vitals.mock';
+import { mockConceptMetadata, mockVitalsConfig, mockVitalsSignsConcept } from '../../../../../__mocks__/vitals.mock';
 import { mockPatient } from '../../../../../__mocks__/patient.mock';
 import VitalsAndBiometricsForm from './vitals-biometrics-form.component';
+
+const mockConceptUnits = new Map<string, string>(
+  mockVitalsSignsConcept.data.results[0].setMembers.map((concept) => [concept.uuid, concept.units]),
+);
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
@@ -11,10 +15,8 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   return {
     ...originalModule,
     useVitalsConceptMetadata: jest.fn().mockImplementation(() => ({
-      data: {
-        conceptUnits: mockConceptUnits,
-        conceptMetadata: mockConceptMetadata,
-      },
+      data: mockConceptUnits,
+      conceptMetadata: mockConceptMetadata,
     })),
   };
 });
@@ -57,7 +59,7 @@ describe('VitalsBiometricsForm: ', () => {
     expect(screen.getByText(/breaths\/min/i)).toBeInTheDocument();
     expect(screen.getByRole('spinbutton', { name: /temperature/i })).toBeInTheDocument();
     expect(screen.getByText(/temp/i)).toBeInTheDocument();
-    expect(screen.getByText(/deg c/i)).toBeInTheDocument();
+    expect(screen.getByText(/DEG C/i)).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /notes/i })).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/type any additional notes here/i)).toBeInTheDocument();
     expect(screen.getByRole('spinbutton', { name: /weight/i })).toBeInTheDocument();

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -40,9 +40,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
   const { t } = useTranslation();
   const session = useSessionUser();
   const config = useConfig() as ConfigObject;
-  const {
-    data: { conceptUnits, conceptMetadata },
-  } = useVitalsConceptMetadata();
+  const { data: conceptUnits, conceptMetadata } = useVitalsConceptMetadata();
   const biometricsUnitsSymbols = config.biometrics;
   const [patientVitalAndBiometrics, setPatientVitalAndBiometrics] = useState<PatientVitalAndBiometric>();
   const [patientBMI, setPatientBMI] = useState<number>();
@@ -58,18 +56,6 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
     weight: config.concepts.weightUuid,
     respiratoryRate: config.concepts.respiratoryRateUuid,
   };
-
-  const [
-    bloodPressureUnit,
-    ,
-    temperatureUnit,
-    heightUnit,
-    weightUnit,
-    pulseUnit,
-    oxygenSaturationUnit,
-    midUpperArmCircumferenceUnit,
-    respiratoryRateUnit,
-  ] = conceptUnits;
 
   const isBMIInNormalRange = (value: number | undefined | string) => {
     if (value === undefined || value === '') return true;
@@ -168,7 +154,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
                 value: patientVitalAndBiometrics?.diastolicBloodPressure || '',
               },
             ]}
-            unitSymbol={bloodPressureUnit}
+            unitSymbol={conceptUnits.get(config.concepts.temperatureUuid) ?? ''}
             inputIsNormal={
               isInNormalRange(
                 conceptMetadata,
@@ -200,7 +186,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
                 value: patientVitalAndBiometrics?.pulse || '',
               },
             ]}
-            unitSymbol={pulseUnit}
+            unitSymbol={conceptUnits.get(config.concepts.pulseUuid) ?? ''}
             inputIsNormal={isInNormalRange(
               conceptMetadata,
               config.concepts['pulseUuid'],
@@ -225,7 +211,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
                 value: patientVitalAndBiometrics?.oxygenSaturation || '',
               },
             ]}
-            unitSymbol={oxygenSaturationUnit}
+            unitSymbol={conceptUnits.get(config.concepts.oxygenSaturationUuid) ?? ''}
             inputIsNormal={isInNormalRange(
               conceptMetadata,
               config.concepts['oxygenSaturationUuid'],
@@ -250,7 +236,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
                 value: patientVitalAndBiometrics?.respiratoryRate || '',
               },
             ]}
-            unitSymbol={respiratoryRateUnit}
+            unitSymbol={conceptUnits.get(config.concepts.respiratoryRateUuid) ?? ''}
             inputIsNormal={isInNormalRange(
               conceptMetadata,
               config.concepts['respiratoryRateUuid'],
@@ -277,7 +263,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
                 value: patientVitalAndBiometrics?.temperature || '',
               },
             ]}
-            unitSymbol={temperatureUnit}
+            unitSymbol={conceptUnits.get(config.concepts.temperatureUuid) ?? ''}
             inputIsNormal={isInNormalRange(
               conceptMetadata,
               config.concepts['temperatureUuid'],
@@ -334,7 +320,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
                 value: patientVitalAndBiometrics?.weight || '',
               },
             ]}
-            unitSymbol={weightUnit}
+            unitSymbol={conceptUnits.get(config.concepts.weightUuid) ?? ''}
             inputIsNormal={true}
             isTablet={isTablet}
           />
@@ -355,7 +341,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
                 value: patientVitalAndBiometrics?.height || '',
               },
             ]}
-            unitSymbol={heightUnit}
+            unitSymbol={conceptUnits.get(config.concepts.heightUuid) ?? ''}
             inputIsNormal={true}
             isTablet={isTablet}
           />
@@ -393,7 +379,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
                 value: patientVitalAndBiometrics?.midUpperArmCircumference || '',
               },
             ]}
-            unitSymbol={midUpperArmCircumferenceUnit}
+            unitSymbol={conceptUnits.get(config.concepts.midUpperArmCircumferenceUuid) ?? ''}
             inputIsNormal={isInNormalRange(
               conceptMetadata,
               config.concepts['midUpperArmCircumferenceUuid'],

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -154,7 +154,7 @@ const VitalsAndBiometricForms: React.FC<VitalsAndBiometricFormProps> = ({ patien
                 value: patientVitalAndBiometrics?.diastolicBloodPressure || '',
               },
             ]}
-            unitSymbol={conceptUnits.get(config.concepts.temperatureUuid) ?? ''}
+            unitSymbol={conceptUnits.get(config.concepts.systolicBloodPressureUuid) ?? ''}
             inputIsNormal={
               isInNormalRange(
                 conceptMetadata,

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
@@ -9,6 +9,7 @@ import { LineChartOptions } from '@carbon/charts/interfaces/charts';
 import { ScaleTypes } from '@carbon/charts/interfaces/enums';
 import { withUnit } from '@openmrs/esm-patient-common-lib';
 import '@carbon/charts/styles.css';
+import { ConfigObject } from '../config-schema';
 
 interface vitalsChartData {
   title: string;
@@ -17,15 +18,14 @@ interface vitalsChartData {
 
 interface VitalsChartProps {
   patientVitals: Array<PatientVitals>;
-  conceptUnits: Array<string>;
+  conceptUnits: Map<string, string>;
+  config: ConfigObject;
 }
 
-const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits }) => {
+const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, config }) => {
   const { t } = useTranslation();
-  const [bloodPressureUnit, , temperatureUnit, , , pulseUnit, oxygenSaturationUnit, , respiratoryRateUnit] =
-    conceptUnits;
   const [selectedVitalSign, setSelectedVitalsSign] = React.useState<vitalsChartData>({
-    title: `BP (${bloodPressureUnit})`,
+    title: `BP (${conceptUnits.get(config.concepts.systolicBloodPressureUuid)})`,
     value: 'systolic',
   });
 
@@ -76,27 +76,27 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits }
   const vitalSigns = [
     {
       id: 'bloodPressure',
-      title: withUnit('BP', bloodPressureUnit),
+      title: withUnit('BP', conceptUnits.get(config.concepts.systolicBloodPressureUuid) ?? '-'),
       value: 'systolic',
     },
     {
       id: 'oxygenSaturation',
-      title: withUnit('SPO2', oxygenSaturationUnit),
+      title: withUnit('SPO2', conceptUnits.get(config.concepts.oxygenSaturationUuid) ?? '-'),
       value: 'oxygenSaturation',
     },
     {
       id: 'temperature',
-      title: withUnit('Temp', temperatureUnit),
+      title: withUnit('Temp', conceptUnits.get(config.concepts.temperatureUuid) ?? '-'),
       value: 'temperature',
     },
     {
       id: 'Respiratory Rate',
-      title: withUnit('R. Rate', respiratoryRateUnit),
+      title: withUnit('R. Rate', conceptUnits.get(config.concepts.respiratoryRateUuid) ?? '-'),
       value: 'respiratoryRate',
     },
     {
       id: 'pulse',
-      title: withUnit('Pulse', pulseUnit),
+      title: withUnit('Pulse', conceptUnits.get(config.concepts.pulseUuid) ?? '-'),
       value: 'pulse',
     },
   ];

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
@@ -8,6 +8,7 @@ import { useConfig } from '@openmrs/esm-framework';
 import { useVitalsConceptMetadata } from '@openmrs/esm-patient-common-lib';
 import { useVitals } from '../vitals.resource';
 import styles from './vitals-header.component.scss';
+import { ConfigObject } from '../../config-schema';
 
 interface VitalsHeaderProps {
   patientUuid: string;
@@ -15,11 +16,10 @@ interface VitalsHeaderProps {
 }
 
 const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVitals }) => {
-  const config = useConfig();
+  const config = useConfig() as ConfigObject;
   const { t } = useTranslation();
   const { data: vitals, isLoading } = useVitals(patientUuid);
-  const { data: conceptData } = useVitalsConceptMetadata();
-  const conceptUnits = conceptData?.conceptUnits ? conceptData.conceptUnits : null;
+  const { data: conceptUnits } = useVitalsConceptMetadata();
   const latestVitals = vitals?.[0];
 
   const [showDetails, setShowDetails] = useState(false);
@@ -50,34 +50,34 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
               <div className={styles.row}>
                 <VitalsHeaderItem
                   unitName={t('temperatureAbbreviated', 'Temp')}
-                  unitSymbol={conceptUnits?.[2] ?? ''}
+                  unitSymbol={conceptUnits.get(config.concepts.temperatureUuid) ?? ''}
                   value={latestVitals?.temperature}
                 />
                 <VitalsHeaderItem
                   unitName={t('bp', 'BP')}
-                  unitSymbol={conceptUnits?.[0] ?? ''}
+                  unitSymbol={conceptUnits.get(config.concepts.systolicBloodPressureUuid) ?? ''}
                   value={`${latestVitals?.systolic} / ${latestVitals?.diastolic}`}
                 />
                 <VitalsHeaderItem
                   unitName={t('heartRate', 'Heart Rate')}
-                  unitSymbol={conceptUnits?.[5] ?? ''}
+                  unitSymbol={conceptUnits.get(config.concepts.pulseUuid) ?? ''}
                   value={latestVitals?.pulse}
                 />
                 <VitalsHeaderItem
                   unitName={t('spo2', 'SpO2')}
-                  unitSymbol={conceptUnits?.[6] ?? ''}
+                  unitSymbol={conceptUnits.get(config.concepts.oxygenSaturationUuid) ?? ''}
                   value={latestVitals?.oxygenSaturation}
                 />
               </div>
               <div className={styles.row}>
                 <VitalsHeaderItem
                   unitName={t('respiratoryRate', 'R. Rate')}
-                  unitSymbol={conceptUnits?.[8] ?? ''}
+                  unitSymbol={conceptUnits.get(config.concepts.respiratoryRateUuid) ?? ''}
                   value={latestVitals?.respiratoryRate}
                 />
                 <VitalsHeaderItem
                   unitName={t('height', 'Height')}
-                  unitSymbol={conceptUnits?.[3] ?? ''}
+                  unitSymbol={conceptUnits.get(config.concepts.heightUuid) ?? ''}
                   value={latestVitals?.height}
                 />
                 <VitalsHeaderItem
@@ -87,7 +87,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
                 />
                 <VitalsHeaderItem
                   unitName={t('weight', 'Weight')}
-                  unitSymbol={conceptUnits?.[4] ?? ''}
+                  unitSymbol={conceptUnits.get(config.concepts.weightUuid) ?? ''}
                   value={latestVitals?.weight}
                 />
               </div>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
@@ -7,13 +7,17 @@ import userEvent from '@testing-library/user-event';
 import { mockPatient } from '../../../../../__mocks__/patient.mock';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { getByTextWithMarkup, swrRender, waitForLoadingToFinish } from '../../../../../tools/test-helpers';
-import { mockFhirVitalsResponse, mockVitalsConfig } from '../../../../../__mocks__/vitals.mock';
+import { mockFhirVitalsResponse, mockVitalsConfig, mockVitalsSignsConcept } from '../../../../../__mocks__/vitals.mock';
 import VitalsHeader from './vitals-header.component';
 
 const testProps = {
   patientUuid: mockPatient.id,
   showRecordVitals: true,
 };
+
+const mockConceptUnits = new Map<string, string>(
+  mockVitalsSignsConcept.data.results[0].setMembers.map((concept) => [concept.uuid, concept.units]),
+);
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
@@ -23,22 +27,20 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   return {
     ...originalModule,
     useVitalsConceptMetadata: jest.fn().mockImplementation(() => ({
-      data: {
-        conceptUnits: ['mmHg', 'mmHg', 'DEG C', 'cm', 'kg', 'beats/min', '%', 'cm', 'breaths/min'],
-        conceptMetadata: [
-          {
-            display: 'Systolic',
-            hiAbsolute: 250,
-            hiCritical: 180,
-            hiNormal: 140,
-            lowAbsolute: 0,
-            lowCritical: 85,
-            lowNormal: 100,
-            units: 'mmHg',
-            uuid: '5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-          },
-        ],
-      },
+      data: mockConceptUnits,
+      conceptMetadata: [
+        {
+          display: 'Systolic',
+          hiAbsolute: 250,
+          hiCritical: 180,
+          hiNormal: 140,
+          lowAbsolute: 0,
+          lowCritical: 85,
+          lowNormal: 100,
+          units: 'mmHg',
+          uuid: '5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        },
+      ],
     })),
   };
 });

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -18,6 +18,8 @@ import {
 import { useTranslation } from 'react-i18next';
 import { patientVitalsBiometricsFormWorkspace } from '../constants';
 import { useVitals } from './vitals.resource';
+import { ConfigObject } from '../config-schema';
+import { useConfig } from '@openmrs/esm-framework';
 
 interface VitalsOverviewProps {
   patientUuid: string;
@@ -29,13 +31,13 @@ interface VitalsOverviewProps {
 
 const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVitals, pageSize, urlLabel, pageUrl }) => {
   const { t } = useTranslation();
+  const config = useConfig() as ConfigObject;
   const displayText = t('vitalSigns', 'Vital signs');
   const headerTitle = t('vitals', 'Vitals');
   const [chartView, setChartView] = React.useState<boolean>();
 
   const { data: vitals, isError, isLoading, isValidating } = useVitals(patientUuid);
-  const { data: conceptData } = useVitalsConceptMetadata();
-  const conceptUnits = conceptData ? conceptData.conceptUnits : null;
+  const { data: conceptUnits } = useVitalsConceptMetadata();
 
   const launchVitalsBiometricsForm = React.useCallback(
     () => launchPatientWorkspace(patientVitalsBiometricsFormWorkspace),
@@ -46,20 +48,20 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
     { key: 'date', header: 'Date and time', isSortable: true },
     {
       key: 'bloodPressure',
-      header: withUnit('BP', conceptUnits?.[0] ?? ''),
+      header: withUnit('BP', conceptUnits.get(config.concepts.systolicBloodPressureUuid) ?? ''),
     },
     {
       key: 'respiratoryRate',
-      header: withUnit('R. Rate', conceptUnits?.[8] ?? ''),
+      header: withUnit('R. Rate', conceptUnits.get(config.concepts.respiratoryRateUuid) ?? ''),
     },
-    { key: 'pulse', header: withUnit('Pulse', conceptUnits?.[5] ?? '') },
+    { key: 'pulse', header: withUnit('Pulse', conceptUnits.get(config.concepts.pulseUuid) ?? '') },
     {
       key: 'spo2',
-      header: withUnit('SPO2', conceptUnits?.[6] ?? ''),
+      header: withUnit('SPO2', conceptUnits.get(config.concepts.oxygenSaturationUuid) ?? ''),
     },
     {
       key: 'temperature',
-      header: withUnit('Temp', conceptUnits?.[2] ?? ''),
+      header: withUnit('Temp', conceptUnits.get(config.concepts.temperatureUuid) ?? ''),
     },
   ];
 
@@ -126,7 +128,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
                 </div>
               </CardHeader>
               {chartView ? (
-                <VitalsChart patientVitals={vitals} conceptUnits={conceptUnits} />
+                <VitalsChart patientVitals={vitals} conceptUnits={conceptUnits} config={config} />
               ) : (
                 <VitalsPagination
                   tableRows={tableRows}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -6,9 +6,9 @@ import { mockPatient } from '../../../../__mocks__/patient.mock';
 import {
   formattedVitals,
   mockConceptMetadata,
-  mockConceptUnits,
   mockFhirVitalsResponse,
   mockVitalsConfig,
+  mockVitalsSignsConcept,
 } from '../../../../__mocks__/vitals.mock';
 import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import VitalsOverview from './vitals-overview.component';
@@ -22,6 +22,10 @@ const testProps = {
   urlLabel: '',
 };
 
+const mockConceptUnits = new Map<string, string>(
+  mockVitalsSignsConcept.data.results[0].setMembers.map((concept) => [concept.uuid, concept.units]),
+);
+
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockUsePagination = usePagination as jest.Mock;
 
@@ -32,10 +36,8 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
     ...originalModule,
     launchPatientWorkspace: jest.fn(),
     useVitalsConceptMetadata: jest.fn().mockImplementation(() => ({
-      data: {
-        conceptUnits: mockConceptUnits,
-        conceptMetadata: mockConceptMetadata,
-      },
+      data: mockConceptUnits,
+      conceptMetadata: mockConceptMetadata,
     })),
   };
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).


## Summary

- As a result of Ampath piloting, the concept unit symbols don't match the corresponding concept symbol. This PR seeks to have this handled in a better approach.
- The screen was tested both against the Ampath instance and OpenMRS SPA instance to get the correct concept unit symbols


## Screenshots

bug state
<img width="1345" alt="Screenshot 2022-01-12 at 08 19 33" src="https://user-images.githubusercontent.com/28008754/149068901-7d16b6de-ffdf-4fd7-95eb-2988648fbb6c.png">

Fix 
![Screenshot 2022-01-12 at 08 23 07](https://user-images.githubusercontent.com/28008754/149068921-c01536da-229b-4a0e-99bc-52e4563b28c7.png)



## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
