### PR TITLE
Updated endpoint to bulk fetch form labels from concept dictionary

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -78,7 +78,7 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
           this.formState = 'ready';
           this.form = form;
           this.labelMap = concepts.reduce((acc, current) => {
-            acc[current.extId] = current.display;
+            acc[current.uuid] = current.display;
             return acc;
           }, {});
         },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Updated endpoint so that all concept labels required for the form are fetched using a single invocation.