### PR TITLE
(fix) active-medications workspace not opening

### DIFF
--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Provider } from 'unistore/react';
 import { orderBasketStore } from './order-basket-store';
 import { DataTableSkeleton } from 'carbon-components-react';
-import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
+import { EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { attach } from '@openmrs/esm-framework';
 import { usePatientOrders } from '../api/api';
 
@@ -22,7 +22,7 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, show
   const { data: activePatientOrders, isError, isLoading, isValidating } = usePatientOrders(patientUuid, 'ACTIVE');
 
   const launchOrderBasket = React.useCallback(() => {
-    attach('patient-chart-workspace-slot', 'order-basket-workspace');
+    launchPatientWorkspace('order-basket-workspace');
   }, []);
 
   if (isLoading) return <DataTableSkeleton role="progressbar" />;

--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import MedicationsDetailsTable from '../components/medications-details-table.component';
-import styles from './active-medications.scss';
 import { useTranslation } from 'react-i18next';
 import { Provider } from 'unistore/react';
 import { orderBasketStore } from './order-basket-store';
 import { DataTableSkeleton } from 'carbon-components-react';
 import { EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { attach } from '@openmrs/esm-framework';
 import { usePatientOrders } from '../api/api';
 
 interface ActiveMedicationsProps {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

The order basket wasn't opening from the summary page. It was using the old `attach` syntax. Not sure how that happened.
