### PR TITLE
O3-1035: Update date formatting for timeline view

### DIFF
--- a/packages/esm-patient-test-results-app/src/timeline/useTimelineData.ts
+++ b/packages/esm-patient-test-results-app/src/timeline/useTimelineData.ts
@@ -11,7 +11,7 @@ const parseTime = (sortedTimes: string[]) => {
   sortedTimes.forEach((datetime) => {
     const dayJsDate = dayjs(datetime);
     const year = dayJsDate.year().toString();
-    const date = dayJsDate.format('MM/DD');
+    const date = dayJsDate.format('DD - MMM');
     const time = dayJsDate.format('HH:mm');
 
     const yearColumn = yearColumns.find(({ year: innerYear }) => year === innerYear);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Updated the date format of the timeline on test results view.
Previously the format was "MM/DD" (Ex: `02/14`)
Updated it to "DD - MMM" (Ex: `02 - Feb`) as in the zeplin design(https://scene.zeplin.io/project/60d59321e8100b0324762e05/screen/60d5e8592e266316d1b21d27)
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

Previous:
<img width="737" alt="Screenshot 2022-02-03 at 14 49 25" src="https://user-images.githubusercontent.com/27498587/152341245-668a29ca-30f0-4e82-8abb-a415b71f7a59.png">

After updating:
<img width="737" alt="Screenshot 2022-02-03 at 14 47 05" src="https://user-images.githubusercontent.com/27498587/152341270-666494e8-e464-467c-9e6a-b2c2b11ad7c3.png">
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

https://issues.openmrs.org/browse/O3-1035
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
