### PR TITLE
(docs) Remove errant comma from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 - [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
 - [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
-- [ ] My work includes tests, or is validated by existing tests.
+- [ ] My work includes tests or is validated by existing tests.
 
 ## Summary
 <!-- Please describe what problems your PR addresses. -->


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests, or is validated by existing tests.

## Related Issue
https://github.com/openmrs/openmrs-esm-core/pull/339