### PR TITLE
(fix) O3-1220: Vitals header does not update upon form submission

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render } from '@testing-library/react';
+import { useConfig } from '@openmrs/esm-framework';
 import { mockConceptMetadata, mockVitalsConfig, mockVitalsSignsConcept } from '../../../../../__mocks__/vitals.mock';
 import { mockPatient } from '../../../../../__mocks__/patient.mock';
 import VitalsAndBiometricsForm from './vitals-biometrics-form.component';
@@ -8,6 +9,8 @@ import VitalsAndBiometricsForm from './vitals-biometrics-form.component';
 const mockConceptUnits = new Map<string, string>(
   mockVitalsSignsConcept.data.results[0].setMembers.map((concept) => [concept.uuid, concept.units]),
 );
+
+const mockedUseConfig = useConfig as jest.Mock;
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
@@ -21,25 +24,19 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   };
 });
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    useConfig: jest.fn(() => mockVitalsConfig),
-  };
-});
-
 jest.mock('../vitals.resource', () => ({
   savePatientVitals: jest.fn(),
 }));
 
 const testProps = {
-  patientUuid: mockPatient.id,
   closeWorkspace: () => {},
+  patientUuid: mockPatient.id,
+  promptBeforeClosing: () => {},
 };
 
 describe('VitalsBiometricsForm: ', () => {
+  beforeEach(() => mockedUseConfig.mockReturnValue(mockVitalsConfig));
+
   it('renders the vitals and biometrics form', async () => {
     renderForm();
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -1,22 +1,22 @@
 import React, { useEffect, useState } from 'react';
-import VitalsBiometricInput from './vitals-biometrics-input.component';
-import styles from './vitals-biometrics-form.component.scss';
 import { useTranslation } from 'react-i18next';
 import { useSWRConfig } from 'swr';
 import {
-  useConfig,
   createErrorHandler,
-  useSessionUser,
+  fhirBaseUrl,
   showToast,
   showNotification,
-  fhirBaseUrl,
+  useConfig,
   useLayoutType,
+  useSessionUser,
 } from '@openmrs/esm-framework';
 import { DefaultWorkspaceProps, useVitalsConceptMetadata } from '@openmrs/esm-patient-common-lib';
 import { Column, Grid, Row, Button, ButtonSet, Form } from 'carbon-components-react';
 import { calculateBMI, isInNormalRange } from './vitals-biometrics-form.utils';
-import { pageSize, savePatientVitals } from '../vitals.resource';
+import { savePatientVitals } from '../vitals.resource';
 import { ConfigObject } from '../../config-schema';
+import styles from './vitals-biometrics-form.component.scss';
+import VitalsBiometricInput from './vitals-biometrics-input.component';
 
 export interface PatientVitalsAndBiometrics {
   systolicBloodPressure: string;
@@ -36,23 +36,12 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
   const isTablet = useLayoutType() === 'tablet';
   const session = useSessionUser();
   const config = useConfig() as ConfigObject;
-  const { mutate } = useSWRConfig();
+  const { cache, mutate }: { cache: any; mutate: Function } = useSWRConfig();
   const { data: conceptUnits, conceptMetadata } = useVitalsConceptMetadata();
   const biometricsUnitsSymbols = config.biometrics;
   const [patientVitalAndBiometrics, setPatientVitalAndBiometrics] = useState<PatientVitalsAndBiometrics>();
   const [patientBMI, setPatientBMI] = useState<number>();
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-
-  const vitalsConcepts = {
-    systolicBloodPressure: config.concepts.systolicBloodPressureUuid,
-    diastolicBloodPressure: config.concepts.diastolicBloodPressureUuid,
-    pulse: config.concepts.pulseUuid,
-    temperature: config.concepts.temperatureUuid,
-    oxygenSaturation: config.concepts.oxygenSaturationUuid,
-    height: config.concepts.heightUuid,
-    weight: config.concepts.weightUuid,
-    respiratoryRate: config.concepts.respiratoryRateUuid,
-  };
 
   const isBMIInNormalRange = (value: number | undefined | string) => {
     if (value === undefined || value === '') return true;
@@ -83,12 +72,14 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
             description: t('vitalsAndBiometricsNowAvailable', 'They are now visible on the Vitals and Biometrics page'),
           });
 
-          mutate(
-            `${fhirBaseUrl}/Observation?subject:Patient=${patientUuid}&code=` +
-              Object.values(vitalsConcepts).join(',') +
-              '&_summary=data&_sort=-date' +
-              `&_count=${pageSize}`,
+          const apiUrlPattern = new RegExp(
+            fhirBaseUrl + '\\/Observation\\?subject\\:Patient\\=' + patientUuid + '\\&code\\=',
           );
+
+          // Find matching keys from SWR's cache and broadcast a revalidation message to their pre-bound SWR hooks
+          Array.from(cache.keys())
+            .filter((url: string) => apiUrlPattern.test(url))
+            .forEach((url: string) => mutate(url));
         }
       })
       .catch((err) => {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
@@ -39,7 +39,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
   const config = useConfig() as ConfigObject;
   const { t } = useTranslation();
   const { data: conceptUnits, conceptMetadata } = useVitalsConceptMetadata();
-  const { vitals, isLoading } = useVitals(patientUuid, true);
+  const { vitals, isLoading, isValidating } = useVitals(patientUuid, true);
   const latestVitals = vitals?.[0];
   const [showDetailsPanel, setShowDetailsPanel] = useState(false);
   const toggleDetailsPanel = () => setShowDetailsPanel(!showDetailsPanel);
@@ -79,6 +79,9 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
               {t('lastRecorded', 'Last recorded')}: {formatDate(parseDate(latestVitals?.date), { mode: 'wide' })}
             </span>
           </span>
+          <div className={styles.backgroundDataFetchingIndicator}>
+            <span>{isValidating ? <InlineLoading /> : null}</span>
+          </div>
           <div className={styles['button-container']}>
             <Button
               className={styles['record-vitals']}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
@@ -49,14 +49,14 @@ export function useVitals(patientUuid: string, includeBiometrics: boolean = fals
         .filter((uuid) => !biometricsConcepts.includes(uuid))
         .join(',');
 
-  const { data, error, isValidating } = useSWR<{ data: VitalsFetchResponse }, Error>(
+  const apiUrl =
     `${fhirBaseUrl}/Observation?subject:Patient=${patientUuid}&code=` +
-      conceptUuids +
-      '&_summary=data&_sort=-date' +
-      `&_count=${pageSize}
-    `,
-    openmrsFetch,
-  );
+    conceptUuids +
+    '&_summary=data&_sort=-date' +
+    `&_count=${pageSize}
+        `;
+
+  const { data, error, isValidating } = useSWR<{ data: VitalsFetchResponse }, Error>(apiUrl, openmrsFetch);
 
   const getVitalSignKey = (conceptUuid: string) => {
     if (conceptUuid === concepts.systolicBloodPressureUuid) return 'systolic';


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue where the values displayed in the vitals header do not update after submitting a new batch of values using the vitals and biometrics form. This is because the revalidation key passed to `mutate` does not match the URL that the form POSTs to.

This PR introduces a regular expression match to obtain matching keys and then invoke the `mutate` function on their pre-bound hooks. Because the key bound to the `useVitals` hook changes based on whether biometrics concepts are included or not, using a regex to perform a partial match is a more robust approach than trying to use a fully formed URL.

## Video

https://user-images.githubusercontent.com/8509731/161515582-cc4a4494-713a-427a-b8f1-d37655e95fdf.mp4


