### PR TITLE
O3-1023 Should be possible to launch patient chart with workspace open

### DIFF
--- a/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/ui-components/patient-chart.component.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { ExtensionSlot, useSessionUser } from '@openmrs/esm-framework';
-import { closeAllWorkspaces, useWorkspaceWindowSize, WorkspaceWindowState } from '@openmrs/esm-patient-common-lib';
+import { changeWorkspaceContext, useWorkspaceWindowSize, WorkspaceWindowState } from '@openmrs/esm-patient-common-lib';
 import { RouteComponentProps } from 'react-router-dom';
 import { useOfflineVisitForPatient, usePatientOrOfflineRegisteredPatient } from '../offline';
 import ChartReview from '../view-components/chart-review.component';
@@ -24,7 +24,7 @@ const PatientChart: React.FC<RouteComponentProps<PatientChartParams>> = ({ match
   const { windowSize, active } = useWorkspaceWindowSize();
 
   useEffect(() => {
-    closeAllWorkspaces();
+    changeWorkspaceContext(patientUuid);
   }, [patientUuid]);
 
   useOfflineVisitForPatient(patientUuid, sessionUser?.sessionLocation?.uuid);

--- a/packages/esm-patient-common-lib/src/workspaces/useWorkspaces.tsx
+++ b/packages/esm-patient-common-lib/src/workspaces/useWorkspaces.tsx
@@ -5,6 +5,7 @@ import {
   OpenWorkspace,
   WorkspaceWindowState,
 } from '@openmrs/esm-patient-common-lib';
+import { WorkspaceStoreState } from '.';
 
 export interface WorkspacesInfo {
   active: boolean;
@@ -18,10 +19,12 @@ export function useWorkspaces(): WorkspacesInfo {
   const [workspaceNeedingConfirmationToOpen, setWorkspaceNeedingConfirmationToOpen] = useState<OpenWorkspace>(null);
 
   useEffect(() => {
-    getWorkspaceStore().subscribe((state) => {
+    function update(state: WorkspaceStoreState) {
       setWorkspaces(state.openWorkspaces.map((w) => ({ ...w, closeWorkspace: () => closeWorkspace(w.name) })));
       setWorkspaceNeedingConfirmationToOpen(state.workspaceNeedingConfirmationToOpen);
-    });
+    }
+    update(getWorkspaceStore().getState());
+    getWorkspaceStore().subscribe(update);
   }, []);
 
   const windowState = useMemo(() => {

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
@@ -2,6 +2,7 @@ import { ExtensionRegistration, getExtensionRegistration, getGlobalStore, transl
 import { WorkspaceWindowState } from '..';
 
 export interface WorkspaceStoreState {
+  patientUuid: string | null;
   openWorkspaces: Array<OpenWorkspace>;
   workspaceNeedingConfirmationToOpen: OpenWorkspace | null;
 }
@@ -134,15 +135,24 @@ export function closeWorkspace(name: string) {
 
 export function closeAllWorkspaces() {
   const store = getWorkspaceStore();
-  store.setState({ openWorkspaces: [] });
+  const state = store.getState();
+  store.setState({ ...state, openWorkspaces: [] });
 }
 
-export interface WorkspaceParcel {
-  unmount: () => void;
-  update: (props) => Promise<any>;
+/**
+ * The set of workspaces is specific to a particular patient. This function
+ * should be used when setting up workspaces for a new patient. If the current
+ * workspace data is for a different patient, the workspace state is cleared.
+ */
+export function changeWorkspaceContext(patientUuid) {
+  const store = getWorkspaceStore();
+  const state = store.getState();
+  if (state.patientUuid != patientUuid) {
+    store.setState({ patientUuid, openWorkspaces: [], workspaceNeedingConfirmationToOpen: null });
+  }
 }
 
-const initialState = { openWorkspaces: [], workspaceNeedingConfirmationToOpen: null };
+const initialState = { patientUuid: null, openWorkspaces: [], workspaceNeedingConfirmationToOpen: null };
 export function getWorkspaceStore() {
   return getGlobalStore<WorkspaceStoreState>('workspace', initialState);
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This makes it possible to launch the patient chart with a workspace open.

## Screenshots

![launch-workspace](https://user-images.githubusercontent.com/1031876/153328211-b7fef41f-30e8-469f-bb1a-41ba4d78fc42.gif)

## Issue

https://issues.openmrs.org/browse/O3-1023
