### PR TITLE
(fix) Fix age based validation

### DIFF
--- a/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 
 import { take, map, tap } from 'rxjs/operators';
 import { Observable, Subject } from 'rxjs';
-import { age } from '@openmrs/esm-framework';
 
 import { ProviderResourceService } from '../openmrs-api/provider-resource.service';
 import { LocationResourceService } from '../openmrs-api/location-resource.service';
@@ -199,7 +198,7 @@ export class FormDataSourceService {
     const model: object = {};
     model['sex'] = patient?.gender === 'male' ? 'M' : 'F';
     model['birthdate'] = new Date(patient?.birthDate);
-    model['age'] = parseInt(age(patient?.birthDate).match(/\d+/g).join(''));
+    model['age'] = this.calculateAge(patient?.birthDate);
 
     // define gender based constant:
     if (patient?.gender === 'female') {
@@ -210,5 +209,11 @@ export class FormDataSourceService {
     }
 
     return model;
+  }
+
+  private calculateAge(birthday) {
+    const ageDifMs = Date.now() - new Date(birthday).getTime();
+    const ageDate = new Date(ageDifMs);
+    return Math.abs(ageDate.getUTCFullYear() - 1970);
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes validation that relies on the `age` model. The form entry wrapper depends on the `age` helper from `@openmrs/esm-framework` - which at present does not compute the correct `age` value from the given birth date. 

I've added a `calculateAge` function that returns the correct age from the patient's birth date.
