### PR TITLE
(fix): Fix medications details table overflow menu

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -173,7 +173,7 @@ const MedicationsDetailsTable = connect<
             </Button>
           )}
         </CardHeader>
-        <TableContainer>
+        <TableContainer data-floating-menu-container>
           <DataTable
             size="short"
             headers={tableHeaders}
@@ -407,7 +407,7 @@ function OrderBasketItemActions({
   }, [items, setItems, medication]);
 
   return (
-    <OverflowMenu data-floating-menu-container selectorPrimaryFocus={'#modify'} flipped>
+    <OverflowMenu selectorPrimaryFocus={'#modify'} flipped>
       {showModifyButton && (
         <OverflowMenuItem
           className={styles.menuItem}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Move the `data-floating-menu-container` attribute higher up to the `TableContainer ` so the overflow menu gets placed appropriately in the DOM. 

## Screenshots

> Before

Notice how the overflow menu items don't get overlaid on top of the DataTable. The user needs to scroll down to see all of the menu items.

<img width="967" alt="Screenshot 2022-02-10 at 21 58 06" src="https://user-images.githubusercontent.com/8509731/153478850-410e2921-3ce1-4794-acb3-8631137595de.png">

> After

Overflow menu items get properly overlaid over the DataTable.

<img width="964" alt="Screenshot 2022-02-10 at 21 57 31" src="https://user-images.githubusercontent.com/8509731/153479039-aa17dbcb-ae70-42b7-946f-3b0c5797016d.png">


