### PR TITLE
O3-1010: Full-screen clinical forms

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.css
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.css
@@ -1,59 +1,97 @@
 .error-text {
-    color: var(--omrs-color-danger);
-}
-
-.error {
-    margin-left: 30px !important;
+  color: var(--omrs-color-danger);
 }
 
 .title-icon-size {
-    height:0.8rem;
-    width:0.8rem;
+  height: 0.8rem;
+  width: 0.8rem;
 }
 
 .no-errors {
-    display: none;
+  display: none;
 }
-.sidebar.open {
-    margin-top: -1px;
-    width: 55%;
-    height: 80%;
-    padding: 4px;
-    overflow-y: scroll;
-    overflow-x: hidden;
+
+.sidebar .open {
+  margin-top: -1px;
+  width: 55%;
+  height: 80%;
+  padding: 4px;
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
-.sidebar.closed {
-    height: 80px;
-    width: 28px;
-    margin-top: -1px;
+
+.sidebar .closed {
+  height: 80px;
+  width: 28px;
+  margin-top: -1px;
 }
-.error-content.closed {
-    display: none;
+
+.error-content .closed {
+  display: none;
 }
 
 .error-content {
-    border-top: 1px solid lightgray;
-    margin: -4px;
-    padding: 4px;
+  border-top: 1px solid lightgray;
+  margin: -4px;
+  padding: 4px;
 }
 
-.error-title.closed {
-    transform: rotate(90deg);
-    margin-top: 14px;
+.error-title .closed {
+  transform: rotate(90deg);
+  margin-top: 14px;
 }
 
-.no-padding{
-    margin-left: -2rem;
-    margin-right: -2rem;
-}
-.button-margin {
-    margin: 2rem;
+.no-padding {
+  margin-left: -2rem;
+  margin-right: -2rem;
 }
 
 .center {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100vh;
 }
 
+.form-container {
+  font-size: 40px !important;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.button-set button {
+  height: 4rem;
+  align-items: baseline;
+  min-width: 50%;
+}
+
+/* Desktop */
+:host-context(.omrs-breakpoint-gt-tablet) .form-container {
+  height: calc(100vh - 6rem);
+}
+
+:host-context(.omrs-breakpoint-gt-tablet) .button-set {
+  padding: 0rem;
+}
+
+/* Tablet */
+:host-context(.omrs-breakpoint-lt-desktop) .form-container {
+  height: calc(100vh - 3rem);
+}
+
+:host-context(.omrs-breakpoint-lt-desktop) .button-set {
+  padding: 1.5rem 1rem;
+  background-color: white;
+}
+
+.loader-container {
+  height: 100vh;
+}
+
+.loader {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 50%;
+}

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
@@ -1,26 +1,41 @@
 <div class="error-text">{{ loadingError }}</div>
 <div class="form-title" [ngClass]="{'error': hasValidationErrors}">
-    <span *ngIf="encounter" class="omrs-type-body-small" style="color: var(--omrs-color-ink-medium-contrast);">
-        <svg class="omrs-icon title-icon-size" fill="var(--omrs-color-ink-low-contrast)">
-            <use xlink:href="#omrs-icon-calendar"></use>
-        </svg>
-        {{encounterDate + " "}}
-        <svg class="omrs-icon title-icon-size" fill="var(--omrs-color-ink-low-contrast)">
-            <use xlink:href="#omrs-icon-access-time"></use>
-        </svg>
-        {{encounterTime}}
-    </span>
+  <span *ngIf="encounter" class="omrs-type-body-small" style="color: var(--omrs-color-ink-medium-contrast);">
+    <svg class="omrs-icon title-icon-size" fill="var(--omrs-color-ink-low-contrast)">
+      <use xlink:href="#omrs-icon-calendar"></use>
+    </svg>
+    {{encounterDate + " "}}
+    <svg class="omrs-icon title-icon-size" fill="var(--omrs-color-ink-low-contrast)">
+      <use xlink:href="#omrs-icon-access-time"></use>
+    </svg>
+    {{encounterTime}}
+  </span>
 </div>
 <div *ngIf="!formSubmitted" [ngClass]="{'error': hasValidationErrors}">
-    <div class="content" (click)="onErrorPanelLostFocus()">
-        <form class="bx--form no-padding" *ngIf="formSchema" [formGroup]="form.rootNode.control">
-            <form-renderer [node]="form.rootNode"></form-renderer>
-        </form>
-        <div class="bx--row button-margin">
-            <button (click)="closeForm()" class="bx--btn bx--btn--secondary" type="button"
-                style="width: 50%;">Cancel</button>
-            <button class="bx--btn bx--btn--primary" (click)="onSubmit($event)" type="submit"
-                style="width: 50%;">Save</button>
+  <div class="content" (click)="onErrorPanelLostFocus()">
+    <div *ngIf="isLoading" class="loader-container">
+      <div class="bx--inline-loading" aria-live="assertive" class="loader">
+        <div class="bx--inline-loading__animation">
+          <div aria-atomic="true" aria-labelledby="loading-id-2" aria-live="assertive" class="bx--loading bx--loading--small">
+            <label id="loading-id-2" class="bx--visually-hidden">Active loading indicator</label>
+            <svg class="bx--loading__svg" viewBox="0 0 100 100">
+              <title>Active loading indicator</title>
+              <circle class="bx--loading__background" cx="50%" cy="50%" r="44"></circle>
+              <circle class="bx--loading__stroke" cx="50%" cy="50%" r="44"></circle>
+            </svg>
+          </div>
         </div>
+        <div class="bx--inline-loading__text">Loading...</div>
+      </div>
     </div>
+    <div *ngIf="!isLoading" class="form-container">
+      <form class="bx--form no-padding" *ngIf="formSchema" [formGroup]="form.rootNode.control">
+        <form-renderer [node]="form.rootNode"></form-renderer>
+      </form>
+      <div class="bx-btn--set button-set">
+        <button class="bx--btn bx--btn--secondary" (click)="closeForm()" type="button">Discard</button>
+        <button class="bx--btn bx--btn--primary" (click)="onSubmit($event)" type="submit">Save and close</button>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

A follow-up to https://github.com/openmrs/openmrs-esm-patient-chart/pull/504.

We need to adapt the design of clinical forms built using the form engine to make maximal use of the workspace.

These changes include:

- Making the form container full screen so that form content fills the height of the viewport.
- Pin action buttons to the bottom of the viewport.
- Render a loading spinner when the form schema is loading.

## Screenshots

<img width="1920" alt="Screenshot 2022-01-18 at 14 23 13" src="https://user-images.githubusercontent.com/8509731/149930125-1efb991f-27e0-4807-baf6-42160c47388e.png">

<img width="969" alt="Screenshot 2022-01-18 at 14 23 31" src="https://user-images.githubusercontent.com/8509731/149930113-60881c67-9152-4c98-a38e-301de313fcc2.png">

## Issue

https://issues.openmrs.org/browse/O3-1010