### PR TITLE
OHRI-452 Form Patient Banner - Optional hideActionsOverflow, optional param

### DIFF
--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -15,9 +15,16 @@ interface PatientBannerProps {
   patientUuid: string;
   onClick?: (patientUuid: string) => void;
   onTransition?: () => void;
+  hideActionsOverflow?: boolean;
 }
 
-const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, onClick, onTransition }) => {
+const PatientBanner: React.FC<PatientBannerProps> = ({
+  patient,
+  patientUuid,
+  onClick,
+  onTransition,
+  hideActionsOverflow,
+}) => {
   const { t } = useTranslation();
   const overFlowMenuRef = React.useRef(null);
 
@@ -66,23 +73,28 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, onC
                 className={styles.flexRow}
               />
             </div>
-            <div ref={overFlowMenuRef}>
-              <CustomOverflowMenuComponent
-                menuTitle={
-                  <>
-                    <span className={styles.actionsButtonText}>{t('actions', 'Actions')}</span>{' '}
-                    <OverflowMenuVertical16 style={{ marginLeft: '0.5rem' }} />
-                  </>
-                }
-              >
-                <ExtensionSlot
-                  extensionSlotName="patient-actions-slot"
-                  key="patient-actions-slot"
-                  className={styles.overflowMenuItemList}
-                  state={patientActionsSlotState}
-                />
-              </CustomOverflowMenuComponent>
-            </div>
+            {
+              !hideActionsOverflow && (
+                <div ref={overFlowMenuRef}>
+                <CustomOverflowMenuComponent
+                  menuTitle={
+                    <>
+                      <span className={styles.actionsButtonText}>{t('actions', 'Actions')}</span>{' '}
+                      <OverflowMenuVertical16 style={{ marginLeft: '0.5rem' }} />
+                    </>
+                  }
+                >
+                  <ExtensionSlot
+                    extensionSlotName="patient-actions-slot"
+                    key="patient-actions-slot"
+                    className={styles.overflowMenuItemList}
+                    state={patientActionsSlotState}
+                  />
+                </CustomOverflowMenuComponent>
+              </div>
+              )
+            }
+            
           </div>
           <div className={styles.demographics}>
             <span>{capitalize(patient.gender)}</span> &middot; <span>{age(patient.birthDate)}</span> &middot;{' '}

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -73,9 +73,8 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
                 className={styles.flexRow}
               />
             </div>
-            {
-              !hideActionsOverflow && (
-                <div ref={overFlowMenuRef}>
+            {!hideActionsOverflow && (
+              <div ref={overFlowMenuRef}>
                 <CustomOverflowMenuComponent
                   menuTitle={
                     <>
@@ -92,9 +91,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
                   />
                 </CustomOverflowMenuComponent>
               </div>
-              )
-            }
-            
+            )}
           </div>
           <div className={styles.demographics}>
             <span>{capitalize(patient.gender)}</span> &middot; <span>{age(patient.birthDate)}</span> &middot;{' '}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->
This is the current Patient Banner on the Form:
![Screen Shot 2022-03-09 at 13 58 13](https://user-images.githubusercontent.com/4475142/157440528-1677003f-8701-4998-89f2-ee3bc5aba768.png)

The objective is to make this an option Overflow Button, since for this scenario, the actions don't apply for our context. 
![Screen Shot 2022-03-09 at 14 02 12](https://user-images.githubusercontent.com/4475142/157440619-85032db4-da2a-429a-a044-700fcf746d22.png)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1154?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D

## Other
<!-- Anything not covered above -->
