### PR TITLE
(fix) Restore top border to PatientChartPagination component

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/notes-overview.scss
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.scss
@@ -35,11 +35,6 @@
   margin: 0.5rem 0;
 }
 
-.pagination {
-  :first-child {
-    border-top: none;
-  }
-}
 
 .hiddenRow {
   display: none;

--- a/packages/esm-patient-notes-app/src/notes/notes-pagination.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-pagination.component.tsx
@@ -51,7 +51,7 @@ const NotesPagination: React.FC<FormsProps> = ({ notes, pageSize, pageUrl, urlLa
   );
 
   return (
-    <div>
+    <>
       <DataTable rows={tableRows} headers={tableHeaders} isSortable size="short" useZebraStyles>
         {({ rows, headers, getTableProps, getTableContainerProps, getHeaderProps, getRowProps }) => (
           <TableContainer {...getTableContainerProps}>
@@ -106,18 +106,16 @@ const NotesPagination: React.FC<FormsProps> = ({ notes, pageSize, pageUrl, urlLa
           </TableContainer>
         )}
       </DataTable>
-      <div className={styles.pagination}>
-        <PatientChartPagination
-          pageNumber={currentPage}
-          totalItems={notes.length}
-          currentItems={paginatedNotes.length}
-          pageUrl={pageUrl}
-          pageSize={pageSize}
-          onPageNumberChange={({ page }) => goTo(page)}
-          urlLabel={urlLabel}
-        />
-      </div>
-    </div>
+      <PatientChartPagination
+        pageNumber={currentPage}
+        totalItems={notes.length}
+        currentItems={paginatedNotes.length}
+        pageUrl={pageUrl}
+        pageSize={pageSize}
+        onPageNumberChange={({ page }) => goTo(page)}
+        urlLabel={urlLabel}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR deletes styling that removed a top border from the PatientChartPagination component. With this change, a top border now appears above the component, effectively separating it visually from the datatable.

## Screenshots

<img width="879" alt="Screenshot 2022-04-06 at 15 31 17" src="https://user-images.githubusercontent.com/8509731/161978181-3a6f346d-9b0b-4486-9aba-c1aa35ceef7a.png">

