### PR TITLE
#O3-1329 implementation of round numbers by default and configuration…

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/config-schema.ts
+++ b/packages/esm-generic-patient-widgets-app/src/config-schema.ts
@@ -23,6 +23,9 @@ export const configSchema = {
       color: {
         _type: Type.String,
       },
+      decimalPlaces: {
+        _type: Type.Number,
+      },
     },
     _default: [
       {

--- a/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
@@ -48,7 +48,19 @@ const ObsTable: React.FC<ObsTableProps> = ({ patientUuid }) => {
               break;
 
             case 'Number':
-              rowData[obs.conceptUuid] = obs.valueQuantity?.value;
+              let decimalPlaces: number = config.data.find(
+                (ele: any) => ele.concept === obs.conceptUuid,
+              )?.decimalPlaces;
+
+              if (obs.valueQuantity?.value % 1 !== 0) {
+                if (decimalPlaces > 0) {
+                  rowData[obs.conceptUuid] = obs.valueQuantity?.value.toFixed(decimalPlaces);
+                } else {
+                  rowData[obs.conceptUuid] = obs.valueQuantity?.value.toFixed(2);
+                }
+              } else {
+                rowData[obs.conceptUuid] = obs.valueQuantity?.value;
+              }
               break;
 
             case 'Coded':
@@ -59,7 +71,7 @@ const ObsTable: React.FC<ObsTableProps> = ({ patientUuid }) => {
 
         return rowData;
       }),
-    [obssByDate],
+    [config.data, obssByDate],
   );
 
   const { results, goTo, currentPage } = usePagination(tableRows, config.table.pageSize);


### PR DESCRIPTION
… in  obs-by-encounter widget

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Currently, the obs-by-encounter widget does not round displayed numbers. By default, it seems like the obs-by-encounter widget should round decimal points to, 2 numbers, but allow the rounding needs to be configured via the configuration.

## Screenshots
<img width="974" alt="image" src="https://user-images.githubusercontent.com/106243905/177366279-5e443f4d-535a-4dc9-9af8-0d301ab470b9.png">

## Related Issue
https://issues.openmrs.org/browse/O3-1329
