### PR TITLE
(chore) Reuse built artifacts in pre-release and release jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,7 +718,7 @@ jobs:
 
     needs: build
 
-    # if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' }}
 
     steps:
       - name: Download built artifacts
@@ -732,9 +732,9 @@ jobs:
       - run: npx lerna bootstrap
       - run: yarn lerna version patch --no-git-tag-version --no-push --yes
       - run: yarn lerna version "$(node -e "console.log(require('./lerna.json').version)")-pre.${{ github.run_number }}" --no-git-tag-version --yes
-      # - run: git config user.email "info@openmrs.org" && git config user.name "OpenMRS CI"
-      # - run: git add . && git commit -m "Prerelease version" --no-verify
-      # - run: yarn run ci:prepublish
+      - run: git config user.email "info@openmrs.org" && git config user.name "OpenMRS CI"
+      - run: git add . && git commit -m "Prerelease version" --no-verify
+      - run: yarn run ci:prepublish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
@@ -743,7 +743,7 @@ jobs:
 
     needs: build
 
-    #if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'release' }}
 
     steps:
       - name: Download built artifacts
@@ -755,6 +755,6 @@ jobs:
           node-version: '16'
           registry-url: "https://registry.npmjs.org"
       - run: npx lerna bootstrap
-      # - run: yarn run ci:publish
+      - run: yarn run ci:publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,7 +718,7 @@ jobs:
 
     needs: build
 
-    if: ${{ github.event_name == 'push' }}
+    # if: ${{ github.event_name == 'push' }}
 
     steps:
       - name: Download built artifacts
@@ -732,9 +732,9 @@ jobs:
       - run: npx lerna bootstrap
       - run: yarn lerna version patch --no-git-tag-version --no-push --yes
       - run: yarn lerna version "$(node -e "console.log(require('./lerna.json').version)")-pre.${{ github.run_number }}" --no-git-tag-version --yes
-      - run: git config user.email "info@openmrs.org" && git config user.name "OpenMRS CI"
-      - run: git add . && git commit -m "Prerelease version" --no-verify
-      - run: yarn run ci:prepublish
+      # - run: git config user.email "info@openmrs.org" && git config user.name "OpenMRS CI"
+      # - run: git add . && git commit -m "Prerelease version" --no-verify
+      # - run: yarn run ci:prepublish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
@@ -743,7 +743,7 @@ jobs:
 
     needs: build
 
-    if: ${{ github.event_name == 'release' }}
+    #if: ${{ github.event_name == 'release' }}
 
     steps:
       - name: Download built artifacts
@@ -755,6 +755,6 @@ jobs:
           node-version: '16'
           registry-url: "https://registry.npmjs.org"
       - run: npx lerna bootstrap
-      - run: yarn run ci:publish
+      # - run: yarn run ci:publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -139,7 +139,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -181,7 +181,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -223,7 +223,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -265,7 +265,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -307,7 +307,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -349,7 +349,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -391,7 +391,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -433,7 +433,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -475,7 +475,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -517,7 +517,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -559,7 +559,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -601,7 +601,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -643,7 +643,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -685,7 +685,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Compute Timestamp
         run: echo "TIMESTAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Prepare Directory
@@ -721,6 +721,8 @@ jobs:
     if: ${{ github.event_name == 'push' }}
 
     steps:
+      - name: Download built artifacts
+        uses: actions/download-artifact@v3
       - uses: actions/checkout@v2
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -728,7 +730,6 @@ jobs:
           node-version: '16'
           registry-url: "https://registry.npmjs.org"
       - run: npx lerna bootstrap
-      - run: yarn turbo run build
       - run: yarn lerna version patch --no-git-tag-version --no-push --yes
       - run: yarn lerna version "$(node -e "console.log(require('./lerna.json').version)")-pre.${{ github.run_number }}" --no-git-tag-version --yes
       - run: git config user.email "info@openmrs.org" && git config user.name "OpenMRS CI"
@@ -745,6 +746,8 @@ jobs:
     if: ${{ github.event_name == 'release' }}
 
     steps:
+      - name: Download built artifacts
+        uses: actions/download-artifact@v3
       - uses: actions/checkout@v2
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -752,7 +755,6 @@ jobs:
           node-version: '16'
           registry-url: "https://registry.npmjs.org"
       - run: npx lerna bootstrap
-      - run: yarn turbo run build
       - run: yarn run ci:publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR modifies the `release` and `pre-release` jobs to reuse artifacts from the `build` job. Presently, these jobs don't always run successfully. This is most often due to the CI running out of memory. Reusing built artifacts obviates the need to redo the expensive build step.