### PR TITLE
fix `session` failing on form-component

### DIFF
--- a/packages/esm-patient-forms-app/src/forms/forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.tsx
@@ -43,7 +43,7 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
     ? data?.filter((formInfo) => isValidOfflineFormEncounter(formInfo.form, htmlFormEntryForms))
     : data;
   formsToDisplay = formsToDisplay?.filter((formInfo) =>
-    userHasAccess(formInfo.form.encounterType.editPrivilege?.display, session.user),
+    userHasAccess(formInfo.form.encounterType.editPrivilege?.display, session?.user),
   );
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
   const { programConfigs } = useProgramConfig(patientUuid, showRecommendedFormsTab);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
`useSession` can return `null`, therefore accessing user property results in the component failing. This PR fixes it

## Screenshots
bug
<img width="388" alt="Screenshot 2022-05-05 at 10 56 31" src="https://user-images.githubusercontent.com/28008754/166883683-13d61dc5-6cc2-447c-8ad6-7aa25b36f212.png">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
