### PR TITLE
03-1277:obs-by-encounter-widget should support more concept types

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
@@ -20,6 +20,12 @@ const ObsSwitchable: React.FC<ObsSwitchableProps> = ({ patientUuid }) => {
   const config = useConfig() as ConfigObject;
   const [chartView, setChartView] = React.useState<boolean>();
   const { data, error, isLoading, isValidating } = useObs(patientUuid);
+  const isChartButtonVisible =
+    data.filter(
+      (obs) =>
+        typeof (obs?.valueQuantity?.value ?? obs.valueCodeableConcept?.coding[0]?.display ?? obs.valueString) !==
+        'number',
+    ).length > 0;
 
   return (
     <>
@@ -44,15 +50,17 @@ const ObsSwitchable: React.FC<ObsSwitchableProps> = ({ patientUuid }) => {
                       iconDescription={t('tableView', 'Table View')}
                       onClick={() => setChartView(false)}
                     />
-                    <Button
-                      className={styles.toggle}
-                      size="field"
-                      kind={chartView ? 'tertiary' : 'ghost'}
-                      hasIconOnly
-                      renderIcon={ChartLineSmooth16}
-                      iconDescription={t('chartView', 'Chart View')}
-                      onClick={() => setChartView(true)}
-                    />
+                    {!isChartButtonVisible && (
+                      <Button
+                        className={styles.toggle}
+                        size="field"
+                        kind={chartView ? 'tertiary' : 'ghost'}
+                        hasIconOnly
+                        renderIcon={ChartLineSmooth16}
+                        iconDescription={t('chartView', 'Chart View')}
+                        onClick={() => setChartView(true)}
+                      />
+                    )}
                   </div>
                 </div>
               </CardHeader>

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
@@ -88,7 +88,7 @@ describe('Switchable obs viewer: ', () => {
       expect(within(table).getByRole('columnheader', { name: new RegExp(header, 'i') })).toBeInTheDocument(),
     );
 
-    const expectedTableRows = [/2\d — Oct — 2021, \d\d:\d\d PM 180/, /1\d — Oct — 2021, \d\d:\d\d AM 198 200/];
+    const expectedTableRows = [/2\d — Oct — 2021, \d\d:\d\d PM -- 180/, /1\d — Oct — 2021, \d\d:\d\d AM 198 200/];
 
     expectedTableRows.map((row) =>
       expect(within(table).getByRole('row', { name: new RegExp(row, 'i') })).toBeInTheDocument(),

--- a/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
@@ -41,7 +41,8 @@ const ObsTable: React.FC<ObsTableProps> = ({ patientUuid }) => {
           date: formatDatetime(new Date(obss[0].issued), { mode: 'wide' }),
         };
         for (let obs of obss) {
-          rowData[obs.conceptUuid] = obs.valueQuantity.value;
+          const obsValue = obs?.valueQuantity?.value ?? obs.valueCodeableConcept?.coding[0]?.display ?? obs.valueString;
+          rowData[obs.conceptUuid] = obsValue;
         }
         return rowData;
       }),
@@ -75,7 +76,7 @@ const ObsTable: React.FC<ObsTableProps> = ({ patientUuid }) => {
                 {rows.map((row) => (
                   <TableRow key={row.id}>
                     {row.cells.map((cell) => (
-                      <TableCell key={cell.id}>{cell.value?.content ?? cell.value}</TableCell>
+                      <TableCell key={cell.id}>{cell.value?.content ?? cell.value ?? '--'}</TableCell>
                     ))}
                   </TableRow>
                 ))}

--- a/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
+++ b/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { openmrsFetch, fhirBaseUrl, useConfig, FHIRResource } from '@openmrs/esm-framework';
+import { openmrsFetch, fhirBaseUrl, useConfig, FHIRResource, OpenmrsResource } from '@openmrs/esm-framework';
 
 export const pageSize = 100;
 
@@ -54,7 +54,13 @@ export interface UseObsResult {
 
 type ObsResult = FHIRResource['resource'] & {
   conceptUuid: string;
+  valueCodeableConcept?: CodeableConcept;
+  valueString?: string;
 };
+
+interface CodeableConcept {
+  coding: Array<OpenmrsResource>;
+}
 
 function isUuid(input: string) {
   return input.length === 36;


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Currently, the obs-by-encounter-widget only supports numeric obs, as we only load only the [valueQuantity property](https://github.com/openmrs/openmrs-esm-patient-chart/blob/1f4e8323dc85dec6a9b5960395acf50310f13bdb/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx#L44). This PR support text-based and coded obs. Though the numeric obs are graphed,  the none numeric value chart view is hidden.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
