### PR TITLE
O3-905  Patient chart tests depend on time zone

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "verify": "lerna run lint && lerna run test && lerna run typescript",
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx}\"",
     "prepare": "husky install",
-    "test": "jest --config jest.config.json --verbose false --passWithNoTests",
-    "test-watch": "jest --watch --config jest.config.json",
+    "test": "TZ=UTC jest --config jest.config.json --verbose false --passWithNoTests",
+    "test-watch": "TZ=UTC jest --watch --config jest.config.json",
     "coverage": "yarn test --coverage",
     "extract-translations": "lerna run extract-translations"
   },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

Without this, four tests fail when run from a computer on Pacific Time. With this change, the tests pass regardless of the time zone of the computer running them.

## Issue

https://issues.openmrs.org/browse/O3-905
