### PR TITLE
(fix): Fix encounter note metadata display

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/notes-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/notes-summary.component.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import styles from '../visit-detail-overview.scss';
-import { Note } from '../visit.resource';
 import { useTranslation } from 'react-i18next';
-import capitalize from 'lodash-es/capitalize';
+import { Note } from '../visit.resource';
+import styles from '../visit-detail-overview.scss';
 
 interface NotesSummaryProps {
   notes: Array<Note>;
@@ -13,12 +12,13 @@ const NotesSummary: React.FC<NotesSummaryProps> = ({ notes }) => {
 
   return (
     <React.Fragment>
-      {notes.length > 0 ? (
+      {notes.length ? (
         notes.map((note: Note, i) => (
           <div className={styles.notesContainer} key={i}>
             <p className={`${styles.noteText} ${styles.bodyLong01}`}>{note.note}</p>
             <p className={styles.metadata}>
-              {note.time} &middot; {note.provider.name}, {note.provider.role}
+              {note.time} {note.provider.name ? <span>&middot; {note.provider.name} </span> : null}
+              {note.provider.role ? <span>&middot; {note.provider.role}</span> : null}
             </p>
           </div>
         ))

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -69,7 +69,7 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ encounters, patientUuid }) 
               name: enc.encounterProviders.length ? enc.encounterProviders[0].provider.person.display : '',
               role: enc.encounterProviders.length ? enc.encounterProviders[0].encounterRole.display : '',
             },
-            time: formatTime(parseDate(obs.obsDatetime)),
+            time: enc.encounterDatetime ? formatTime(parseDate(enc.encounterDatetime)) : '',
             concept: obs.concept,
           });
         }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This fixes the way encounter note metadata gets displayed in visit summary cards.

## Screenshots

> Before
<img width="941" alt="Screenshot 2022-02-26 at 12 31 59" src="https://user-images.githubusercontent.com/8509731/155838291-0f46a359-8f26-4904-82c9-c69255b4fb5b.png">

> After
<img width="926" alt="Screenshot 2022-02-26 at 12 39 31" src="https://user-images.githubusercontent.com/8509731/155838303-863a9cc1-fdcb-4995-b193-5eddea3bf073.png">

<img width="928" alt="Screenshot 2022-02-26 at 12 40 09" src="https://user-images.githubusercontent.com/8509731/155838314-ded151cb-8b6b-4ddc-8755-4df7f29218fc.png">

## Related Issue
 https://issues.openmrs.org/browse/O3-1114