### PR TITLE
(fix) Fix alignment and positioning of side rail tooltips

### DIFF
--- a/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
+++ b/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
@@ -24,8 +24,8 @@ const ClinicalFormActionButton: React.FC = () => {
       renderIcon={Document20}
       hasIconOnly
       iconDescription={t('form', 'Form')}
-      tooltipAlignment="end"
-      tooltipPosition="bottom"
+      tooltipAlignment="start"
+      tooltipPosition="left"
     />
   );
 };

--- a/packages/esm-patient-medications-app/src/medications-summary/order-basket-action-button.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/order-basket-action-button.component.tsx
@@ -44,8 +44,8 @@ const OrderBasketActionButton: React.FC = () => {
         )}
         hasIconOnly
         iconDescription={t('orders', 'Orders')}
-        tooltipAlignment="end"
-        tooltipPosition="bottom"
+        tooltipAlignment="start"
+        tooltipPosition="left"
         onClick={launchOrdersWorkspace}
       />
     </>

--- a/packages/esm-patient-notes-app/src/visit-note-action-button.component.tsx
+++ b/packages/esm-patient-notes-app/src/visit-note-action-button.component.tsx
@@ -34,8 +34,8 @@ const VisitNoteActionButton: React.FC = () => {
       renderIcon={Pen20}
       hasIconOnly
       iconDescription={t('note', 'Note')}
-      tooltipAlignment="end"
-      tooltipPosition="bottom"
+      tooltipAlignment="start"
+      tooltipPosition="left"
     />
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the alignment and positioning of tooltips in the side rail. Presently, tooltips for some buttons in the side rail get cut off by the right margin of the page.

## Videos

> Current

https://user-images.githubusercontent.com/8509731/162152035-c095e3ac-2cfd-40b5-b246-aea6513b551c.mp4

> Fixed

https://user-images.githubusercontent.com/8509731/162151344-9e5ecfec-2dff-4470-8e60-f29431be3f06.mp4

Related: https://github.com/openmrs/openmrs-esm-patient-management/pull/154