### PR TITLE
Adds isExpanded option to createDashboardGroup and scrollable patient chart sidenav

### DIFF
--- a/packages/esm-patient-chart-app/src/root.scss
+++ b/packages/esm-patient-chart-app/src/root.scss
@@ -7,6 +7,11 @@
   position: relative;
 }
 
+.patientChartWrapper > nav {
+  overflow-y: scroll;
+  padding-bottom: 3rem;
+}
+
 .caption01 {
   @include carbon--type-style("caption-01");
 }

--- a/packages/esm-patient-common-lib/src/nav-group/DashboardGroupExtension.tsx
+++ b/packages/esm-patient-common-lib/src/nav-group/DashboardGroupExtension.tsx
@@ -7,16 +7,17 @@ export interface DashboardGroupExtensionProps {
   title: string;
   slotName?: string;
   basePath: string;
+  isExpanded?: boolean;
 }
 
-export const DashboardGroupExtension = ({ title, slotName, basePath }: DashboardGroupExtensionProps) => {
+export const DashboardGroupExtension = ({ title, slotName, basePath, isExpanded }: DashboardGroupExtensionProps) => {
   useEffect(() => {
     registerNavGroup(slotName);
   }, [slotName]);
 
   return (
     <Accordion>
-      <AccordionItem open title={title} style={{ border: 'none' }}>
+      <AccordionItem open={isExpanded ?? true} title={title} style={{ border: 'none' }}>
         <ExtensionSlot extensionSlotName={slotName ?? title} state={{ basePath }} />
       </AccordionItem>
     </Accordion>

--- a/packages/esm-patient-common-lib/src/nav-group/createDashboardGroup.tsx
+++ b/packages/esm-patient-common-lib/src/nav-group/createDashboardGroup.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import { DashboardGroupExtension } from './DashboardGroupExtension';
 
-export const createDashboardGroup = ({ title, slotName }: { title: string; slotName: string }) => {
+export const createDashboardGroup = ({
+  title,
+  slotName,
+  isExpanded,
+}: {
+  title: string;
+  slotName: string;
+  isExpanded?: boolean;
+}) => {
   const DashboardGroup = ({ basePath }: { basePath: string }) => {
-    return <DashboardGroupExtension title={title} slotName={slotName} basePath={basePath} />;
+    return <DashboardGroupExtension title={title} slotName={slotName} basePath={basePath} isExpanded={isExpanded} />;
   };
   return DashboardGroup;
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
- Add overflow to patient chart sidenav to make it scrollable on smaller screens and when more nav items are added
- Adds `isExpanded` parameter to launch createDashboardGroup in collapsed mode

## Screenshots

<img width="231" alt="Screenshot 2022-06-10 at 15 19 48" src="https://user-images.githubusercontent.com/15266028/173062868-3cf3efe8-0abb-4752-a64a-2bd3d1157325.png">


https://user-images.githubusercontent.com/15266028/173062425-2cd3dedf-f88d-47b3-ac5d-08398ec006ef.mov


