### PR TITLE
O3-1196: Tablet design (horizontal): "Select local photo instead" button is hidden in attachment popup

### DIFF
--- a/packages/esm-patient-attachments-app/src/attachments/camera-upload.scss
+++ b/packages/esm-patient-attachments-app/src/attachments/camera-upload.scss
@@ -1,3 +1,5 @@
+@import "~@openmrs/esm-styleguide/src/vars";
+
 .cameraSection {
   padding: 10px;
 }
@@ -28,4 +30,10 @@
 
 .uploadFile {
   display: none;
+}
+
+@media (max-height: $breakpoint-tablet-min){
+  .frameContent {
+    width: 70%;
+  }  
 }

--- a/packages/esm-patient-attachments-app/src/attachments/camera-upload.scss
+++ b/packages/esm-patient-attachments-app/src/attachments/camera-upload.scss
@@ -32,8 +32,8 @@
   display: none;
 }
 
-@media (max-height: $breakpoint-tablet-min){
+@media (max-width: $breakpoint-tablet-max){
   .frameContent {
-    width: 70%;
+    width: 65%;
   }  
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Adjust the size of the camera feed area respective to the height of the tablet horizontal view.

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://user-images.githubusercontent.com/27495258/160955870-c4cc68d1-345e-4820-b642-37471c5c00a1.png)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1196

## Other
<!-- Anything not covered above -->
