### PR TITLE
Constrain tooltip flex container

### DIFF
--- a/packages/esm-patient-test-results-app/src/overview/common-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.component.tsx
@@ -81,9 +81,11 @@ const CommonOverview: React.FC<CommonOverviewProps> = ({
                 title,
                 data,
                 description: (
-                  <div className={`${styles.meta} ${insertSeparator ? '' : styles.cardHeader}`}>
-                    {formatDate(effectiveDateTime)}
-                    <InfoTooltip effectiveDateTime={effectiveDateTime} issuedDateTime={issuedDateTime} />
+                  <div className={`${insertSeparator ? '' : styles.cardHeader}`}>
+                    <div className={styles.meta}>
+                      {formatDate(effectiveDateTime)}
+                      <InfoTooltip effectiveDateTime={effectiveDateTime} issuedDateTime={issuedDateTime} />
+                    </div>
                   </div>
                 ),
                 tableHeaders: headers,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This is a follow-up to https://github.com/openmrs/openmrs-esm-patient-chart/pull/495. 

It limits the scope of the flex container so that it only affects the div containing the `Ordered Date` and the tooltip. The current approach interferes with the rendering of the DataTable header bottom border.

## Screenshots

| Before
<img width="617" alt="Screenshot 2022-01-12 at 00 15 30" src="https://user-images.githubusercontent.com/8509731/149022724-76e43022-87b0-4140-b39f-51ccfd4950a6.png">

| After
<img width="613" alt="Screenshot 2022-01-12 at 00 09 24" src="https://user-images.githubusercontent.com/8509731/149022746-5b884140-9d22-4528-bf19-b2c243c263ca.png">
 