### PR TITLE
O3-1116: Update test-result observation request count

### DIFF
--- a/packages/esm-patient-test-results-app/src/loadPatientTestData/helpers.ts
+++ b/packages/esm-patient-test-results-app/src/loadPatientTestData/helpers.ts
@@ -7,8 +7,8 @@ import {
   OBSERVATION_INTERPRETATION,
 } from '@openmrs/esm-patient-common-lib';
 
-const PAGE_SIZE = 100;
-const CHUNK_PREFETCH_COUNT = 6;
+const PAGE_SIZE = 300;
+const CHUNK_PREFETCH_COUNT = 1;
 
 const retrieveFromIterator = <T>(iteratorOrIterable: IterableIterator<T>, length: number): Array<T | undefined> => {
   const iterator = iteratorOrIterable[Symbol.iterator]();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Currently, the esm-test-results loadPatientData makes 6 Observation requests with the size of 100 even if the total is less than 100.  
I updated the count and the number of chunks to prefetch the first 300 objects with a single request. If the total is bigger than 300, it will request the remaining objects in chunks of 300.

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

![image](https://user-images.githubusercontent.com/27498587/155022938-4fab86ed-119c-44e6-91a4-1d942ce6a590.png)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

https://issues.openmrs.org/browse/O3-1116
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
