### PR TITLE
(fix) O3-1273 Clicking a form with no active visit fails to launch start visit prompt.

### DIFF
--- a/packages/esm-patient-common-lib/src/launchStartVisitPrompt.tsx
+++ b/packages/esm-patient-common-lib/src/launchStartVisitPrompt.tsx
@@ -1,9 +1,7 @@
+import { showModal } from "@openmrs/esm-framework";
+
 export function launchStartVisitPrompt() {
-  window.dispatchEvent(
-    new CustomEvent('visit-dialog', {
-      detail: {
-        type: 'prompt',
-      },
-    }),
-  );
+  const dispose = showModal('start-visit-dialog', {
+    closeModal: () => dispose(),
+  });
 }

--- a/packages/esm-patient-common-lib/src/launchStartVisitPrompt.tsx
+++ b/packages/esm-patient-common-lib/src/launchStartVisitPrompt.tsx
@@ -1,4 +1,4 @@
-import { showModal } from "@openmrs/esm-framework";
+import { showModal } from '@openmrs/esm-framework';
 
 export function launchStartVisitPrompt() {
   const dispose = showModal('start-visit-dialog', {

--- a/packages/esm-patient-forms-app/src/config-schema.ts
+++ b/packages/esm-patient-forms-app/src/config-schema.ts
@@ -65,11 +65,11 @@ export const configSchema = {
   showHtmlFormEntryForms: {
     _type: Type.Boolean,
     _default: true,
-    _description: 'Whether HTML Form Entry forms should be included in lists of forms',
+    _description: 'Whether HTML Form Entry forms should be included in lists of forms.',
   },
   showRecommendedFormsTab: {
     _type: Type.Boolean,
-    _description: 'Whether to display recommended forms tab',
+    _description: 'Whether to display recommended forms tab. Requires AMPATH ETL.',
     _default: false,
   },
 };

--- a/packages/esm-patient-forms-app/src/form-entry-interop.ts
+++ b/packages/esm-patient-forms-app/src/form-entry-interop.ts
@@ -1,7 +1,7 @@
 import { navigate, Visit } from '@openmrs/esm-framework';
 import { HtmlFormEntryForm } from './config-schema';
 import isEmpty from 'lodash-es/isEmpty';
-import { formEntrySub, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { formEntrySub, launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
 
 export function launchFormEntryOrHtmlForms(
   currentVisit: Visit | undefined,
@@ -21,7 +21,7 @@ export function launchFormEntryOrHtmlForms(
       });
     }
   } else {
-    startVisitPrompt();
+    launchStartVisitPrompt();
   }
 }
 
@@ -29,14 +29,4 @@ export function launchFormEntry(formUuid: string, patientUuid: string, encounter
   formEntrySub.next({ formUuid, encounterUuid });
   launchPatientWorkspace('patient-form-entry-workspace', { workspaceTitle: formName });
   navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/chart` });
-}
-
-function startVisitPrompt() {
-  window.dispatchEvent(
-    new CustomEvent('visit-dialog', {
-      detail: {
-        type: 'prompt',
-      },
-    }),
-  );
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Clicking a form with no visit open would do nothing. Now it launches the start visit modal.

## Screenshots
![Peek 2022-04-22 16-42](https://user-images.githubusercontent.com/1031876/164844966-93b8d521-35f5-47d9-9e2f-eb2dda15bdfc.gif)

## Related Issue
https://issues.openmrs.org/browse/O3-1273

