### PR TITLE
03-1240: Fix patient-banner re-renders b/c of offline activeVisitSWR

### DIFF
--- a/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.component.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import styles from './active-visit-tag.scss';
 import { useTranslation } from 'react-i18next';
 import { Tag, TooltipDefinition } from 'carbon-components-react';
-import { formatDatetime, parseDate, useVisit } from '@openmrs/esm-framework';
+import { formatDatetime, parseDate } from '@openmrs/esm-framework';
+import { useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
 interface ActiveVisitBannerTagProps {
   patientUuid: string;
   patient: fhir.Patient;
 }
 const ActiveVisitBannerTag: React.FC<ActiveVisitBannerTagProps> = ({ patientUuid, patient }) => {
   const { t } = useTranslation();
-  const { currentVisit } = useVisit(patientUuid);
+  const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
   const deceasedBoolean = patient.deceasedDateTime ? false : true;
   return (
     currentVisit &&

--- a/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.test.tsx
@@ -2,19 +2,20 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import ActiveVisitBannerTag from './active-visit-tag.component';
-import { formatDatetime, useVisit } from '@openmrs/esm-framework';
+import { formatDatetime } from '@openmrs/esm-framework';
 import { mockCurrentVisit } from '../../../../__mocks__/visits.mock';
+import { useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
 
-const mockUseVisit = useVisit as jest.Mock;
+const mockUseVisitOrOfflineVisit = useVisitOrOfflineVisit as jest.Mock;
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...(jest.requireActual('@openmrs/esm-framework') as any),
-  useVisit: jest.fn(),
+jest.mock('@openmrs/esm-patient-common-lib', () => ({
+  ...(jest.requireActual('@openmrs/esm-patient-common-lib') as any),
+  useVisitOrOfflineVisit: jest.fn(),
 }));
 
 describe('ActiveVisitBannerTag: ', () => {
   it('renders an active visit tag in the patient banner when an active visit is ongoing', () => {
-    mockUseVisit.mockReturnValue({
+    mockUseVisitOrOfflineVisit.mockReturnValue({
       currentVisit: mockCurrentVisit,
       error: null,
     });
@@ -33,7 +34,7 @@ describe('ActiveVisitBannerTag: ', () => {
   });
 
   it('should not render active visit tag if patient is dead', () => {
-    mockUseVisit.mockReturnValue({
+    mockUseVisitOrOfflineVisit.mockReturnValue({
       currentVisit: mockCurrentVisit,
       error: null,
     });

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
@@ -23,9 +23,8 @@ interface PatientChartParams {
 const PatientChart: React.FC<RouteComponentProps<PatientChartParams>> = ({ match }) => {
   const { patientUuid, view } = match.params;
   const { isLoading: isLoadingPatient, patient } = usePatientOrOfflineRegisteredPatient(patientUuid);
-  const visitSwr = useVisitOrOfflineVisit(patientUuid);
   const { windowSize, active } = useWorkspaceWindowSize();
-  const state = useMemo(() => ({ patient, patientUuid, activeVisit: visitSwr }), [patient, patientUuid, visitSwr]);
+  const state = useMemo(() => ({ patient, patientUuid }), [patient, patientUuid]);
   const { offlineVisitTypeUuid } = useConfig();
 
   // We are responsible for creating a new offline visit while in offline mode.


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
1. This PR fixes issue with `Patient-Banner` re-rendering every time `useVisitOrOfflineVisit` hook runs. As described in the ticket [03-1240](https://issues.openmrs.org/projects/O3/issues/O3-1240?filter=myopenissues). 

@manuelroemer from code the intention is to pass the activeVisit to the `patient-header-slot` to display the active-visit-tag even when offline. I have moved that to the `active-visit-tag` component. Am I missing something out here?

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
