### PR TITLE
More workspace enhancements

### DIFF
--- a/packages/esm-patient-chart-app/src/workspace/context-workspace.component.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/context-workspace.component.tsx
@@ -63,7 +63,10 @@ const ContextWorkspace: React.FC<RouteComponentProps<ContextWorkspaceParams>> = 
       }`
       }`}
     >
-      <Header aria-label="Workspace Title" className={styles.header}>
+      <Header
+        aria-label="Workspace Title"
+        className={`${styles.header} ${maximized ? `${styles.fullWidth}` : `${styles.dynamicWidth}`}`}
+      >
         <HeaderName prefix="">{title}</HeaderName>
         <HeaderGlobalBar>
           <ExtensionSlot extensionSlotName={patientChartWorkspaceHeaderSlot} state={props} />
@@ -87,7 +90,7 @@ const ContextWorkspace: React.FC<RouteComponentProps<ContextWorkspaceParams>> = 
         </HeaderGlobalBar>
       </Header>
       <ExtensionSlot
-        className={`${styles.fixed} ${maximized ? `${styles.fullWidth}` : `${styles.dynamicWidth}`}`}
+        className={`${styles.fixed} ${maximized && !isTablet ? `${styles.fullWidth}` : `${styles.dynamicWidth}`}`}
         extensionSlotName={patientChartWorkspaceSlot}
         state={props}
       />

--- a/packages/esm-patient-chart-app/src/workspace/context-workspace.scss
+++ b/packages/esm-patient-chart-app/src/workspace/context-workspace.scss
@@ -1,11 +1,5 @@
 @import "../root.scss";
 
-.container {
-  border-width: 0.0625rem 0 0.0625rem 0.0625rem;
-  border-style: solid;
-  border-color: $text-03;
-}
-
 .header {
   background-color: $ui-03;
   top: 3rem;
@@ -22,39 +16,8 @@
   }
 
   &:not(.maximized) {
-    position: sticky;
-  }
-}
-
-/* Tablet */
-:global(.omrs-breakpoint-lt-desktop) .container {
-  background-color: $ui-01;
-  position: fixed;
-  top: 3rem;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1000;
-
-  > .dynamicWidth {
-    width: 100%;
-  }
-}
-
-
-/* Desktop */
-:global(.omrs-breakpoint-gt-tablet) .container {
-  background-color: $ui-02;
-  margin-right: 50px;
-  flex: 1;
-  
-  &.maximized {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 1000;
+    right: auto;
+    left: auto;
   }
 }
 
@@ -72,7 +35,7 @@
   right: auto;
   left: auto;
   overflow-y: auto;
-  bottom: 1px;
+  background-color: $ui-02;
 }
 
 .fullWidth {
@@ -82,4 +45,48 @@
 
 .dynamicWidth {
   width: calc(50% - 9.6rem);
+}
+
+/* Desktop */
+:global(.omrs-breakpoint-gt-tablet) {
+  .maximized {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1000;
+  }
+  
+  .container {
+    margin-right: 3rem;
+    flex: 1;
+    height: 100vh;
+  }
+}
+
+/* Tablet */
+:global(.omrs-breakpoint-lt-desktop) {
+  .container {
+    background-color: $ui-01;
+    position: fixed;
+    top: 3rem;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1000;
+  }
+
+  .header {
+    display: none;
+  }
+
+  .fixed {
+    top: 3rem;
+    background-color: $ui-01;
+  }
+
+  .dynamicWidth {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR offers further enhancements to the workspace following the changes introduced by https://github.com/openmrs/openmrs-esm-patient-chart/pull/492. These include:

- Hide the workspace header in tablet mode. Though not explicitly mentioned, this idea gets consistently demonstrated in the designs.
- Change the workspace window positioning when maximized to `fixed` instead of `absolute`.
- Remove the `sticky` positioning property from the workspace header. Now that everything is `fixed` positioned, elements in the workspace header adjust accordingly.
- Set the workspace header height to `100vh` or 100% of the viewport height. This is a necessary precursor for full-screen workspace forms with action buttons pinned to the bottom of the viewport.

## Video

> Note that the forms demonstrated in the explainer video below are slightly tweaked versions of their production equivalents. The main difference is that the ones shown here are adapted to fit the full viewport height with the action buttons pinned to the bottom. These changes will follow in a subsequent pull request. 

https://user-images.githubusercontent.com/8509731/149156027-fcef031a-2e1e-40c7-88a8-9bff25bf47ff.mp4
