### PR TITLE
fix: Provide missing patient UUID to queued offline actions.

### DIFF
--- a/packages/esm-form-entry-app/src/offline.ts
+++ b/packages/esm-form-entry-app/src/offline.ts
@@ -113,6 +113,7 @@ async function queueEncounterRequest(item: QueuedEncounterRequest) {
   const descriptor: QueueItemDescriptor = {
     id: item.body.uuid,
     displayName: 'Patient form',
+    patientUuid: item.body.patient,
     dependencies: [
       {
         type: 'visit',

--- a/packages/esm-patient-chart-app/src/offline.ts
+++ b/packages/esm-patient-chart-app/src/offline.ts
@@ -96,6 +96,7 @@ async function createOfflineVisitForPatient(patientUuid: string, location: strin
   const descriptor: QueueItemDescriptor = {
     id: offlineVisit.uuid,
     displayName: 'Offline visit',
+    patientUuid,
     dependencies: isVisitForOfflineRegisteredPatient
       ? [
           {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

When queuing up sync items, we can provide a patient UUID. This should be done whenever possible so that other UI compoenents, e.g. the offline actions table, can display the action's associated patient.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
