### PR TITLE
O3-683: Independently scrollable chart body and workspace

### DIFF
--- a/packages/esm-patient-chart-app/src/root.scss
+++ b/packages/esm-patient-chart-app/src/root.scss
@@ -1,5 +1,6 @@
-@import "carbon-components/scss/globals/scss/typography.scss";
 @import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
+@import "~carbon-components/src/globals/scss/mixins";
 
 .patientChartWrapper {
   display: flex;

--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.scss
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.scss
@@ -13,6 +13,7 @@ $actionPanelOffset: 48px;
   display: flex;
   height: 100%;
   right: 0;
+  z-index: 1001;
 }
 
 :global(.omrs-breakpoint-gt-tablet) .actionPanel {

--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
@@ -40,16 +40,18 @@ export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
     <aside className={styles.rightSideNav}>
       <ExtensionSlot extensionSlotName={CHARTS_ACTION_MENU_ITEMS_SLOT} />
       <Button
-        onClick={() => checkViewMode()}
-        iconDescription="WorkSpace Items"
+        onClick={checkViewMode}
+        iconDescription={t('workspaceItems', 'Workspace items')}
         className={`${styles.iconButton} ${openWindows > 0 && styles.activeIconButton} `}
         kind="ghost"
         hasIconOnly
+        tooltipPosition="bottom"
+        tooltipAlignment="end"
       >
-        <div>
+        <>
           <Pen20 />{' '}
           {windowSize.size === WorkspaceWindowState.hidden && <WarningFilled16 className={styles.warningButton} />}
-        </div>
+        </>
       </Button>
     </aside>
   ) : (

--- a/packages/esm-patient-chart-app/src/ui-components/notifications-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/notifications-button.component.tsx
@@ -9,7 +9,15 @@ interface NotificationsButtonInterface {
 
 const NotificationsButton: React.FC<NotificationsButtonInterface> = ({ onClick }) => {
   return (
-    <Button onClick={onClick} iconDescription="Notifications" className={styles.iconButton} kind="ghost" hasIconOnly>
+    <Button
+      onClick={onClick}
+      iconDescription="Notifications"
+      className={styles.iconButton}
+      kind="ghost"
+      hasIconOnly
+      tooltipPosition="bottom"
+      tooltipAlignment="end"
+    >
       <Notification20 aria-label="Notifications" />
     </Button>
   );

--- a/packages/esm-patient-chart-app/src/workspace/context-workspace.component.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/context-workspace.component.tsx
@@ -56,8 +56,11 @@ const ContextWorkspace: React.FC<RouteComponentProps<ContextWorkspaceParams>> = 
 
   return (
     <aside
-      className={`${styles.container} ${maximized && styles.maximized} ${
-        isWorkspaceOpen ? `${styles.show}` : `${styles.hide}`
+      className={`${styles.container} ${maximized ? `${styles.maximized}` : undefined} ${
+        isWorkspaceOpen
+          ? `${styles.show}`
+          : `${styles.hide}
+      }`
       }`}
     >
       <Header aria-label="Workspace Title" className={styles.header}>
@@ -79,10 +82,15 @@ const ContextWorkspace: React.FC<RouteComponentProps<ContextWorkspaceParams>> = 
             onClick={() => updateWindowSize(WorkspaceWindowState.hidden)}
             renderIcon={ArrowRight16}
             tooltipPosition="bottom"
+            tooltipAlignment="end"
           />
         </HeaderGlobalBar>
       </Header>
-      <ExtensionSlot extensionSlotName={patientChartWorkspaceSlot} state={props} />
+      <ExtensionSlot
+        className={`${styles.fixed} ${maximized ? `${styles.fullWidth}` : `${styles.dynamicWidth}`}`}
+        extensionSlotName={patientChartWorkspaceSlot}
+        state={props}
+      />
     </aside>
   );
 };

--- a/packages/esm-patient-chart-app/src/workspace/context-workspace.scss
+++ b/packages/esm-patient-chart-app/src/workspace/context-workspace.scss
@@ -1,7 +1,4 @@
 @import "../root.scss";
-@import "~@openmrs/esm-styleguide/src/vars";
-@import "~carbon-components/src/globals/scss/vars";
-@import "~carbon-components/src/globals/scss/mixins";
 
 .container {
   border-width: 0.0625rem 0 0.0625rem 0.0625rem;
@@ -11,7 +8,6 @@
 
 .header {
   background-color: $ui-03;
-  position: sticky;
   top: 3rem;
   border-bottom: 1px solid $text-03;
   z-index: 1000;
@@ -24,6 +20,10 @@
       color: inherit;
     }
   }
+
+  &:not(.maximized) {
+    position: sticky;
+  }
 }
 
 /* Tablet */
@@ -35,11 +35,12 @@
   right: 0;
   bottom: 0;
   z-index: 1000;
+
+  > .dynamicWidth {
+    width: 100%;
+  }
 }
 
-:global(.omrs-breakpoint-lt-desktop) .header {
-  display: none;
-}
 
 /* Desktop */
 :global(.omrs-breakpoint-gt-tablet) .container {
@@ -63,4 +64,22 @@
 
 .show {
   display: inline-block;
+}
+
+.fixed {
+  position: fixed !important;
+  top: 6rem;
+  right: auto;
+  left: auto;
+  overflow-y: auto;
+  bottom: 1px;
+}
+
+.fullWidth {
+  // Subtract side rail width
+  width: calc(100% - 50px);
+}
+
+.dynamicWidth {
+  width: calc(50% - 9.6rem);
 }

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -18,7 +18,7 @@
   "endDate": "End date",
   "endVisit": "End Visit",
   "endVisitError": "Error ending current visit",
-  "hide": "Hide workspace",
+  "hide": "Hide",
   "loading": "Loading",
   "loadVisitInfo": "Load Visit Info",
   "location": "Location",
@@ -57,6 +57,7 @@
   "visitLocation": "Visit Location",
   "visitSummary": "Visit Summary",
   "visitType": "Visit type",
+  "workspaceItems": "Workspace items",
   "workspaceModalText": "Launching a new form in the workspace could cause you to lose unsaved work on the <2>{formName}</2> form.",
   "workspaceWarning": "Workspace warning"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This ensures that the user can scroll independently between the patient chart body and the workspace when a form is open.

## Video

> Note that because the detach function is currently borked, closing or discarding an active form from the workspace would not work. This is why I have to override the active form each time I launch a new one in the video below.

https://user-images.githubusercontent.com/8509731/148730910-1e6e32e7-c415-4e8d-867c-1e0ce005da2b.mp4

## Issue

https://issues.openmrs.org/projects/MF/issues/O3-683
