### PR TITLE
O3-1105: (feat) Add metadata to visit notes display

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { openmrsFetch, useConfig, usePagination } from '@openmrs/esm-framework';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { mockVisitNotes, formattedVisitNotes } from '../../../../__mocks__/visit-notes.mock';
@@ -118,6 +119,14 @@ describe('NotesOverview: ', () => {
     );
 
     expect(screen.getAllByRole('row').length).toEqual(6);
+
+    // Expanding a row displays any associated visit notes
+    userEvent.click(screen.getAllByRole('button', { name: /expand current row/i })[0]);
+    expect(screen.getByText(/No visit note to display/i)).toBeInTheDocument();
+
+    // Collapsing the row hides the visit note
+    userEvent.click(screen.getByRole('button', { name: /collapse current row/i }));
+    expect(screen.queryByText(/No visit note to display/i)).not.toBeInTheDocument();
   });
 });
 

--- a/packages/esm-patient-notes-app/src/notes/notes-pagination.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-pagination.component.tsx
@@ -87,11 +87,12 @@ const NotesPagination: React.FC<FormsProps> = ({ notes, pageSize, pageUrl, urlLa
                             <div className={styles.copy}>
                               <span className={styles.content}>{tableRows?.[i]?.encounterNote}</span>
                               <span className={styles.metadata}>
-                                {formatTime(new Date(tableRows?.[i]?.encounterNoteRecordedAt))}
+                                {formatTime(new Date(tableRows?.[i]?.encounterNoteRecordedAt))} &middot;{' '}
+                                {tableRows?.[i]?.encounterProvider}, {tableRows?.[i]?.encounterProviderRole}
                               </span>
                             </div>
                           ) : (
-                            <span className={styles.copy}>{t('noVisitNoteToDisplay', 'No Visit Note to display')}</span>
+                            <span className={styles.copy}>{t('noVisitNoteToDisplay', 'No visit note to display')}</span>
                           )}
                         </div>
                       </TableExpandedRow>

--- a/packages/esm-patient-notes-app/src/types/index.ts
+++ b/packages/esm-patient-notes-app/src/types/index.ts
@@ -6,8 +6,9 @@ export interface RESTPatientNote {
   uuid: string;
   display: string;
   encounterDatetime: string;
-  location: { uuid: string; display: string; name: string };
   encounterType: { name: string; uuid: string };
+  encounterProviders: [{ encounterRole: { uuid: string; display: string }; provider: { person: { display: string } } }];
+  location: { uuid: string; display: string; name: string };
   auditInfo: {
     creator: any;
     uuid: string;
@@ -17,7 +18,6 @@ export interface RESTPatientNote {
     changedBy?: any;
     dateChanged?: Date;
   };
-  encounterProviders: [{ provider: { person: { display: string } } }];
   obs: Array<ObsData>;
 }
 
@@ -27,6 +27,8 @@ export interface PatientNote {
   encounterDate: string;
   encounterNote: string;
   encounterNoteRecordedAt: string;
+  encounterProvider: string;
+  encounterProviderRole: string;
 }
 
 export interface DiagnosisData {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary
 
This PR is a follow-up to https://github.com/openmrs/openmrs-esm-patient-chart/pull/555. It adds the following metadata about a visit note to the visit notes widget:
    
- The encounter provider.
- Their role.

## Screenshots

![image](https://user-images.githubusercontent.com/8509731/155324175-c14481eb-9bc2-40dc-b74a-68cac6cc8101.png)