### PR TITLE
(fix) Minor bug where extensionId is used instead of extension name

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Redirect } from 'react-router-dom';
-import { useExtensionSlotMeta, useExtensionStore } from '@openmrs/esm-framework';
+import { useExtensionStore } from '@openmrs/esm-framework';
 import { useNavGroups } from '@openmrs/esm-patient-common-lib';
 import { basePath } from '../../constants';
 import { DashboardView, DashboardConfig } from './dashboard-view.component';

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Extension, ExtensionData, ExtensionSlot, useExtensionSlotMeta } from '@openmrs/esm-framework';
+import {
+  Extension,
+  ExtensionData,
+  ExtensionSlot,
+  getExtensionNameFromId,
+  useExtensionSlotMeta,
+} from '@openmrs/esm-framework';
 import { useRouteMatch } from 'react-router-dom';
 import { basePath } from '../../constants';
 import styles from './dashboard-view.scss';
@@ -42,7 +48,7 @@ export function DashboardView({ dashboard, patientUuid, patient }: DashboardView
 
   const wrapItem = React.useCallback(
     (slot: React.ReactNode, extension: ExtensionData) => {
-      const { columnSpan = 1 } = dashboardMeta[extension.extensionId];
+      const { columnSpan = 1 } = dashboardMeta[getExtensionNameFromId(extension.extensionId)];
       return <div style={{ gridColumn: `span ${columnSpan}` }}>{slot}</div>;
     },
     [dashboardMeta],


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Extension metas are indexed by extension name, not extension ID.

## Screenshots

```json
{
  "@openmrs/esm-patient-chart-app": {
    "extensions": {
      "patient-chart-allergies-dashboard-slot": {
        "add": [
          "obs-by-encounter-widget#hiv"
        ],
        "configure": {
          "obs-by-encounter-widget#hiv" : {
            "title" : "HIV Widget"
          }
        }
      }
    }
  }
}
```

![Screenshot from 2022-03-09 16-41-13](https://user-images.githubusercontent.com/1031876/157564588-76a30e17-338d-4117-a7e3-f83ca2c0badd.png)

