### PR TITLE
(feat) Remove pagination from medications widget

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import Add16 from '@carbon/icons-react/es/add/16';
 import User16 from '@carbon/icons-react/es/user/16';
 import capitalize from 'lodash-es/capitalize';
@@ -9,7 +9,6 @@ import {
   InlineLoading,
   OverflowMenu,
   OverflowMenuItem,
-  Pagination,
   Table,
   TableBody,
   TableCell,
@@ -22,7 +21,6 @@ import {
 import { getDosage } from '../utils/get-dosage';
 import { useTranslation } from 'react-i18next';
 import { compare } from '../utils/compare';
-import { paginate } from '../utils/pagination';
 import { connect } from 'unistore/react';
 import { OrderBasketStore, OrderBasketStoreActions, orderBasketStoreActions } from '../medications/order-basket-store';
 import { Order } from '../types/order';
@@ -62,10 +60,6 @@ const MedicationsDetailsTable = connect<
     setItems,
   }: ActiveMedicationsProps & OrderBasketStore & OrderBasketStoreActions) => {
     const { t } = useTranslation();
-    const [page, setPage] = useState(1);
-    const [pageSize, setPageSize] = useState(10);
-    const [paginatedMedications] = paginate(medications, page, pageSize);
-
     const openOrderBasket = React.useCallback(() => launchPatientWorkspace('order-basket-workspace'), []);
 
     const tableHeaders = [
@@ -83,7 +77,7 @@ const MedicationsDetailsTable = connect<
       },
     ];
 
-    const tableRows = paginatedMedications.map((medication, id) => ({
+    const tableRows = medications?.map((medication, id) => ({
       id: `${id}`,
       details: {
         sortKey: medication.drug?.name,
@@ -174,69 +168,56 @@ const MedicationsDetailsTable = connect<
             </Button>
           )}
         </CardHeader>
-        <TableContainer data-floating-menu-container>
-          <DataTable
-            size="short"
-            headers={tableHeaders}
-            rows={tableRows}
-            isSortable={true}
-            sortRow={sortRow}
-            overflowMenuOnHover={false}
-          >
-            {({ rows, headers, getTableProps, getHeaderProps, getRowProps }) => (
-              <>
-                <Table {...getTableProps()} useZebraStyles>
-                  <TableHead>
-                    <TableRow>
-                      {headers.map((header) => (
-                        <TableHeader
-                          {...getHeaderProps({
-                            header,
-                            isSortable: header.isSortable,
-                          })}
-                        >
-                          {header.header}
-                        </TableHeader>
-                      ))}
-                      <TableHeader />
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {rows.map((row, rowIndex) => (
-                      <TableRow className={styles.row} {...getRowProps({ row })}>
-                        {row.cells.map((cell) => (
-                          <TableCell key={cell.id}>{cell.value?.content ?? cell.value}</TableCell>
-                        ))}
-                        <TableCell className="bx--table-column-menu">
-                          <OrderBasketItemActions
-                            showDiscontinueButton={showDiscontinueButton}
-                            showModifyButton={showModifyButton}
-                            showReorderButton={showReorderButton}
-                            medication={medications[rowIndex]}
-                            items={items}
-                            setItems={setItems}
-                          />
-                        </TableCell>
-                      </TableRow>
+        <DataTable
+          data-floating-menu-container
+          size="short"
+          headers={tableHeaders}
+          rows={tableRows}
+          isSortable={true}
+          sortRow={sortRow}
+          overflowMenuOnHover={false}
+        >
+          {({ rows, headers, getTableProps, getHeaderProps, getRowProps }) => (
+            <TableContainer>
+              <Table {...getTableProps()} useZebraStyles>
+                <TableHead>
+                  <TableRow>
+                    {headers.map((header) => (
+                      <TableHeader
+                        {...getHeaderProps({
+                          header,
+                          isSortable: header.isSortable,
+                        })}
+                      >
+                        {header.header}
+                      </TableHeader>
                     ))}
-                  </TableBody>
-                </Table>
-              </>
-            )}
-          </DataTable>
-        </TableContainer>
-        <div className={styles.paginationContainer}>
-          <Pagination
-            page={page}
-            pageSize={pageSize}
-            pageSizes={[10, 20, 30, 40, 50]}
-            totalItems={medications.length}
-            onChange={({ page, pageSize }) => {
-              setPage(page);
-              setPageSize(pageSize);
-            }}
-          />
-        </div>
+                    <TableHeader />
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.map((row, rowIndex) => (
+                    <TableRow className={styles.row} {...getRowProps({ row })}>
+                      {row.cells.map((cell) => (
+                        <TableCell key={cell.id}>{cell.value?.content ?? cell.value}</TableCell>
+                      ))}
+                      <TableCell className="bx--table-column-menu">
+                        <OrderBasketItemActions
+                          showDiscontinueButton={showDiscontinueButton}
+                          showModifyButton={showModifyButton}
+                          showReorderButton={showReorderButton}
+                          medication={medications[rowIndex]}
+                          items={items}
+                          setItems={setItems}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </DataTable>
       </div>
     );
   },

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.scss
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.scss
@@ -47,11 +47,3 @@
 .menuItem {
   max-width: none;
 }
-
-.paginationContainer {
-  border-top: 1px solid $ui-03;
-
-  & > :global(.bx--pagination) {
-    border: none;
-  }
-}

--- a/packages/esm-patient-medications-app/src/medications/active-medications.test.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { openmrsFetch } from '@openmrs/esm-framework';
+import { screen, within } from '@testing-library/react';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { mockDrugOrders } from '../../../../__mocks__/medication.mock';
 import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
-import { openmrsFetch } from '@openmrs/esm-framework';
 import ActiveMedications from './active-medications.component';
 
 const testProps = {
@@ -14,7 +14,41 @@ const testProps = {
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
 describe('ActiveMedications: ', () => {
-  test('renders the active medications widget', async () => {
+  test('renders an empty state view when there are no active medications to display', async () => {
+    mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
+
+    renderActiveMedications();
+
+    await waitForLoadingToFinish();
+
+    expect(screen.getByRole('heading', { name: /active medications/i })).toBeInTheDocument();
+    expect(screen.getByTitle(/empty data illustration/i)).toBeInTheDocument();
+    expect(screen.getByText(/There are no active medications to display for this patient/i)).toBeInTheDocument();
+    expect(screen.getByText(/Record active medications/i)).toBeInTheDocument();
+  });
+
+  test('renders an error state view if there is a problem fetching medications data', async () => {
+    const error = {
+      message: 'You are not logged in',
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+      },
+    };
+
+    mockOpenmrsFetch.mockRejectedValueOnce(error);
+
+    renderActiveMedications();
+
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /medications/i })).toBeInTheDocument();
+    expect(screen.getByText(/Error 401: Unauthorized/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sorry, there was a problem displaying this information/i)).toBeInTheDocument();
+  });
+
+  test('renders a tabular overview of the active medications recorded for a patient', async () => {
     mockOpenmrsFetch.mockReturnValueOnce(mockDrugOrders);
 
     renderActiveMedications();
@@ -22,13 +56,24 @@ describe('ActiveMedications: ', () => {
     await waitForLoadingToFinish();
 
     expect(screen.getByRole('heading', { name: /active medications/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /previous page/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add/i })).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    expect(screen.getByRole('table')).toBeInTheDocument();
 
     const expectedColumnHeaders = [/start date/, /details/];
     expectedColumnHeaders.forEach((header) => {
       expect(screen.getByRole('columnheader', { name: new RegExp(header, 'i') })).toBeInTheDocument();
     });
+
+    const expectedTableRows = [
+      /09-Sept-2021 -- Aspirin — 81mg — tablet DOSE 81 mg — oral — once daily — indefinite duration/,
+      /09-Sept-2021 -- Efavirenz — 600mg — tablet DOSE 600 mg — oral — once daily — indefinite duration/,
+    ];
+
+    expectedTableRows.map((row) =>
+      expect(within(table).getByRole('row', { name: new RegExp(row, 'i') })).toBeInTheDocument(),
+    );
   });
 });
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

The original scope of this feature involved replacing the stock Carbon pagination used in the medications widget with our custom `PatientChartPagination` component.

Instead, Ciaran's guidance is that the medications widget shouldn't have pagination controls anyway. This change is corroborated by the [designs](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d5e12ebc329c17022caf7e) as well.

This PR effects that change in addition to making minor code improvements and adding tests.

## Screenshots

<img width="888" alt="Screenshot 2022-03-02 at 15 51 45" src="https://user-images.githubusercontent.com/8509731/156365268-c0083303-e7b2-49ab-aa7e-7b7c6252357e.png">

<img width="910" alt="Screenshot 2022-03-02 at 15 51 26" src="https://user-images.githubusercontent.com/8509731/156365275-8eca742b-aa51-4d56-ae90-136df075b885.png">

