### PR TITLE
Removes frontendDependencies as we use peerDependencies for this

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/index.ts
+++ b/packages/esm-generic-patient-widgets-app/src/index.ts
@@ -7,10 +7,6 @@ const backendDependencies = {
   fhir2: '^1.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const moduleName = '@openmrs/esm-generic-patient-widgets-app';
 
@@ -34,4 +30,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-allergies-app/src/index.ts
+++ b/packages/esm-patient-allergies-app/src/index.ts
@@ -17,10 +17,6 @@ const backendDependencies = {
   fhir2: '^1.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
@@ -98,4 +94,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-appointments-app/src/index.ts
+++ b/packages/esm-patient-appointments-app/src/index.ts
@@ -8,10 +8,6 @@ const backendDependencies = {
   'webservices.rest': '^2.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const moduleName = '@openmrs/esm-patient-appointments-app';
 
@@ -59,4 +55,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-attachments-app/src/index.ts
+++ b/packages/esm-patient-attachments-app/src/index.ts
@@ -8,10 +8,6 @@ const backendDependencies = {
   'webservices.rest': '^2.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const moduleName = '@openmrs/esm-patient-attachments-app';
 
@@ -61,4 +57,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-banner-app/src/index.ts
+++ b/packages/esm-patient-banner-app/src/index.ts
@@ -6,10 +6,6 @@ const backendDependencies = {
   'webservices.rest': '^2.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
@@ -45,4 +41,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-biometrics-app/src/index.ts
+++ b/packages/esm-patient-biometrics-app/src/index.ts
@@ -16,10 +16,6 @@ const backendDependencies = {
   fhir2: '^1.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
@@ -83,4 +79,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -10,10 +10,6 @@ const importTranslation = require.context('../translations', false, /.json$/, 'l
 
 const backendDependencies = {};
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   setupOfflineVisitsSync();
   setupCacheableRoutes();
@@ -156,4 +152,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-clinical-view-app/src/index.ts
+++ b/packages/esm-patient-clinical-view-app/src/index.ts
@@ -7,10 +7,6 @@ const importTranslation = require.context('../translations', false, /.json$/, 'l
 
 const backendDependencies = {};
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const moduleName = '@openmrs/esm-patient-clinical-view-app';
 
@@ -63,4 +59,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-conditions-app/src/index.ts
+++ b/packages/esm-patient-conditions-app/src/index.ts
@@ -9,10 +9,6 @@ const backendDependencies = {
   fhir2: '^1.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const moduleName = '@openmrs/esm-patient-conditions-app';
 
@@ -60,4 +56,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-forms-app/src/index.ts
+++ b/packages/esm-patient-forms-app/src/index.ts
@@ -9,10 +9,6 @@ const backendDependencies = {
   'webservices.rest': '^2.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const moduleName = '@openmrs/esm-patient-forms-app';
 
@@ -111,4 +107,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-immunizations-app/src/index.ts
+++ b/packages/esm-patient-immunizations-app/src/index.ts
@@ -10,10 +10,6 @@ const backendDependencies = {
   fhir2: '^1.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const moduleName = '@openmrs/esm-patient-immunizations-app';
 
@@ -61,4 +57,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-medications-app/src/index.ts
+++ b/packages/esm-patient-medications-app/src/index.ts
@@ -8,10 +8,6 @@ const backendDependencies = {
   'webservices.rest': '^2.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const moduleName = '@openmrs/esm-patient-medications-app';
 
@@ -64,4 +60,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-notes-app/src/index.ts
+++ b/packages/esm-patient-notes-app/src/index.ts
@@ -15,10 +15,6 @@ const backendDependencies = {
   fhir2: '^1.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
@@ -68,4 +64,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-programs-app/src/index.ts
+++ b/packages/esm-patient-programs-app/src/index.ts
@@ -8,10 +8,6 @@ const backendDependencies = {
   'webservices.rest': '^2.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const moduleName = '@openmrs/esm-patient-programs-app';
 
@@ -59,4 +55,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-test-results-app/src/index.ts
+++ b/packages/esm-patient-test-results-app/src/index.ts
@@ -16,10 +16,6 @@ const backendDependencies = {
   fhir2: '^1.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
@@ -68,4 +64,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/esm-patient-vitals-app/src/index.ts
+++ b/packages/esm-patient-vitals-app/src/index.ts
@@ -9,10 +9,6 @@ const backendDependencies = {
   fhir2: '^1.2.0',
 };
 
-const frontendDependencies = {
-  '@openmrs/esm-framework': process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
@@ -76,4 +72,4 @@ function setupOpenMRS() {
   };
 }
 
-export { backendDependencies, frontendDependencies, importTranslation, setupOpenMRS };
+export { backendDependencies, importTranslation, setupOpenMRS };


### PR DESCRIPTION
This functionality was removed in esm-core in [0690298](https://github.com/openmrs/openmrs-esm-core/commit/0690298e2423175cd158e8b2f9868ea5ace0d8ed)

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->

Removes the frontendDependency stuff from the patient chart as this has been deprecated anyway.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
