### PR TITLE
(bug) fix test-results not showing on encounters widget

### DIFF
--- a/__mocks__/visits.mock.ts
+++ b/__mocks__/visits.mock.ts
@@ -244,10 +244,10 @@ export const visitOverviewDetailMockDataNotEmpty = {
               {
                 uuid: '5171be48-bcfc-4f74-972c-4212db900dc0',
                 display: 'Super User: Unknown',
-                encounterRole: { uuid: 'a0b03050-c99b-11e0-9572-0800200c9a66', display: 'Unknown' },
+                encounterRole: { uuid: 'a0b03050-c99b-11e0-9572-0800200c9a66', display: 'Admin' },
                 provider: {
                   uuid: 'f9badd80-ab76-11e2-9e96-0800200c9a66',
-                  person: { uuid: '24252571-dd5a-11e6-9d9c-0242ac150002', display: 'Super User' },
+                  person: { uuid: '24252571-dd5a-11e6-9d9c-0242ac150002', display: 'Dr James Cook' },
                 },
               },
             ],

--- a/packages/esm-patient-chart-app/src/config-schemas/openmrs-esm-patient-chart-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schemas/openmrs-esm-patient-chart-schema.ts
@@ -1,3 +1,25 @@
-export const esmPatientChartSchema = {};
+import { Type } from '@openmrs/esm-framework';
+
+export const esmPatientChartSchema = {
+  visitDiagnosisConceptUuid: {
+    _default: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    _type: Type.ConceptUuid,
+  },
+  problemListConceptUuid: {
+    _default: '1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    _type: Type.ConceptUuid,
+  },
+  diagnosisOrderConceptUuid: {
+    _default: '159946AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    _type: Type.ConceptUuid,
+  },
+  notesConceptUuids: {
+    _default: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'],
+    _type: Type.Array,
+    _elements: {
+      _type: Type.ConceptUuid,
+    },
+  },
+};
 
 export interface ChartConfig {}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/notes-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/notes-summary.component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styles from '../visit-detail-overview.scss';
 import { Note } from '../visit.resource';
 import { useTranslation } from 'react-i18next';
+import capitalize from 'lodash-es/capitalize';
 
 interface NotesSummaryProps {
   notes: Array<Note>;
@@ -15,7 +16,8 @@ const NotesSummary: React.FC<NotesSummaryProps> = ({ notes }) => {
       {notes.length > 0 ? (
         notes.map((note: Note, ind) => (
           <React.Fragment key={ind}>
-            <p className={`${styles.medicationBlock} ${styles.bodyLong01}`}>{note.note}</p>
+            <p className={styles.noteTitle}>{capitalize(note.concept.display)}</p>
+            <p className={`${styles.noteText} ${styles.bodyLong01}`}>{note.note}</p>
             <p className={styles.caption01} style={{ color: '#525252' }}>
               {note.time} &middot; {note.provider.name} &middot; {note.provider.role}
             </p>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/tests-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/tests-summary.component.tsx
@@ -13,7 +13,7 @@ const TestsSummary = ({ patientUuid, encounters }: { patientUuid: string; encoun
 
   return (
     <ExtensionSlot
-      extensionSlotName="test-results-filtered-overview"
+      extensionSlotName="test-results-filtered-overview-slot"
       state={{ filter, patientUuid } as ExternalOverviewProps}
     />
   );

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-detail.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-detail.component.tsx
@@ -60,7 +60,7 @@ const VisitDetailComponent: React.FC<VisitDetailComponentProps> = ({ visit, pati
             kind="ghost"
             onClick={() => setListView(false)}
           >
-            {t('allEncounters', 'All Encounters')}
+            {t('Encounters', 'Encounters')}
           </Button>
         </div>
       </div>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.test.tsx
@@ -7,14 +7,26 @@ import {
   visitOverviewDetailMockDataNotEmpty,
 } from '../../../../../../__mocks__/visits.mock';
 import userEvent from '@testing-library/user-event';
-import { ExtensionSlot } from '@openmrs/esm-framework';
 
 const mockEncounter = visitOverviewDetailMockData.data.results[0].encounters.map((encounter) => encounter);
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ExtensionSlot: jest.fn().mockImplementation((ext) => ext.extensionSlotName),
-}));
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+
+  return {
+    ...originalModule,
+    ExtensionSlot: jest.fn().mockImplementation((ext) => ext.extensionSlotName),
+    useConfig: jest.fn(() => {
+      return {
+        notesConceptUuids: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'some-uuid2'],
+        visitDiagnosisConceptUuid: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        problemListConceptUuid: '1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        diagnosisOrderConceptUuid: '159946AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      };
+    }),
+  };
+});
 
 describe('VisitSummary', () => {
   const renderVisitSummary = () => {
@@ -64,8 +76,8 @@ describe('VisitSummary', () => {
     const notesTab = screen.getByRole('tab', { name: /Notes/i });
     userEvent.click(notesTab);
 
-    expect(screen.getByText(/Dr James Cook/i)).toBeInTheDocument();
-    expect(screen.getByText(/Admin/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Dr James Cook/i)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/Admin/i)[0]).toBeInTheDocument();
     expect(screen.getByText(/^Patient seems very unwell$/i)).toBeInTheDocument();
 
     // should display medication panel

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -26,7 +26,7 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
         <div className={styles.toggleSwitch}>
           <ContentSwitcher onChange={() => setToggleAll((prevState) => !prevState)}>
             <Switch name={'first'} text={t('visitSummary', 'Visit summary')} />
-            <Switch name={'second'} text={t('encounters', 'Encounters')} />
+            <Switch name={'second'} text={t('allEncounters', 'All Encounters')} />
           </ContentSwitcher>
         </div>
         <div className={styles.container}>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.scss
@@ -222,3 +222,16 @@ tab > button:first {
 .toggleSwitch div {
   width: 30%;
 }
+
+.noteTitle {
+  @extend .productiveHeading01;
+  color: $ui-05;
+  margin: $spacing-02 0;
+}
+
+.noteText {
+  background-color: $openmrs-background-grey;
+  padding: 0.625rem 6.75rem 0.75rem 1.063rem;
+  width: 100% !important;
+  margin: $spacing-02 0;
+}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -70,12 +70,12 @@ describe('VisitDetailOverview', () => {
 
     await waitForLoadingToFinish();
 
-    const allEncountersButton = screen.getByRole('button', { name: /All Encounters/i });
-    userEvent.click(allEncountersButton);
+    const encountersButton = screen.getByRole('button', { name: /Encounters/i });
+    userEvent.click(encountersButton);
 
     expect(screen.getByRole('table')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /ECH Aug 18, 2021/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /All encounters/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /encounters/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Visit summary/i })).toBeInTheDocument();
     expect(screen.getByRole('row', { name: /Vitals/i })).toBeInTheDocument();
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -1,14 +1,10 @@
 import useSWR from 'swr';
-import { openmrsFetch, Visit } from '@openmrs/esm-framework';
+import { openmrsFetch, OpenmrsResource, Visit } from '@openmrs/esm-framework';
 
 export function useVisits(patientUuid: string) {
   const customRepresentation =
     'custom:(uuid,encounters:(uuid,encounterDatetime,' +
-    'orders:(uuid,dateActivated,' +
-    'drug:(uuid,name,strength),doseUnits:(uuid,display),' +
-    'dose,route:(uuid,display),frequency:(uuid,display),' +
-    'duration,durationUnits:(uuid,display),numRefills,' +
-    'orderType:(uuid,display),orderer:(uuid,person:(uuid,display))),' +
+    'orders:full,' +
     'obs:(uuid,concept:(uuid,display,conceptClass:(uuid,display)),' +
     'display,groupMembers:(uuid,concept:(uuid,display),' +
     'value:(uuid,display)),value),encounterType:(uuid,display),' +
@@ -159,6 +155,7 @@ export interface Order {
 }
 
 export interface Note {
+  concept: OpenmrsResource;
   note: string;
   provider: {
     name: string;

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -14,6 +14,7 @@
   "edit": "Edit",
   "editPastVisit": "Edit Past Visit",
   "encounters": "Encounters",
+  "Encounters": "Encounters",
   "endActiveVisit": "End active visit",
   "endDate": "End date",
   "endVisit": "End Visit",

--- a/packages/esm-patient-test-results-app/src/index.ts
+++ b/packages/esm-patient-test-results-app/src/index.ts
@@ -60,6 +60,16 @@ function setupOpenMRS() {
         online: true,
         offline: true,
       },
+      {
+        id: 'test-results-filtered-overview',
+        slot: 'test-results-filtered-overview-slot',
+        load: getAsyncLifecycle(() => import('./overview/external-overview.component'), options),
+        meta: {
+          columnSpan: 4,
+        },
+        online: true,
+        offline: true,
+      },
     ],
   };
 }

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.scss
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.scss
@@ -1,0 +1,5 @@
+
+.recent-results-grid {
+    display: grid;
+    background-color: white;
+  }

--- a/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/external-overview.component.tsx
@@ -1,0 +1,100 @@
+import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import styles from './external-overview.component.scss';
+import { EmptyState, ExternalOverviewProps, PanelFilterProps } from '@openmrs/esm-patient-common-lib';
+import { parseSingleEntry, OverviewPanelEntry } from './useOverviewData';
+import usePatientResultsData from '../loadPatientTestData/usePatientResultsData';
+import CommonOverview from './common-overview.component';
+import { navigate } from '@openmrs/esm-framework';
+import { Button, DataTableSkeleton } from 'carbon-components-react';
+import ArrowRight16 from '@carbon/icons-react/es/arrow--right/16';
+
+const resultsToShow = 3;
+
+function useFilteredOverviewData(patientUuid: string, filter: (filterProps: PanelFilterProps) => boolean = () => true) {
+  const { sortedObs, loaded, error } = usePatientResultsData(patientUuid);
+
+  const overviewData = useMemo(() => {
+    return Object.entries(sortedObs)
+      .flatMap(([panelName, { entries, type, uuid }]) => {
+        return entries.map((e) => [e, uuid, type, panelName] as PanelFilterProps);
+      })
+      .filter(filter)
+      .map(([entry, uuid, type, panelName]: PanelFilterProps): OverviewPanelEntry => {
+        return [
+          panelName,
+          type,
+          parseSingleEntry(entry, type, panelName),
+          new Date(entry.effectiveDateTime),
+          new Date(entry.issued),
+          uuid,
+        ];
+      })
+      .sort(([, , , date1], [, , , date2]) => date2.getTime() - date1.getTime());
+  }, [filter, sortedObs]);
+
+  return { overviewData, loaded, error };
+}
+
+const ExternalOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter }) => {
+  const { t } = useTranslation();
+  const { overviewData, loaded, error } = useFilteredOverviewData(patientUuid, filter);
+
+  const cardTitle = t('recentResults', 'Recent Results');
+  const handleSeeAll = useCallback(() => {
+    navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/chart/test-results` });
+  }, [patientUuid]);
+
+  return (
+    <RecentResultsGrid>
+      {loaded ? (
+        <>
+          {(() => {
+            if (overviewData.length) {
+              return (
+                <div className={styles.widgetCard}>
+                  <div className={styles.externalOverviewHeader}>
+                    <h4 className={`${styles.productiveHeading03} ${styles.text02}`}>{cardTitle}</h4>
+                    <Button
+                      kind="ghost"
+                      renderIcon={ArrowRight16}
+                      iconDescription="See all results"
+                      onClick={handleSeeAll}
+                    >
+                      {t('seeAllResults', 'See all results')}
+                    </Button>
+                  </div>
+                  <CommonOverview
+                    {...{
+                      patientUuid,
+                      overviewData: overviewData.slice(0, resultsToShow),
+                      insertSeparator: true,
+                      deactivateToolbar: true,
+                      isPatientSummaryDashboard: false,
+                      hideToolbar: true,
+                    }}
+                  />
+                  {overviewData.length > resultsToShow && (
+                    <Button onClick={handleSeeAll} kind="ghost">
+                      {t('moreResultsAvailable', 'More results available')}
+                    </Button>
+                  )}
+                </div>
+              );
+            } else {
+              return <EmptyState headerTitle={cardTitle} displayText={t('recentTestResults', 'recent test results')} />;
+            }
+          })()}
+        </>
+      ) : (
+        <DataTableSkeleton columnCount={3} />
+      )}
+    </RecentResultsGrid>
+  );
+};
+
+export default ExternalOverview;
+
+const RecentResultsGrid = (props) => {
+  return <div {...props} className={styles['recent-results-grid']} />;
+};


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- update visit custom representation to full, this is because for instance not using drug order endpoint, this will cause the REST API to fail e.g AMRS.
- Add test-results view on the encounters widget to display test-results.
- Add configurable concepts for encounters instead of using fixed concept name on visit-detail component.
- Updated the global toggle button on encounters to be `All Encounters` and for individual encounter to simply `encounters`
- Add concept name for each clinical type as shown in the gif below.


## Screenshots

![encounters](https://user-images.githubusercontent.com/28008754/151429337-fcddbcd4-518e-40eb-900a-d9de756866e4.gif)



## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
