### PR TITLE
O3-578: Restore Generic Dashboard Links

### DIFF
--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -6,7 +6,6 @@ import {
   defineExtensionConfigSchema,
 } from '@openmrs/esm-framework';
 import { createDashboardLink } from '@openmrs/esm-patient-common-lib';
-import { capitalize } from 'lodash-es';
 import { esmPatientChartSchema } from './config-schema';
 import { moduleName, spaBasePath } from './constants';
 import { setupCacheableRoutes, setupOfflineVisitsSync } from './offline';

--- a/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
@@ -1,17 +1,17 @@
 import React, { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { last } from 'lodash';
-
 import { ConfigurableLink } from '@openmrs/esm-framework';
 import styles from './dashboardextension.scss';
 
 export interface DashboardExtensionProps {
   title: string;
   basePath: string;
-  currentPath: string;
 }
 
-export const DashboardExtension = ({ title, basePath, currentPath }: DashboardExtensionProps) => {
-  const navLink = useMemo(() => decodeURIComponent(last(currentPath.split('/'))), [currentPath]);
+export const DashboardExtension = ({ title, basePath }: DashboardExtensionProps) => {
+  const location = useLocation<Location>();
+  const navLink = useMemo(() => decodeURIComponent(last(location.pathname.split('/'))), [location.pathname]);
 
   const activeClassName = title === navLink ? 'active-left-nav-link' : 'non-active';
 

--- a/packages/esm-patient-common-lib/src/dashboards/createDashboardLink.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/createDashboardLink.tsx
@@ -3,8 +3,7 @@ import { DashboardLinkConfig } from '../types';
 import { DashboardExtension } from './DashboardExtension';
 
 export const createDashboardLink = (db: DashboardLinkConfig) => {
-  const Dashboard = ({ basePath, currentPath }: { basePath: string; currentPath: string }) => {
-    return <DashboardExtension title={db.title} basePath={basePath} currentPath={currentPath} />;
+  return ({ basePath }: { basePath: string }) => {
+    return <DashboardExtension title={db.title} basePath={basePath} />;
   };
-  return Dashboard;
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This is a very simple follow-up commit to O3-578 to fix a kind of obscure feature: the Generic Dashboards that are creatable via configuration rather than code. When calling `createDashboardLink()`, we're able to get the `currentPath` passed down to the `DashboardExtension` component. However, the Generic Dashboards widget directly creates a `DashboardExtension` component in a context where we don't have the `currentPath` design. This switches things so we rely on the `location` supplied by the react-router `useLocation()` hook which should work in both contexts and not add any noticeable overhead.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
