### PR TITLE
(feat) O3-1038 Workspace system should allow notifying with unsaved changes

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergies-form.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergies-form.test.tsx
@@ -108,6 +108,7 @@ describe('AllergiesForm: ', () => {
 
 const testProps = {
   closeWorkspace: () => {},
+  promptBeforeClosing: (testFcn) => {},
   patient: mockPatient,
   patientUuid: mockPatient.id,
 };

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
@@ -37,7 +37,7 @@ enum AllergenTypes {
   ENVIRONMENT = 'ENVIRONMENT',
 }
 
-const AllergyForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, patientUuid }) => {
+const AllergyForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, promptBeforeClosing, patientUuid }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const { concepts } = useConfig();
@@ -65,6 +65,22 @@ const AllergyForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, patientU
   const [severityOfWorstReaction, setSeverityOfWorstReaction] = useState('');
   const allergenTypes = [t('drug', 'Drug'), t('food', 'Food'), t('environmental', 'Environmental')];
   const severityLevels = [t('mild', 'Mild'), t('moderate', 'Moderate'), t('severe', 'Severe')];
+
+  useEffect(() => {
+    promptBeforeClosing(() => {
+      return Boolean(
+        nonCodedAllergenType || nonCodedAllergicReaction || onsetDate || selectedAllergen || severityOfWorstReaction,
+      );
+    });
+  }, [
+    promptBeforeClosing,
+    nonCodedAllergenType,
+    nonCodedAllergicReaction,
+    onsetDate,
+    selectedAllergen,
+    selectedAllergenType,
+    severityOfWorstReaction,
+  ]);
 
   useEffect(() => {
     const allergenUuids = [drugAllergenUuid, foodAllergenUuid, environmentalAllergenUuid, allergyReactionUuid];
@@ -114,7 +130,7 @@ const AllergyForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, patientU
         severity: {
           uuid: severityOfWorstReaction,
         },
-        comment: comment,
+        comment,
         reactions: allergicReactions?.map((reaction) => {
           return reaction === otherConceptUuid
             ? { reaction: { uuid: reaction }, reactionNonCoded: nonCodedAllergicReaction }

--- a/packages/esm-patient-chart-app/src/workspace/workspace-renderer.component.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-renderer.component.tsx
@@ -31,15 +31,15 @@ export function WorkspaceRenderer({ workspace, patientUuid, active }: WorkspaceR
     };
   }, [workspace]);
 
-  const closeWorkspace = React.useMemo(() => workspace?.closeWorkspace, [workspace]);
   const props = React.useMemo(
     () =>
       workspace && {
-        closeWorkspace,
+        closeWorkspace: workspace.closeWorkspace,
+        promptBeforeClosing: workspace.promptBeforeClosing,
         patientUuid,
         ...workspace.additionalProps,
       },
-    [workspace, workspace.additionalProps, patientUuid, closeWorkspace],
+    [workspace, workspace.additionalProps, workspace.closeWorkspace, workspace.promptBeforeClosing, patientUuid],
   );
 
   return (

--- a/packages/esm-patient-common-lib/src/types/workspace.ts
+++ b/packages/esm-patient-common-lib/src/types/workspace.ts
@@ -10,5 +10,10 @@ export enum WorkspaceWindowState {
 /** The default parameters received by all workspaces */
 export interface DefaultWorkspaceProps {
   closeWorkspace(): void;
+  /**
+   * Call this with a no-args function that returns true if the user should be prompted before
+   * this workspace is closed; e.g. if there is unsaved data.
+   */
+  promptBeforeClosing(testFcn: () => boolean): void;
   patientUuid: string;
 }

--- a/packages/esm-patient-common-lib/src/workspaces/useWorkspaces.tsx
+++ b/packages/esm-patient-common-lib/src/workspaces/useWorkspaces.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import {
-  getWorkspaceStore,
-  closeWorkspace,
-  OpenWorkspace,
-  WorkspaceWindowState,
-} from '@openmrs/esm-patient-common-lib';
+import { getWorkspaceStore, OpenWorkspace, WorkspaceWindowState } from '@openmrs/esm-patient-common-lib';
 import { Prompt, WorkspaceStoreState } from './workspaces';
 
 export interface WorkspacesInfo {
@@ -20,7 +15,7 @@ export function useWorkspaces(): WorkspacesInfo {
 
   useEffect(() => {
     function update(state: WorkspaceStoreState) {
-      setWorkspaces(state.openWorkspaces.map((w) => ({ ...w, closeWorkspace: () => closeWorkspace(w.name) })));
+      setWorkspaces(state.openWorkspaces);
       setPrompt(state.prompt);
     }
     update(getWorkspaceStore().getState());
@@ -30,7 +25,7 @@ export function useWorkspaces(): WorkspacesInfo {
   const windowState = useMemo(() => {
     if (workspaces.length === 0) {
       return WorkspaceWindowState.hidden;
-    } else if (workspaces.length === 1) {
+    } else {
       return workspaces[0].preferredWindowSize;
     }
   }, [workspaces]);

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.test.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.test.ts
@@ -82,6 +82,23 @@ describe('workspace system', () => {
     expect(store.getState().openWorkspaces[0].name).toBe('order-meds');
   });
 
+  test("respects promptBeforeClosing function", () => {
+    const store = getWorkspaceStore();
+    registerWorkspace({ name: 'hiv', title: 'HIV', load: jest.fn() });
+    registerWorkspace({ name: 'diabetes', title: 'Diabetes', load: jest.fn() });
+    launchPatientWorkspace('hiv');
+    store.getState().openWorkspaces[0].promptBeforeClosing(() => false);
+    launchPatientWorkspace('diabetes');
+    expect(store.getState().prompt).toBeNull();
+    expect(store.getState().openWorkspaces[0].name).toBe("diabetes");
+    store.getState().openWorkspaces[0].promptBeforeClosing(() => true);
+    launchPatientWorkspace('hiv');
+    expect(store.getState().openWorkspaces[0].name).toBe("diabetes");
+    expect(store.getState().prompt.title).toMatch(/active form open/);
+    store.getState().prompt.onConfirm();
+    expect(store.getState().openWorkspaces[0].name).toBe("hiv");
+  });
+
   test('is compatible with workspaces registered as extensions', () => {
     const store = getWorkspaceStore();
     registerExtension('lab-results', {

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.test.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.test.ts
@@ -82,7 +82,7 @@ describe('workspace system', () => {
     expect(store.getState().openWorkspaces[0].name).toBe('order-meds');
   });
 
-  test("respects promptBeforeClosing function", () => {
+  test('respects promptBeforeClosing function', () => {
     const store = getWorkspaceStore();
     registerWorkspace({ name: 'hiv', title: 'HIV', load: jest.fn() });
     registerWorkspace({ name: 'diabetes', title: 'Diabetes', load: jest.fn() });
@@ -90,13 +90,13 @@ describe('workspace system', () => {
     store.getState().openWorkspaces[0].promptBeforeClosing(() => false);
     launchPatientWorkspace('diabetes');
     expect(store.getState().prompt).toBeNull();
-    expect(store.getState().openWorkspaces[0].name).toBe("diabetes");
+    expect(store.getState().openWorkspaces[0].name).toBe('diabetes');
     store.getState().openWorkspaces[0].promptBeforeClosing(() => true);
     launchPatientWorkspace('hiv');
-    expect(store.getState().openWorkspaces[0].name).toBe("diabetes");
+    expect(store.getState().openWorkspaces[0].name).toBe('diabetes');
     expect(store.getState().prompt.title).toMatch(/active form open/);
     store.getState().prompt.onConfirm();
-    expect(store.getState().openWorkspaces[0].name).toBe("hiv");
+    expect(store.getState().openWorkspaces[0].name).toBe('hiv');
   });
 
   test('is compatible with workspaces registered as extensions', () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Adds a mechanism for workspaces to toggle whether or not to prompt before opening another workspace.

Default behavior is the same as what happens currently.

Usage is as demonstrated in the Allergies form in this PR:

```typescript
 useEffect(() => {
    promptBeforeClosing(() => Boolean(input1 || input2));
  }, [promptBeforeClosing, input1, input2]);
```

### Note

I chose to implement this like this to allow for the theoretical possibility of performance optimizations via uncontrolled state, e.g.

```tsx
const inputText = useRef('');

useEffect(() => {
  promptBeforeClosing(() => Boolean(inputText.current));
}, [promptBeforeClosing]);
```

So in this example the `inputText` would only be checked when `promptBeforeClosing` is called.

This might never be used this way, and so might never matter. But anyway it's not really any more complicated than the alternative API I considered:

```tsx
const [text, setText] = useState();

useEffect(() => {
  setPromptBeforeClosing(Boolean(text));
}, [setPromptBeforeClosing, text]);
```

## Screenshots

![Peek 2022-02-17 19-05](https://user-images.githubusercontent.com/1031876/154609863-5781695f-c6cb-4cb4-a5ea-d3f6e8133a6e.gif)

## Issue

https://issues.openmrs.org/browse/O3-1038
