### PR TITLE
Move useContextWorkspaceSize hook to esm-common-lib and rename to useWorkspaceWindow

### DIFF
--- a/packages/esm-patient-chart-app/src/root.component.tsx
+++ b/packages/esm-patient-chart-app/src/root.component.tsx
@@ -5,7 +5,7 @@ import SideMenu from './view-components/side-menu.component';
 import { BrowserRouter, Route } from 'react-router-dom';
 import { basePath, dashboardPath, spaRoot } from './constants';
 import styles from './root.scss';
-import { ContextWindowSizeProvider } from './hooks/useContextWindowSize';
+import { WorkspaceWindowSizeProvider } from '@openmrs/esm-patient-common-lib';
 import { SWRConfig } from 'swr';
 
 const swrConfiguration = {
@@ -17,13 +17,13 @@ export default function Root() {
   return (
     <SWRConfig value={swrConfiguration}>
       <BrowserRouter basename={spaRoot}>
-        <ContextWindowSizeProvider>
+        <WorkspaceWindowSizeProvider>
           <div className={styles.patientChartWrapper}>
             <SideMenu />
             <Route path={dashboardPath} component={PatientChart} />
             <Route path={basePath} component={ContextWorkspace} />
           </div>
-        </ContextWindowSizeProvider>
+        </WorkspaceWindowSizeProvider>
       </BrowserRouter>
     </SWRConfig>
   );

--- a/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/action-menu.component.tsx
@@ -6,7 +6,7 @@ import styles from './action-menu.component.scss';
 import { ExtensionSlot, useLayoutType } from '@openmrs/esm-framework';
 import { HeaderPanel, Button } from 'carbon-components-react';
 import { isDesktop } from '../utils';
-import { useContextWorkspace } from '../hooks/useContextWindowSize';
+import { useWorkspaceWindow } from '@openmrs/esm-patient-common-lib';
 import { useWorkspace } from '../hooks/useWorkspace';
 import { useTranslation } from 'react-i18next';
 import { WorkspaceWindowState } from '../types';
@@ -22,7 +22,7 @@ export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
   const { t } = useTranslation();
   const layout = useLayoutType();
   const { windowState: screenMode, active } = useWorkspace();
-  const { openWindows, updateWindowSize, windowSize } = useContextWorkspace();
+  const { openWindows, updateWindowSize, windowSize } = useWorkspaceWindow();
 
   const checkViewMode = () => {
     if (active) {

--- a/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { detachAll, ExtensionSlot, useSessionUser } from '@openmrs/esm-framework';
 import ActionMenu from './action-menu.component';
 import { useOfflineVisitForPatient, usePatientOrOfflineRegisteredPatient } from '../offline';
-import { useContextWorkspace } from '../hooks/useContextWindowSize';
+import { useWorkspaceWindow } from '@openmrs/esm-patient-common-lib';
 import { WorkspaceWindowState } from '../types';
 import WorkspaceNotification from './workspace-notification.component';
 
@@ -22,7 +22,7 @@ const PatientChart: React.FC<RouteComponentProps<PatientChartParams>> = ({ match
   const { isLoading, patient } = usePatientOrOfflineRegisteredPatient(patientUuid);
   const sessionUser = useSessionUser();
   const state = useMemo(() => ({ patient, patientUuid }), [patient, patientUuid]);
-  const { windowSize, openWindows } = useContextWorkspace();
+  const { windowSize, openWindows } = useWorkspaceWindow();
 
   useEffect(() => {
     detachAll('patient-chart-workspace-slot');

--- a/packages/esm-patient-chart-app/src/workspace/context-workspace.component.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/context-workspace.component.tsx
@@ -7,7 +7,7 @@ import Maximize16 from '@carbon/icons-react/es/maximize/16';
 import Minimize16 from '@carbon/icons-react/es/minimize/16';
 import { ExtensionSlot, useLayoutType, useBodyScrollLock } from '@openmrs/esm-framework';
 import { isDesktop } from '../utils';
-import { useContextWorkspace } from '../hooks/useContextWindowSize';
+import { useWorkspaceWindow } from '@openmrs/esm-patient-common-lib';
 import { useWorkspace } from '../hooks/useWorkspace';
 import { patientChartWorkspaceHeaderSlot, patientChartWorkspaceSlot } from '../constants';
 import { WorkspaceWindowState } from '../types';
@@ -24,7 +24,7 @@ const ContextWorkspace: React.FC<RouteComponentProps<ContextWorkspaceParams>> = 
 
   const { patientUuid } = match.params;
   const { active, title, closeWorkspace, extensions } = useWorkspace();
-  const { windowSize, updateWindowSize } = useContextWorkspace();
+  const { windowSize, updateWindowSize } = useWorkspaceWindow();
   const { size } = windowSize;
 
   const hidden = size === WorkspaceWindowState.hidden;

--- a/packages/esm-patient-common-lib/src/index.ts
+++ b/packages/esm-patient-common-lib/src/index.ts
@@ -8,5 +8,6 @@ export * from './launchStartVisitPrompt';
 export * from './pagination';
 export * from './time-helper';
 export * from './useVitalsConceptMetadata';
+export * from './useWorkspaceWindowSize';
 export * from './launchPatientWorkspace';
 export * from './form-entry/form-entry';

--- a/packages/esm-patient-common-lib/src/useWorkspaceWindowSize.tsx
+++ b/packages/esm-patient-common-lib/src/useWorkspaceWindowSize.tsx
@@ -1,14 +1,14 @@
 import { useAssignedExtensionIds } from '@openmrs/esm-framework';
 import React, { createContext, useContext, useMemo, useEffect, useCallback } from 'react';
-import { patientChartWorkspaceSlot } from '../constants';
-import { useWorkspace } from '../hooks/useWorkspace';
-import { WorkspaceWindowState } from '../types';
+import { patientChartWorkspaceSlot } from '../../esm-patient-chart-app/src/constants';
+import { useWorkspace } from '../../esm-patient-chart-app/src/hooks/useWorkspace';
+import { WorkspaceWindowState } from '../../esm-patient-chart-app/src/types';
 
 interface WindowSize {
   size: WorkspaceWindowState;
 }
 
-interface ContextWindowSizeContextShape {
+interface WorkspaceWindowSizeContextShape {
   windowSize: WindowSize;
   updateWindowSize?(value: WorkspaceWindowState): any;
   openWindows: number;
@@ -24,41 +24,41 @@ const reducer = (state: WindowSize, action: WorkspaceWindowState) => {
   }
 };
 
-const ContextWindowSizeContext = createContext<ContextWindowSizeContextShape>({
+const WorkspaceWindowSizeContext = createContext<WorkspaceWindowSizeContextShape>({
   windowSize: { size: WorkspaceWindowState.normal },
   openWindows: 0,
 });
 
-export const useContextWorkspace = () => {
-  const value = useContext(ContextWindowSizeContext);
+export const useWorkspaceWindow = () => {
+  const value = useContext(WorkspaceWindowSizeContext);
   return value;
 };
 
-export const ContextWindowSizeProvider: React.FC = ({ children }) => {
+export const WorkspaceWindowSizeProvider: React.FC = ({ children }) => {
   const extensions = useAssignedExtensionIds(patientChartWorkspaceSlot);
   const initialValue: WindowSize = { size: WorkspaceWindowState.normal };
-  const [contextWorkspaceWindowSize, updateContextWorkspaceWindowSize] = React.useReducer(reducer, initialValue);
+  const [workspaceWindowSize, updateWorkspaceWindowSize] = React.useReducer(reducer, initialValue);
   const { windowState: screenMode } = useWorkspace();
 
   useEffect(() => {
     if (extensions.length > 0 && screenMode === WorkspaceWindowState.maximized) {
-      updateContextWorkspaceWindowSize(WorkspaceWindowState.maximized);
+      updateWorkspaceWindowSize(WorkspaceWindowState.maximized);
     } else {
-      updateContextWorkspaceWindowSize(WorkspaceWindowState.reopened);
+      updateWorkspaceWindowSize(WorkspaceWindowState.reopened);
     }
   }, [extensions.length, screenMode]);
 
   const updateWindowSize = useCallback((action: WorkspaceWindowState) => {
-    updateContextWorkspaceWindowSize(action);
+    updateWorkspaceWindowSize(action);
   }, []);
 
   const windowSizeValue = useMemo(() => {
     return {
-      windowSize: contextWorkspaceWindowSize,
+      windowSize: workspaceWindowSize,
       updateWindowSize: updateWindowSize,
       openWindows: extensions.length,
     };
-  }, [contextWorkspaceWindowSize, extensions.length, updateWindowSize]);
+  }, [workspaceWindowSize, extensions.length, updateWindowSize]);
 
-  return <ContextWindowSizeContext.Provider value={windowSizeValue}>{children}</ContextWindowSizeContext.Provider>;
+  return <WorkspaceWindowSizeContext.Provider value={windowSizeValue}>{children}</WorkspaceWindowSizeContext.Provider>;
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

This moves a hook needed by OHRI into a place where they can use it, and renames all the things in that file.