### PR TITLE
(feat) Paginate medications widget

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -9,7 +9,6 @@ import {
   InlineLoading,
   OverflowMenu,
   OverflowMenuItem,
-  Pagination,
   Table,
   TableBody,
   TableCell,
@@ -225,18 +224,6 @@ const MedicationsDetailsTable = connect<
             )}
           </DataTable>
         </TableContainer>
-        <div className={styles.paginationContainer}>
-          <Pagination
-            page={page}
-            pageSize={pageSize}
-            pageSizes={[10, 20, 30, 40, 50]}
-            totalItems={medications.length}
-            onChange={({ page, pageSize }) => {
-              setPage(page);
-              setPageSize(pageSize);
-            }}
-          />
-        </div>
       </div>
     );
   },

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.scss
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.scss
@@ -2,6 +2,7 @@
 
 .widgetCard {
   border: 1px solid $ui-03;
+  border-bottom: none;
 }
 
 .row {
@@ -49,7 +50,7 @@
 }
 
 .paginationContainer {
-  border-top: 1px solid $ui-03;
+  border: 1px solid $ui-03;
 
   & > :global(.bx--pagination) {
     border: none;

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -3,14 +3,17 @@ import FloatingOrderBasketButton from './floating-order-basket-button.component'
 import MedicationsDetailsTable from '../components/medications-details-table.component';
 import { DataTableSkeleton } from 'carbon-components-react';
 import { useTranslation } from 'react-i18next';
-import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
+import { usePagination } from '@openmrs/esm-framework';
+import { EmptyState, ErrorState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import { usePatientOrders } from '../api/api';
+import styles from './medications-summary.scss';
 
 export interface MedicationsSummaryProps {
   patientUuid: string;
 }
 
 export default function MedicationsSummary({ patientUuid }: MedicationsSummaryProps) {
+  const orderCount = 5;
   const { t } = useTranslation();
 
   const {
@@ -26,6 +29,18 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
     isValidating: isValidatingPastOrders,
   } = usePatientOrders(patientUuid, 'any');
 
+  const {
+    results: paginatedActiveOrders,
+    goTo: goToActiveOrdersPage,
+    currentPage: currentPageActiveOrders,
+  } = usePagination(activeOrders ?? [], orderCount);
+
+  const {
+    results: paginatedPastOrders,
+    goTo: goToPastOrdersPage,
+    currentPage: currentPagePastOrders,
+  } = usePagination(pastOrders ?? [], orderCount);
+
   return (
     <>
       <div style={{ marginBottom: '1.5rem' }}>
@@ -37,15 +52,26 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
           if (isErrorActiveOrders) return <ErrorState error={isErrorActiveOrders} headerTitle={headerTitle} />;
           if (activeOrders?.length) {
             return (
-              <MedicationsDetailsTable
-                isValidating={isValidatingActiveOrders}
-                title={t('activeMedications', 'Active Medications')}
-                medications={activeOrders}
-                showDiscontinueButton={true}
-                showModifyButton={true}
-                showReorderButton={false}
-                showAddNewButton={false}
-              />
+              <>
+                <MedicationsDetailsTable
+                  isValidating={isValidatingActiveOrders}
+                  title={t('activeMedications', 'Active Medications')}
+                  medications={paginatedActiveOrders}
+                  showDiscontinueButton={true}
+                  showModifyButton={true}
+                  showReorderButton={false}
+                  showAddNewButton={false}
+                />
+                <div className={styles.paginationContainer}>
+                  <PatientChartPagination
+                    currentItems={paginatedActiveOrders.length}
+                    onPageNumberChange={({ page }) => goToActiveOrdersPage(page)}
+                    pageNumber={currentPageActiveOrders}
+                    pageSize={orderCount}
+                    totalItems={activeOrders.length}
+                  />
+                </div>
+              </>
             );
           }
           return <EmptyState displayText={displayText} headerTitle={headerTitle} />;
@@ -60,15 +86,26 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
           if (isErrorPastOrders) return <ErrorState error={isErrorPastOrders} headerTitle={headerTitle} />;
           if (pastOrders?.length) {
             return (
-              <MedicationsDetailsTable
-                isValidating={isValidatingPastOrders}
-                title={t('pastMedications', 'Past Medications')}
-                medications={pastOrders}
-                showDiscontinueButton={true}
-                showModifyButton={true}
-                showReorderButton={false}
-                showAddNewButton={false}
-              />
+              <>
+                <MedicationsDetailsTable
+                  isValidating={isValidatingPastOrders}
+                  title={t('pastMedications', 'Past Medications')}
+                  medications={paginatedPastOrders}
+                  showDiscontinueButton={true}
+                  showModifyButton={true}
+                  showReorderButton={false}
+                  showAddNewButton={false}
+                />
+                <div className={styles.paginationContainer}>
+                  <PatientChartPagination
+                    currentItems={paginatedPastOrders.length}
+                    onPageNumberChange={({ page }) => goToPastOrdersPage(page)}
+                    pageNumber={currentPagePastOrders}
+                    pageSize={orderCount}
+                    totalItems={pastOrders.length}
+                  />
+                </div>
+              </>
             );
           }
           return <EmptyState displayText={displayText} headerTitle={headerTitle} />;

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.scss
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.scss
@@ -1,1 +1,10 @@
 @import "../root.scss";
+
+.paginationContainer {
+  border: 1px solid $ui-03;
+  border-top: none;
+
+  & > :global(.bx--pagination) {
+    border: none;
+  }
+}

--- a/packages/esm-patient-medications-app/src/medications/active-medications.scss
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.scss
@@ -3,3 +3,8 @@
 .title {
   @extend .productiveHeading03;
 }
+
+.paginationContainer {
+  border: 1px solid $ui-03;
+  border-top: none;
+}

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket.scss
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket.scss
@@ -21,7 +21,9 @@
 
 .activeMedicationsContainer {
   border: 1px solid $ui-03;
+  border-bottom: none;
 }
+  
 
 .tablet {
   padding: 1.5rem 1rem;
@@ -51,5 +53,15 @@
 :global(.omrs-breakpoint-lt-desktop) {
   .container {
     height: calc(100vh - 6rem);
+  }
+}
+
+.paginationContainer {
+  border: 1px solid $ui-03;
+  border-top: none;
+  overflow-x: hidden;
+
+  & > :global(.bx--pagination) {
+    border: none;
   }
 }

--- a/packages/esm-patient-medications-app/translations/en.json
+++ b/packages/esm-patient-medications-app/translations/en.json
@@ -67,6 +67,7 @@
   "searchForAnOrder": "Search for an order above",
   "searchResultsExactMatchesForTerm": "{count} exact match(es) for \"{searchTerm}\"",
   "searchResultsExactMatchesForTerm_plural": "{count} exact match(es) for \"{searchTerm}\"",
+  "seeAll": "See all",
   "signAndClose": "Sign and close",
   "startDate": "Start date",
   "takeAsNeeded": "Take As Needed",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 style guide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR makes the following changes to the medications widget:

- Replaces the stock carbon pagination in the Active Medications widget with our custom PatientChartPagination component. This brings the look and feel of the component in line with the rest of the widgets in the patient chart.
- Adds pagination to both the active and past medications widgets in the orders dashboard.
- Adds pagination to the active medications table displayed in the order basket as well.

## Screenshots
<img width="940" alt="image" src="https://user-images.githubusercontent.com/8509731/156178511-a1585c48-01a5-4e47-8f48-9c273ddf3ede.png">

<img width="901" alt="Screenshot 2022-03-01 at 16 35 06" src="https://user-images.githubusercontent.com/8509731/156178688-bfb2d18a-de07-4a6f-a756-a37483e04f7b.png">

<img width="822" alt="Screenshot 2022-03-01 at 16 36 14" src="https://user-images.githubusercontent.com/8509731/156178837-35a00464-9f5a-4b6f-bb08-587a97df8e9c.png">

