### PR TITLE
(chore) Add `lint` and `typescript` jobs to cached `build` pipeline

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
-      - run: yarn run verify 
-      - run: yarn turbo run build --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="${{ github.repository_owner }}"
+      - run: yarn run test
+      - run: yarn turbo run lint typescript build --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="${{ github.repository_owner }}"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Add the `lint` and `typescript` jobs to the `build` pipeline so they can leverage turbo's remote caching. Turbo [efficiently schedules](https://turborepo.org/docs/features/pipelines) how to run these commands efficiently schedules execution of these commands. Note how the CI run for the latest commit took just 6 minutes. 

(The key thing to look out for when reading the workflow log is `cache hit, replaying output {cache-id}` - Turbo replays a stored cache artefact from a previous run when nothing has changed in a particular package).