### PR TITLE
(feat) `useSWRImmutable` for fetching vitals concept metadata

### DIFF
--- a/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
+++ b/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
@@ -1,14 +1,13 @@
-import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
 import { openmrsFetch } from '@openmrs/esm-framework';
 
 export function useVitalsConceptMetadata() {
   const customRepresentation =
     'custom:(setMembers:(uuid,display,hiNormal,hiAbsolute,hiCritical,lowNormal,lowAbsolute,lowCritical,units))';
 
-  const { data, error } = useSWR<{ data: VitalsConceptMetadataResponse }, Error>(
-    `/ws/rest/v1/concept/?q=VITALS SIGNS&v=${customRepresentation}`,
-    openmrsFetch,
-  );
+  const apiUrl = `/ws/rest/v1/concept/?q=VITALS SIGNS&v=${customRepresentation}`;
+
+  const { data, error } = useSWRImmutable<{ data: VitalsConceptMetadataResponse }, Error>(apiUrl, openmrsFetch);
 
   const conceptMetadata = data?.data?.results[0]?.setMembers;
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 import { PatientVitalsAndBiometrics } from './vitals-biometrics-form/vitals-biometrics-form.component';
-import { openmrsFetch, fhirBaseUrl, useConfig, FHIRResource, parseDate } from '@openmrs/esm-framework';
+import { openmrsFetch, fhirBaseUrl, useConfig, FHIRResource } from '@openmrs/esm-framework';
 import { ConfigObject } from '../config-schema';
 import { calculateBMI } from './vitals-biometrics-form/vitals-biometrics-form.utils';
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Starting from version 1.0 of SWR, we can use the [useSWRImmutable](https://swr.vercel.app/docs/revalidation#disable-automatic-revalidations) hook to mark a resource as immutable. This means that once data is fetched and cached, it will not get revalidated again. 

The `useVitalsConceptMetadata` hook fetches data from the concept resource. This data is unlikely to change very often. 

This PR modifies `useVitalsConceptMetadata` to use the `useSWRImmutable` hook for fetching data. It also removes an unused import from the vitals resource. 

