### PR TITLE
Typeahead visual fixes

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
@@ -154,7 +154,7 @@ const ConditionsForm: React.FC<ConditionsFormProps> = ({ patientUuid, isTablet }
 
   return (
     <Form style={{ margin: '2rem' }} onSubmit={handleSubmit}>
-      <FormGroup style={{ width: '50%' }} legendText={t('condition', 'Condition')}>
+      <FormGroup legendText={t('condition', 'Condition')}>
         <Search
           light={isTablet}
           size="xl"
@@ -193,7 +193,7 @@ const ConditionsForm: React.FC<ConditionsFormProps> = ({ patientUuid, isTablet }
               );
             }
             return (
-              <Tile light className={styles.emptyResults}>
+              <Tile light={isTablet} className={styles.emptyResults}>
                 <span>
                   {t('noResultsFor', 'No results for')} <strong>"{searchTerm}"</strong>
                 </span>

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
@@ -3,13 +3,15 @@
 @import "~carbon-components/src/globals/scss/mixins";
 
 .condition {
-  padding: 0.875rem;
+  padding: 1rem 0.75rem;
 }
 
 .conditionsList {
+  margin-top: 0.25rem;
   background-color: $ui-02;
   max-height: 14rem;
   overflow-y: auto;
+  border: 1px solid $ui-03;
 }
 
 .conditionsList li:hover {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -14,13 +14,15 @@
 }
 
 .diagnosis {
-  padding: 0.875rem;
+  padding: 1rem 0.75rem;
 }
 
 .diagnosisList {
+  margin-top: 0.25rem;
   background-color: $ui-02;
   max-height: 14rem;
   overflow-y: auto;
+  border: 1px solid $ui-03;
 }
 
 .diagnosisList li:hover {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

UI fixes to the typeahead search inputs in the Conditions and Visit Note forms that include:

- Addition of a bit of top margin and a border around the search results container to help distinguish it from the rest of the form content.
- Application of just enough padding to the search results so that the last result gets partially hidden from view. The intention here is to make it apparent to the user that the search results container is scrollable when it has more than five results. Without this, it might not be immediately obvious that the container is scrollable.
- Making the search input in the `Conditions` form full-width. I think this is an improvement especially for conditions with longer names that might not be immediately parseable on first viewing.

## Screenshots

> Before

![Screenshot 2022-01-10 at 12 03 32](https://user-images.githubusercontent.com/8509731/148740839-afd94b89-275a-485b-a191-7975510c346d.png)

> After

![Screenshot 2022-01-10 at 11 39 56](https://user-images.githubusercontent.com/8509731/148740143-28bd3aa8-8348-4d40-a8ff-6cebc28685dc.png)

![Screenshot 2022-01-10 at 11 39 17](https://user-images.githubusercontent.com/8509731/148740169-6e1472e2-fa40-4729-9b20-1aa34e76a7dc.png)

![Screenshot 2022-01-10 at 11 39 00](https://user-images.githubusercontent.com/8509731/148740195-86942b7b-e62e-41f1-8554-c13ba2695be4.png)

