### PR TITLE
(bug) fix clinical form name not updating

### DIFF
--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.test.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.test.ts
@@ -32,6 +32,26 @@ describe('workspace system', () => {
     allergies.closeWorkspace();
     expect(store.getState().openWorkspaces.length).toEqual(0);
   });
+  test('updates workspace title when provided with `workspaceTitle` prop', () => {
+    const store = getWorkspaceStore();
+    registerWorkspace({ name: 'POC HIV Form', title: 'Clinical Form', load: jest.fn() });
+    launchPatientWorkspace('POC HIV Form', { workspaceTitle: 'POC HIV Form' });
+
+    expect(store.getState().openWorkspaces.length).toEqual(1);
+
+    const POCHIVForm = store.getState().openWorkspaces[0];
+    expect(POCHIVForm.name).toBe('POC HIV Form');
+    expect(POCHIVForm.additionalProps['workspaceTitle']).toBe('POC HIV Form');
+
+    launchPatientWorkspace('POC HIV Form', { workspaceTitle: 'POC HIV Form Updated' });
+
+    expect(POCHIVForm.additionalProps['workspaceTitle']).toBe('POC HIV Form Updated');
+    expect(store.getState().openWorkspaces.length).toEqual(1);
+
+    POCHIVForm.closeWorkspace();
+
+    expect(store.getState().openWorkspaces.length).toEqual(0);
+  });
 
   test('coexisting and non-coexisting workspaces', () => {
     const store = getWorkspaceStore();

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
@@ -120,6 +120,7 @@ export function launchPatientWorkspace(name: string, additionalProps?: object) {
     if (existingIdx >= 0) {
       const restOfWorkspaces = [...state.openWorkspaces];
       restOfWorkspaces.splice(existingIdx, 1);
+      state.openWorkspaces[existingIdx].additionalProps = newWorkspace.additionalProps;
       const openWorkspaces = [state.openWorkspaces[existingIdx], ...restOfWorkspaces];
       store.setState({ ...state, openWorkspaces });
     } else if (!promptCheckFcn || promptCheckFcn()) {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x ] My work includes tests or is validated by existing tests.

## Summary
This fixes a bug when a new form is launched it doesn't update the form name shown on the workspace renderer, this is critical to clinical who may fill a wrong form  

## Screenshots
![Kapture 2022-04-16 at 22 12 53](https://user-images.githubusercontent.com/28008754/163688416-c51c1e8b-dcc8-4056-842f-4a925f169376.gif)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
