### PR TITLE
O3-1269: Form names should try use display property

### DIFF
--- a/packages/esm-patient-forms-app/src/constants.ts
+++ b/packages/esm-patient-forms-app/src/constants.ts
@@ -1,5 +1,5 @@
 export const customFormRepresentation =
-  '(uuid,name,encounterType:(uuid,name),version,published,retired,resources:(uuid,name,dataType,valueReference))';
+  '(uuid,name,display,encounterType:(uuid,name),version,published,retired,resources:(uuid,name,dataType,valueReference))';
 export const customEncounterRepresentation = `custom:(uuid,encounterDatetime,encounterType:(uuid,name),form:${customFormRepresentation}`;
 
 export const formEncounterUrl = `/ws/rest/v1/form?v=custom:${customFormRepresentation}`;

--- a/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
@@ -73,7 +73,7 @@ const FormView: React.FC<FormViewProps> = ({ forms, patientUuid, patient, pageSi
         return {
           id: formInfo.form.uuid,
           lastCompleted: formInfo.lastCompleted ? formatDatetime(formInfo.lastCompleted) : undefined,
-          formName: formInfo.form.name,
+          formName: formInfo.form.display ?? formInfo.form.name,
           formUuid: formInfo.form.uuid,
           encounterUuid: formInfo?.associatedEncounters[0]?.uuid,
         };
@@ -131,7 +131,7 @@ const FormView: React.FC<FormViewProps> = ({ forms, patientUuid, patient, pageSi
                                     patient,
                                     htmlFormEntryForms,
                                     '',
-                                    results[index].form.name,
+                                    results[index].form.display ?? results[index].form.name,
                                   )
                                 }
                                 role="presentation"
@@ -149,7 +149,7 @@ const FormView: React.FC<FormViewProps> = ({ forms, patientUuid, patient, pageSi
                                       patient,
                                       htmlFormEntryForms,
                                       first(results[index].associatedEncounters)?.uuid,
-                                      results[index].form.name,
+                                      results[index].form.display ?? results[index].form.name,
                                     )
                                   }
                                 />

--- a/packages/esm-patient-forms-app/src/types/index.ts
+++ b/packages/esm-patient-forms-app/src/types/index.ts
@@ -5,6 +5,7 @@ export interface FormEncounter {
   uuid: string;
   encounterType?: EncounterType;
   name: string;
+  display: string;
   version: string;
   published: boolean;
   retired: boolean;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Update the names of the form to default to the `display` property and fall back to `name` if the `display` property is not available. This is to support localization through the user's locale.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
