### PR TITLE
Fix typo on Forms  & Notes

### DIFF
--- a/packages/esm-patient-forms-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-forms-app/src/dashboard.meta.tsx
@@ -2,5 +2,5 @@ export const dashboardMeta = {
   name: 'forms',
   slot: 'patient-chart-form-dashboard-slot',
   config: { columns: 1, type: 'grid' },
-  title: 'Forms & notes',
+  title: 'Forms & Notes',
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.


## Summary

- Fix a typo on ```Forms & Notes``` link


## Screenshots

before

<img width="646" alt="Screenshot 2022-01-13 at 11 20 18" src="https://user-images.githubusercontent.com/28008754/149292464-71cf8d86-a56f-4709-b416-3456ee95d4cf.png">


after

<img width="726" alt="Screenshot 2022-01-13 at 11 19 10" src="https://user-images.githubusercontent.com/28008754/149292491-1adafd3c-392f-4ada-91b2-bb1ef35323d9.png">



## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
