### PR TITLE
(fix) The intermittent 'Cannot redeclare block-scoped variable' type error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,9 @@
     ],
     "resolveJsonModule": true,
     "noEmit": true,
-    "target": "esnext"
+    "target": "esnext",
+    "paths": {
+      "@openmrs/*": ["./node_modules/@openmrs/*"]
+    }
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Prevents this error:

```
 Error: ../../node_modules/@openmrs/esm-framework/node_modules/@openmrs/esm-globals/src/types.ts(51,9): error TS2451: Cannot redeclare block-scoped variable '__webpack_init_sharing__'.
```
