### PR TITLE
(bug) fix error on loading deceased patient tag

### DIFF
--- a/__mocks__/mockDeceasedPatient.ts
+++ b/__mocks__/mockDeceasedPatient.ts
@@ -37,6 +37,7 @@ export const mockDeceasedPatient = {
   gender: 'male',
   birthDate: '1972-04-04',
   deceasedBoolean: true,
+  deceasedDateTime: '1972-04-04',
   address: [
     {
       id: '0c244eae-85c8-4cc9-b168-96b51f864e77',

--- a/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.component.tsx
@@ -4,7 +4,6 @@ import styles from './active-visit-tag.scss';
 import { useTranslation } from 'react-i18next';
 import { Tag, TooltipDefinition } from 'carbon-components-react';
 import { useVisit } from '@openmrs/esm-framework';
-
 interface ActiveVisitBannerTagProps {
   patientUuid: string;
   patient: fhir.Patient;
@@ -12,10 +11,10 @@ interface ActiveVisitBannerTagProps {
 const ActiveVisitBannerTag: React.FC<ActiveVisitBannerTagProps> = ({ patientUuid, patient }) => {
   const { t } = useTranslation();
   const { currentVisit } = useVisit(patientUuid);
-
+  const deceasedBoolean = patient.deceasedDateTime ? false : true;
   return (
     currentVisit &&
-    !patient.deceasedBoolean && (
+    deceasedBoolean && (
       <TooltipDefinition
         align="end"
         tooltipText={

--- a/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.test.tsx
@@ -19,8 +19,8 @@ describe('ActiveVisitBannerTag: ', () => {
       currentVisit: mockCurrentVisit.visitData,
       error: null,
     });
-
-    render(<ActiveVisitBannerTag patientUuid={mockPatient.id} patient={mockPatient} />);
+    const patient = { ...mockPatient, deceasedDateTime: null };
+    render(<ActiveVisitBannerTag patientUuid={mockPatient.id} patient={patient} />);
 
     const visitMetadata =
       mockCurrentVisit.visitData.visitType.name +
@@ -33,5 +33,26 @@ describe('ActiveVisitBannerTag: ', () => {
       }),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Active Visit/i })).toBeInTheDocument();
+  });
+
+  it('should not render active visit tag if patient is dead', () => {
+    mockUseVisit.mockReturnValue({
+      currentVisit: mockCurrentVisit.visitData,
+      error: null,
+    });
+    const patient = { ...mockPatient, deceasedDateTime: '2002-04-04' };
+    render(<ActiveVisitBannerTag patientUuid={mockPatient.id} patient={patient} />);
+
+    const visitMetadata =
+      mockCurrentVisit.visitData.visitType.name +
+      ' Started: ' +
+      dayjs(mockCurrentVisit.visitData.startDatetime).format('DD - MMM - YYYY @ HH:mm');
+
+    expect(
+      screen.queryByRole('tooltip', {
+        name: visitMetadata,
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Active Visit/i })).not.toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.component.tsx
@@ -1,30 +1,27 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tag, TooltipDefinition } from 'carbon-components-react';
+import { formatDatetime } from '@openmrs/esm-framework';
 import styles from './deceased-patient-tag.scss';
 
 interface DeceasedPatientBannerTagProps {
-  patient: Pick<fhir.Patient, 'deceasedBoolean'>;
+  patient: Pick<fhir.Patient, 'deceasedDateTime'>;
 }
-
 const DeceasedPatientBannerTag: React.FC<DeceasedPatientBannerTagProps> = ({ patient }) => {
   const { t } = useTranslation();
-  return (
-    <>
-      {patient?.deceasedBoolean ? (
-        <TooltipDefinition
-          align="end"
-          tooltipText={
-            <div className={styles.tooltipPadding}>
-              <h6 style={{ marginBottom: '0.5rem' }}>{t('deceased', 'Deceased')}</h6>
-            </div>
-          }
-        >
-          <Tag type="red">{t('deceased', 'Deceased')}</Tag>
-        </TooltipDefinition>
-      ) : null}
-    </>
-  );
+  return patient.deceasedDateTime ? (
+    <TooltipDefinition
+      align="end"
+      tooltipText={
+        <div className={styles.tooltipPadding}>
+          <h6 style={{ marginBottom: '0.5rem' }}>{t('deceased', 'Deceased')}</h6>
+          <span>{formatDatetime(new Date(patient.deceasedDateTime))}</span>
+        </div>
+      }
+    >
+      <Tag type="red">{t('deceased', 'Deceased')}</Tag>
+    </TooltipDefinition>
+  ) : null;
 };
 
 export default DeceasedPatientBannerTag;

--- a/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.test.tsx
@@ -3,17 +3,39 @@ import { render, screen } from '@testing-library/react';
 import DeceasedPatientBannerTag from './deceased-patient-tag.component';
 import { mockDeceasedPatient } from '../../../../__mocks__/mockDeceasedPatient';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
+import { formatDatetime } from '@openmrs/esm-framework';
+import dayjs from 'dayjs';
+
+const mockFormatDateTime = formatDatetime as jest.Mock;
+
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+
+  return {
+    ...originalModule,
+    formatDatetime: jest.fn(),
+  };
+});
 
 describe('DeceasedPatientTag', () => {
+  beforeEach(() => {
+    mockFormatDateTime.mockImplementation((dateTime) => dayjs(dateTime).format('DD-MMM-YYYY HH:mm'));
+  });
+
   it('renders a deceased tag in the patient banner for patients who died', () => {
     render(<DeceasedPatientBannerTag patient={mockDeceasedPatient} />);
+  });
 
+  it('renders a deceased tag in the patient banner for patients who died', () => {
+    render(<DeceasedPatientBannerTag patient={mockDeceasedPatient} />);
+    expect(screen.getByRole('tooltip', { name: / 04-Apr-1972 00:00/i }));
     expect(screen.getByRole('button', { name: /Deceased/ })).toBeInTheDocument();
   });
 
-  it('doesnot render Deceased tag for patients who are still alive', () => {
-    render(<DeceasedPatientBannerTag patient={mockPatient} />);
-
+  it('does not render Deceased tag for patients who are still alive', () => {
+    const patient = { ...mockPatient, deceasedDateTime: null };
+    render(<DeceasedPatientBannerTag patient={patient} />);
+    expect(screen.queryByRole('tooltip', { name: / 04-Apr-1972 00:00/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Deceased/ })).not.toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -14,7 +14,15 @@ import { ExtensionSlot, age } from '@openmrs/esm-framework';
 interface PatientBannerProps {
   patient: Pick<
     fhir.Patient,
-    'id' | 'name' | 'gender' | 'birthDate' | 'identifier' | 'address' | 'telecom' | 'deceasedBoolean'
+    | 'id'
+    | 'name'
+    | 'gender'
+    | 'birthDate'
+    | 'identifier'
+    | 'address'
+    | 'telecom'
+    | 'deceasedBoolean'
+    | 'deceasedDateTime'
   >;
   patientUuid: string;
   onClick?: (patientUuid: string) => void;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).


## Summary

- Currently if you try perform a search, the `deceased-tag` has a bug
- Update the deceased-tag to check the `death-date` instead of `fhir.Patient.deceasedBoolean` because regardless of whether the patient is dead or not the property always returns `undefined`


## Screenshoot
![deceased](https://user-images.githubusercontent.com/28008754/150976374-234bbee8-85a3-4fb4-8b9d-59177402d376.gif)




## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
