### PR TITLE
(fix) Eliminate the need for dashboards to have names

### DIFF
--- a/packages/esm-patient-allergies-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-allergies-app/src/dashboard.meta.tsx
@@ -1,5 +1,4 @@
 export const dashboardMeta = {
-  name: 'allergies',
   slot: 'patient-chart-allergies-dashboard-slot',
   config: { columns: 1 },
   title: 'Allergies',

--- a/packages/esm-patient-appointments-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-appointments-app/src/dashboard.meta.tsx
@@ -1,5 +1,4 @@
 export const dashboardMeta = {
-  name: 'appointments',
   slot: 'patient-chart-appointments-dashboard-slot',
   config: { columns: 1 },
   title: 'Appointments',

--- a/packages/esm-patient-attachments-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-attachments-app/src/dashboard.meta.tsx
@@ -1,5 +1,4 @@
 export const dashboardMeta = {
-  name: 'attachments',
   slot: 'patient-chart-attachments-dashboard-slot',
   config: { columns: 1 },
   title: 'Attachments',

--- a/packages/esm-patient-biometrics-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-biometrics-app/src/dashboard.meta.tsx
@@ -1,5 +1,4 @@
 export const dashboardMeta = {
-  name: 'vitals_and_biometrics',
   slot: 'patient-chart-vitals-biometrics-dashboard-slot',
   config: { columns: 1 },
   title: 'Vitals & Biometrics',

--- a/packages/esm-patient-chart-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-chart-app/src/dashboard.meta.tsx
@@ -1,12 +1,10 @@
 export const summaryDashboardMeta = {
-  name: 'summary',
   slot: 'patient-chart-summary-dashboard-slot',
   config: { columns: 4 },
   title: 'Patient Summary',
 };
 
 export const encountersDashboardMeta = {
-  name: 'visits',
   slot: 'patient-chart-encounters-dashboard-slot',
   config: { columns: 1 },
   title: 'Visits',

--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -34,7 +34,7 @@ function setupOpenMRS() {
     },
     {
       path: `${spaBasePath}/:view`,
-      title: ([_, key]) => `${capitalize(key).replace(/_/g, ' ')} dashboard`,
+      title: ([_, key]) => `${decodeURIComponent(key)} dashboard`,
       parent: spaBasePath,
     },
   ]);

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
@@ -6,7 +6,7 @@ import { basePath } from '../../constants';
 import { DashboardView, DashboardConfig } from './dashboard-view.component';
 
 function makePath(target: DashboardConfig, params: Record<string, string> = {}) {
-  const parts = `${basePath}/${target.name}`.split('/');
+  const parts = `${basePath}/${encodeURIComponent(target.title)}`.split('/');
 
   Object.keys(params).forEach((key) => {
     for (let i = 0; i < parts.length; i++) {
@@ -48,7 +48,7 @@ const ChartReview: React.FC<ChartReviewProps> = ({ patientUuid, patient, view })
   const dashboards = ungroupedDashboards.concat(groupedDashboards) as Array<DashboardConfig>;
 
   const defaultDashboard = dashboards[0];
-  const dashboard = dashboards.find((dashboard) => dashboard.name === view);
+  const dashboard = dashboards.find((dashboard) => dashboard.title === view);
 
   if (!defaultDashboard) {
     return null;

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.test.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.test.tsx
@@ -38,7 +38,7 @@ jest.mock('react-router-dom', () => {
 const testProps = {
   patient: mockPatient,
   patientUuid: mockPatient.id,
-  view: 'summary',
+  view: 'Patient Summary',
 };
 
 function slotMetaFromStore(store, slotName) {
@@ -58,7 +58,6 @@ describe('ChartReview: ', () => {
             {
               name: 'charts-summary-dashboard',
               meta: {
-                name: 'summary',
                 slot: 'patient-chart-summary-dashboard-slot',
                 config: {
                   columns: 4,
@@ -69,7 +68,6 @@ describe('ChartReview: ', () => {
             {
               name: 'test-results-summary-dashboard',
               meta: {
-                name: 'test-results',
                 slot: 'patient-chart-test-results-dashboard-slot',
                 config: {
                   columns: 1,

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
@@ -20,7 +20,6 @@ export interface DashbardLayoutConfig {
 }
 
 export interface DashboardConfig {
-  name: string;
   slot: string;
   title: string;
   config: DashbardLayoutConfig;

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
@@ -21,7 +21,8 @@ interface PatientChartParams {
 }
 
 const PatientChart: React.FC<RouteComponentProps<PatientChartParams>> = ({ match }) => {
-  const { patientUuid, view } = match.params;
+  const { patientUuid, view: encodedView } = match.params;
+  const view = decodeURIComponent(encodedView);
   const { isLoading: isLoadingPatient, patient } = usePatientOrOfflineRegisteredPatient(patientUuid);
   const { windowSize, active } = useWorkspaceWindowSize();
   const state = useMemo(() => ({ patient, patientUuid }), [patient, patientUuid]);

--- a/packages/esm-patient-chart-app/src/side-nav/generic-dashboard.component.tsx
+++ b/packages/esm-patient-chart-app/src/side-nav/generic-dashboard.component.tsx
@@ -3,10 +3,6 @@ import { Type, useConfig } from '@openmrs/esm-framework';
 import { DashboardExtension } from '@openmrs/esm-patient-common-lib';
 
 export const genericDashboardConfigSchema = {
-  name: {
-    _default: 'new-dashboard',
-    _type: Type.String,
-  },
   title: {
     _default: 'New Dashboard',
     _type: Type.String,
@@ -18,7 +14,6 @@ export const genericDashboardConfigSchema = {
 };
 
 export interface GenericDashboardConfig {
-  name: string;
   title: string;
   /** This gets used by the patient chart when it renders the dashboard itself. */
   slot: string;
@@ -30,5 +25,5 @@ interface GenericDashboardProps {
 
 export default function GenericDashboard({ basePath }: GenericDashboardProps) {
   const config = useConfig() as GenericDashboardConfig;
-  return <DashboardExtension title={config.title} name={config.name} basePath={basePath} />;
+  return <DashboardExtension title={config.title} basePath={basePath} />;
 }

--- a/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { ConfigurableLink } from '@openmrs/esm-framework';
 
+console.log("check");
+
 export interface DashboardExtensionProps {
-  name: string;
   title: string;
   basePath: string;
 }
 
-export const DashboardExtension = ({ name, title, basePath }: DashboardExtensionProps) => {
+export const DashboardExtension = ({ title, basePath }: DashboardExtensionProps) => {
   return (
-    <div key={name}>
-      <ConfigurableLink to={`${basePath}/${name}`} className="bx--side-nav__link">
+    <div key={title}>
+      <ConfigurableLink to={`${basePath}/${encodeURIComponent(title)}`} className="bx--side-nav__link">
         {title}
       </ConfigurableLink>
     </div>

--- a/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { ConfigurableLink } from '@openmrs/esm-framework';
 
-console.log("check");
-
 export interface DashboardExtensionProps {
   title: string;
   basePath: string;

--- a/packages/esm-patient-common-lib/src/dashboards/createDashboardLink.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/createDashboardLink.tsx
@@ -4,7 +4,7 @@ import { DashboardExtension } from './DashboardExtension';
 
 export const createDashboardLink = (db: DashboardLinkConfig) => {
   const Dashboard = ({ basePath }: { basePath: string }) => {
-    return <DashboardExtension name={db.name} title={db.title} basePath={basePath} />;
+    return <DashboardExtension title={db.title} basePath={basePath} />;
   };
   return Dashboard;
 };

--- a/packages/esm-patient-common-lib/src/types/index.ts
+++ b/packages/esm-patient-common-lib/src/types/index.ts
@@ -8,7 +8,6 @@ export interface DashbardConfig {
 }
 
 export interface DashboardLinkConfig {
-  name: string;
   title: string;
 }
 

--- a/packages/esm-patient-conditions-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-conditions-app/src/dashboard.meta.tsx
@@ -1,5 +1,4 @@
 export const dashboardMeta = {
-  name: 'conditions',
   slot: 'patient-chart-conditions-dashboard-slot',
   config: { columns: 1 },
   title: 'Conditions',

--- a/packages/esm-patient-forms-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-forms-app/src/dashboard.meta.tsx
@@ -1,5 +1,4 @@
 export const dashboardMeta = {
-  name: 'forms',
   slot: 'patient-chart-form-dashboard-slot',
   config: { columns: 1 },
   title: 'Forms & Notes',

--- a/packages/esm-patient-immunizations-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-immunizations-app/src/dashboard.meta.tsx
@@ -1,5 +1,4 @@
 export const dashboardMeta = {
-  name: 'immunizations',
   slot: 'patient-chart-immunizations-dashboard-slot',
   config: { columns: 1 },
   title: 'Immunizations',

--- a/packages/esm-patient-medications-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-medications-app/src/dashboard.meta.tsx
@@ -1,5 +1,4 @@
 export const dashboardMeta = {
-  name: 'orders',
   slot: 'patient-chart-orders-dashboard-slot',
   config: { columns: 1 },
   title: 'Orders',

--- a/packages/esm-patient-notes-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-notes-app/src/dashboard.meta.tsx
@@ -1,5 +1,4 @@
 export const dashboardMeta = {
-  name: 'encounters',
   slot: 'patient-chart-encounters-dashboard-slot',
   config: { columns: 1 },
   title: 'Encounters',

--- a/packages/esm-patient-programs-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-programs-app/src/dashboard.meta.tsx
@@ -1,5 +1,4 @@
 export const dashboardMeta = {
-  name: 'programs',
   slot: 'patient-chart-programs-dashboard-slot',
   config: { columns: 1 },
   title: 'Programs',

--- a/packages/esm-patient-test-results-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-test-results-app/src/dashboard.meta.tsx
@@ -1,5 +1,4 @@
 export const dashboardMeta = {
-  name: 'test_results',
   slot: 'patient-chart-test-results-dashboard-slot',
   config: { columns: 1 },
   title: 'Test Results',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary

This removes the "name" attribute of dashboards. The title is used for everything.

## Screenshots

![Peek 2022-04-14 17-24](https://user-images.githubusercontent.com/1031876/163496862-5aa38d20-32cb-4d87-8ad5-e856a307baf1.gif)

