### PR TITLE
(chore) Fix pre-release and release CI jobs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -764,7 +764,7 @@ jobs:
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"
-      - run: yarn lerna bootstrap
+      - run: npx lerna bootstrap
       - run: yarn turbo run build
       - run: yarn lerna version patch --no-git-tag-version --no-push --yes
       - run: yarn lerna version "$(node -e "console.log(require('./lerna.json').version)")-pre.${{ github.run_number }}" --no-git-tag-version --yes
@@ -788,7 +788,7 @@ jobs:
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"
-      - run: yarn lerna bootstrap
+      - run: npx lerna bootstrap
       - run: yarn turbo run build
       - run: yarn run ci:publish
         env:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the currently failing pre-release and release CI jobs by changing their bootstrap command from `yarn lerna bootstrap` to `npx lerna bootstrap`.

## Screenshots

> From the most recent [CI run](https://github.com/openmrs/openmrs-esm-patient-chart/runs/5695081619?check_suite_focus=true).

<img width="725" alt="Screenshot 2022-03-25 at 22 25 32" src="https://user-images.githubusercontent.com/8509731/160188185-f09c450f-49a4-4af7-9d60-87e459bbe72e.png">

