### PR TITLE
O3-976: Share Patient Chart Common Lib

### DIFF
--- a/packages/esm-generic-patient-widgets-app/package.json
+++ b/packages/esm-generic-patient-widgets-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-allergies-app/package.json
+++ b/packages/esm-patient-allergies-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-appointments-app/package.json
+++ b/packages/esm-patient-appointments-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-attachments-app/package.json
+++ b/packages/esm-patient-attachments-app/package.json
@@ -45,6 +45,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-banner-app/package.json
+++ b/packages/esm-patient-banner-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-biometrics-app/package.json
+++ b/packages/esm-patient-biometrics-app/package.json
@@ -42,6 +42,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-chart-app/package.json
+++ b/packages/esm-patient-chart-app/package.json
@@ -42,6 +42,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-clinical-view-app/package.json
+++ b/packages/esm-patient-clinical-view-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "^10.19.0",
     "carbon-icons": "^7.0.7",
     "dayjs": "^1.8.24",

--- a/packages/esm-patient-conditions-app/package.json
+++ b/packages/esm-patient-conditions-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-forms-app/package.json
+++ b/packages/esm-patient-forms-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-immunizations-app/package.json
+++ b/packages/esm-patient-immunizations-app/package.json
@@ -42,6 +42,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-medications-app/package.json
+++ b/packages/esm-patient-medications-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-notes-app/package.json
+++ b/packages/esm-patient-notes-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-programs-app/package.json
+++ b/packages/esm-patient-programs-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-test-results-app/package.json
+++ b/packages/esm-patient-test-results-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",

--- a/packages/esm-patient-vitals-app/package.json
+++ b/packages/esm-patient-vitals-app/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "3.x",
+    "@openmrs/esm-patient-common-lib": "3.x",
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "dayjs": "1.x",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Right now the common lib is duplicated for each MF of patient-chart. Now, with dynamic module sharing in place we should actually add it to the dynamically shared libs.

## Screenshots

*None.*

## Issue

See [O3-976](https://issues.openmrs.org/browse/O3-976?filter=-1).

## Other

For whatever reason I cannot log in locally. Always get unauthenticated as response when entering the credentials. This was the same behavior as online at https://openmrs-spa.org/openmrs/spa/login. So I guess its a current backend issue.
