### PR TITLE
Additional medications widget fixes

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.scss
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.scss
@@ -2,7 +2,9 @@
 
 .widgetCard {
   border: 1px solid $ui-03;
+}
 
+.row {
   span {
     margin: auto;
   }
@@ -13,7 +15,6 @@
 }
 
 .medicationRecord {
-  padding: 0.5rem 0;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -25,7 +26,7 @@
   flex-flow: column wrap;
   align-items: flex-start;
   justify-content: space-between;
-  padding: 0.75rem 0;
+  padding: 0.25rem 0;
 
   span {
     margin: 0rem;
@@ -40,5 +41,17 @@
 .tooltip {
   svg {
     fill: black;
+  }
+}
+
+.menuItem {
+  max-width: none;
+}
+
+.paginationContainer {
+  border-top: 1px solid $ui-03;
+
+  & > :global(.bx--pagination) {
+    border: none;
   }
 }

--- a/packages/esm-patient-medications-app/src/medications-summary/floating-order-basket-button.scss
+++ b/packages/esm-patient-medications-app/src/medications-summary/floating-order-basket-button.scss
@@ -3,7 +3,7 @@
 .floatingOrderBasketButton {
   position: fixed;
   bottom: 1rem;
-  right: 1rem;
+  right: 3rem;
   height: 56px;
   font-weight: bold;
   padding-right: 15px !important;

--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
@@ -30,17 +30,15 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, show
   if (activePatientOrders?.length) {
     return (
       <Provider store={orderBasketStore}>
-        <div className={styles.activeMedicationContainer}>
-          <MedicationsDetailsTable
-            isValidating={isValidating}
-            title={t('activeMedications', 'Active Medications')}
-            medications={activePatientOrders}
-            showDiscontinueButton={true}
-            showModifyButton={true}
-            showReorderButton={false}
-            showAddNewButton={showAddMedications}
-          />
-        </div>
+        <MedicationsDetailsTable
+          isValidating={isValidating}
+          title={t('activeMedications', 'Active Medications')}
+          medications={activePatientOrders}
+          showDiscontinueButton={true}
+          showModifyButton={true}
+          showReorderButton={false}
+          showAddNewButton={showAddMedications}
+        />
       </Provider>
     );
   }

--- a/packages/esm-patient-medications-app/src/medications/active-medications.scss
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.scss
@@ -1,12 +1,5 @@
 @import '../root.scss';
 
-.activeMedicationContainer {
-  display: flex;
-  justify-content: space-between;
-  background-color: $ui-background;
-  flex-direction: column;
-}
-
 .title {
   @extend .productiveHeading03;
 }

--- a/packages/esm-patient-medications-app/translations/en.json
+++ b/packages/esm-patient-medications-app/translations/en.json
@@ -23,6 +23,7 @@
   "editRouteComboBoxPlaceholder": "Route",
   "editRouteComboBoxTitle": "Enter Route",
   "emptyOrderBasket": "Your basket is empty",
+  "endDate": "End date",
   "error": "Error",
   "freeTextDosage": "Free Text Dosage",
   "indication": "Indication",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This commit provides fixes for design issues in the medications widget. These include:

- Setting the Datatable size to `short` to match the appearance of other tables in the chart.
- Set the `overflowMenuOnHover` property of the DataTable definition to `false` so that the order basket action items overflow menu always remains visible.
- Add [styling](https://www.carbondesignsystem.com/components/overflow-menu/usage#formatting) to the overflowMenuItem entry for the `discontinue` action that marks it out visually as having potentially dangerous side effects. 
- Show an `End date` value for past medications. 
- Add some right margin to the Floating Action Button. It's currently partly obscured by the side rail.
- Fix an errant margin in the table pagination.

## Screenshots

<img width="944" alt="Screenshot 2022-01-19 at 16 40 00" src="https://user-images.githubusercontent.com/8509731/150295824-d05a4742-fb2a-4439-b038-706a042ef959.png">

