### PR TITLE
(fix): only try to process dashboard extensions once the patient-chart-dashboard-slot has been mounted

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
@@ -29,6 +29,10 @@ const ChartReview: React.FC<ChartReviewProps> = ({ patientUuid, patient, view })
   const extensionStore = useExtensionStore();
   const { navGroups } = useNavGroups();
 
+  if (!('patient-chart-dashboard-slot' in extensionStore.slots)) {
+    return null;
+  }
+
   const ungroupedDashboards = extensionStore.slots['patient-chart-dashboard-slot'].assignedExtensions.map(
     (e) => e.meta,
   );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Without this in tablet mode I was getting the error: `TypeError: extensionStore.slots['patient-chart-dashboard-slot'] is undefined`.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
