### PR TITLE
(chore) Bump setup-node

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup git
         uses: actions/checkout@v2
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: "16"
       - run: npx lerna bootstrap


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR bumps the `setup-node` action in the `file-size-reporter` workflow to its latest version. The hope is that this fixes an issue that's causing the workflow to fail.

Currently, the `file-size-reporter` workflow is failing because the node version that gets installed does not match what the workflow expects. See the attached screenshot for more information.