### PR TITLE
(fix) Fix object property access bug in forms widget

### DIFF
--- a/packages/esm-patient-forms-app/src/forms/forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.tsx
@@ -43,7 +43,7 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
     ? data?.filter((formInfo) => isValidOfflineFormEncounter(formInfo.form, htmlFormEntryForms))
     : data;
   formsToDisplay = formsToDisplay?.filter((formInfo) =>
-    userHasAccess(formInfo.form.encounterType.editPrivilege?.display, session?.user),
+    userHasAccess(formInfo?.form?.encounterType?.editPrivilege?.display, session?.user),
   );
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
   const { programConfigs } = useProgramConfig(patientUuid, showRecommendedFormsTab);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes a property access bug that causes the forms widget to fail to load in some cases.

## Screenshots

> Bug
<img width="1224" alt="forms-widget-bug" src="https://user-images.githubusercontent.com/8509731/170011367-c66b47ea-d0a1-4b49-8fc1-c523aac7264e.png">

> Console error
<img width="766" alt="property-access-bug" src="https://user-images.githubusercontent.com/8509731/170011386-f5fa1ca4-15b8-4d7c-8b59-20858e5ac5fb.png">

> Fix (forms widget now visible)
<img width="1312" alt="Screenshot 2022-05-24 at 13 03 19" src="https://user-images.githubusercontent.com/8509731/170011427-3601ab0d-51e4-46d6-9e29-cf207533ed0e.png">

