### PR TITLE
(test) Rename swrRender helper method

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import { within } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch, useConfig, usePagination } from '@openmrs/esm-framework';
-import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import ObsSwitchable from './obs-switchable.component';
 import { ConfigObject } from '../config-schema';
 import { mockWeightAndViralLoadResult } from '../../../../__mocks__/generic-widgets.mock';
@@ -130,5 +130,5 @@ describe('Switchable obs viewer: ', () => {
 });
 
 function renderObsSwitchable() {
-  swrRender(<ObsSwitchable patientUuid={'foo-patient-123'} />);
+  renderWithSwr(<ObsSwitchable patientUuid={'foo-patient-123'} />);
 }

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { mockFhirAllergyIntoleranceResponse } from '../../../../__mocks__/allergies.mock';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
-import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import AllergiesDetailedSummary from './allergies-detailed-summary.component';
 
 const testProps = {
@@ -78,5 +78,5 @@ describe('AllergiesDetailedSummary: ', () => {
 });
 
 function renderAllergiesDetailedSummary() {
-  swrRender(<AllergiesDetailedSummary {...testProps} />);
+  renderWithSwr(<AllergiesDetailedSummary {...testProps} />);
 }

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
 import { mockAllergies, mockFhirAllergyIntoleranceResponse } from '../../../../__mocks__/allergies.mock';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
-import { patientChartBasePath, swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { patientChartBasePath, renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import AllergiesOverview from './allergies-overview.component';
 
 const testProps = {
@@ -100,5 +100,5 @@ describe('AllergiesOverview: ', () => {
 });
 
 function renderAllergiesOverview() {
-  swrRender(<AllergiesOverview {...testProps} />);
+  renderWithSwr(<AllergiesOverview {...testProps} />);
 }

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-tile.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-tile.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { openmrsFetch } from '@openmrs/esm-framework';
-import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { mockFhirAllergyIntoleranceResponse } from '../../../../__mocks__/allergies.mock';
 import AllergiesTile from './allergies-tile.component';
@@ -35,5 +35,5 @@ describe('AllergiesTile', () => {
 });
 
 function renderAllergiesTile() {
-  swrRender(<AllergiesTile {...testProps} />);
+  renderWithSwr(<AllergiesTile {...testProps} />);
 }

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.test.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { mockAppointmentsData } from '../../../../__mocks__/appointments.mock';
-import { patientChartBasePath, swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { patientChartBasePath, renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import AppointmentsBase from './appointments-base.component';
 
 const testProps = {
@@ -105,5 +105,5 @@ describe('AppointmensOverview', () => {
 });
 
 function renderAppointments() {
-  swrRender(<AppointmentsBase {...testProps} />);
+  renderWithSwr(<AppointmentsBase {...testProps} />);
 }

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-form.test.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-form.test.tsx
@@ -7,7 +7,7 @@ import { mockLocations, mockLocationsDataResponse } from '../../../../__mocks__/
 import { openmrsFetch, showNotification, showToast } from '@openmrs/esm-framework';
 import { mockSessionDataResponse } from '../../../../__mocks__/session.mock';
 import { mockAppointmentsData, mockUseAppointmentServiceData } from '../../../../__mocks__/appointments.mock';
-import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import { createAppointment } from './appointments.resource';
 import AppointmentForm from './appointments-form.component';
 
@@ -191,5 +191,5 @@ describe('AppointmentForm', () => {
 });
 
 function renderAppointmentsForm() {
-  swrRender(<AppointmentForm {...testProps} />);
+  renderWithSwr(<AppointmentForm {...testProps} />);
 }

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { openmrsFetch } from '@openmrs/esm-framework';
-import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import ContactDetails from './contact-details.component';
 import * as usePatientContactAttributeMock from '../hooks/usePatientAttributes';
 
@@ -103,7 +103,7 @@ describe('ContactDetails: ', () => {
   });
 
   it('renders an empty state view when address and contact details is not available', () => {
-    swrRender(<ContactDetails address={null} telecom={null} patientId={'some-uuid'} />);
+    renderWithSwr(<ContactDetails address={null} telecom={null} patientId={'some-uuid'} />);
     spyOn(usePatientContactAttributeMock, 'usePatientContactAttributes').and.returnValue({
       isLoading: false,
       contactAttributes: [],
@@ -117,5 +117,5 @@ describe('ContactDetails: ', () => {
 });
 
 function renderContactDetails() {
-  swrRender(<ContactDetails {...testProps} />);
+  renderWithSwr(<ContactDetails {...testProps} />);
 }

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.test.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.test.tsx
@@ -7,7 +7,7 @@ import {
   mockBiometricsResponse,
   mockConceptMetadata,
 } from '../../../../__mocks__/biometrics.mock';
-import { patientChartBasePath, swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { patientChartBasePath, renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import BiometricsOverview from './biometrics-overview.component';
 import { mockVitalsSignsConcept } from '../../../../__mocks__/vitals.mock';
 
@@ -129,5 +129,5 @@ describe('BiometricsOverview: ', () => {
 });
 
 function renderBiometricsOverview() {
-  swrRender(<BiometricsOverview {...testProps} />);
+  renderWithSwr(<BiometricsOverview {...testProps} />);
 }

--- a/packages/esm-patient-biometrics-app/src/biometrics/weight-tile.test.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/weight-tile.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { openmrsFetch } from '@openmrs/esm-framework';
-import { getByTextWithMarkup, swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { getByTextWithMarkup, renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { mockBiometricsResponse, mockConceptMetadata } from '../../../../__mocks__/biometrics.mock';
 import WeightTile from './weight-tile.component';
@@ -66,5 +66,5 @@ describe('WeightTile', () => {
 });
 
 function renderWeightTile() {
-  swrRender(<WeightTile {...testProps} />);
+  renderWithSwr(<WeightTile {...testProps} />);
 }

--- a/packages/esm-patient-chart-app/src/visit/past-visit-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/past-visit-overview.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { openmrsFetch } from '@openmrs/esm-framework';
-import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import PastVisitOverview from './past-visit-overview.component';
 
 const testProps = {
@@ -73,5 +73,5 @@ describe('PastVisitOverview', () => {
 });
 
 function renderPastVisitOverview() {
-  swrRender(<PastVisitOverview {...testProps} />);
+  renderWithSwr(<PastVisitOverview {...testProps} />);
 }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch } from '@openmrs/esm-framework';
-import { swrRender, waitForLoadingToFinish } from '../../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../../tools/test-helpers';
 import { visitOverviewDetailMockData } from '../../../../../__mocks__/visits.mock';
 import { mockPatient } from '../../../../../__mocks__/patient.mock';
 import VisitDetailOverview from './visit-detail-overview.component';
@@ -93,5 +93,5 @@ describe('VisitDetailOverview', () => {
 });
 
 function renderVisitDetailOverview() {
-  swrRender(<VisitDetailOverview {...testProps} />);
+  renderWithSwr(<VisitDetailOverview {...testProps} />);
 }

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
@@ -5,7 +5,7 @@ import { attach, openmrsFetch } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { mockFhirConditionsResponse } from '../../../../__mocks__/conditions.mock';
-import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import ConditionsDetailedSummary from './conditions-detailed-summary.component';
 
 const mockAttach = attach as jest.Mock;
@@ -101,5 +101,5 @@ it('clicking the Add button or Record Conditions link launches the conditions fo
 });
 
 function renderConditionsDetailedSummary() {
-  swrRender(<ConditionsDetailedSummary />);
+  renderWithSwr(<ConditionsDetailedSummary />);
 }

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
@@ -5,7 +5,7 @@ import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { mockConditions, mockFhirConditionsResponse } from '../../../../__mocks__/conditions.mock';
-import { patientChartBasePath, swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { patientChartBasePath, renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import ConditionsOverview from './conditions-overview.component';
 
 const testProps = {
@@ -128,5 +128,5 @@ describe('ConditionsOverview: ', () => {
 });
 
 function renderConditionsOverview() {
-  swrRender(<ConditionsOverview {...testProps} />);
+  renderWithSwr(<ConditionsOverview {...testProps} />);
 }

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.test.tsx
@@ -4,7 +4,7 @@ import {
   mockPatientImmunizationsSearchResponse,
   mockPaginatedImmunizations,
 } from '../../../../__mocks__/immunizations.mock';
-import { patientChartBasePath, swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { patientChartBasePath, renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
 import ImmunizationsOverview from './immunizations-overview.component';
@@ -102,5 +102,5 @@ describe('ImmunizationOverview: ', () => {
 });
 
 function renderImmunizationsOverview() {
-  swrRender(<ImmunizationsOverview {...testProps} />);
+  renderWithSwr(<ImmunizationsOverview {...testProps} />);
 }

--- a/packages/esm-patient-medications-app/src/medications/active-medications.test.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.test.tsx
@@ -3,7 +3,7 @@ import { openmrsFetch } from '@openmrs/esm-framework';
 import { screen, within } from '@testing-library/react';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { mockDrugOrders } from '../../../../__mocks__/medication.mock';
-import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import ActiveMedications from './active-medications.component';
 
 const testProps = {
@@ -78,5 +78,5 @@ describe('ActiveMedications: ', () => {
 });
 
 function renderActiveMedications() {
-  swrRender(<ActiveMedications {...testProps} />);
+  renderWithSwr(<ActiveMedications {...testProps} />);
 }

--- a/packages/esm-patient-notes-app/src/notes/notes-detailed-summary.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-detailed-summary.test.tsx
@@ -3,7 +3,7 @@ import { screen, within } from '@testing-library/react';
 import { openmrsFetch, useConfig, usePagination } from '@openmrs/esm-framework';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { mockVisitNotes, formattedVisitNotes } from '../../../../__mocks__/visit-notes.mock';
-import { patientChartBasePath, swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { patientChartBasePath, renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import NotesDetailedSummary from './notes-detailed-summary.component';
 import { ConfigMock } from '../../../../__mocks__/chart-widgets-config.mock';
 
@@ -120,5 +120,5 @@ describe('NotesDetailedSummary: ', () => {
 });
 
 function renderNotesDetailedSummary() {
-  swrRender(<NotesDetailedSummary {...testProps} />);
+  renderWithSwr(<NotesDetailedSummary {...testProps} />);
 }

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { openmrsFetch, useConfig, usePagination } from '@openmrs/esm-framework';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import { mockVisitNotes, formattedVisitNotes } from '../../../../__mocks__/visit-notes.mock';
-import { patientChartBasePath, swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { patientChartBasePath, renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import { ConfigMock } from '../../../../__mocks__/chart-widgets-config.mock';
 import NotesOverview from './notes-overview.component';
 
@@ -129,5 +129,5 @@ describe('NotesOverview: ', () => {
 });
 
 function renderNotesOverview() {
-  swrRender(<NotesOverview {...testProps} />);
+  renderWithSwr(<NotesOverview {...testProps} />);
 }

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
 import { mockEnrolledProgramsResponse } from '../../../../__mocks__/programs.mock';
-import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import ProgramsDetailedSummary from './programs-detailed-summary.component';
 
@@ -100,5 +100,5 @@ describe('ProgramsDetailedSummary ', () => {
 });
 
 function renderProgramsOverview() {
-  swrRender(<ProgramsDetailedSummary />);
+  renderWithSwr(<ProgramsDetailedSummary />);
 }

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
@@ -5,7 +5,7 @@ import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { mockEnrolledProgramsResponse } from '../../../../__mocks__/programs.mock';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
-import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import ProgramsOverview from './programs-overview.component';
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
@@ -109,5 +109,5 @@ describe('ProgramsOverview', () => {
 });
 
 function renderProgramsOverview() {
-  swrRender(<ProgramsOverview {...testProps} />);
+  renderWithSwr(<ProgramsOverview {...testProps} />);
 }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { getByTextWithMarkup, swrRender, waitForLoadingToFinish } from '../../../../../tools/test-helpers';
+import { getByTextWithMarkup, renderWithSwr, waitForLoadingToFinish } from '../../../../../tools/test-helpers';
 import { mockPatient } from '../../../../../__mocks__/patient.mock';
 import {
   mockConceptMetadata,
@@ -109,5 +109,5 @@ describe('VitalsHeader: ', () => {
 });
 
 function renderVitalsHeader() {
-  swrRender(<VitalsHeader {...testProps} />);
+  renderWithSwr(<VitalsHeader {...testProps} />);
 }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -11,7 +11,7 @@ import {
   mockVitalsConfig,
   mockVitalsSignsConcept,
 } from '../../../../__mocks__/vitals.mock';
-import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import VitalsOverview from './vitals-overview.component';
 
 const testProps = {
@@ -182,5 +182,5 @@ describe('VitalsOverview: ', () => {
 });
 
 function renderVitalsOverview() {
-  swrRender(<VitalsOverview {...testProps} />);
+  renderWithSwr(<VitalsOverview {...testProps} />);
 }

--- a/tools/test-helpers.tsx
+++ b/tools/test-helpers.tsx
@@ -16,7 +16,7 @@ const swrWrapper = ({ children }) => {
   );
 };
 
-export const swrRender = (ui, options?) => render(ui, { wrapper: swrWrapper, ...options });
+export const renderWithSwr = (ui, options?) => render(ui, { wrapper: swrWrapper, ...options });
 
 // Custom matcher that queries elements split up by multiple HTML elements by text
 export function getByTextWithMarkup(text: RegExp | string) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR renames the SWR `render` helper method from `swrRender` to `renderWithSwr`. `renderWithSwr` is arguably more descriptive. It also blends well with similar helpers such as `renderWithRouter`.