### PR TITLE
(feat) Timeline Results Grouping O3-1060

### DIFF
--- a/packages/esm-patient-test-results-app/src/config-schema.ts
+++ b/packages/esm-patient-test-results-app/src/config-schema.ts
@@ -1,3 +1,35 @@
-export const configSchema = {};
+import { Type } from '@openmrs/esm-framework';
 
-export interface ConfigObject {}
+export const configSchema = {
+  concepts: {
+    _type: Type.Array,
+    _elements: {
+      conceptUuid: {
+        _type: Type.UUID,
+        _description: 'UUID of concept to load from /obstree',
+      },
+      defaultOpen: {
+        _type: Type.Boolean,
+        _description: 'Set default behavior of filter accordion',
+      },
+    },
+    _default: [
+      {
+        conceptUuid: '5035a431-51de-40f0-8f25-4a98762eb796',
+        defaultOpen: false,
+      },
+      {
+        conceptUuid: '5566957d-9144-4fc5-8700-1882280002c1',
+        defaultOpen: true,
+      },
+    ],
+  },
+};
+
+export interface ObsTreeEntry {
+  conceptUuid: string;
+  defaultOpen: boolean;
+}
+export interface ConfigObject {
+  concepts: Array<ObsTreeEntry>;
+}

--- a/packages/esm-patient-test-results-app/src/config-schema.ts
+++ b/packages/esm-patient-test-results-app/src/config-schema.ts
@@ -16,11 +16,19 @@ export const configSchema = {
     _default: [
       {
         conceptUuid: '5035a431-51de-40f0-8f25-4a98762eb796',
-        defaultOpen: false,
+        defaultOpen: true,
       },
       {
         conceptUuid: '5566957d-9144-4fc5-8700-1882280002c1',
-        defaultOpen: true,
+        defaultOpen: false,
+      },
+      {
+        conceptUuid: '36d88354-1081-40af-b70a-2c4981b31367',
+        defaultOpen: false,
+      },
+      {
+        conceptUuid: 'acb5bab3-af2a-47c4-a985-934fd0113589',
+        defaultOpen: false,
       },
     ],
   },

--- a/packages/esm-patient-test-results-app/src/filter/filter-context.tsx
+++ b/packages/esm-patient-test-results-app/src/filter/filter-context.tsx
@@ -6,7 +6,7 @@ import { TreeNode } from './filter-set';
 const initialState = {
   checkboxes: {},
   parents: {},
-  root: { display: '', flatName: '' },
+  roots: [{ display: '', flatName: '' }],
   tests: {},
   lowestParents: [],
 };
@@ -25,13 +25,13 @@ const initialContext = {
 interface StateProps {
   checkboxes: { [key: string]: boolean };
   parents: { [key: string]: string[] };
-  root: { [key: string]: any };
+  roots: { [key: string]: any }[];
 }
 interface FilterContextProps {
   state: StateProps;
   checkboxes: { [key: string]: boolean };
   parents: { [key: string]: string[] };
-  root: TreeNode;
+  roots: TreeNode[];
   tests: { [key: string]: any };
   lowestParents: { display: string; flatName: string }[];
   timelineData: { [key: string]: any };
@@ -43,7 +43,7 @@ interface FilterContextProps {
 }
 
 interface FilterProviderProps {
-  root: any;
+  roots: any[];
   children: React.ReactNode;
 }
 
@@ -53,12 +53,12 @@ interface obsShape {
 
 const FilterContext = createContext<FilterContextProps>(initialContext);
 
-const FilterProvider = ({ root, children }: FilterProviderProps) => {
+const FilterProvider = ({ roots, children }: FilterProviderProps) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const actions = useMemo(
     () => ({
-      initialize: (tree) => dispatch({ type: 'initialize', tree: tree }),
+      initialize: (trees) => dispatch({ type: 'initialize', trees: trees }),
       toggleVal: (name) => {
         dispatch({ type: 'toggleVal', name: name });
       },
@@ -107,10 +107,10 @@ const FilterProvider = ({ root, children }: FilterProviderProps) => {
   }, [activeTests, state.tests]);
 
   useEffect(() => {
-    if (root?.display && !Object.keys(state?.checkboxes).length) {
-      actions.initialize(root);
+    if (roots?.length && !Object.keys(state?.checkboxes).length) {
+      actions.initialize(roots);
     }
-  }, [actions, state, root]);
+  }, [actions, state, roots]);
 
   return (
     <FilterContext.Provider
@@ -118,7 +118,7 @@ const FilterProvider = ({ root, children }: FilterProviderProps) => {
         state,
         checkboxes: state.checkboxes,
         parents: state.parents,
-        root: state.root,
+        roots: state.roots,
         tests: state.tests,
         lowestParents: state.lowestParents,
         timelineData,

--- a/packages/esm-patient-test-results-app/src/filter/filter-context.tsx
+++ b/packages/esm-patient-test-results-app/src/filter/filter-context.tsx
@@ -1,23 +1,20 @@
 import React, { createContext, useReducer, useEffect, useMemo, useState } from 'react';
 import { parseTime } from '../timeline/useTimelineData';
 import reducer from './filter-reducer';
+import { TreeNode } from './filter-set';
 
 const initialState = {
   checkboxes: {},
   parents: {},
-  root: {},
+  root: { display: '', flatName: '' },
   tests: {},
 };
 
 const initialContext = {
   state: initialState,
-  checkboxes: {},
-  parents: {},
-  root: {},
-  tests: {},
+  ...initialState,
   timelineData: {},
   activeTests: [],
-  someChecked: false,
   initialize: () => {},
   toggleVal: () => {},
   updateParent: () => {},
@@ -32,11 +29,10 @@ interface FilterContextProps {
   state: StateProps;
   checkboxes: { [key: string]: boolean };
   parents: { [key: string]: string[] };
-  root: { [key: string]: any };
+  root: TreeNode;
   tests: { [key: string]: any };
   timelineData: { [key: string]: any };
   activeTests: string[];
-  someChecked: boolean;
   initialize: any;
   toggleVal: any;
   updateParent: any;
@@ -73,8 +69,6 @@ const FilterProvider = ({ root, children }: FilterProviderProps) => {
     return Object.keys(state?.checkboxes)?.filter((key) => state.checkboxes[key]) || [];
   }, [state.checkboxes]);
 
-  const someChecked = Boolean(activeTests.length);
-
   const timelineData = useMemo(() => {
     if (!state?.tests) {
       return {
@@ -82,9 +76,10 @@ const FilterProvider = ({ root, children }: FilterProviderProps) => {
         loaded: false,
       };
     }
-    const tests: obsShape = Object.fromEntries(
-      Object.entries(state.tests).filter(([name, entry]) => activeTests.includes(name)),
-    );
+    const tests: obsShape = activeTests?.length
+      ? Object.fromEntries(Object.entries(state.tests).filter(([name, entry]) => activeTests.includes(name)))
+      : state.tests;
+
     const allTimes = [
       ...new Set(
         Object.values(tests)
@@ -121,7 +116,6 @@ const FilterProvider = ({ root, children }: FilterProviderProps) => {
         tests: state.tests,
         timelineData,
         activeTests,
-        someChecked,
         initialize: actions.initialize,
         toggleVal: actions.toggleVal,
         updateParent: actions.updateParent,

--- a/packages/esm-patient-test-results-app/src/filter/filter-context.tsx
+++ b/packages/esm-patient-test-results-app/src/filter/filter-context.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useReducer, useEffect, useMemo } from 'react';
 import reducer from './filter-reducer';
-import mockConceptTree from '../hiv/mock-concept-tree';
 
 const initialState = {
   checkboxes: {},
@@ -35,12 +34,13 @@ interface FilterContextProps {
 
 interface FilterProviderProps {
   sortedObs: any; // this data structure will change later
+  root: any;
   children: React.ReactNode;
 }
 
 const FilterContext = createContext<FilterContextProps>(initialContext);
 
-const FilterProvider = ({ sortedObs, children }: FilterProviderProps) => {
+const FilterProvider = ({ sortedObs, root, children }: FilterProviderProps) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const actions = useMemo(
@@ -62,9 +62,9 @@ const FilterProvider = ({ sortedObs, children }: FilterProviderProps) => {
   useEffect(() => {
     const tests = (sortedObs && Object.keys(sortedObs)) || [];
     if (tests.length && !Object.keys(state?.checkboxes).length) {
-      actions.initialize(mockConceptTree);
+      actions.initialize(root);
     }
-  }, [sortedObs, actions, state]);
+  }, [sortedObs, actions, state, root]);
 
   return (
     <FilterContext.Provider

--- a/packages/esm-patient-test-results-app/src/filter/filter-context.tsx
+++ b/packages/esm-patient-test-results-app/src/filter/filter-context.tsx
@@ -8,6 +8,7 @@ const initialState = {
   parents: {},
   root: { display: '', flatName: '' },
   tests: {},
+  lowestParents: [],
 };
 
 const initialContext = {
@@ -15,6 +16,7 @@ const initialContext = {
   ...initialState,
   timelineData: {},
   activeTests: [],
+  someChecked: false,
   initialize: () => {},
   toggleVal: () => {},
   updateParent: () => {},
@@ -31,8 +33,10 @@ interface FilterContextProps {
   parents: { [key: string]: string[] };
   root: TreeNode;
   tests: { [key: string]: any };
+  lowestParents: { display: string; flatName: string }[];
   timelineData: { [key: string]: any };
   activeTests: string[];
+  someChecked: boolean;
   initialize: any;
   toggleVal: any;
   updateParent: any;
@@ -69,10 +73,12 @@ const FilterProvider = ({ root, children }: FilterProviderProps) => {
     return Object.keys(state?.checkboxes)?.filter((key) => state.checkboxes[key]) || [];
   }, [state.checkboxes]);
 
+  const someChecked = Boolean(activeTests.length);
+
   const timelineData = useMemo(() => {
     if (!state?.tests) {
       return {
-        data: { parsedTime: {} as ReturnType<typeof parseTime>, rowData: {}, panelName: '' },
+        data: { parsedTime: {} as ReturnType<typeof parseTime>, rowData: [], panelName: '' },
         loaded: false,
       };
     }
@@ -88,10 +94,10 @@ const FilterProvider = ({ root, children }: FilterProviderProps) => {
       ),
     ];
     allTimes.sort((a, b) => (new Date(a) < new Date(b) ? 1 : -1));
-    const rows = {};
+    const rows = [];
     Object.keys(tests).forEach((test) => {
       const newEntries = allTimes.map((time: string) => tests[test].obs.find((entry) => entry.obsDatetime === time));
-      rows[test] = { ...tests[test], entries: newEntries };
+      rows.push({ ...tests[test], entries: newEntries });
     });
     const panelName = 'timeline';
     return {
@@ -114,8 +120,10 @@ const FilterProvider = ({ root, children }: FilterProviderProps) => {
         parents: state.parents,
         root: state.root,
         tests: state.tests,
+        lowestParents: state.lowestParents,
         timelineData,
         activeTests,
+        someChecked,
         initialize: actions.initialize,
         toggleVal: actions.toggleVal,
         updateParent: actions.updateParent,

--- a/packages/esm-patient-test-results-app/src/filter/filter-reducer.ts
+++ b/packages/esm-patient-test-results-app/src/filter/filter-reducer.ts
@@ -4,9 +4,11 @@ export const getName = (prefix, name) => {
 
 const computeParents = (prefix, node) => {
   var parents = {};
-  const leaves = [];
-  const tests = [];
+  var leaves = [];
+  var tests = [];
+  var lowestParents = [];
   if (node?.subSets?.length && node.subSets[0].obs) {
+    // lowest parent
     let activeLeaves = [];
     node.subSets.forEach((leaf) => {
       if (leaf.hasData) {
@@ -16,38 +18,41 @@ const computeParents = (prefix, node) => {
     let activeTests = [];
     node.subSets.forEach((leaf) => {
       if (leaf.obs.length) {
-        const { flatName, ...rest } = leaf;
-        activeTests.push([flatName, rest]);
+        activeTests.push([leaf.flatName, leaf]);
       }
     });
     leaves.push(...activeLeaves);
     tests.push(...activeTests);
+    lowestParents.push({ flatName: node.flatName, display: node.display });
   } else if (node?.subSets?.length) {
     node.subSets.map((subNode) => {
       const {
         parents: newParents,
         leaves: newLeaves,
         tests: newTests,
+        lowestParents: newLowestParents,
       } = computeParents(getName(prefix, node.display), subNode);
       parents = { ...parents, ...newParents };
       leaves.push(...newLeaves);
       tests.push(...newTests);
+      lowestParents.push(...newLowestParents);
     });
   }
   parents[node.flatName] = leaves;
-  return { parents, leaves, tests };
+  return { parents, leaves, tests, lowestParents };
 };
 
 const reducer = (state, action) => {
   switch (action.type) {
     case 'initialize':
-      const { parents, leaves, tests } = computeParents('', action.tree);
+      const { parents, leaves, tests, lowestParents } = computeParents('', action.tree);
       const flatTests = Object.fromEntries(tests);
       return {
         checkboxes: Object.fromEntries(leaves?.map((leaf) => [leaf, false])) || {},
         parents: parents,
         root: action.tree,
         tests: flatTests,
+        lowestParents: lowestParents,
       };
     case 'toggleVal':
       return {

--- a/packages/esm-patient-test-results-app/src/filter/filter-reducer.ts
+++ b/packages/esm-patient-test-results-app/src/filter/filter-reducer.ts
@@ -20,7 +20,7 @@ const reducer = (state, action) => {
     case 'initialize':
       const { parents, leaves } = computeParents(action.tree);
       return {
-        checkboxes: Object.fromEntries(leaves.map((leaf) => [leaf, true])),
+        checkboxes: Object.fromEntries(leaves?.map((leaf) => [leaf, true])) || {},
         parents: parents,
       };
     case 'toggleVal':

--- a/packages/esm-patient-test-results-app/src/filter/filter-reducer.ts
+++ b/packages/esm-patient-test-results-app/src/filter/filter-reducer.ts
@@ -45,12 +45,28 @@ const computeParents = (prefix, node) => {
 const reducer = (state, action) => {
   switch (action.type) {
     case 'initialize':
-      const { parents, leaves, tests, lowestParents } = computeParents('', action.tree);
+      let parents = {},
+        leaves = [],
+        tests = [],
+        lowestParents = [];
+      action.trees?.forEach((tree) => {
+        // if anyone knows a shorthand for this i'm stoked to learn it :)
+        const {
+          parents: newParents,
+          leaves: newLeaves,
+          tests: newTests,
+          lowestParents: newLP,
+        } = computeParents('', tree);
+        parents = { ...parents, ...newParents };
+        leaves = [...leaves, ...newLeaves];
+        tests = [...tests, ...newTests];
+        lowestParents = [...lowestParents, ...newLP];
+      });
       const flatTests = Object.fromEntries(tests);
       return {
         checkboxes: Object.fromEntries(leaves?.map((leaf) => [leaf, false])) || {},
         parents: parents,
-        root: action.tree,
+        roots: action.trees,
         tests: flatTests,
         lowestParents: lowestParents,
       };

--- a/packages/esm-patient-test-results-app/src/filter/filter-reducer.ts
+++ b/packages/esm-patient-test-results-app/src/filter/filter-reducer.ts
@@ -1,27 +1,37 @@
 const computeParents = (node) => {
   var parents = {};
   const leaves = [];
-  if (node?.subSets?.length) {
+  const tests = [];
+  if (node?.subSets?.length && node.subSets[0].datatype) {
+    leaves.push(...node.subSets.map((leaf) => leaf.display));
+    tests.push(
+      ...node.subSets.map((leaf) => {
+        const { display, ...rest } = leaf;
+        return [display, rest];
+      }),
+    );
+  } else if (node?.subSets?.length) {
     node.subSets.map((subNode) => {
-      const { parents: newParents, leaves: newLeaves } = computeParents(subNode);
+      const { parents: newParents, leaves: newLeaves, tests: newTests } = computeParents(subNode);
       parents = { ...parents, ...newParents };
       leaves.push(...newLeaves);
+      tests.push(...newTests);
     });
   }
-  if (node?.obs?.length) {
-    leaves.push(...node.obs.map((leaf) => leaf.display));
-  }
   parents[node.display] = leaves;
-  return { parents: parents, leaves: leaves };
+  return { parents, leaves, tests };
 };
 
 const reducer = (state, action) => {
   switch (action.type) {
     case 'initialize':
-      const { parents, leaves } = computeParents(action.tree);
+      const { parents, leaves, tests } = computeParents(action.tree);
+      const flatTests = Object.fromEntries(tests);
       return {
         checkboxes: Object.fromEntries(leaves?.map((leaf) => [leaf, true])) || {},
         parents: parents,
+        root: action.tree,
+        tests: flatTests,
       };
     case 'toggleVal':
       return {

--- a/packages/esm-patient-test-results-app/src/filter/filter-set.scss
+++ b/packages/esm-patient-test-results-app/src/filter/filter-set.scss
@@ -23,10 +23,6 @@
   margin: $spacing-02 0;
 }
 
-.filterContainerExpanded {
-  border-left: 0.3rem solid var(--brand-01);
-}
-
 .filterNode {
   padding: 1rem;
 }
@@ -37,6 +33,7 @@
 
 .nestedAccordion > :global(.bx--accordion--start) > :global(.bx--accordion__item--active) {
   border-left: 0.3rem solid var(--brand-01);
+  margin: 1.5rem 0;
 }
 
 .nestedAccordion :global {

--- a/packages/esm-patient-test-results-app/src/filter/filter-set.scss
+++ b/packages/esm-patient-test-results-app/src/filter/filter-set.scss
@@ -36,6 +36,14 @@
     display: block;
   }
 
+  .bx--accordion__title {
+    margin: 0 0 0 0.8rem;
+  }
+
+  .bx--accordion__arrow {
+    margin: 0.4rem 0 0 1rem;
+  }
+
   // Chevron transformations
   .bx--accordion__item > button[aria-expanded="false"] > .bx--accordion__arrow {
     transform: rotate(90deg);
@@ -47,7 +55,17 @@
     fill: var(--brand-01);
   }
 
+  /** first node **/
   .bx--accordion--start > .bx--accordion__item > button[aria-expanded="true"] {
     background-color: $ui-03;
+  }
+
+  .bx--accordion--start > .bx--accordion__item > button > .bx--accordion__title > .bx--checkbox-wrapper > .bx--checkbox-label {
+    font-size: 110%;
+    font-weight: 700;
+  }
+
+  .bx--checkbox-label-text {
+    padding: 0 0 0 .75rem;
   }
 }

--- a/packages/esm-patient-test-results-app/src/filter/filter-set.scss
+++ b/packages/esm-patient-test-results-app/src/filter/filter-set.scss
@@ -2,6 +2,22 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.floatingRightButton {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  z-index: 9;
+}
+.expandButton {
+  background-color: white;
+  border: 1px solid black;
+}
+
+.floatingRightButton > .expandButton > svg {
+  margin: 0;
+}
+
+
 .filterContainer {
   background-color: $openmrs-background-grey;
   margin: $spacing-02 0;
@@ -62,3 +78,4 @@
     padding: 0 0 0 .75rem;
   }
 }
+

--- a/packages/esm-patient-test-results-app/src/filter/filter-set.scss
+++ b/packages/esm-patient-test-results-app/src/filter/filter-set.scss
@@ -7,7 +7,7 @@
   margin: $spacing-02 0;
 }
 
-.filterContainerActive {
+.filterContainerExpanded {
   border-left: 0.3rem solid var(--brand-01);
 }
 
@@ -18,6 +18,10 @@
 .filterItem {
   padding: 0.5rem 1rem 0.5rem 4rem;
   border-bottom: 1px solid $ui-03;
+}
+
+.nestedAccordion > :global(.bx--accordion--start) > :global(.bx--accordion__item--active) {
+  border-left: 0.3rem solid var(--brand-01);
 }
 
 .nestedAccordion :global {
@@ -53,16 +57,6 @@
     /*rtl:ignore*/
     transform: rotate(-90deg);
     fill: var(--brand-01);
-  }
-
-  /** first node **/
-  .bx--accordion--start > .bx--accordion__item > button[aria-expanded="true"] {
-    background-color: $ui-03;
-  }
-
-  .bx--accordion--start > .bx--accordion__item > button > .bx--accordion__title > .bx--checkbox-wrapper > .bx--checkbox-label {
-    font-size: 110%;
-    font-weight: 700;
   }
 
   .bx--checkbox-label-text {

--- a/packages/esm-patient-test-results-app/src/filter/filter-set.scss
+++ b/packages/esm-patient-test-results-app/src/filter/filter-set.scss
@@ -17,7 +17,6 @@
 
 .filterItem {
   padding: 0.5rem 1rem 0.5rem 4rem;
-  border-bottom: 1px solid $ui-03;
 }
 
 .nestedAccordion > :global(.bx--accordion--start) > :global(.bx--accordion__item--active) {

--- a/packages/esm-patient-test-results-app/src/filter/filter-set.tsx
+++ b/packages/esm-patient-test-results-app/src/filter/filter-set.tsx
@@ -1,7 +1,8 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 import styles from './filter-set.scss';
 import { Accordion, AccordionItem, Checkbox } from 'carbon-components-react';
 import FilterContext from './filter-context';
+import { useConfig } from '@openmrs/esm-framework';
 
 interface Observation {
   display: string;
@@ -31,12 +32,17 @@ const isIndeterminate = (kids, checkboxes) => {
 };
 
 const FilterSet = () => {
-  const { root } = useContext(FilterContext);
+  const { roots } = useContext(FilterContext);
+  const config = useConfig();
 
   return (
-    <div className={`${styles.filterContainer} ${styles.nestedAccordion}`}>
-      <FilterNode root={root} level={0} open />
-    </div>
+    <>
+      {roots?.map((root, index) => (
+        <div className={`${styles.filterContainer} ${styles.nestedAccordion}`}>
+          <FilterNode root={root} level={0} open={config.concepts[index].defaultOpen} />
+        </div>
+      ))}
+    </>
   );
 };
 
@@ -49,7 +55,7 @@ const FilterNode = ({ root, level, open }: FilterNodeProps) => {
       <AccordionItem
         title={
           <Checkbox
-            id={root?.display}
+            id={root?.flatName}
             checked={allChildrenChecked}
             indeterminate={indeterminate}
             labelText={`${root?.display} (${parents?.[root?.flatName]?.length})`}

--- a/packages/esm-patient-test-results-app/src/filter/filter-set.tsx
+++ b/packages/esm-patient-test-results-app/src/filter/filter-set.tsx
@@ -8,12 +8,12 @@ interface Observation {
 }
 interface TreeNode {
   display: string;
+  datatype: string;
   subSets?: TreeNode[];
   obs?: Observation[];
 }
 
 interface FilterProps {
-  root: TreeNode;
   maxNest?: number;
   children?: React.ReactNode;
 }
@@ -32,8 +32,8 @@ const isIndeterminate = (kids, checkboxes) => {
   return kids && !kids?.every((kid) => checkboxes[kid]) && !kids?.every((kid) => !checkboxes[kid]);
 };
 
-const FilterSet = ({ root, maxNest }: FilterProps) => {
-  const { someChecked, parents, checkboxes, updateParent } = useContext(FilterContext);
+const FilterSet = ({ maxNest }: FilterProps) => {
+  const { someChecked, parents, checkboxes, updateParent, root } = useContext(FilterContext);
   const indeterminate = isIndeterminate(parents[root.display], checkboxes);
   const allChildrenChecked = parents[root.display]?.every((kid) => checkboxes[kid]);
 
@@ -53,12 +53,9 @@ const FilterSet = ({ root, maxNest }: FilterProps) => {
             />
           }
         >
-          {root?.subSets?.map((node, index) => (
-            <FilterNode root={node} level={0} maxNest={maxNest} key={index} />
-          ))}
-          {root?.obs?.map((obs, index) => (
-            <FilterLeaf leaf={obs} key={index} />
-          ))}
+          {!root?.subSets?.[0]?.datatype &&
+            root?.subSets?.map((node, index) => <FilterNode root={node} level={0} maxNest={maxNest} key={index} />)}
+          {root?.subSets?.[0]?.datatype && root.subSets?.map((obs, index) => <FilterLeaf leaf={obs} key={index} />)}
         </AccordionItem>
       </Accordion>
     </div>
@@ -69,7 +66,6 @@ const FilterNode = ({ root, level, maxNest = 3 }: FilterNodeProps) => {
   const { checkboxes, parents, updateParent } = useContext(FilterContext);
   const indeterminate = isIndeterminate(parents[root.display], checkboxes);
   const allChildrenChecked = parents[root.display]?.every((kid) => checkboxes[kid]);
-
   return (
     <Accordion>
       <AccordionItem
@@ -84,12 +80,11 @@ const FilterNode = ({ root, level, maxNest = 3 }: FilterNodeProps) => {
         }
         style={{ paddingLeft: level > 0 && level < maxNest ? '1rem' : '0px' }}
       >
-        {root?.subSets?.map((node, index) => (
-          <FilterNode root={node} level={level + 1} maxNest={maxNest} key={index} />
-        ))}
-        {root?.obs?.map((obs, index) => (
-          <FilterLeaf leaf={obs} key={index} />
-        ))}
+        {!root?.subSets?.[0]?.datatype &&
+          root?.subSets?.map((node, index) => (
+            <FilterNode root={node} level={level + 1} maxNest={maxNest} key={index} />
+          ))}
+        {root?.subSets?.[0]?.datatype && root.subSets?.map((obs, index) => <FilterLeaf leaf={obs} key={index} />)}
       </AccordionItem>
     </Accordion>
   );

--- a/packages/esm-patient-test-results-app/src/filter/filter-set.tsx
+++ b/packages/esm-patient-test-results-app/src/filter/filter-set.tsx
@@ -19,6 +19,7 @@ export interface TreeNode {
 interface FilterNodeProps {
   root: TreeNode;
   level: number;
+  open?: boolean;
 }
 
 interface FilterLeafProps {
@@ -34,12 +35,12 @@ const FilterSet = () => {
 
   return (
     <div className={`${styles.filterContainer} ${styles.nestedAccordion}`}>
-      <FilterNode root={root} level={0} />
+      <FilterNode root={root} level={0} open />
     </div>
   );
 };
 
-const FilterNode = ({ root, level }: FilterNodeProps) => {
+const FilterNode = ({ root, level, open }: FilterNodeProps) => {
   const { checkboxes, parents, updateParent } = useContext(FilterContext);
   const indeterminate = isIndeterminate(parents[root.flatName], checkboxes);
   const allChildrenChecked = parents[root.flatName]?.every((kid) => checkboxes[kid]);
@@ -56,6 +57,7 @@ const FilterNode = ({ root, level }: FilterNodeProps) => {
           />
         }
         style={{ paddingLeft: `${level > 0 ? 1 : 0}rem` }}
+        open={open ?? false}
       >
         {!root?.subSets?.[0]?.obs &&
           root?.subSets?.map((node, index) => <FilterNode root={node} level={level + 1} key={index} />)}

--- a/packages/esm-patient-test-results-app/src/filter/filter-set.tsx
+++ b/packages/esm-patient-test-results-app/src/filter/filter-set.tsx
@@ -48,7 +48,7 @@ const FilterSet = ({ root, maxNest }: FilterProps) => {
               id={root?.display}
               checked={allChildrenChecked}
               indeterminate={indeterminate}
-              labelText={root?.display}
+              labelText={`${root?.display} (${parents?.[root?.display]?.length})`}
               onChange={() => updateParent(root.display)}
             />
           }

--- a/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
+++ b/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
@@ -1,26 +1,22 @@
-import { Button, Column, Grid, InlineLoading, Row } from 'carbon-components-react';
-import React, { useContext, useState } from 'react';
+import { Column, ContentSwitcher, InlineLoading, Row, Switch } from 'carbon-components-react';
+import React, { useState } from 'react';
 import FilterSet from '../filter/filter-set';
-import FilterContext, { FilterProvider } from '../filter/filter-context';
+import { FilterProvider } from '../filter/filter-context';
 import NewTimeline from '../new-timeline/new-timeline';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import useGetObstreeData from '../new-timeline/useObstreeData';
-import { Maximize32, Minimize32 } from '@carbon/icons-react';
-import styles from '../filter/filter-set.scss';
 
 interface obsShape {
   [key: string]: any;
 }
 
-const Results = () => {
-  const { checkboxes } = useContext(FilterContext);
-  return <h4>Results ({Object.keys(checkboxes).length})</h4>;
-};
-
 const HIVCareAndTreatment = () => {
   const concept = '5035a431-51de-40f0-8f25-4a98762eb796'; // bloodwork
   const { data: root, error, loading }: obsShape = useGetObstreeData(concept);
-  const [expanded, setExpanded] = useState(false);
+
+  const [view, setView] = useState<string>('split');
+
+  const expanded = view === 'full';
 
   if (loading) {
     return <InlineLoading />;
@@ -31,29 +27,36 @@ const HIVCareAndTreatment = () => {
   if (!loading && !error && root?.display && root?.subSets?.length) {
     return (
       <FilterProvider root={root}>
-        <div style={{ position: 'relative', width: '100%' }}>
-          <div className={styles.floatingRightButton}>
-            <Button
-              kind="ghost"
-              renderIcon={expanded ? Minimize32 : Maximize32}
-              iconDescription="expand"
-              className={styles.expandButton}
-              onClick={() => setExpanded(!expanded)}
-            ></Button>
-          </div>
-          <div>
-            <Grid style={{ padding: 0 }}>
-              <Row>
-                <Column sm={16} lg={expanded ? 0 : 4}>
-                  <Results />
-                  <FilterSet />
-                </Column>
-                <Column sm={16} lg={expanded ? 12 : 8}>
-                  <NewTimeline />
-                </Column>
-              </Row>
-            </Grid>
-          </div>
+        <div style={{ padding: 0 }}>
+          <Row style={{ padding: '1rem 0' }}>
+            <Column sm={16} lg={expanded ? 0 : 6}>
+              <div style={{ display: 'flex' }}>
+                <h4 style={{ flexGrow: 1 }}>Results</h4>
+                <div style={{ minWidth: '10rem' }}>
+                  <ContentSwitcher>
+                    <Switch name="panel" text="Panel" />
+                    <Switch name="tree" text="Tree" />
+                  </ContentSwitcher>
+                </div>
+              </div>
+            </Column>
+            <Column sm={16} lg={expanded ? 12 : 6} style={{ border: expanded ? null : '0 0 0 1px solid gray' }}>
+              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <ContentSwitcher style={{ maxWidth: '10rem' }} onChange={(e) => setView(`${e.name}`)}>
+                  <Switch name="split" text="Split" />
+                  <Switch name="full" text="Full" />
+                </ContentSwitcher>
+              </div>
+            </Column>
+          </Row>
+          <Row>
+            <Column sm={16} lg={expanded ? 0 : 6}>
+              <FilterSet />
+            </Column>
+            <Column sm={16} lg={expanded ? 12 : 6}>
+              <NewTimeline />
+            </Column>
+          </Row>
         </div>
       </FilterProvider>
     );

--- a/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
+++ b/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
@@ -7,6 +7,7 @@ import { ErrorState } from '@openmrs/esm-patient-common-lib';
 import { useGetManyObstreeData } from '../new-timeline/useObstreeData';
 import styles from '../new-timeline/new-timeline.scss';
 import { useConfig } from '@openmrs/esm-framework';
+import DesktopView from '../desktop-view/desktop-view.component';
 
 export interface ConfigObject {
   title: string;
@@ -21,10 +22,6 @@ export interface ConfigObject {
   };
 }
 
-interface obsShape {
-  [key: string]: any;
-}
-
 const HIVCareAndTreatment = () => {
   const config = useConfig();
   const conceptUuids = config.concepts.map((c) => c.conceptUuid);
@@ -32,6 +29,7 @@ const HIVCareAndTreatment = () => {
   const { roots, loading, errors } = useGetManyObstreeData(conceptUuids);
 
   const [view, setView] = useState<string>('split');
+  const [leftContent, setLeftContent] = useState<string>('tree');
 
   const expanded = view === 'full';
 
@@ -50,7 +48,7 @@ const HIVCareAndTreatment = () => {
               <div style={{ display: 'flex' }}>
                 <h4 style={{ flexGrow: 1 }}>Results</h4>
                 <div style={{ minWidth: '10rem' }}>
-                  <ContentSwitcher>
+                  <ContentSwitcher selectedIndex={1} onChange={(e) => setLeftContent(`${e.name}`)}>
                     <Switch name="panel" text="Panel" />
                     <Switch name="tree" text="Tree" />
                   </ContentSwitcher>
@@ -68,7 +66,8 @@ const HIVCareAndTreatment = () => {
           </Row>
           <Row style={{ height: '100%' }}>
             <Column sm={16} lg={expanded ? 0 : 6} className={styles['column-panel']}>
-              <FilterSet />
+              {leftContent === 'tree' && <FilterSet />}
+              {leftContent === 'panel' && <DesktopView />}
             </Column>
             <Column sm={16} lg={expanded ? 12 : 6} className={styles['column-panel']}>
               <NewTimeline />

--- a/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
+++ b/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
@@ -4,13 +4,18 @@ import mockConceptTree from './mock-concept-tree';
 import FilterSet from '../filter/filter-set';
 import FilterContext, { FilterProvider } from '../filter/filter-context';
 import usePatientResultsData from '../loadPatientTestData/usePatientResultsData';
-import { usePatient } from '@openmrs/esm-framework';
+import { usePatient, openmrsFetch } from '@openmrs/esm-framework';
 import { MultiTimeline } from '../timeline/Timeline';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
+import useSWR from 'swr';
 
 const HIVCareAndTreatment = () => {
   const { patientUuid } = usePatient();
   const { sortedObs, loaded, error } = usePatientResultsData(patientUuid);
+  // const concept = '5035a431-51de-40f0-8f25-4a98762eb796'; // on openmrs-spa.org this is bloodwork
+  // const { data: result } = useSWR(`/ws/rest/v1/obstree?patient=${patientUuid}&concept=${concept}`, openmrsFetch);
+  // console.log('result', result);
+
   if (!loaded) {
     return <InlineLoading />;
   }
@@ -19,7 +24,7 @@ const HIVCareAndTreatment = () => {
   }
   if (loaded && !error && sortedObs && !!Object.keys(sortedObs).length) {
     return (
-      <FilterProvider sortedObs={sortedObs}>
+      <FilterProvider sortedObs={sortedObs} root={mockConceptTree}>
         <Grid>
           <Row>
             <Column sm={16} lg={4}>

--- a/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
+++ b/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
@@ -2,9 +2,9 @@ import { Column, Grid, InlineLoading, Row } from 'carbon-components-react';
 import React from 'react';
 import FilterSet from '../filter/filter-set';
 import { FilterProvider } from '../filter/filter-context';
-import { MultiTimeline } from '../timeline/Timeline';
+import NewTimeline from '../new-timeline/new-timeline';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
-import useGetObstreeData from '../timeline/useObstreeData';
+import useGetObstreeData from '../new-timeline/useObstreeData';
 
 interface obsShape {
   [key: string]: any;
@@ -29,7 +29,7 @@ const HIVCareAndTreatment = () => {
               <FilterSet />
             </Column>
             <Column sm={16} lg={8}>
-              <MultiTimeline />
+              <NewTimeline />
             </Column>
           </Row>
         </Grid>

--- a/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
+++ b/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
@@ -3,17 +3,33 @@ import React, { useState } from 'react';
 import FilterSet from '../filter/filter-set';
 import { FilterProvider } from '../filter/filter-context';
 import NewTimeline from '../new-timeline/new-timeline';
-import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
-import useGetObstreeData from '../new-timeline/useObstreeData';
+import { ErrorState } from '@openmrs/esm-patient-common-lib';
+import { useGetManyObstreeData } from '../new-timeline/useObstreeData';
 import styles from '../new-timeline/new-timeline.scss';
+import { useConfig } from '@openmrs/esm-framework';
+
+export interface ConfigObject {
+  title: string;
+  resultsName: string;
+  data: Array<{
+    concept: string;
+    label: string;
+    color: string;
+  }>;
+  table: {
+    pageSize: number;
+  };
+}
 
 interface obsShape {
   [key: string]: any;
 }
 
 const HIVCareAndTreatment = () => {
-  const concept = '5035a431-51de-40f0-8f25-4a98762eb796'; // bloodwork
-  const { data: root, error, loading }: obsShape = useGetObstreeData(concept);
+  const config = useConfig();
+  const conceptUuids = config.concepts.map((c) => c.conceptUuid);
+  // const { data: root, error, loading }: obsShape = useGetObstreeData(conceptUuids[0]);
+  const { roots, loading, errors } = useGetManyObstreeData(conceptUuids);
 
   const [view, setView] = useState<string>('split');
 
@@ -22,12 +38,12 @@ const HIVCareAndTreatment = () => {
   if (loading) {
     return <InlineLoading />;
   }
-  if (error) {
-    return <ErrorState error={error} headerTitle="Data Load Error" />;
+  if (errors.length) {
+    return <ErrorState error={errors[0]} headerTitle="Data Load Error" />;
   }
-  if (!loading && !error && root?.display && root?.subSets?.length) {
+  if (!loading && !errors.length && roots?.length) {
     return (
-      <FilterProvider root={root}>
+      <FilterProvider roots={roots}>
         <div style={{ padding: 0 }}>
           <Row className={styles['results-header']}>
             <Column sm={16} lg={expanded ? 0 : 6}>
@@ -61,9 +77,6 @@ const HIVCareAndTreatment = () => {
         </div>
       </FilterProvider>
     );
-  }
-  if (!loading && !error && root?.display && root?.subSets?.length === 0) {
-    return <EmptyState displayText="observations" headerTitle="Data Timeline" />;
   }
   return null;
 };

--- a/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
+++ b/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
@@ -5,6 +5,7 @@ import { FilterProvider } from '../filter/filter-context';
 import NewTimeline from '../new-timeline/new-timeline';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import useGetObstreeData from '../new-timeline/useObstreeData';
+import styles from '../new-timeline/new-timeline.scss';
 
 interface obsShape {
   [key: string]: any;
@@ -28,7 +29,7 @@ const HIVCareAndTreatment = () => {
     return (
       <FilterProvider root={root}>
         <div style={{ padding: 0 }}>
-          <Row style={{ padding: '1rem 0' }}>
+          <Row className={styles['results-header']}>
             <Column sm={16} lg={expanded ? 0 : 6}>
               <div style={{ display: 'flex' }}>
                 <h4 style={{ flexGrow: 1 }}>Results</h4>
@@ -49,11 +50,11 @@ const HIVCareAndTreatment = () => {
               </div>
             </Column>
           </Row>
-          <Row>
-            <Column sm={16} lg={expanded ? 0 : 6}>
+          <Row style={{ height: '100%' }}>
+            <Column sm={16} lg={expanded ? 0 : 6} className={styles['column-panel']}>
               <FilterSet />
             </Column>
-            <Column sm={16} lg={expanded ? 12 : 6}>
+            <Column sm={16} lg={expanded ? 12 : 6} className={styles['column-panel']}>
               <NewTimeline />
             </Column>
           </Row>

--- a/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
+++ b/packages/esm-patient-test-results-app/src/hiv/hiv-care-and-treatment.tsx
@@ -1,18 +1,26 @@
-import { Column, Grid, InlineLoading, Row } from 'carbon-components-react';
-import React from 'react';
+import { Button, Column, Grid, InlineLoading, Row } from 'carbon-components-react';
+import React, { useContext, useState } from 'react';
 import FilterSet from '../filter/filter-set';
-import { FilterProvider } from '../filter/filter-context';
+import FilterContext, { FilterProvider } from '../filter/filter-context';
 import NewTimeline from '../new-timeline/new-timeline';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import useGetObstreeData from '../new-timeline/useObstreeData';
+import { Maximize32, Minimize32 } from '@carbon/icons-react';
+import styles from '../filter/filter-set.scss';
 
 interface obsShape {
   [key: string]: any;
 }
 
+const Results = () => {
+  const { checkboxes } = useContext(FilterContext);
+  return <h4>Results ({Object.keys(checkboxes).length})</h4>;
+};
+
 const HIVCareAndTreatment = () => {
   const concept = '5035a431-51de-40f0-8f25-4a98762eb796'; // bloodwork
   const { data: root, error, loading }: obsShape = useGetObstreeData(concept);
+  const [expanded, setExpanded] = useState(false);
 
   if (loading) {
     return <InlineLoading />;
@@ -23,16 +31,30 @@ const HIVCareAndTreatment = () => {
   if (!loading && !error && root?.display && root?.subSets?.length) {
     return (
       <FilterProvider root={root}>
-        <Grid>
-          <Row>
-            <Column sm={16} lg={4}>
-              <FilterSet />
-            </Column>
-            <Column sm={16} lg={8}>
-              <NewTimeline />
-            </Column>
-          </Row>
-        </Grid>
+        <div style={{ position: 'relative', width: '100%' }}>
+          <div className={styles.floatingRightButton}>
+            <Button
+              kind="ghost"
+              renderIcon={expanded ? Minimize32 : Maximize32}
+              iconDescription="expand"
+              className={styles.expandButton}
+              onClick={() => setExpanded(!expanded)}
+            ></Button>
+          </div>
+          <div>
+            <Grid style={{ padding: 0 }}>
+              <Row>
+                <Column sm={16} lg={expanded ? 0 : 4}>
+                  <Results />
+                  <FilterSet />
+                </Column>
+                <Column sm={16} lg={expanded ? 12 : 8}>
+                  <NewTimeline />
+                </Column>
+              </Row>
+            </Grid>
+          </div>
+        </div>
       </FilterProvider>
     );
   }

--- a/packages/esm-patient-test-results-app/src/hiv/mock-concept-tree.ts
+++ b/packages/esm-patient-test-results-app/src/hiv/mock-concept-tree.ts
@@ -57,13 +57,34 @@ const mockConceptTree = {
           display: 'Serum chemistry panel',
           obs: [
             {
-              display: 'Serum chloride',
+              display: 'Alkaline phosphatase',
+            },
+            {
+              display: 'Blood urea nitrogen', //
+            },
+            {
+              display: 'Serum Albumin',
+            },
+            {
+              display: 'Serum calcium',
             },
             {
               display: 'Serum carbon dioxide',
             },
             {
-              display: 'Blood urea nitrogen',
+              display: 'Serum chloride', //
+            },
+            {
+              display: 'Serum creatinine (umol/L)', //
+            },
+            {
+              display: 'Serum carbon dioxide', //
+            },
+            {
+              display: 'Serum sodium', //
+            },
+            {
+              display: 'Serum potassium', //
             },
           ],
         },

--- a/packages/esm-patient-test-results-app/src/hiv/mock-concept-tree.ts
+++ b/packages/esm-patient-test-results-app/src/hiv/mock-concept-tree.ts
@@ -72,4 +72,40 @@ const mockConceptTree = {
   ],
 };
 
+export const mockConceptTree2 = {
+  display: 'Complete Blood Count',
+  obs: [
+    {
+      display: 'Hematocrit',
+      conceptUuid: '1015AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      meta: {
+        datatype: 'Numeric',
+        hiAbsolute: 100,
+        hiCritical: null,
+        hiNormal: 51.9,
+        lowAbsolute: 0,
+        lowCritical: 21,
+        lowNormal: 32.3,
+        range: '32.3 – 51.9',
+        units: '%',
+      },
+      values: [
+        {
+          effectiveDateTime: '2020-05-07T00:00:00+00:00',
+          value: 42,
+        },
+        {
+          effectiveDateTime: '2020-05-07T00:02:00+00:00',
+          value: 43,
+        },
+        {
+          effectiveDateTime: '2020-05-07T00:03:00+00:00',
+          value: 45,
+          notes: 'Maybe there is some special note written here?',
+        },
+      ],
+    },
+  ],
+};
+
 export default mockConceptTree;

--- a/packages/esm-patient-test-results-app/src/hiv/mock-concept-tree.ts
+++ b/packages/esm-patient-test-results-app/src/hiv/mock-concept-tree.ts
@@ -9,6 +9,33 @@ const mockConceptTree = {
           obs: [
             {
               display: 'Hematocrit',
+              conceptUuid: '1015AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              meta: {
+                datatype: 'Numeric',
+                hiAbsolute: 100,
+                hiCritical: null,
+                hiNormal: 51.9,
+                lowAbsolute: 0,
+                lowCritical: 21,
+                lowNormal: 32.3,
+                range: '32.3 – 51.9',
+                units: '%',
+              },
+              values: [
+                {
+                  effectiveDateTime: '2020-05-07T00:00:00+00:00',
+                  value: 42,
+                },
+                {
+                  effectiveDateTime: '2020-05-07T00:02:00+00:00',
+                  value: 43,
+                },
+                {
+                  effectiveDateTime: '2020-05-07T00:03:00+00:00',
+                  value: 45,
+                  notes: 'Maybe there is some special note written here?',
+                },
+              ],
             },
             {
               display: 'Platelets',

--- a/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.scss
+++ b/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.scss
@@ -3,6 +3,32 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
+.results-header {
+  padding: 0.8rem 0;
+  //position: sticky;
+  //top: 45px;
+  z-index: 10;
+  background-color: $openmrs-background-grey;
+}
+
+.column-panel {
+  overflow-y: scroll;
+  height: calc(100vh - 9rem)
+}
+
+.date-header {
+  position: sticky;
+  top: 0px;
+  display: grid;
+  background-color: white;
+  overflow-x: auto;
+  z-index: 9;
+}
+
+.date-header::-webkit-scrollbar {
+  display: none;
+}
+
 .grid {
   width: fit-content;
   background-color: $color-gray-30;
@@ -49,26 +75,30 @@
   }
 }
 
-.recent-results-grid {
-  display: grid;
-  background-color: white;
-  overflow-x: auto;
-  position: sticky;
-  top: 0;
-}
 
-.recent-results-grid::-webkit-scrollbar {
-  display: none;
+.grid-container {
+  padding: 0;
+  box-sizing: border-box;
+  display: grid;
+  grid-auto-flow: row;
+  column-gap: 1px;
+  row-gap: 0px;
+  background-color: $color-gray-30;
+  grid-template: auto auto / 9em auto;
+  border-collapse: collapse;
+  overflow-x: auto;
+  width: 100%;
+  background-color: white;
 }
 
 
 .row-header {
-  @extend .timeline-cell;
-  justify-items: baseline;
-  align-items: center;
-  background-color: $color-gray-30;
-  grid-column: span 2 / auto;
+  overflow: hidden;
+  align-self: flex-start;
+  background-color: $ui-03;
+  padding: 0.6rem 1rem;
 }
+
 
 .row-start-cell {
   @extend .timeline-cell;
@@ -88,18 +118,6 @@
   background-color: $ui-03;
 }
 
-.date-header {
-  position: sticky;
-  top: 45px;
-  display: grid;
-  background-color: white;
-  overflow-x: auto;
-  z-index: 9;
-}
-
-.date-header::-webkit-scrollbar {
-  display: none;
-}
 
 .date-header-container {
   position: sticky;
@@ -115,19 +133,17 @@
   border-collapse: collapse;
 }
 
-.grid-container {
-  padding: 0;
-  box-sizing: border-box;
-
-  display: grid;
-  grid-auto-flow: row;
-  column-gap: 1px;
-  row-gap: 0px;
-  background-color: $color-gray-30;
-  grid-template: auto auto / 9em auto;
-  border-collapse: collapse;
+.date-header-inner {
+  overflow-x: auto;
+}
+.date-header-inner::-webkit-scrollbar {
+  display: none;
 }
 
+
+.date-header::-webkit-scrollbar {
+  display: none;
+}
 .date-header-container::-webkit-scrollbar {
   display: none;
 }

--- a/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.scss
+++ b/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.scss
@@ -109,6 +109,8 @@
     @include carbon--type-style('productive-heading-01');
     color: $text-01;
     left: 0;
+    width: 100%;
+    word-wrap: normal;
   }
 }
 

--- a/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.scss
+++ b/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.scss
@@ -1,0 +1,202 @@
+
+@import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
+@import "~carbon-components/src/globals/scss/mixins";
+
+.grid {
+  width: fit-content;
+  background-color: $color-gray-30;
+  display: grid;
+  grid-auto-rows: auto;
+  gap: 1px;
+  justify-items: center;
+  align-items: center;
+}
+
+.day-column, .year-column {
+  @include carbon--type-style('productive-heading-01');
+  color: $text-02;
+}
+
+.time-column {
+  @include carbon--type-style('body-short-01');
+  color: $text-02;
+  scroll-snap-align: start;
+}
+
+.padded-main {
+  box-sizing: border-box;
+  padding: 20px;
+}
+
+.timeline-cell {
+  background-color: white;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  justify-items: center;
+  align-items: center;
+  padding: 0.5rem;
+}
+
+.timeline-data-cell {
+  @extend .timeline-cell;
+  justify-items: first baseline;
+
+  p {
+    @include carbon--type-style('body-short-01');
+    color: $text-02;
+  }
+}
+
+.row-start-cell {
+  @extend .timeline-cell;
+  position: sticky;
+  left: 0;
+  display: grid;
+  grid-auto-flow: row;
+  gap: 0.5px;
+  justify-items: baseline;
+  align-items: center;
+  padding: 1rem;
+}
+
+.timeline-cell-zebra {
+  background-color: $ui-03;
+}
+
+.padding-container {
+  padding: 0px 0 0 0;
+  box-sizing: border-box;
+
+  display: grid;
+  grid-auto-flow: row;
+  column-gap: 1px;
+  row-gap: 0px;
+  background-color: $color-gray-30;
+  grid-template: auto auto / 9em auto;
+  border-collapse: collapse;
+}
+
+.padding-container::-webkit-scrollbar {
+  display: none;
+}
+
+.time-slot-inner {
+  background-color: $ui-03;
+  padding: 3px 10px;
+  justify-self: stretch;
+  align-self: stretch;
+  display: grid;
+  align-items: center;
+
+  div {
+    position: sticky;
+    left: calc(10em + 10px);
+    width: max-content;
+  }
+}
+
+.corner-grid-element {
+  grid-row: span 1;
+  position: sticky;
+  left: 0px;
+  top: 0px;
+  z-index: 3;
+  padding: 0rem 1rem;
+
+  div {
+    @include carbon--type-style('productive-heading-01');
+    color: $text-01;
+    left: 0;
+  }
+}
+
+.shadow {
+  box-shadow: 8px 0 20px 0 rgba(0, 0, 0 , 0.15);
+}
+
+.trendline-link {
+  @include carbon--type-style('body-short-01');
+  color: $interactive-01;
+  cursor: pointer;
+}
+
+.range-units {
+  @include carbon--type-style('helper-text-01');
+  color: $text-05;
+}
+
+.off-scale-high,
+.off-scale-low,
+.critically-high,
+.critically-low,
+.high,
+.low {
+  p {
+    @include carbon--type-style('productive-heading-01');
+    color: $text-01;
+  }
+}
+
+.high,
+.low {
+  box-shadow: 0 0 0 1px #000000;
+}
+
+.critically-high,
+.critically-low {
+  box-shadow: 0 0 0 1px $danger, inset 0 0 0 1px $danger;
+}
+
+.off-scale-low {
+  p::after {
+    content: " ↓↓↓";
+  }
+}
+
+.off-scale-high {
+  p::after {
+    content: " ↑↑↑";
+  }
+}
+
+.critically-low {
+  p::after {
+    content: " ↓↓";
+  }
+}
+
+.critically-high {
+  p::after {
+    content: " ↑↑";
+  }
+}
+
+.low {
+  p::after {
+    content: " ↓";
+  }
+}
+
+.high {
+  p::after {
+    content: " ↑";
+  }
+}
+
+.shadow-box {
+  grid-row: 2 / -1;
+  grid-column: 1 / 2;
+}
+
+.recent-results-grid {
+  display: grid;
+  background-color: white;
+  overflow: auto;
+  max-height: calc(100vh - 9rem);
+}
+
+.recent-results-grid::-webkit-scrollbar {
+  display: none;
+}

--- a/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.scss
+++ b/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.scss
@@ -49,10 +49,33 @@
   }
 }
 
+.recent-results-grid {
+  display: grid;
+  background-color: white;
+  overflow-x: auto;
+  position: sticky;
+  top: 0;
+}
+
+.recent-results-grid::-webkit-scrollbar {
+  display: none;
+}
+
+
+.row-header {
+  @extend .timeline-cell;
+  justify-items: baseline;
+  align-items: center;
+  background-color: $color-gray-30;
+  grid-column: span 2 / auto;
+}
+
 .row-start-cell {
   @extend .timeline-cell;
+  position: -webkit-sticky; /* Safari */
   position: sticky;
   left: 0;
+  top: auto;
   display: grid;
   grid-auto-flow: row;
   gap: 0.5px;
@@ -65,8 +88,35 @@
   background-color: $ui-03;
 }
 
-.padding-container {
-  padding: 0px 0 0 0;
+.date-header {
+  position: sticky;
+  top: 45px;
+  display: grid;
+  background-color: white;
+  overflow-x: auto;
+  z-index: 9;
+}
+
+.date-header::-webkit-scrollbar {
+  display: none;
+}
+
+.date-header-container {
+  position: sticky;
+  top: 0;
+  padding: 0;
+  box-sizing: border-box;
+  display: grid;
+  grid-auto-flow: row;
+  column-gap: 1px;
+  row-gap: 0px;
+  background-color: $color-gray-30;
+  grid-template: auto auto / 9em auto;
+  border-collapse: collapse;
+}
+
+.grid-container {
+  padding: 0;
   box-sizing: border-box;
 
   display: grid;
@@ -78,7 +128,10 @@
   border-collapse: collapse;
 }
 
-.padding-container::-webkit-scrollbar {
+.date-header-container::-webkit-scrollbar {
+  display: none;
+}
+.grid-container::-webkit-scrollbar {
   display: none;
 }
 
@@ -192,13 +245,3 @@
   grid-column: 1 / 2;
 }
 
-.recent-results-grid {
-  display: grid;
-  background-color: white;
-  overflow: auto;
-  max-height: calc(100vh - 9rem);
-}
-
-.recent-results-grid::-webkit-scrollbar {
-  display: none;
-}

--- a/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.tsx
+++ b/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.tsx
@@ -108,13 +108,11 @@ interface NewDataRowsProps {
 }
 
 const NewDataRows: React.FC<NewDataRowsProps> = ({ timeColumns, rowData, sortedTimes, showShadow }) => {
-  console.log('rowData??', rowData);
   return (
     <Grid dataColumns={timeColumns.length} padding style={{ gridColumn: 'span 2' }}>
       {rowData.map((row, index) => {
         const obs = row.entries;
         const { units = '', range = '' } = row;
-        console.log('this should print?');
         return (
           <React.Fragment key={index}>
             <NewRowStartCell

--- a/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.tsx
+++ b/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import useScrollIndicator from '../timeline/useScroll';
 import { PaddingContainer, Grid, ShadowBox } from '../timeline/helpers';
 import { EmptyState, OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
@@ -176,6 +176,7 @@ const DateHeaderGrid: React.FC<DateHeaderGridProps> = ({ timeColumns, yearColumn
 export const NewTimeline = () => {
   const { activeTests, timelineData, parents, checkboxes, someChecked, lowestParents } = useContext(FilterContext);
   const [xIsScrolled, yIsScrolled, containerRef] = useScrollIndicator(0, 32);
+  const [currentPanel, setCurrentPanel] = useState(lowestParents?.[0]?.display || 'Timeline');
 
   const {
     data: {
@@ -191,17 +192,23 @@ export const NewTimeline = () => {
   }
   if (activeTests && timelineData && loaded) {
     return (
-      <RecentResultsGrid>
-        <PaddingContainer ref={containerRef}>
-          <PanelNameCorner showShadow={xIsScrolled} panelName={panelName} />
-          <DateHeaderGrid
-            {...{
-              timeColumns,
-              yearColumns,
-              dayColumns,
-              showShadow: yIsScrolled,
-            }}
-          />
+      <>
+        <div>
+          <RecentResultsGrid>
+            <PaddingContainer ref={containerRef}>
+              <PanelNameCorner showShadow={xIsScrolled} panelName={currentPanel} />
+              <DateHeaderGrid
+                {...{
+                  timeColumns,
+                  yearColumns,
+                  dayColumns,
+                  showShadow: yIsScrolled,
+                }}
+              />
+            </PaddingContainer>
+          </RecentResultsGrid>
+        </div>
+        <div>
           {lowestParents.map((parent) => {
             if (parents[parent.flatName].some((kid) => checkboxes[kid]) || !someChecked) {
               const subRows = someChecked
@@ -211,30 +218,29 @@ export const NewTimeline = () => {
               // show kid rows
               return (
                 <>
-                  <div>{parent.display}</div>
-                  <NewDataRows
-                    {...{
-                      timeColumns,
-                      rowData: subRows,
-                      sortedTimes,
-                      showShadow: xIsScrolled,
-                    }}
-                  />
+                  <RecentResultsGrid>
+                    <PaddingContainer ref={containerRef}>
+                      <div style={{ backgroundColor: 'lightgray' }}>
+                        <h6>{parent.display}</h6>
+                      </div>
+                      <NewDataRows
+                        {...{
+                          timeColumns,
+                          rowData: subRows,
+                          sortedTimes,
+                          showShadow: xIsScrolled,
+                        }}
+                      />
+                      <ShadowBox />
+                    </PaddingContainer>
+                  </RecentResultsGrid>
+                  <div style={{ height: '2em' }}></div>
                 </>
               );
             } else return null;
           })}
-          {/* <NewDataRows
-            {...{
-              timeColumns,
-              rowData,
-              sortedTimes,
-              showShadow: xIsScrolled,
-            }}
-          /> */}
-          <ShadowBox />
-        </PaddingContainer>
-      </RecentResultsGrid>
+        </div>
+      </>
     );
   }
   return null;

--- a/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.tsx
+++ b/packages/esm-patient-test-results-app/src/new-timeline/new-timeline.tsx
@@ -1,0 +1,190 @@
+import React, { useContext } from 'react';
+import useScrollIndicator from '../timeline/useScroll';
+import { PaddingContainer, Grid, NewGridItems, ShadowBox } from '../timeline/helpers';
+import { EmptyState, OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
+import FilterContext from '../filter/filter-context';
+import styles from './new-timeline.scss';
+
+const RecentResultsGrid = (props) => {
+  return <div {...props} className={styles['recent-results-grid']} />;
+};
+
+const TimeSlotsInner: React.FC<{
+  style?: React.CSSProperties;
+  className?: string;
+}> = ({ className, ...props }) => (
+  <div className={styles['time-slot-inner'] + (className ? ' ' + className : '')} {...props} />
+);
+
+export const TimeSlots: React.FC<{
+  style?: React.CSSProperties;
+  className?: string;
+}> = ({ children = undefined, ...props }) => (
+  <TimeSlotsInner {...props}>
+    <div>{children}</div>
+  </TimeSlotsInner>
+);
+
+interface PanelNameCornerProps {
+  showShadow: boolean;
+  panelName: string;
+}
+
+const PanelNameCorner: React.FC<PanelNameCornerProps> = ({ showShadow, panelName }) => (
+  <TimeSlots className={`${styles['corner-grid-element']} ${showShadow ? `${styles.shadow}` : ''}`}>
+    {panelName}
+  </TimeSlots>
+);
+
+interface DataEntry {
+  value: number | string;
+  effectiveDateTime: string;
+  interpretation: OBSERVATION_INTERPRETATION;
+}
+
+interface DataRow {
+  [_: string]: {
+    entries: Array<DataEntry>;
+    display: string;
+    name: string;
+    type: string;
+    uuid: string;
+    units: string;
+    range: string;
+  };
+}
+
+export const NewRowStartCell = ({ title, range, units, shadow = false }) => (
+  <div
+    className={styles['row-start-cell']}
+    style={{
+      boxShadow: shadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
+    }}
+  >
+    <span className={styles['trendline-link']}>{title}</span>
+    <span className={styles['range-units']}>
+      {range} {units}
+    </span>
+  </div>
+);
+
+interface NewDataRowsProps {
+  rowData: DataRow;
+  timeColumns: Array<string>;
+  sortedTimes: Array<string>;
+  showShadow: boolean;
+}
+
+const NewDataRows: React.FC<NewDataRowsProps> = ({ timeColumns, rowData, sortedTimes, showShadow }) => {
+  return (
+    <Grid dataColumns={timeColumns.length} padding style={{ gridColumn: 'span 2' }}>
+      {Object.values(rowData).map((row, rowCount) => {
+        const obs = row.entries;
+        const { units = '', range = '' } = row;
+
+        return (
+          <React.Fragment key={rowCount}>
+            <NewRowStartCell
+              {...{
+                units,
+                range,
+                title: row.display,
+                shadow: showShadow,
+              }}
+            />
+            <NewGridItems {...{ sortedTimes, obs, zebra: !!(rowCount % 2) }} />
+          </React.Fragment>
+        );
+      })}
+    </Grid>
+  );
+};
+
+interface DateHeaderGridProps {
+  timeColumns: Array<string>;
+  yearColumns: Array<Record<string, number | string>>;
+  dayColumns: Array<Record<string, number | string>>;
+  showShadow: boolean;
+}
+
+const DateHeaderGrid: React.FC<DateHeaderGridProps> = ({ timeColumns, yearColumns, dayColumns, showShadow }) => (
+  <Grid
+    dataColumns={timeColumns.length}
+    style={{
+      gridTemplateRows: 'repeat(3, 24px)',
+      position: 'sticky',
+      top: '0px',
+      zIndex: 2,
+      boxShadow: showShadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
+    }}
+  >
+    {yearColumns.map(({ year, size }) => {
+      return (
+        <TimeSlots key={year} className={styles['year-column']} style={{ gridColumn: `${size} span` }}>
+          {year}
+        </TimeSlots>
+      );
+    })}
+    {dayColumns.map(({ day, year, size }) => {
+      return (
+        <TimeSlots key={`${day} - ${year}`} className={styles['day-column']} style={{ gridColumn: `${size} span` }}>
+          {day}
+        </TimeSlots>
+      );
+    })}
+    {timeColumns.map((time, i) => {
+      return (
+        <TimeSlots key={time + i} className={styles['time-column']}>
+          {time}
+        </TimeSlots>
+      );
+    })}
+  </Grid>
+);
+
+export const NewTimeline = () => {
+  const { activeTests, timelineData } = useContext(FilterContext);
+  const [xIsScrolled, yIsScrolled, containerRef] = useScrollIndicator(0, 32);
+
+  const {
+    data: {
+      parsedTime: { yearColumns, dayColumns, timeColumns, sortedTimes },
+      rowData,
+      panelName,
+    },
+    loaded,
+  } = timelineData;
+
+  if (rowData && Object.keys(rowData)?.length === 0) {
+    return <EmptyState displayText={'timeline data'} headerTitle="Data Timeline" />;
+  }
+  if (activeTests && timelineData && loaded) {
+    return (
+      <RecentResultsGrid>
+        <PaddingContainer ref={containerRef}>
+          <PanelNameCorner showShadow={xIsScrolled} panelName={panelName} />
+          <DateHeaderGrid
+            {...{
+              timeColumns,
+              yearColumns,
+              dayColumns,
+              showShadow: yIsScrolled,
+            }}
+          />
+          <NewDataRows
+            {...{
+              timeColumns,
+              rowData,
+              sortedTimes,
+              showShadow: xIsScrolled,
+            }}
+          />
+          <ShadowBox />
+        </PaddingContainer>
+      </RecentResultsGrid>
+    );
+  }
+  return null;
+};
+
+export default NewTimeline;

--- a/packages/esm-patient-test-results-app/src/timeline/Timeline.tsx
+++ b/packages/esm-patient-test-results-app/src/timeline/Timeline.tsx
@@ -14,8 +14,11 @@ import {
 } from './helpers';
 import { ObsRecord, EmptyState, ObsMetaInfo, OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import styles from './timeline.scss';
-import { RecentResultsGrid } from '../overview/recent-overview.component';
 import FilterContext from '../filter/filter-context';
+
+const RecentResultsGrid = (props) => {
+  return <div {...props} className={styles['recent-results-grid']} />;
+};
 
 interface PanelNameCornerProps {
   showShadow: boolean;

--- a/packages/esm-patient-test-results-app/src/timeline/Timeline.tsx
+++ b/packages/esm-patient-test-results-app/src/timeline/Timeline.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { InlineLoading } from 'carbon-components-react';
 import useScrollIndicator from './useScroll';
-import { useManyTimelineData, usePatientPanels, useTimelineData } from './useTimelineData';
+import { useTimelineData } from './useTimelineData';
 import {
   PaddingContainer,
   TimeSlots,
@@ -115,10 +115,11 @@ interface DataEntry {
 interface DataRow {
   [_: string]: {
     entries: Array<DataEntry>;
-    meta: ObsMetaInfo;
     name: string;
     type: string;
     uuid: string;
+    units: string;
+    range: string;
   };
 }
 interface NewDataRowsProps {
@@ -132,7 +133,7 @@ const NewDataRows: React.FC<NewDataRowsProps> = ({ timeColumns, rowData, sortedT
   <Grid dataColumns={timeColumns.length} padding style={{ gridColumn: 'span 2' }}>
     {Object.entries(rowData).map(([title, row], rowCount) => {
       const obs = row.entries;
-      const { units = '', range = '' } = row.meta;
+      const { units = '', range = '' } = row;
 
       return (
         <React.Fragment key={rowCount}>
@@ -216,14 +217,9 @@ export const Timeline: React.FC<TimelineParams> = ({
   return <EmptyState displayText={'timeline data'} headerTitle="Data Timeline" />;
 };
 
-export const MultiTimeline = ({ patientUuid }) => {
-  const { data: panels } = usePatientPanels(patientUuid);
-  const { activeTests } = useContext(FilterContext);
-
+export const MultiTimeline = () => {
+  const { activeTests, timelineData } = useContext(FilterContext);
   const [xIsScrolled, yIsScrolled, containerRef] = useScrollIndicator(0, 32);
-
-  const uuids = activeTests.map((test) => panels[test]);
-  const timelineData = useManyTimelineData(patientUuid, uuids);
 
   const {
     data: {
@@ -263,6 +259,7 @@ export const MultiTimeline = ({ patientUuid }) => {
       </RecentResultsGrid>
     );
   }
+  return null;
 };
 
 export default Timeline;

--- a/packages/esm-patient-test-results-app/src/timeline/Timeline.tsx
+++ b/packages/esm-patient-test-results-app/src/timeline/Timeline.tsx
@@ -1,20 +1,10 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { InlineLoading } from 'carbon-components-react';
 import useScrollIndicator from './useScroll';
 import { useTimelineData } from './useTimelineData';
-import {
-  PaddingContainer,
-  TimeSlots,
-  Grid,
-  RowStartCell,
-  NewRowStartCell,
-  GridItems,
-  NewGridItems,
-  ShadowBox,
-} from './helpers';
-import { ObsRecord, EmptyState, ObsMetaInfo, OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
+import { PaddingContainer, TimeSlots, Grid, RowStartCell, GridItems, ShadowBox } from './helpers';
+import { ObsRecord, EmptyState, OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import styles from './timeline.scss';
-import FilterContext from '../filter/filter-context';
 
 const RecentResultsGrid = (props) => {
   return <div {...props} className={styles['recent-results-grid']} />;
@@ -106,52 +96,6 @@ const DataRows: React.FC<DataRowsProps> = ({ timeColumns, rowData, sortedTimes, 
   </Grid>
 );
 
-interface DataEntry {
-  value: number | string;
-  effectiveDateTime: string;
-  interpretation: OBSERVATION_INTERPRETATION;
-}
-
-interface DataRow {
-  [_: string]: {
-    entries: Array<DataEntry>;
-    name: string;
-    type: string;
-    uuid: string;
-    units: string;
-    range: string;
-  };
-}
-interface NewDataRowsProps {
-  rowData: DataRow;
-  timeColumns: Array<string>;
-  sortedTimes: Array<string>;
-  showShadow: boolean;
-}
-
-const NewDataRows: React.FC<NewDataRowsProps> = ({ timeColumns, rowData, sortedTimes, showShadow }) => (
-  <Grid dataColumns={timeColumns.length} padding style={{ gridColumn: 'span 2' }}>
-    {Object.entries(rowData).map(([title, row], rowCount) => {
-      const obs = row.entries;
-      const { units = '', range = '' } = row;
-
-      return (
-        <React.Fragment key={rowCount}>
-          <NewRowStartCell
-            {...{
-              units,
-              range,
-              title,
-              shadow: showShadow,
-            }}
-          />
-          <NewGridItems {...{ sortedTimes, obs, zebra: !!(rowCount % 2) }} />
-        </React.Fragment>
-      );
-    })}
-  </Grid>
-);
-
 interface TimelineParams {
   patientUuid: string;
   panelUuid?: string;
@@ -215,51 +159,6 @@ export const Timeline: React.FC<TimelineParams> = ({
       </RecentResultsGrid>
     );
   return <EmptyState displayText={'timeline data'} headerTitle="Data Timeline" />;
-};
-
-export const MultiTimeline = () => {
-  const { activeTests, timelineData } = useContext(FilterContext);
-  const [xIsScrolled, yIsScrolled, containerRef] = useScrollIndicator(0, 32);
-
-  const {
-    data: {
-      parsedTime: { yearColumns, dayColumns, timeColumns, sortedTimes },
-      rowData,
-      panelName,
-    },
-    loaded,
-  } = timelineData;
-
-  if (activeTests?.length === 0) {
-    return <EmptyState displayText={'timeline data'} headerTitle="Data Timeline" />;
-  }
-  if (activeTests && timelineData && loaded) {
-    return (
-      <RecentResultsGrid>
-        <PaddingContainer ref={containerRef}>
-          <PanelNameCorner showShadow={xIsScrolled} panelName={panelName} />
-          <DateHeaderGrid
-            {...{
-              timeColumns,
-              yearColumns,
-              dayColumns,
-              showShadow: yIsScrolled,
-            }}
-          />
-          <NewDataRows
-            {...{
-              timeColumns,
-              rowData,
-              sortedTimes,
-              showShadow: xIsScrolled,
-            }}
-          />
-          <ShadowBox />
-        </PaddingContainer>
-      </RecentResultsGrid>
-    );
-  }
-  return null;
 };
 
 export default Timeline;

--- a/packages/esm-patient-test-results-app/src/timeline/Timeline.tsx
+++ b/packages/esm-patient-test-results-app/src/timeline/Timeline.tsx
@@ -12,7 +12,7 @@ import {
   NewGridItems,
   ShadowBox,
 } from './helpers';
-import { ObsRecord, EmptyState } from '@openmrs/esm-patient-common-lib';
+import { ObsRecord, EmptyState, ObsMetaInfo, OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import styles from './timeline.scss';
 import { RecentResultsGrid } from '../overview/recent-overview.component';
 import FilterContext from '../filter/filter-context';
@@ -102,8 +102,24 @@ const DataRows: React.FC<DataRowsProps> = ({ timeColumns, rowData, sortedTimes, 
     })}
   </Grid>
 );
+
+interface DataEntry {
+  value: number | string;
+  effectiveDateTime: string;
+  interpretation: OBSERVATION_INTERPRETATION;
+}
+
+interface DataRow {
+  [_: string]: {
+    entries: Array<DataEntry>;
+    meta: ObsMetaInfo;
+    name: string;
+    type: string;
+    uuid: string;
+  };
+}
 interface NewDataRowsProps {
-  rowData: { entries: any[]; meta: { units: string; range: string } };
+  rowData: DataRow;
   timeColumns: Array<string>;
   sortedTimes: Array<string>;
   showShadow: boolean;
@@ -112,7 +128,6 @@ interface NewDataRowsProps {
 const NewDataRows: React.FC<NewDataRowsProps> = ({ timeColumns, rowData, sortedTimes, showShadow }) => (
   <Grid dataColumns={timeColumns.length} padding style={{ gridColumn: 'span 2' }}>
     {Object.entries(rowData).map(([title, row], rowCount) => {
-      console.log('row', row);
       const obs = row.entries;
       const { units = '', range = '' } = row.meta;
 

--- a/packages/esm-patient-test-results-app/src/timeline/helpers.tsx
+++ b/packages/esm-patient-test-results-app/src/timeline/helpers.tsx
@@ -33,7 +33,7 @@ export const Main: React.FC = () => <main className={styles['padded-main']} />;
 
 export const ShadowBox: React.FC = () => <div className={styles['shadow-box']} />;
 
-const TimelineCell: React.FC<{
+export const TimelineCell: React.FC<{
   text: string;
   interpretation?: OBSERVATION_INTERPRETATION;
   zebra: boolean;
@@ -95,20 +95,6 @@ export const RowStartCell = ({ title, range, units, shadow = false, openTrendlin
   </div>
 );
 
-export const NewRowStartCell = ({ title, range, units, shadow = false }) => (
-  <div
-    className={styles['row-start-cell']}
-    style={{
-      boxShadow: shadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
-    }}
-  >
-    <span className={styles['trendline-link']}>{title}</span>
-    <span className={styles['range-units']}>
-      {range} {units}
-    </span>
-  </div>
-);
-
 export const TimeSlots: React.FC<{
   style?: React.CSSProperties;
   className?: string;
@@ -128,19 +114,6 @@ export const GridItems = React.memo<{
       if (!obs[i]) return <TimelineCell key={i} text={'--'} zebra={zebra} />;
       const interpretation = obs[i].meta.assessValue(obs[i].value);
       return <TimelineCell key={i} text={obs[i].value} interpretation={interpretation} zebra={zebra} />;
-    })}
-  </>
-));
-
-export const NewGridItems = React.memo<{
-  sortedTimes: Array<string>;
-  obs: any;
-  zebra: boolean;
-}>(({ sortedTimes, obs, zebra }) => (
-  <>
-    {sortedTimes.map((_, i) => {
-      if (!obs[i]) return <TimelineCell key={i} text={''} zebra={zebra} />;
-      return <TimelineCell key={i} text={obs[i].value} interpretation={obs[i].interpretation} zebra={zebra} />;
     })}
   </>
 ));

--- a/packages/esm-patient-test-results-app/src/timeline/helpers.tsx
+++ b/packages/esm-patient-test-results-app/src/timeline/helpers.tsx
@@ -140,8 +140,7 @@ export const NewGridItems = React.memo<{
   <>
     {sortedTimes.map((_, i) => {
       if (!obs[i]) return <TimelineCell key={i} text={''} zebra={zebra} />;
-      const interpretation = 'NORMAL' || obs[i].meta.assessValue(obs[i].value);
-      return <TimelineCell key={i} text={obs[i].value} interpretation={interpretation} zebra={zebra} />;
+      return <TimelineCell key={i} text={obs[i].value} interpretation={obs[i].interpretation} zebra={zebra} />;
     })}
   </>
 ));

--- a/packages/esm-patient-test-results-app/src/timeline/helpers.tsx
+++ b/packages/esm-patient-test-results-app/src/timeline/helpers.tsx
@@ -95,6 +95,20 @@ export const RowStartCell = ({ title, range, units, shadow = false, openTrendlin
   </div>
 );
 
+export const NewRowStartCell = ({ title, range, units, shadow = false }) => (
+  <div
+    className={styles['row-start-cell']}
+    style={{
+      boxShadow: shadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
+    }}
+  >
+    <span className={styles['trendline-link']}>{title}</span>
+    <span className={styles['range-units']}>
+      {range} {units}
+    </span>
+  </div>
+);
+
 export const TimeSlots: React.FC<{
   style?: React.CSSProperties;
   className?: string;
@@ -113,6 +127,20 @@ export const GridItems = React.memo<{
     {sortedTimes.map((_, i) => {
       if (!obs[i]) return <TimelineCell key={i} text={'--'} zebra={zebra} />;
       const interpretation = obs[i].meta.assessValue(obs[i].value);
+      return <TimelineCell key={i} text={obs[i].value} interpretation={interpretation} zebra={zebra} />;
+    })}
+  </>
+));
+
+export const NewGridItems = React.memo<{
+  sortedTimes: Array<string>;
+  obs: any;
+  zebra: boolean;
+}>(({ sortedTimes, obs, zebra }) => (
+  <>
+    {sortedTimes.map((_, i) => {
+      if (!obs[i]) return <TimelineCell key={i} text={''} zebra={zebra} />;
+      const interpretation = 'NORMAL' || obs[i].meta.assessValue(obs[i].value);
       return <TimelineCell key={i} text={obs[i].value} interpretation={interpretation} zebra={zebra} />;
     })}
   </>

--- a/packages/esm-patient-test-results-app/src/timeline/timeline.scss
+++ b/packages/esm-patient-test-results-app/src/timeline/timeline.scss
@@ -65,22 +65,16 @@
 }
 
 .padding-container {
-  height: fit-content;
-  max-height: 100%;
-  width: fit-content;
-  max-width: 100%;
   padding: 0px 0 0 0;
   box-sizing: border-box;
-  margin: 0;
-  overflow: auto;
 
-  scrollbar-width: none;
   display: grid;
   grid-auto-flow: row;
   column-gap: 1px;
   row-gap: 0px;
   background-color: $color-gray-30;
   grid-template: auto auto / 9em auto;
+  border-collapse: collapse;
 }
 
 .padding-container::-webkit-scrollbar {
@@ -193,4 +187,15 @@
 .shadow-box {
   grid-row: 2 / -1;
   grid-column: 1 / 2;
+}
+
+.recent-results-grid {
+  display: grid;
+  background-color: white;
+  overflow: auto;
+  max-height: calc(100vh - 50px);
+}
+
+.recent-results-grid::-webkit-scrollbar {
+  display: none;
 }

--- a/packages/esm-patient-test-results-app/src/timeline/timeline.scss
+++ b/packages/esm-patient-test-results-app/src/timeline/timeline.scss
@@ -193,7 +193,7 @@
   display: grid;
   background-color: white;
   overflow: auto;
-  max-height: calc(100vh - 50px);
+  max-height: calc(100vh - 9rem);
 }
 
 .recent-results-grid::-webkit-scrollbar {

--- a/packages/esm-patient-test-results-app/src/timeline/useObstreeData.ts
+++ b/packages/esm-patient-test-results-app/src/timeline/useObstreeData.ts
@@ -1,0 +1,40 @@
+import { usePatient, openmrsFetch } from '@openmrs/esm-framework';
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { assessValue, exist } from '../loadPatientTestData/helpers';
+
+const augmentObstreeData = (node) => {
+  const outData = JSON.parse(JSON.stringify(node));
+  if (outData?.subSets?.length) {
+    outData.subSets = outData.subSets.map((subNode) => augmentObstreeData(subNode));
+  }
+  if (exist(outData?.hiNormal, outData?.lowNormal)) {
+    outData.range = `${outData.lowNormal} – ${outData.hiNormal}`;
+  }
+  if (outData?.obs?.length) {
+    const assess = assessValue(outData);
+    outData.obs = outData.obs.map((ob) => ({ ...ob, interpretation: assess(ob.value) }));
+  }
+  return { ...outData };
+};
+
+const useGetObstreeData = (conceptUuid) => {
+  const { patientUuid } = usePatient();
+  const response = useSWR(`/ws/rest/v1/obstree?patient=${patientUuid}&concept=${conceptUuid}`, openmrsFetch);
+  const result = useMemo(() => {
+    if (response.data) {
+      const { data, ...rest } = response;
+      const newData = augmentObstreeData(data?.data);
+      return { ...rest, loading: false, data: newData };
+    } else {
+      return {
+        data: {},
+        error: false,
+        loading: true,
+      };
+    }
+  }, [response]);
+  return result;
+};
+
+export default useGetObstreeData;

--- a/packages/esm-patient-test-results-app/src/timeline/useTimelineData.ts
+++ b/packages/esm-patient-test-results-app/src/timeline/useTimelineData.ts
@@ -2,9 +2,8 @@ import { useMemo } from 'react';
 import usePatientResultsData from '../loadPatientTestData/usePatientResultsData';
 import { ObsRecord } from '@openmrs/esm-patient-common-lib';
 import { formatDate, formatTime, parseDate } from '@openmrs/esm-framework';
-import { exist } from '../loadPatientTestData/helpers';
 
-const parseTime = (sortedTimes: string[]) => {
+export const parseTime = (sortedTimes: string[]) => {
   const yearColumns: Array<{ year: string; size: number }> = [],
     dayColumns: Array<{ year: string; day: string; size: number }> = [],
     timeColumns: string[] = [];
@@ -96,114 +95,4 @@ export const useTimelineData = (patientUuid: string, panelUuid?: string) => {
     };
   }, [sortedObs, loaded, error, panelUuid]);
   return timelineData;
-};
-
-const parsePanel = (panelData) => {
-  const sample = panelData?.entries?.[0];
-  const outData = {
-    uuid: panelData.uuid,
-    type: panelData.type,
-    name: sample.name,
-    meta: {
-      ...sample.meta,
-      range: exist(sample?.meta?.lowNormal, sample?.meta?.hiNormal)
-        ? `${sample.meta.lowNormal} – ${sample.meta.hiNormal}`
-        : null,
-    },
-    entries: [],
-  };
-  let transformedEntries = [];
-  panelData.entries.forEach((entry) => {
-    transformedEntries.push({
-      value: entry.value,
-      effectiveDateTime: entry.effectiveDateTime,
-      interpretation:
-        entry.meta.assessValue && typeof entry.meta.assessValue === 'function'
-          ? entry.meta.assessValue(entry.value)
-          : '--',
-    });
-  });
-  outData.entries = transformedEntries || [];
-  return outData;
-};
-
-/**
- * Gets all patient sorted obs from usePatientResultsData, filters for panelUuids (if provided),
- * then transforms data to be used by DataTable
- *
- * @param patientUuid - required patient identifier
- * @param panelUuids - optional panel identifier
- * @returns object of {data, loaded, error?} where data is formatted for use by the
- * timeline data table
- *
- */
-export const useManyTimelineData = (patientUuid: string, panelUuids?: string[]) => {
-  const { sortedObs, loaded, error } = usePatientResultsData(patientUuid);
-
-  const timelineData = useMemo(() => {
-    if (!sortedObs || !loaded || !!error)
-      return {
-        data: { parsedTime: {} as ReturnType<typeof parseTime>, rowData: {}, panelName: '' },
-        loaded,
-        error,
-      };
-    // look for the specified panelUuid. If none is specified, just take any obs
-    const panels = Object.entries(sortedObs).filter(([, { uuid }]) => panelUuids.includes(uuid)) || [];
-
-    let rows = {};
-
-    panels?.forEach((panel) => {
-      const [panelName, panelData] = panel;
-      if (panelData) {
-        rows[panelName] = parsePanel(panelData);
-      }
-    });
-
-    const allTimes = [
-      ...new Set(
-        Object.keys(rows)
-          .map((row) => rows[row].entries.map((e) => e.effectiveDateTime))
-          .flat(),
-      ),
-    ];
-    allTimes.sort((a, b) => (new Date(a) < new Date(b) ? 1 : -1));
-    Object.keys(rows).forEach((row) => {
-      const newEntries = allTimes.map((time) => rows[row].entries.find((entry) => entry.effectiveDateTime === time));
-      rows[row].entries = newEntries;
-    });
-    const panelName = 'Timeline';
-    return {
-      data: { parsedTime: parseTime(allTimes), rowData: rows, panelName },
-      loaded: true,
-    };
-  }, [sortedObs, loaded, error, panelUuids]);
-  return timelineData;
-};
-
-/**
- * Very bad way to get panelUuid that for all tests that pertain to a patient
- * Hopefully there's a better endpoint for this
- *
- * @param patientUuid - required patient identifier
- * @returns Object of {data, loaded, error} where data is an object in format
- * "PanelName": panelUuid
- *
- */
-export const usePatientPanels = (patientUuid: string) => {
-  const { sortedObs, loaded, error } = usePatientResultsData(patientUuid);
-
-  const panels = useMemo(() => {
-    if (!sortedObs || !loaded || !!error)
-      return {
-        data: [{ parsedTime: {} as ReturnType<typeof parseTime> }],
-        loaded,
-        error,
-      };
-
-    const outData = {};
-    Object.entries(sortedObs).forEach(([key, value]) => (outData[key] = value.uuid));
-    return { loaded: true, data: outData };
-  }, [sortedObs, loaded, error]);
-
-  return panels;
 };

--- a/packages/esm-patient-test-results-app/src/timeline/useTimelineData.ts
+++ b/packages/esm-patient-test-results-app/src/timeline/useTimelineData.ts
@@ -110,6 +110,10 @@ const parsePanel = (panelData) => {
     transformedEntries.push({
       value: entry.value,
       effectiveDateTime: entry.effectiveDateTime,
+      interpretation:
+        entry.meta.assessValue && typeof entry.meta.assessValue === 'function'
+          ? entry.meta.assessValue(entry.value)
+          : '--',
     });
   });
   outData.entries = transformedEntries || [];
@@ -132,7 +136,7 @@ export const useManyTimelineData = (patientUuid: string, panelUuids?: string[]) 
   const timelineData = useMemo(() => {
     if (!sortedObs || !loaded || !!error)
       return {
-        data: { parsedTime: {} as ReturnType<typeof parseTime> },
+        data: { parsedTime: {} as ReturnType<typeof parseTime>, rowData: {}, panelName: '' },
         loaded,
         error,
       };

--- a/packages/esm-patient-test-results-app/src/timeline/useTimelineData.ts
+++ b/packages/esm-patient-test-results-app/src/timeline/useTimelineData.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import usePatientResultsData from '../loadPatientTestData/usePatientResultsData';
 import { ObsRecord } from '@openmrs/esm-patient-common-lib';
 import { formatDate, formatTime, parseDate } from '@openmrs/esm-framework';
+import { exist } from '../loadPatientTestData/helpers';
 
 const parseTime = (sortedTimes: string[]) => {
   const yearColumns: Array<{ year: string; size: number }> = [],
@@ -98,11 +99,17 @@ export const useTimelineData = (patientUuid: string, panelUuid?: string) => {
 };
 
 const parsePanel = (panelData) => {
+  const sample = panelData?.entries?.[0];
   const outData = {
     uuid: panelData.uuid,
     type: panelData.type,
-    name: panelData.entries[0].name,
-    meta: panelData.entries[0].meta,
+    name: sample.name,
+    meta: {
+      ...sample.meta,
+      range: exist(sample?.meta?.lowNormal, sample?.meta?.hiNormal)
+        ? `${sample.meta.lowNormal} – ${sample.meta.hiNormal}`
+        : null,
+    },
     entries: [],
   };
   let transformedEntries = [];


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Work in progress draft PR that extends FilterSet context to support Lowest Parent which is needed to make timeline groupings. Some progress has been made to the timeline grouping UI, although there is still more work to be done until this is finished

New progress:
- Style changes to filter (indent first node, undo 0th node bold, remove border from leaves, apply disable to no data)
- Remove tests with no data from timeline
- Disable checkboxes in filter for tests with no data
- "nothing checked means everything is checked"
- Check/Uncheck test only affect displaying that test in that parent. Other parents with same test will not be affected
- Timeline tests are grouped based on their lowest common parent
- Maximize / Minimize Timeline Button 
- Grouped title doesn't stretch full width
- Separate groups don't scroll horizontally together
- Group head (datetimes) are not sticky to top of page
- Configuration
- Multiple /obstree requests

Not working:
- Include Panel Data
- Loading of Trendline
- Tablet view, floating action button for filter
- List of filters at top bar
- Modular extension
- Unit Tests
- Deduplicate code


## Screenshots


## Related Issue
Ticket -> https://issues.openmrs.org/browse/O3-1060
Concept -> https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/621e53c282619babb9a9d6b5

## Other
This is just a draft PR. Feel free to take a look and suggest changes 🙂 . More better changes, + code cleanup refactor coming soon.
