### PR TITLE
Attachments widget does not support PDF files

### DIFF
--- a/packages/esm-patient-attachments-app/src/attachments/attachment-thumbnail.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachment-thumbnail.component.tsx
@@ -27,7 +27,8 @@ function PdfThumbnail(props: ImageProps) {
 
   return (
     <div className={styles.pdfThumbnail} onClick={handleClick} role="button" tabIndex={0}>
-      <img src={props.src} alt={props.title} style={props.style} />
+      <embed src={props.src} style={{ ...props.style, pointerEvents: 'none', width: '100%' }} />
+      {/* <img src={props.src} alt={props.title} style={props.style} /> */}
     </div>
   );
 }

--- a/packages/esm-patient-attachments-app/src/attachments/attachment-thumbnail.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachment-thumbnail.component.tsx
@@ -28,7 +28,6 @@ function PdfThumbnail(props: ImageProps) {
   return (
     <div className={styles.pdfThumbnail} onClick={handleClick} role="button" tabIndex={0}>
       <embed src={props.src} style={{ ...props.style, pointerEvents: 'none', width: '100%' }} />
-      {/* <img src={props.src} alt={props.title} style={props.style} /> */}
     </div>
   );
 }

--- a/packages/esm-patient-attachments-app/src/attachments/attachment-thumbnail.scss
+++ b/packages/esm-patient-attachments-app/src/attachments/attachment-thumbnail.scss
@@ -15,6 +15,10 @@
   }
 }
 
+.pdfThumbnail {
+  cursor: pointer;
+}
+
 .captionText {
   color: #2e2eef;
   cursor: pointer;

--- a/packages/esm-patient-attachments-app/src/attachments/camera-upload.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/camera-upload.component.tsx
@@ -72,12 +72,12 @@ const CameraUpload: React.FC<CameraUploadProps> = ({ onSavePhoto, onTakePhoto, c
           <>
             {!error && <Camera onTakePhoto={handleTakePhoto} onCameraStart={setMediaStream} onCameraError={setError} />}
             <div>
-              <label htmlFor="uploadPhoto" className={styles.choosePhoto}>
-                {t('selectPhoto', 'Select local photo instead')}
+              <label htmlFor="uploadPhotoOrPdf" className={styles.choosePhotoOrPdf}>
+                {t('selectPhotoOrPdf', 'Select local photo or Pdf instead')}
               </label>
               <input
                 type="file"
-                id="uploadPhoto"
+                id="uploadPhotoOrPdf"
                 accept="image/*, application/pdf"
                 className={styles.uploadFile}
                 onChange={upload}

--- a/packages/esm-patient-attachments-app/src/attachments/camera-upload.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/camera-upload.component.tsx
@@ -53,7 +53,7 @@ const CameraUpload: React.FC<CameraUploadProps> = ({ onSavePhoto, onTakePhoto, c
     };
   }, []);
 
-  const willSaveImage = useCallback(
+  const willSaveImageOrPdf = useCallback(
     (dataUri: string, caption: string) => onSavePhoto?.(dataUri, caption),
     [onSavePhoto],
   );
@@ -65,7 +65,7 @@ const CameraUpload: React.FC<CameraUploadProps> = ({ onSavePhoto, onTakePhoto, c
           <ImagePreview
             content={dataUri}
             onCancelCapture={clearCamera}
-            onSaveImage={willSaveImage}
+            onSaveImageOrPdf={willSaveImageOrPdf}
             collectCaption={collectCaption}
           />
         ) : (

--- a/packages/esm-patient-attachments-app/src/attachments/camera-upload.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/camera-upload.component.tsx
@@ -75,7 +75,13 @@ const CameraUpload: React.FC<CameraUploadProps> = ({ onSavePhoto, onTakePhoto, c
               <label htmlFor="uploadPhoto" className={styles.choosePhoto}>
                 {t('selectPhoto', 'Select local photo instead')}
               </label>
-              <input type="file" id="uploadPhoto" accept="image/*" className={styles.uploadFile} onChange={upload} />
+              <input
+                type="file"
+                id="uploadPhoto"
+                accept="image/*, application/pdf"
+                className={styles.uploadFile}
+                onChange={upload}
+              />
             </div>
           </>
         )}

--- a/packages/esm-patient-attachments-app/src/attachments/camera-upload.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/camera-upload.component.tsx
@@ -53,7 +53,7 @@ const CameraUpload: React.FC<CameraUploadProps> = ({ onSavePhoto, onTakePhoto, c
     };
   }, []);
 
-  const willSaveImageOrPdf = useCallback(
+  const willSaveAttachment = useCallback(
     (dataUri: string, caption: string) => onSavePhoto?.(dataUri, caption),
     [onSavePhoto],
   );
@@ -65,19 +65,19 @@ const CameraUpload: React.FC<CameraUploadProps> = ({ onSavePhoto, onTakePhoto, c
           <ImagePreview
             content={dataUri}
             onCancelCapture={clearCamera}
-            onSaveImageOrPdf={willSaveImageOrPdf}
+            onSaveImageOrPdf={willSaveAttachment}
             collectCaption={collectCaption}
           />
         ) : (
           <>
             {!error && <Camera onTakePhoto={handleTakePhoto} onCameraStart={setMediaStream} onCameraError={setError} />}
             <div>
-              <label htmlFor="uploadPhotoOrPdf" className={styles.choosePhotoOrPdf}>
-                {t('selectPhotoOrPdf', 'Select local photo or Pdf instead')}
+              <label htmlFor="uploadFile" className={styles.choosePhotoOrPdf}>
+                {t('selectFile', 'Select local File instead')}
               </label>
               <input
                 type="file"
-                id="uploadPhotoOrPdf"
+                id="uploadFile"
                 accept="image/*, application/pdf"
                 className={styles.uploadFile}
                 onChange={upload}

--- a/packages/esm-patient-attachments-app/src/attachments/camera-upload.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/camera-upload.component.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState, useRef } from 'react';
-import ImagePreview from './image-preview.component';
+import FilePreview from './image-preview.component';
 import styles from './camera-upload.scss';
 import Camera from 'react-html5-camera-photo';
 import { showToast } from '@openmrs/esm-framework';
@@ -62,10 +62,10 @@ const CameraUpload: React.FC<CameraUploadProps> = ({ onSavePhoto, onTakePhoto, c
     <div className={styles.cameraSection}>
       <div className={styles.frameContent}>
         {dataUri ? (
-          <ImagePreview
+          <FilePreview
             content={dataUri}
             onCancelCapture={clearCamera}
-            onSaveImageOrPdf={willSaveAttachment}
+            onSaveFile={willSaveAttachment}
             collectCaption={collectCaption}
           />
         ) : (

--- a/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
@@ -4,14 +4,14 @@ import { UserHasAccess } from '@openmrs/esm-framework';
 import { Button, ButtonSet, TextInput } from 'carbon-components-react';
 import styles from './image-preview.scss';
 
-interface ImageOrPdfPreviewProps {
+interface FilePreviewProps {
   content: string;
   collectCaption: boolean;
   onSaveImageOrPdf?(dataUri: string, caption: string): void;
   onCancelCapture?(): void;
 }
 
-export default function ImagePreview(props: ImageOrPdfPreviewProps) {
+export default function FilePreview(props: FilePreviewProps) {
   const [saving, setSaving] = useState(false);
   const [caption, setCaption] = useState('');
   const { t } = useTranslation();

--- a/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
@@ -44,7 +44,7 @@ export default function FilePreview(props: FilePreviewProps) {
 
   return (
     <form className={styles.overview} onSubmit={saveImageOrPdf}>
-      <img src={props.content} alt={t('webcamPreview', 'Webcam preview')} />
+      <embed src={props.content} />
       {props.collectCaption && (
         <div className={styles.captionFrame}>
           <TextInput

--- a/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
@@ -4,27 +4,27 @@ import { UserHasAccess } from '@openmrs/esm-framework';
 import { Button, ButtonSet, TextInput } from 'carbon-components-react';
 import styles from './image-preview.scss';
 
-interface ImagePreviewProps {
+interface ImageOrPdfPreviewProps {
   content: string;
   collectCaption: boolean;
-  onSaveImage?(dataUri: string, caption: string): void;
+  onSaveImageOrPdf?(dataUri: string, caption: string): void;
   onCancelCapture?(): void;
 }
 
-export default function ImagePreview(props: ImagePreviewProps) {
+export default function ImagePreview(props: ImageOrPdfPreviewProps) {
   const [saving, setSaving] = useState(false);
   const [caption, setCaption] = useState('');
   const { t } = useTranslation();
 
-  const saveImage = useCallback(
+  const saveImageOrPdf = useCallback(
     (e: SyntheticEvent) => {
       if (!saving) {
         e.preventDefault();
-        props.onSaveImage?.(props.content, caption);
+        props.onSaveImageOrPdf?.(props.content, caption);
         setSaving(true);
       }
     },
-    [props.onSaveImage, saving],
+    [props.onSaveImageOrPdf, saving],
   );
 
   const cancelCapture = useCallback(
@@ -43,7 +43,7 @@ export default function ImagePreview(props: ImagePreviewProps) {
   }, []);
 
   return (
-    <form className={styles.overview} onSubmit={saveImage}>
+    <form className={styles.overview} onSubmit={saveImageOrPdf}>
       <img src={props.content} alt={t('webcamPreview', 'Webcam preview')} />
       {props.collectCaption && (
         <div className={styles.captionFrame}>
@@ -59,7 +59,7 @@ export default function ImagePreview(props: ImagePreviewProps) {
       )}
       <UserHasAccess privilege="Create Attachment">
         <ButtonSet className={styles.buttonSetOverrides}>
-          <Button size="small" onClick={saveImage} disabled={saving}>
+          <Button size="small" onClick={saveImageOrPdf} disabled={saving}>
             {t('save', 'Save')}
           </Button>
           <Button kind="danger" size="small" onClick={cancelCapture} disabled={saving}>

--- a/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
@@ -7,7 +7,7 @@ import styles from './image-preview.scss';
 interface FilePreviewProps {
   content: string;
   collectCaption: boolean;
-  onSaveImageOrPdf?(dataUri: string, caption: string): void;
+  onSaveFile?(dataUri: string, caption: string): void;
   onCancelCapture?(): void;
 }
 
@@ -20,11 +20,11 @@ export default function FilePreview(props: FilePreviewProps) {
     (e: SyntheticEvent) => {
       if (!saving) {
         e.preventDefault();
-        props.onSaveImageOrPdf?.(props.content, caption);
+        props.onSaveFile?.(props.content, caption);
         setSaving(true);
       }
     },
-    [props.onSaveImageOrPdf, saving],
+    [props.onSaveFile, saving],
   );
 
   const cancelCapture = useCallback(

--- a/packages/esm-patient-attachments-app/src/attachments/utils.ts
+++ b/packages/esm-patient-attachments-app/src/attachments/utils.ts
@@ -29,7 +29,6 @@ export function createGalleryEntry(data: any) {
   return {
     id: `${data.uuid}`,
     src: `${window.openmrsBase}${attachmentUrl}/${data.uuid}/bytes`,
-    // thumbnail: `${window.openmrsBase}${attachmentUrl}/${data.uuid}/bytes?view=complexdata.view.thumbnail`,
     thumbnail: `${window.openmrsBase}${attachmentUrl}/${data.uuid}/bytes`,
     // thumbnailWidth: 320,
     // thumbnailHeight: 212,

--- a/packages/esm-patient-attachments-app/src/attachments/utils.ts
+++ b/packages/esm-patient-attachments-app/src/attachments/utils.ts
@@ -29,8 +29,8 @@ export function createGalleryEntry(data: any) {
   return {
     id: `${data.uuid}`,
     src: `${window.openmrsBase}${attachmentUrl}/${data.uuid}/bytes`,
-    thumbnail: `${window.openmrsBase}${attachmentUrl}/${data.uuid}/bytes?view=complexdata.view.thumbnail`,
-    // thumbnail: `${window.openmrsBase}${attachmentUrl}/${res.data.uuid}/bytes`,
+    // thumbnail: `${window.openmrsBase}${attachmentUrl}/${data.uuid}/bytes?view=complexdata.view.thumbnail`,
+    thumbnail: `${window.openmrsBase}${attachmentUrl}/${data.uuid}/bytes`,
     // thumbnailWidth: 320,
     // thumbnailHeight: 212,
     thumbnailWidth: 170,

--- a/packages/esm-patient-attachments-app/translations/en.json
+++ b/packages/esm-patient-attachments-app/translations/en.json
@@ -9,6 +9,5 @@
   "delete": "Delete",
   "deleteSelected": "Delete selected",
   "save": "Save",
-  "selectFile": "Select local file instead",
-  "webcamPreview": "Webcam preview"
+  "selectFile": "Select local file instead"
 }

--- a/packages/esm-patient-attachments-app/translations/en.json
+++ b/packages/esm-patient-attachments-app/translations/en.json
@@ -9,6 +9,6 @@
   "delete": "Delete",
   "deleteSelected": "Delete selected",
   "save": "Save",
-  "selectPhoto": "Select local photo instead",
+  "selectFile": "Select local file instead",
   "webcamPreview": "Webcam preview"
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
I added a MIME media type  `application/pdf` to allow a user upload a PDF file(s) when selecting an image from local storage.

## Screenshots

https://user-images.githubusercontent.com/33891016/167677764-5e9630e1-734a-4f60-97c2-2e45665577c5.mp4



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
[<!-- https://issues.openmrs.org/browse/O3- -->](https://issues.openmrs.org/browse/O3-962)

## Other
<!-- Anything not covered above -->
