### PR TITLE
O3-1332:Results Viewer: Resizable Columns

### DIFF
--- a/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.styles.scss
+++ b/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.styles.scss
@@ -53,3 +53,17 @@
   }
 }
 
+.columnPanel {
+  position: relative;
+}
+ 
+.dragHandler {
+  width: 3px;
+  height: 100%;
+  background-color: transparent;
+  position: absolute;
+  top: 0;
+  left: 100%;
+  cursor: col-resize;
+  z-index: 100;
+}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I added a drag element in-between the columns to enable a user drag the  column width to their desired width in a 'split' mode. While respecting some reasonable minWidth for each column.
## Screenshots

https://user-images.githubusercontent.com/33891016/175060443-a92d48d2-2c0b-459f-a5e7-01f5579bcc7c.mp4


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
