### PR TITLE
O3-1020: Form entry widget should only list published forms

### DIFF
--- a/packages/esm-patient-forms-app/src/hooks/use-forms.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-forms.ts
@@ -8,7 +8,8 @@ import { isFormFullyCached } from '../offline-forms/offline-form-helpers';
 export function useFormEncounters(cachedOfflineFormsOnly = false) {
   return useSWR([formEncounterUrl, cachedOfflineFormsOnly], async () => {
     const res = await openmrsFetch<ListResponse<FormEncounter>>(formEncounterUrl);
-    const forms = res.data?.results ?? [];
+    // Only show published forms
+    const forms = res.data?.results?.filter((form) => form.published) ?? [];
 
     if (!cachedOfflineFormsOnly) {
       return forms;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Clinical forms listed in the Form Entry widget should get filtered by their `published` status to omit `retired` or `unpublished` ones.

## Issue

https://issues.openmrs.org/browse/O3-1020

