### PR TITLE
(bugfix) Results Viewer Filter Correctly Set hasData

### DIFF
--- a/packages/esm-patient-test-results-app/src/grouped-timeline/useObstreeData.ts
+++ b/packages/esm-patient-test-results-app/src/grouped-timeline/useObstreeData.ts
@@ -11,8 +11,11 @@ export const getName = (prefix, name) => {
 const augmentObstreeData = (node, prefix) => {
   const outData = JSON.parse(JSON.stringify(node));
   outData.flatName = getName(prefix, node.display);
+  outData.hasData = false;
+
   if (outData?.subSets?.length) {
     outData.subSets = outData.subSets.map((subNode) => augmentObstreeData(subNode, getName(prefix, node?.display)));
+    outData.hasData = outData.subSets.some((subNode) => subNode.hasData);
   }
   if (exist(outData?.hiNormal, outData?.lowNormal)) {
     outData.range = `${outData.lowNormal} – ${outData.hiNormal}`;
@@ -21,9 +24,8 @@ const augmentObstreeData = (node, prefix) => {
     const assess = assessValue(outData);
     outData.obs = outData.obs.map((ob) => ({ ...ob, interpretation: assess(ob.value) }));
     outData.hasData = true;
-  } else {
-    outData.hasData = false;
   }
+
   return { ...outData };
 };
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Fixes [O3-1266](https://issues.openmrs.org/browse/O3-1266)
Parents weren't setting `hasData` tag correctly. Now parents' hasData updates with children's hasData

## Screenshots
No UI changes

## Related Issue
[O3-1266](https://issues.openmrs.org/browse/O3-1266)

## Other
