### PR TITLE
O3-1012: Show orderer name on tooltip hover

### DIFF
--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -15,7 +15,7 @@ export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any') 
   const customRepresentation =
     'custom:(uuid,dosingType,orderNumber,accessionNumber,' +
     'patient:ref,action,careSetting:ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,' +
-    'orderType:ref,encounter:ref,orderer:ref,orderReason,orderReasonNonCoded,orderType,urgency,instructions,' +
+    'orderType:ref,encounter:ref,orderer:(uuid,display,person:(display)),orderReason,orderReasonNonCoded,orderType,urgency,instructions,' +
     'commentToFulfiller,drug:(uuid,name,strength,dosageForm:(display,uuid),concept),dose,doseUnits:ref,' +
     'frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,numRefills,dosingInstructions,' +
     'duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)';

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -18,6 +18,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TooltipIcon,
 } from 'carbon-components-react';
 import { getDosage } from '../utils/get-dosage';
 import { useTranslation } from 'react-i18next';
@@ -62,7 +63,7 @@ const MedicationsDetailsTable = connect<
     const { t } = useTranslation();
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(10);
-    const [currentMedicationPage] = paginate(medications, page, pageSize);
+    const [paginatedMedications] = paginate(medications, page, pageSize);
 
     const openOrderBasket = React.useCallback(() => launchPatientWorkspace('order-basket-workspace'), []);
 
@@ -81,7 +82,7 @@ const MedicationsDetailsTable = connect<
       },
     ];
 
-    const tableRows = currentMedicationPage.map((medication, id) => ({
+    const tableRows = paginatedMedications.map((medication, id) => ({
       id: `${id}`,
       details: {
         sortKey: medication.drug?.name,
@@ -134,11 +135,9 @@ const MedicationsDetailsTable = connect<
       startDate: {
         sortKey: dayjs(medication.dateActivated).toDate(),
         content: (
-          <div className={styles.leftColumn}>
+          <div className={styles.startDateColumn}>
             <span>{dayjs(medication.dateActivated).format('DD-MMM-YYYY')}</span>
-            <span className={styles.indicationRow}>
-              <User16 />
-            </span>
+            <InfoTooltip orderer={medication.orderer?.person?.display ?? '--'} />
           </div>
         ),
       },
@@ -220,6 +219,14 @@ const MedicationsDetailsTable = connect<
     );
   },
 );
+
+function InfoTooltip({ orderer }) {
+  return (
+    <TooltipIcon className={styles.tooltip} align="start" direction="top" tooltipText={orderer} renderIcon={User16}>
+      {orderer}
+    </TooltipIcon>
+  );
+}
 
 function OrderBasketItemActions({
   showDiscontinueButton,

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.scss
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.scss
@@ -6,30 +6,39 @@
   span {
     margin: auto;
   }
+
+  p {
+    padding: 0.25rem 0;
+  }
 }
 
 .medicationRecord {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  padding: 0.5rem 0;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 }
 
-.leftColumn {
+.startDateColumn {
   height: 100%;
   display: flex;
-  flex-direction: column;
+  flex-flow: column wrap;
+  align-items: flex-start;
   justify-content: space-between;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-}
+  padding: 0.75rem 0;
 
-.indicationRow {
-  padding: 0.25rem 0;
+  span {
+    margin: 0rem;
+  }
 }
 
 .dosage {
   @include carbon--type-style("productive-heading-01");
   color: $text-01;
+}
+
+.tooltip {
+  svg {
+    fill: black;
+  }
 }

--- a/packages/esm-patient-medications-app/src/types/order.ts
+++ b/packages/esm-patient-medications-app/src/types/order.ts
@@ -39,7 +39,13 @@ export interface Order {
     retired: boolean;
     uuid: string;
   };
-  orderer: OpenmrsResource;
+  orderer: {
+    display: string;
+    person: {
+      display: string;
+    };
+    uuid: string;
+  };
   patient: OpenmrsResource;
   previousOrder: { uuid: string; type: string; display: string } | null;
   quantity: number;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Per the designs, the medications table should show the `name` value of the `orderer` property when the user hovers over the tooltip.

## Screenshots

<img width="1364" alt="Screenshot 2022-01-18 at 17 04 35" src="https://user-images.githubusercontent.com/8509731/149953022-8a06b1a6-1e81-44cc-ba0c-ac1e5ff6a2a1.png">

Zeplin screen https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d5e1219e59fc08d68cde52
