### PR TITLE
(fix): Fix styling of the recorded date in the vitals header

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
@@ -72,7 +72,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
               <WarningFilled20 title={'WarningFilled'} aria-label="Warning" className={styles['warning-icon']} />
             ) : null}
             <span className={styles.heading}>{t('vitalsAndBiometrics', 'Vitals and biometrics')}</span>
-            <span className={`${styles.bodyShort01} ${styles.text02}`}>
+            <span className={styles['body-text']}>
               {t('lastRecorded', 'Last recorded')}: {formatDate(parseDate(latestVitals?.date), { mode: 'wide' })}
             </span>
           </span>
@@ -184,9 +184,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
     <div className={styles['vitals-header']}>
       <span className={styles.container}>
         <span className={styles.heading}>{t('vitalsAndBiometrics', 'Vitals and biometrics')}</span>
-        <span className={styles['empty-state']}>
-          {t('noDataRecorded', 'No data has been recorded for this patient')}
-        </span>
+        <span className={styles['body-text']}>{t('noDataRecorded', 'No data has been recorded for this patient')}</span>
       </span>
 
       <div className={styles.container}>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
@@ -89,7 +89,7 @@
   @include carbon--type-style('body-short-01');
 }
 
-.empty-state {
-  @extend .record-vitals;
+.body-text {
+  @include carbon--type-style('body-short-01');
   color: $text-02;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the styling of the recorded date display in the vitals and biometrics header.

## Screenshots
> Before

<img width="1008" alt="Screenshot 2022-02-26 at 11 08 11" src="https://user-images.githubusercontent.com/8509731/155835669-d1ce065e-1bac-42b0-9ebf-00fbc1c42e21.png">

> After

<img width="1008" alt="Screenshot 2022-02-26 at 11 04 23" src="https://user-images.githubusercontent.com/8509731/155835696-50c20115-9aed-419c-a014-de710616967b.png">


## Related Issue
<!-- https://issues.openmrs.org/browse/O3-1103
