### PR TITLE
(feat) Tweak empty state illustration dimensions

### DIFF
--- a/packages/esm-patient-common-lib/src/empty-state/empty-data-illustration.component.tsx
+++ b/packages/esm-patient-common-lib/src/empty-state/empty-data-illustration.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-export const EmptyDataIllustration = ({ width = '61', height = '59' }) => {
+export const EmptyDataIllustration = ({ width = '64', height = '64' }) => {
   return (
-    <svg width={width} height={height} viewBox="0 0 61 59">
+    <svg width={width} height={height} viewBox="0 0 64 64">
       <title>Empty data illustration</title>
       <g fill="none" fillRule="evenodd">
         <path


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR tweaks the dimensions of the empty state illustration so that it doesn't get cut off at certain zoom levels, as is currently the case.

## Screenshots

<img width="899" alt="Screenshot 2022-06-10 at 22 35 19" src="https://user-images.githubusercontent.com/8509731/173137610-bc0af82b-5d4a-421e-97ac-05c01a3e9796.png">


