### PR TITLE
(feat) Better dashboard titles in breadcrumbs menu

### DIFF
--- a/packages/esm-patient-biometrics-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-biometrics-app/src/dashboard.meta.tsx
@@ -1,5 +1,5 @@
 export const dashboardMeta = {
-  name: 'vitalsAndBiometrics',
+  name: 'vitals_and_biometrics',
   slot: 'patient-chart-vitals-biometrics-dashboard-slot',
   config: { columns: 1 },
   title: 'Vitals & Biometrics',

--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -1,7 +1,6 @@
-import capitalize from 'lodash-es/capitalize';
-import replace from 'lodash-es/replace';
 import { registerBreadcrumbs, defineConfigSchema, getAsyncLifecycle, getSyncLifecycle } from '@openmrs/esm-framework';
 import { createDashboardLink } from '@openmrs/esm-patient-common-lib';
+import { capitalize } from 'lodash-es';
 import { esmPatientChartSchema } from './config-schema';
 import { moduleName, spaBasePath } from './constants';
 import { setupCacheableRoutes, setupOfflineVisitsSync } from './offline';
@@ -25,7 +24,7 @@ function setupOpenMRS() {
     },
     {
       path: `${spaBasePath}/:view`,
-      title: ([_, key]) => `${capitalize(key)} Dashboard`,
+      title: ([_, key]) => `${capitalize(key).replace(/_/g, ' ')} dashboard`,
       parent: spaBasePath,
     },
   ]);

--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -1,4 +1,5 @@
 import capitalize from 'lodash-es/capitalize';
+import replace from 'lodash-es/replace';
 import { registerBreadcrumbs, defineConfigSchema, getAsyncLifecycle, getSyncLifecycle } from '@openmrs/esm-framework';
 import { createDashboardLink } from '@openmrs/esm-patient-common-lib';
 import { esmPatientChartSchema } from './config-schema';
@@ -108,7 +109,6 @@ function setupOpenMRS() {
           view: 'visits',
         },
       },
-      ,
       {
         name: 'past-visits-overview',
         load: getAsyncLifecycle(() => import('./visit/past-visit-overview.component'), {

--- a/packages/esm-patient-clinical-view-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-clinical-view-app/src/dashboard.meta.tsx
@@ -1,5 +1,5 @@
 export const dashboardMeta = {
-  name: 'clinical-views',
+  name: 'clinical_views',
   slot: 'patient-chart-clinical-view-dashboard-slot',
   config: { columns: 1 },
   title: 'Clinical Views',

--- a/packages/esm-patient-test-results-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-test-results-app/src/dashboard.meta.tsx
@@ -1,5 +1,5 @@
 export const dashboardMeta = {
-  name: 'test-results',
+  name: 'test_results',
   slot: 'patient-chart-test-results-dashboard-slot',
   config: { columns: 1 },
   title: 'Test Results',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This improves the display of dashboard titles in the breadcrumbs menu. More specifically, it improves how dashboard titles containing more than one word are displayed. It introduces a convention where the dashboard `name` is an underscore delimited string (e.g. `clinical_views`). Then in the `title` property of the `registerBreadcrumbs` invocation, we replace the underscores from the string with spaces and capitalize the result. 

With this, we end up with `Vitals and biometrics dashboard` instead of `Vitalsandbiometrics Dashboard` in the current case.

## Screenshots

> Before
<img width="363" alt="image" src="https://user-images.githubusercontent.com/8509731/154356377-816c3609-b19a-4a3d-8fe6-08321021dce0.png">

> After

> Dashboard names consisting of more than one word 
<img width="314" alt="Screenshot 2022-02-16 at 23 35 45" src="https://user-images.githubusercontent.com/8509731/154355645-c0246bab-b89a-43b6-8f4c-06e650d11cf1.png">
<img width="372" alt="Screenshot 2022-02-16 at 23 35 29" src="https://user-images.githubusercontent.com/8509731/154355672-4c808fc4-8a4c-47d7-bd8f-0ae8269d5173.png">
<img width="333" alt="Screenshot 2022-02-16 at 23 35 23" src="https://user-images.githubusercontent.com/8509731/154355689-20980ffa-16e2-4ae7-84ba-24077dacc577.png">

> One word dashboard names (these remain as before)
<img width="322" alt="Screenshot 2022-02-16 at 23 35 16" src="https://user-images.githubusercontent.com/8509731/154355710-f513cc05-d859-4595-8786-df9f94e0b147.png">
<img width="287" alt="Screenshot 2022-02-16 at 23 35 39" src="https://user-images.githubusercontent.com/8509731/154355960-c5e87455-7ef7-42f3-893e-7593435ab97b.png">

