### PR TITLE
03-1083: Prevent users submitting two clinical form encounters

### DIFF
--- a/packages/esm-form-entry-app/src/app/app.module.ts
+++ b/packages/esm-form-entry-app/src/app/app.module.ts
@@ -15,9 +15,10 @@ import { FormDataSourceService } from './form-data-source/form-data-source.servi
 import { FormSubmissionService } from './form-submission/form-submission.service';
 import { MonthlyScheduleResourceService } from './services/monthly-scheduled-resource.service';
 import { ConfigResourceService } from './services/config-resource.service';
+import { LoaderComponent } from './loader/loader.component';
 
 @NgModule({
-  declarations: [AppComponent, EmptyRouteComponent, FeWrapperComponent],
+  declarations: [AppComponent, EmptyRouteComponent, FeWrapperComponent, LoaderComponent],
   imports: [BrowserModule, FormEntryModule, ReactiveFormsModule, BrowserAnimationsModule, OpenmrsApiModule],
   providers: [
     FormSchemaService,

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
@@ -11,25 +11,15 @@
       </div>
       <div class="bx-btn--set button-set">
         <button class="bx--btn bx--btn--secondary" (click)="closeForm()" type="button">Discard</button>
-        <button class="bx--btn bx--btn--primary" (click)="onSubmit($event)" type="submit">Save and close</button>
+        <button [disabled]="isSubmitting" class="bx--btn bx--btn--primary" (click)="onSubmit($event)" type="submit">
+          <span *ngIf="!isSubmitting">Save and close</span>
+          <loader *ngIf="isSubmitting" loadingMessage="Submitting"></loader>
+        </button>
       </div>
     </div>
   </div>
 </div>
 
 <div *ngIf="isLoading" class="loader-container">
-  <div class="bx--inline-loading" aria-live="assertive" class="loader">
-    <div class="bx--inline-loading__animation">
-      <div aria-atomic="true" aria-labelledby="loading-id-2" aria-live="assertive"
-        class="bx--loading bx--loading--small">
-        <label id="loading-id-2" class="bx--visually-hidden">Active loading indicator</label>
-        <svg class="bx--loading__svg" viewBox="0 0 100 100">
-          <title>Active loading indicator</title>
-          <circle class="bx--loading__background" cx="50%" cy="50%" r="44"></circle>
-          <circle class="bx--loading__stroke" cx="50%" cy="50%" r="44"></circle>
-        </svg>
-      </div>
-    </div>
-    <div class="bx--inline-loading__text">Loading...</div>
-  </div>
+  <loader class="loader" loadingMessage="Loading..."></loader>
 </div>

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -54,6 +54,7 @@ export class FeWrapperComponent implements OnInit {
   prevEncounter: Encounter;
   isLoading: boolean = true;
   config: FormEntryConfig;
+  isSubmitting: boolean = false;
 
   public get encounterDate(): string {
     return moment(this.encounter?.encounterDatetime).format('YYYY-MM-DD');
@@ -116,6 +117,7 @@ export class FeWrapperComponent implements OnInit {
 
   public onSubmit(event: any) {
     if (this.isFormValid()) {
+      this.isSubmitting = true;
       this.saveForm().subscribe(
         (response) => {
           this.encounterUuid = response[0] && response[0].uuid;
@@ -138,13 +140,12 @@ export class FeWrapperComponent implements OnInit {
             this.closeForm();
           }
         },
-        (error) => {
-          console.error('Error submitting form', error);
-          this.singleSpaProps.closeWorkspace();
+        (error: Error) => {
+          this.isSubmitting = false;
           showToast({
             critical: true,
             kind: 'error',
-            description: `An error has occurred while submitting the form ${JSON.stringify(error, null, 2)}`,
+            description: `An error has occurred while submitting the form ${JSON.stringify(error?.message, null, 2)}`,
             title: this.formName,
           });
         },

--- a/packages/esm-form-entry-app/src/app/loader/loader.component.html
+++ b/packages/esm-form-entry-app/src/app/loader/loader.component.html
@@ -1,0 +1,12 @@
+<div class="bx--inline-loading" aria-live="assertive" style="width: fit-content;">
+    <div class="bx--inline-loading__animation">
+        <div aria-atomic="true" aria-labelledby="loading-id-5" aria-live="assertive"
+            class="bx--loading bx--loading--small"><label id="loading-id-5" class="bx--visually-hidden">Active
+                loading indicator</label><svg class="bx--loading__svg" viewBox="0 0 100 100">
+                <title>Active loading indicator</title>
+                <circle class="bx--loading__background" cx="50%" cy="50%" r="44"></circle>
+                <circle class="bx--loading__stroke" cx="50%" cy="50%" r="44"></circle>
+            </svg></div>
+    </div>
+    <div class="bx--inline-loading__text">{{loadingMessage}}</div>
+</div>

--- a/packages/esm-form-entry-app/src/app/loader/loader.component.ts
+++ b/packages/esm-form-entry-app/src/app/loader/loader.component.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'loader',
+  templateUrl: './loader.component.html',
+})
+export class LoaderComponent {
+  @Input()
+  loadingMessage: string;
+}

--- a/packages/esm-patient-forms-app/src/forms/form-view.component.scss
+++ b/packages/esm-patient-forms-app/src/forms/form-view.component.scss
@@ -40,6 +40,7 @@
     display: flex;
     justify-content: space-between;
     cursor: pointer;
+    align-items: center;
 
     &>svg {
       visibility: hidden;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- This PR fixes issue reported by QA, where clinicians are clicking the `Save and Close` button more than once in the fear their changes won't have been saved. Am introducing a submitting status on the `Save and Close` button on clinical forms to inform the user that the form is being submitted and disenabling the `Save and close` button while the form is being submitted. 
- Introduced `loader-component` to avoid repeating `inline-loading` html markup for loading spinner


## Screenshots
![Screen Recording 2022-02-09 at 10 48 38 AM](https://user-images.githubusercontent.com/28008754/153156342-080afb4e-6310-4391-9c35-650cb03238aa.gif)



## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
