### PR TITLE
(chore) Use cross-env to pass TZ=UTC environment variable to jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "verify": "lerna run lint && lerna run test && lerna run typescript",
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx}\"",
     "prepare": "husky install",
-    "test": "TZ=UTC jest --config jest.config.json --verbose false --passWithNoTests",
-    "test-watch": "TZ=UTC jest --watch --config jest.config.json",
+    "test": "cross-env TZ=UTC jest --config jest.config.json --verbose false --passWithNoTests",
+    "test-watch": "cross-env TZ=UTC jest --watch --config jest.config.json",
     "coverage": "yarn test --coverage"
   },
   "devDependencies": {
@@ -44,6 +44,7 @@
     "babel-jest": "^26.3.0",
     "babel-preset-minify": "^0.5.1",
     "concurrently": "^6.5.1",
+    "cross-env": "^7.0.3",
     "css-loader": "^6.6.0",
     "d3-selection": "^3.0.0",
     "dayjs": "^1.8.36",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6878,6 +6878,13 @@ critters@0.0.12:
     postcss "^8.3.7"
     pretty-bytes "^5.3.0"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
@@ -6896,7 +6903,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

`yarn test` was not working on Powershell because Powershell doesn't understand POSIX syntax for environment variables. [cross-env](https://www.npmjs.com/package/cross-env) makes it work in any shell.
