### PR TITLE
03-1028: (enhancement) add support to display value codeable concept

### DIFF
--- a/packages/esm-patient-common-lib/src/types/test-results.ts
+++ b/packages/esm-patient-common-lib/src/types/test-results.ts
@@ -38,7 +38,8 @@ export type OBSERVATION_INTERPRETATION =
   | 'OFF_SCALE_HIGH'
   | 'LOW'
   | 'CRITICALLY_LOW'
-  | 'OFF_SCALE_LOW';
+  | 'OFF_SCALE_LOW'
+  | '--';
 
 export interface ExternalOverviewProps {
   patientUuid: string;

--- a/packages/esm-patient-test-results-app/src/loadPatientTestData/loadPatientData.ts
+++ b/packages/esm-patient-test-results-app/src/loadPatientTestData/loadPatientData.ts
@@ -33,6 +33,11 @@ function parseSingleObsData(
       delete entry.valueQuantity;
     }
 
+    if (entry.valueCodeableConcept) {
+      entry.value = entry?.valueCodeableConcept.coding[0].display;
+      delete entry.valueCodeableConcept;
+    }
+
     entry.name = testConceptNameMap[entry.conceptClass];
   };
 }

--- a/packages/esm-patient-test-results-app/src/overview/useOverviewData.ts
+++ b/packages/esm-patient-test-results-app/src/overview/useOverviewData.ts
@@ -9,6 +9,11 @@ export interface OverviewPanelData {
   range: string;
   interpretation: OBSERVATION_INTERPRETATION;
   value?: string | number;
+  valueCodeableConcept?: Coding;
+}
+
+interface Coding {
+  coding: Array<{ code: string; display: string }>;
 }
 
 export type OverviewPanelEntry = [string, string, Array<OverviewPanelData>, Date, Date, string];
@@ -20,7 +25,7 @@ export function parseSingleEntry(entry: ObsRecord, type: string, panelName: stri
         id: entry.id,
         name: panelName,
         range: entry.meta?.range || '--',
-        interpretation: entry.meta.assessValue(entry.value),
+        interpretation: entry.meta.assessValue ? entry.meta.assessValue(entry.value) : '--',
         value: entry.value,
       },
     ];


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- At the moment, test results value only display `valueQuantity` thats is a non-codeable concept value, this PR seeks to have add ability to display codeable concept value as shown in the screenshoot below.
- Fix a bug where, `assessValue` fails when an undefined value is returned


## Screenshots
### bug state
![Screenshot 2022-01-26 at 11 15 22](https://user-images.githubusercontent.com/28008754/151128030-0a9e82ea-3fca-4ae0-b01c-e12dddc67f1d.png)
![Screenshot 2022-01-26 at 11 16 39](https://user-images.githubusercontent.com/28008754/151128060-81164df5-4124-4260-9e6a-981569ba30f5.png)

### fixed state
![Screenshot 2022-01-26 at 11 20 22](https://user-images.githubusercontent.com/28008754/151128111-c05b60d3-b1a3-489c-a227-6ebfc9dc7c50.png)



## Issue
[https://issues.openmrs.org/browse/O3-1028](https://issues.openmrs.org/browse/O3-1028)


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
