### PR TITLE
O3-1011: Fix Start Visit form time picker validator regex

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -157,7 +157,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({ isTablet, patientUuid }
                 labelText={t('time', 'Time')}
                 light={isTablet}
                 onChange={(event) => setVisitTime(event.target.value)}
-                pattern="(1[012]|[1-9]):[0-5][0-9](\\s)?"
+                pattern="^(1[0-2]|0?[1-9]):([0-5]?[0-9])$"
                 style={{ marginLeft: '0.125rem', flex: 'none' }}
                 value={visitTime}
               >


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

The regular expression supplied to the pattern prop of the TimePicker input in the Start Visit form isn't working as it should. It's currently excluding some valid dates. 

This commit fixes the regex so it matches all valid 12-hour clock values.

## Screenshots

> This tooltip was incorrectly shown for a visit started at 3:14 PM.

<img width="737" alt="Screenshot 2022-01-12 at 15 16 53" src="https://user-images.githubusercontent.com/8509731/149937926-c5e0e4d2-38dd-43dd-9f70-4e4162ed6640.png">

