### PR TITLE
(feat) Add a build script for patient-common-lib

### DIFF
--- a/packages/esm-patient-common-lib/package.json
+++ b/packages/esm-patient-common-lib/package.json
@@ -7,6 +7,7 @@
   "main": "src/index.ts",
   "source": true,
   "scripts": {
+    "build": "webpack --mode production",
     "lint": "eslint src --ext ts,tsx",
     "typescript": "tsc"
   },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [n/a] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [n/a] My work includes tests or is validated by existing tests.

## Summary
Adds a build script for esm-patient-common-lib. Hopefully this will result in a `/dist/openmrs-esm-patient-common-lib.js` file after all github actions. This built file is required for outside modules who do not transpile TypeScript.

## Screenshots
none

## Related Issue
none

## Other
none
