### PR TITLE
Nav menu should use standard `usePatient()` hook

### DIFF
--- a/packages/esm-patient-chart-app/src/ui-components/nav.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/nav.component.tsx
@@ -1,27 +1,10 @@
-import React, { useEffect, useState } from 'react';
-import { ExtensionSlot } from '@openmrs/esm-framework';
+import React, { useMemo } from 'react';
+import { ExtensionSlot, usePatient } from '@openmrs/esm-framework';
 import { spaBasePath } from '../constants';
 
-function getPatientUuidFromUrl() {
-  const match = /\/patient\/([a-zA-Z0-9\-]+)\/?/.exec(location.pathname);
-  return match && match[1];
-}
-
 const PatientChartNavMenu: React.FC = () => {
-  const [patientUuid, setPatientUuid] = useState(getPatientUuidFromUrl);
-  const basePath = spaBasePath.replace(':patientUuid', patientUuid);
-
-  useEffect(() => {
-    const handler = () => {
-      const currentPatientUuid = getPatientUuidFromUrl();
-
-      if (currentPatientUuid !== patientUuid) {
-        setPatientUuid(currentPatientUuid);
-      }
-    };
-    window.addEventListener('popstate', handler);
-    return () => window.removeEventListener('popstate', handler);
-  }, [patientUuid]);
+  const { patientUuid } = usePatient();
+  const basePath = useMemo(() => spaBasePath.replace(':patientUuid', patientUuid), [patientUuid]);
 
   return <ExtensionSlot state={{ basePath }} extensionSlotName="patient-chart-dashboard-slot" />;
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Nav menu was trying to determine the patient by parsing the URL itself, but it wasn't being updated at the appropriate time. This changes it to use the `usePatient()` hook.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
