### PR TITLE
(refactor) Rename pagination components to "PaginatedX"

### DIFF
--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import Add16 from '@carbon/icons-react/es/add/16';
+import { Button, DataTableSkeleton, InlineLoading } from 'carbon-components-react';
 import ChartLineSmooth16 from '@carbon/icons-react/es/chart--line-smooth/16';
 import Table16 from '@carbon/icons-react/es/table/16';
-import BiometricsChart from './biometrics-chart.component';
-import BiometricsPagination from './biometrics-pagination.component';
-import { Button, DataTableSkeleton, InlineLoading } from 'carbon-components-react';
-import { useTranslation } from 'react-i18next';
 import { formatDatetime, parseDate, useConfig } from '@openmrs/esm-framework';
-import { useBiometrics } from './biometrics.resource';
 import {
   CardHeader,
   EmptyState,
@@ -18,7 +15,10 @@ import {
 } from '@openmrs/esm-patient-common-lib';
 import { ConfigObject } from '../config-schema';
 import { patientVitalsBiometricsFormWorkspace } from '../constants';
+import { useBiometrics } from './biometrics.resource';
 import styles from './biometrics-overview.scss';
+import BiometricsChart from './biometrics-chart.component';
+import PaginatedBiometrics from './paginated-biometrics.component';
 
 interface BiometricsBaseProps {
   patientUuid: string;
@@ -112,7 +112,7 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
         {chartView ? (
           <BiometricsChart patientBiometrics={biometrics} conceptUnits={conceptUnits} config={config} />
         ) : (
-          <BiometricsPagination
+          <PaginatedBiometrics
             tableRows={tableRows}
             pageSize={pageSize}
             urlLabel={urlLabel}

--- a/packages/esm-patient-biometrics-app/src/biometrics/paginated-biometrics.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/paginated-biometrics.component.tsx
@@ -14,7 +14,7 @@ import { usePagination } from '@openmrs/esm-framework';
 import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import { PatientBiometrics } from './biometrics.resource';
 
-interface BiometricsPaginationProps {
+interface PaginatedBiometricsProps {
   tableRows: Array<PatientBiometrics>;
   pageSize: number;
   pageUrl: string;
@@ -22,7 +22,7 @@ interface BiometricsPaginationProps {
   tableHeaders: Array<{ key: string; header: string }>;
 }
 
-const BiometricsPagination: React.FC<BiometricsPaginationProps> = ({
+const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
   tableRows,
   pageSize,
   pageUrl,
@@ -78,4 +78,4 @@ const BiometricsPagination: React.FC<BiometricsPaginationProps> = ({
   );
 };
 
-export default BiometricsPagination;
+export default PaginatedBiometrics;

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import Add16 from '@carbon/icons-react/es/add/16';
-import NotesPagination from './notes-pagination.component';
-import styles from './notes-overview.scss';
 import { useTranslation } from 'react-i18next';
 import { Button, DataTableSkeleton, InlineLoading } from 'carbon-components-react';
 import { useVisit } from '@openmrs/esm-framework';
-import { useVisitNotes } from './visit-notes.resource';
 import {
   CardHeader,
   EmptyState,
@@ -13,6 +10,9 @@ import {
   launchPatientWorkspace,
   launchStartVisitPrompt,
 } from '@openmrs/esm-patient-common-lib';
+import { useVisitNotes } from './visit-notes.resource';
+import PaginatedNotes from './paginated-notes.component';
+import styles from './notes-overview.scss';
 
 interface NotesOverviewProps {
   patientUuid: string;
@@ -58,7 +58,7 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, showAddNote, pag
                   </Button>
                 )}
               </CardHeader>
-              <NotesPagination notes={visitNotes} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />
+              <PaginatedNotes notes={visitNotes} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />
             </div>
           );
         return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchVisitNoteForm} />;

--- a/packages/esm-patient-notes-app/src/notes/paginated-notes.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/paginated-notes.component.tsx
@@ -18,14 +18,14 @@ import { useTranslation } from 'react-i18next';
 import { PatientNote } from '../types';
 import styles from './notes-overview.scss';
 
-interface FormsProps {
+interface PaginatedNotes {
   notes: Array<PatientNote>;
   pageSize: number;
   pageUrl: string;
   urlLabel: string;
 }
 
-const NotesPagination: React.FC<FormsProps> = ({ notes, pageSize, pageUrl, urlLabel }) => {
+const PaginatedNotes: React.FC<PaginatedNotes> = ({ notes, pageSize, pageUrl, urlLabel }) => {
   const { t } = useTranslation();
   const { results: paginatedNotes, goTo, currentPage } = usePagination(notes, pageSize);
 
@@ -119,4 +119,4 @@ const NotesPagination: React.FC<FormsProps> = ({ notes, pageSize, pageUrl, urlLa
   );
 };
 
-export default NotesPagination;
+export default PaginatedNotes;

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -13,7 +13,7 @@ import {
 import { usePagination } from '@openmrs/esm-framework';
 import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 
-interface VitalsPaginationProps {
+interface PaginatedVitalsProps {
   tableRows: Array<any>;
   pageSize: number;
   pageUrl: string;
@@ -21,13 +21,7 @@ interface VitalsPaginationProps {
   tableHeaders: Array<any>;
 }
 
-const VitalsPagination: React.FC<VitalsPaginationProps> = ({
-  tableRows,
-  pageSize,
-  pageUrl,
-  urlLabel,
-  tableHeaders,
-}) => {
+const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({ tableRows, pageSize, pageUrl, urlLabel, tableHeaders }) => {
   const { results: paginatedVitals, goTo, currentPage } = usePagination(tableRows, pageSize);
 
   return (
@@ -77,4 +71,4 @@ const VitalsPagination: React.FC<VitalsPaginationProps> = ({
   );
 };
 
-export default VitalsPagination;
+export default PaginatedVitals;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -18,7 +18,7 @@ import { ConfigObject } from '../config-schema';
 import { useVitals } from './vitals.resource';
 import styles from './vitals-overview.scss';
 import VitalsChart from './vitals-chart.component';
-import VitalsPagination from './vitals-pagination.component';
+import PaginatedVitals from './paginated-vitals.component';
 
 interface VitalsOverviewProps {
   patientUuid: string;
@@ -129,7 +129,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
               {chartView ? (
                 <VitalsChart patientVitals={vitals} conceptUnits={conceptUnits} config={config} />
               ) : (
-                <VitalsPagination
+                <PaginatedVitals
                   tableRows={tableRows}
                   pageSize={pageSize}
                   urlLabel={urlLabel}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR renames some components that use the `{component-name}Pagination` naming convention. A name like `PaginatedVitals` is arguably clearer and more concise than `VitalsPagination`.

Summary of components changes:

- `BiometricsPagination` -> `PaginatedBiometrics`
- `NotesPagination` -> `PaginatedNotes`
- `VitalsPagination` -> `PaginatedVitals`