### PR TITLE
Add contextual information to test results overview

### DIFF
--- a/packages/esm-patient-test-results-app/src/overview/common-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.component.tsx
@@ -2,8 +2,7 @@ import React, { useCallback } from 'react';
 import dayjs from 'dayjs';
 import Table16 from '@carbon/icons-react/es/table/16';
 import ChartLine16 from '@carbon/icons-react/es/chart--line/16';
-import Information16 from '@carbon/icons-react/es/information/16';
-import { Button, TableToolbarContent, TableToolbar } from 'carbon-components-react';
+import { Button, TableToolbarContent, TableToolbar, Tooltip } from 'carbon-components-react';
 import { EmptyState } from '@openmrs/esm-patient-common-lib';
 import { OverviewPanelEntry } from './useOverviewData';
 import { useTranslation } from 'react-i18next';
@@ -72,7 +71,7 @@ const CommonOverview: React.FC<CommonOverviewProps> = ({
   return (
     <>
       {(() => {
-        const cards = overviewData.map(([title, type, data, date, uuid]) => (
+        const cards = overviewData.map(([title, type, data, effectiveDateTime, issuedDateTime, uuid]) => (
           <article
             key={uuid}
             className={`${insertSeparator ? '' : `${styles.card} ${isActiveCard(uuid) ? styles.activeCard : ''}`}`}
@@ -82,9 +81,9 @@ const CommonOverview: React.FC<CommonOverviewProps> = ({
                 title,
                 data,
                 description: (
-                  <div className={insertSeparator ? '' : styles.cardHeader}>
-                    {formatDate(date)}
-                    <InfoButton />
+                  <div className={`${styles.meta} ${insertSeparator ? '' : styles.cardHeader}`}>
+                    {formatDate(effectiveDateTime)}
+                    <InfoTooltip effectiveDateTime={effectiveDateTime} issuedDateTime={issuedDateTime} />
                   </div>
                 ),
                 tableHeaders: headers,
@@ -145,7 +144,22 @@ const CommonOverview: React.FC<CommonOverviewProps> = ({
 
 const Separator = ({ ...props }) => <div {...props} className={styles.separator} />;
 
-const InfoButton = () => <Information16 className={styles['infoButton']} />;
+const InfoTooltip = ({ effectiveDateTime, issuedDateTime }) => {
+  const { t } = useTranslation();
+  return (
+    <Tooltip align="start">
+      <div className={styles.tooltip}>
+        <p>{t('dateCollected', 'Displaying date collected')}</p>
+        <p>
+          <span className={styles.label}>{t('resulted', 'Resulted')}: </span> {formatDate(issuedDateTime)}
+        </p>
+        <p>
+          <span className={styles.label}>{t('ordered', 'Ordered')}: </span> {formatDate(effectiveDateTime)}
+        </p>
+      </div>
+    </Tooltip>
+  );
+};
 
 function formatDate(date: Date) {
   return dayjs(date).format('DD - MMM - YYYY · HH:mm');

--- a/packages/esm-patient-test-results-app/src/overview/common-overview.scss
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.scss
@@ -1,4 +1,6 @@
 @import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
+@import "~carbon-components/src/globals/scss/mixins";
 
 .card {
   border: 1px solid $ui-03;
@@ -31,10 +33,24 @@
   margin-left: 0.75rem;
 }
 
-.infoButton {
-  margin-left: 10px;
-  padding-top: 1px;
-  box-sizing: content-box;
-  position: absolute;
-  color: black;
+.meta {
+  display: flex;
+}
+
+.tooltip {
+  @include carbon--type-style('body-short-01');
+  color: $ui-01;
+
+  p {
+    margin: 0.5rem 0;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+  }
+}
+
+.label {
+  @include carbon--type-style('label-01');
+  color: $labeldropdown;
+  margin-right: 0.25rem;
 }

--- a/packages/esm-patient-test-results-app/src/overview/useOverviewData.ts
+++ b/packages/esm-patient-test-results-app/src/overview/useOverviewData.ts
@@ -11,7 +11,7 @@ export interface OverviewPanelData {
   value?: string | number;
 }
 
-export type OverviewPanelEntry = [string, string, Array<OverviewPanelData>, Date, string];
+export type OverviewPanelEntry = [string, string, Array<OverviewPanelData>, Date, Date, string];
 
 export function parseSingleEntry(entry: ObsRecord, type: string, panelName: string): Array<OverviewPanelData> {
   if (type === 'Test') {
@@ -51,6 +51,7 @@ function useOverviewData(patientUuid: string) {
             type,
             parseSingleEntry(newestEntry, type, panelName),
             new Date(newestEntry.effectiveDateTime),
+            new Date(newestEntry.issued),
             uuid,
           ];
         })

--- a/packages/esm-patient-test-results-app/translations/en.json
+++ b/packages/esm-patient-test-results-app/translations/en.json
@@ -1,9 +1,12 @@
 {
   "backToTimeline": "Back to timeline",
   "date": "Date",
+  "dateCollected": "Displaying date collected",
   "moreResultsAvailable": "More results available",
+  "ordered": "Ordered",
   "recentResults": "Recent Results",
   "recentTestResults": "recent test results",
+  "resulted": "Resulted",
   "seeAllResults": "See all results",
   "testResults": "test results",
   "timeline": "Timeline",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Add information about the date a result got ordered and the date it got issued to the test results overview. This information gets displayed when the user clicks on the tooltip icon.

## Video

https://user-images.githubusercontent.com/8509731/148782784-43c194e6-01a8-4841-a3ba-a66c0df3d0b7.mp4

## Remaining work

The tooltip button icon needs to change to `InformationFilled16` when the tooltip is open, per the designs.