### PR TITLE
(fix) Fixed label loading for concepts on repeating sections on AMPATH

### DIFF
--- a/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts
@@ -193,6 +193,21 @@ export class FormSchemaService {
     return formUuids;
   }
 
+  private processQuestionForUnlabeledConcepts(question) {
+    let concepts = [];
+    if (!question.label && question.extras.questionOptions?.concept) {
+      concepts.push(question.extras.questionOptions.concept);
+    }
+    if (question.extras.questionOptions.answers) {
+      question.extras.questionOptions.answers.forEach((answer) => {
+        if (!answer.label) {
+          concepts.push(answer.concept);
+        }
+      });
+    }
+    return concepts;
+  }
+
   private traverseForUnlabeledConcepts(o, type?) {
     let concepts = [];
     if (o.children) {
@@ -212,20 +227,12 @@ export class FormSchemaService {
                 concepts = concepts.concat(childrenConcepts);
                 break;
               case 'repeating':
-                const repeatingConcepts = this.traverseRepeatingGroupForUnlabeledConcepts(o.children[key].children);
-                concepts = concepts.concat(repeatingConcepts);
+                for (const question of o.children[key].question.questions) {
+                  concepts = concepts.concat(this.processQuestionForUnlabeledConcepts(question));
+                }
                 break;
               default:
-                if (!question.label && question.extras.questionOptions?.concept) {
-                  concepts.push(question.extras.questionOptions.concept);
-                }
-                if (question.extras.questionOptions.answers) {
-                  question.extras.questionOptions.answers.forEach((answer) => {
-                    if (!answer.label) {
-                      concepts.push(answer.concept);
-                    }
-                  });
-                }
+                concepts = concepts.concat(this.processQuestionForUnlabeledConcepts(question));
                 break;
             }
           }

--- a/packages/esm-form-entry-app/src/app/services/concept.service.ts
+++ b/packages/esm-form-entry-app/src/app/services/concept.service.ts
@@ -41,7 +41,7 @@ export class ConceptService {
           }),
           catchError((error: Response) => {
             console.error(error.status);
-            return observableOf(error.json());
+            return observableOf({ extId: conceptUuid, display: conceptUuid });
           }),
         ),
       );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
When an AMPATH form is loaded, it's schema is traversed for concepts without specified labels so that they can be dynamically loaded, according to user lang, from the concept dictionary.

Currently, there's an issue that causes the concept data not to be loaded for questions that are inside AMPATH repeating sections, causing rendered labels to be blank on ngx-openmrs-formentry.

This PR fixes the above issue so that all concepts specified on AMPATH schema without labels are loaded. If concept data is not found within the concept dictionary, the concept id, as specified in the AMPATH schema, is used as label so that ngx-openmrs-formentry has always has a label to render.