### PR TITLE
O3-1276: Users need a way to exit the workspace when forms don't load

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.css
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.css
@@ -1,7 +1,3 @@
-.error-text {
-  color: var(--omrs-color-danger);
-}
-
 .error-tile {
   width: 60%;
   margin: 1.25rem auto;

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.css
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.css
@@ -2,6 +2,64 @@
   color: var(--omrs-color-danger);
 }
 
+.error-tile {
+  width: 60%;
+  margin: 1.25rem auto;
+  display: flex;
+  flex-flow: column wrap;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem 0 1.75rem;
+}
+
+/* Tablet */
+:host-context(.omrs-breakpoint-lt-desktop) .error-tile {
+  background-color: white;
+}
+
+.heading {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #161616;
+}
+
+.helperText {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  letter-spacing: 0.16px;
+  color: #525252;
+}
+
+.separator {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: #525252;
+  width: 12rem;
+  margin: 1rem auto;
+  overflow: hidden;
+  text-align: center;
+}
+
+.separator::before, .separator::after {
+  background-color: #a8a8a8;
+  content: "";
+  display: inline-block;
+  height: 1px;
+  position: relative;
+  vertical-align: middle;
+  width: 50%;
+}
+
+.separator::before {
+  right: 1rem;
+  margin-left: -50%;
+}
+
+.separator::after {
+  left: 1rem;
+  margin-right: -50%;
+}
+
 .title-icon-size {
   height: 0.8rem;
   width: 0.8rem;

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
@@ -1,4 +1,15 @@
-<div class="error-text">{{ loadingError }}</div>
+<div *ngIf="loadingError" class="form-container">
+  <div class="bx--tile error-tile">
+    <h4 class="heading">There was an error with this form</h4>
+    <p class="helperText">
+      Try opening another form
+    </p>
+    <p class="separator">or</p>
+    <button class="bx--btn bx--btn--sm bx--btn--ghost" (click)="closeForm()">
+      Close this panel
+    </button>
+  </div>
+</div>
 <div *ngIf="formState !== 'submitted'" [ngClass]="{'error': formState === 'readyWithValidationErrors'}">
   <div class="content">
     <div *ngIf="formState === 'ready' || formState === 'readyWithValidationErrors' || formState === 'submitting' || formState === 'submissionError'" class="form-container">

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.scss
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.scss
@@ -1,3 +1,7 @@
+@import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
+@import "~carbon-components/src/globals/scss/mixins";
+
 .error-tile {
   width: 60%;
   margin: 1.25rem auto;
@@ -10,34 +14,31 @@
 
 /* Tablet */
 :host-context(.omrs-breakpoint-lt-desktop) .error-tile {
-  background-color: white;
+  background-color: $ui-02;
 }
 
 .heading {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #161616;
+  @include carbon--type-style('productive-heading-02');
+  color: $text-01;
 }
 
 .helperText {
   margin-top: 0.5rem;
-  font-size: 0.875rem;
-  letter-spacing: 0.16px;
-  color: #525252;
+  @include carbon--type-style('body-long-01');
+  color: $text-02;
 }
 
 .separator {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  color: #525252;
+  @include carbon--type-style('body-short-01');
+  color: $text-02;
   width: 12rem;
-  margin: 1rem auto;
+  margin: 1.375rem auto;
   overflow: hidden;
   text-align: center;
 }
 
 .separator::before, .separator::after {
-  background-color: #a8a8a8;
+  background-color: $text-03;
   content: "";
   display: inline-block;
   height: 1px;
@@ -142,7 +143,7 @@
 
 :host-context(.omrs-breakpoint-lt-desktop) .button-set {
   padding: 1.5rem 1rem;
-  background-color: white;
+  background-color: $ui-02;
 }
 
 .loader-container {

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -29,7 +29,7 @@ type FormState =
 @Component({
   selector: 'my-app-fe-wrapper',
   templateUrl: './fe-wrapper.component.html',
-  styleUrls: ['./fe-wrapper.component.css'],
+  styleUrls: ['./fe-wrapper.component.scss'],
 })
 export class FeWrapperComponent implements OnInit, OnDestroy {
   private launchFormSubscription?: Subscription;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Presently, the form engine handles rendering a form and its action buttons when a user launches a clinical form. If there is a problem loading a form, its action buttons won't get loaded either (see the attached screenshot). In such a circumstance, the user cannot exit from the workspace. This situation is often very frustrating.

Ciarán has helpfully crafted up an [error state design](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/626a6020dd92b8014fbf3235) which affords the user with a way to back out of the workspace when a form fails to load. The user can click on the `Close this panel` button to exit the workspace. In future, an affordance would navigate the user to the forms list from where they could choose an alternative form to open.

This PR implements the empty state design in the workspace.

## Screenshots

> Before

<img width="1920" alt="workspace-error-state" src="https://user-images.githubusercontent.com/8509731/165822799-c5644523-4163-4c1e-a7f9-680ac82c239d.png">

> After

<img width="1541" alt="workspace-error-state-for-clinical-forms" src="https://user-images.githubusercontent.com/8509731/165822884-5d6cfcd7-30a5-48e7-98b1-7d84937ef723.png">

## Issue

https://issues.openmrs.org/browse/O3-1276