### PR TITLE
(enhancement) squash console test results error, export visit-details as extension slot

### DIFF
--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -148,6 +148,14 @@ function setupOpenMRS() {
           moduleName,
         }),
       },
+      {
+        id: 'visit-detail-overview',
+        slot: 'visit-detail-overview-slot',
+        load: getAsyncLifecycle(() => import('./visit/visits-widget/past-visits-components/visit-detail.component'), {
+          featureName: 'visit-details',
+          moduleName,
+        }),
+      },
     ],
   };
 }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-detail.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-detail.component.tsx
@@ -5,8 +5,7 @@ import VisitSummary from './visit-summary.component';
 import { Button } from 'carbon-components-react';
 import { useTranslation } from 'react-i18next';
 import { Encounter } from '../visit.resource';
-import { formatDate, formatDatetime, formatTime, parseDate, Visit } from '@openmrs/esm-framework';
-import dayjs from 'dayjs';
+import { formatDatetime, formatTime, parseDate, Visit } from '@openmrs/esm-framework';
 
 interface VisitDetailComponentProps {
   visit: Visit;
@@ -16,7 +15,7 @@ interface VisitDetailComponentProps {
 
 const VisitDetailComponent: React.FC<VisitDetailComponentProps> = ({ visit, patientUuid, listViewOverride }) => {
   const { t } = useTranslation();
-  const [listView, setListView] = useState(false);
+  const [listView, setListView] = useState(listViewOverride);
   const encounters = useMemo(
     () =>
       visit.encounters.map((encounter: Encounter) => ({

--- a/packages/esm-patient-test-results-app/src/overview/common-datatable.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-datatable.component.tsx
@@ -33,8 +33,11 @@ const CommonDataTable: React.FC<CommonDataTableProps> = ({ title, data, descript
       {({ rows, headers, getHeaderProps, getRowProps, getTableProps, getTableContainerProps }) => (
         <TableContainer
           className={`${styles.tableContainer} ${isTablet ? `${styles.tablet}` : `${styles.desktop}`}`}
-          title={title}
-          description={description}
+          title={
+            <>
+              {title} {description}
+            </>
+          }
           {...getTableContainerProps()}
         >
           {toolbar}

--- a/packages/esm-patient-test-results-app/src/overview/common-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.component.tsx
@@ -81,7 +81,7 @@ const CommonOverview: React.FC<CommonOverviewProps> = ({
                 title,
                 data,
                 description: (
-                  <div className={`${insertSeparator ? '' : styles.cardHeader}`}>
+                  <div className={styles.cardHeader}>
                     <div className={styles.meta}>
                       {formatDate(effectiveDateTime)}
                       <InfoTooltip effectiveDateTime={effectiveDateTime} issuedDateTime={issuedDateTime} />

--- a/packages/esm-patient-test-results-app/src/overview/common-overview.scss
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.scss
@@ -18,6 +18,9 @@
     padding-top: 0.188rem;
     border-bottom: 0.375rem solid var(--brand-03);
   }
+  @include carbon--type-style("body-short-01");
+  color: $text-02;
+  margin-top: $spacing-02;
 }
 
 .columns {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- export `visit-detail` component as extension to be used on active-visit, the code is similar, therefore no need to have duplicate code doing the same thing.  [see here](https://github.com/openmrs/openmrs-esm-patient-management/blob/main/packages/esm-active-visits-app/src/visits-summary).
- squash console error when opening `test-results` as seen here below 
![Screenshot 2022-02-07 at 16 50 03](https://user-images.githubusercontent.com/28008754/152800537-540563c9-d1e7-404e-88ee-4d619d03c194.png)



## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
