### PR TITLE
(feat) Form Entry Hide Submit Cancel Buttons + Outside Submit Control

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
@@ -18,7 +18,7 @@
           <form-renderer [labelMap]="labelMap" [node]="form.rootNode"></form-renderer>
         </form>
       </div>
-      <div class="bx-btn--set button-set">
+      <div *ngIf="showDiscardSubmitButtons" class="bx-btn--set button-set">
         <button class="bx--btn bx--btn--secondary" (click)="closeForm()" type="button">Discard</button>
         <button [disabled]="formState === 'submitting'" class="bx--btn bx--btn--primary" (click)="onSubmit()" type="submit">
           <span *ngIf="formState !== 'submitting'">Save and close</span>

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -38,6 +38,7 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
   public loadingError?: string;
   public labelMap: {} = {};
   public formState: FormState = 'initial';
+  public showDiscardSubmitButtons: boolean = true;
   public language: string = (window as any).i18next.language.substring(0, 2).toLowerCase();
 
   public constructor(
@@ -61,6 +62,7 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
 
   public launchForm() {
     this.formState = 'loading';
+    this.showDiscardSubmitButtons = this.singleSpaPropsService.getProp('showDiscardSubmitButtons') ?? true;
     this.launchFormSubscription?.unsubscribe();
     this.launchFormSubscription = this.loadAllFormDependencies()
       .pipe(

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -8,7 +8,7 @@ import { FormSubmissionService } from '../form-submission/form-submission.servic
 import { EncounterResourceService } from '../openmrs-api/encounter-resource.service';
 import { Encounter, FormSchema, Order } from '../types';
 // @ts-ignore
-import { showToast, showNotification, getSynchronizationItems } from '@openmrs/esm-framework';
+import { showToast, showNotification, getSynchronizationItems, createGlobalStore } from '@openmrs/esm-framework';
 import { PatientPreviousEncounterService } from '../openmrs-api/patient-previous-encounter.service';
 
 import { patientFormSyncItem, PatientFormSyncItemContent } from '../offline/sync';
@@ -25,6 +25,8 @@ type FormState =
   | 'submitting'
   | 'submitted'
   | 'submissionError';
+
+const store = createGlobalStore('ampath-form-state', {});
 
 @Component({
   selector: 'my-app-fe-wrapper',
@@ -260,6 +262,6 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
   private changeState = (state) => {
     const formUuid = this.singleSpaPropsService.getPropOrThrow('formUuid');
     this.formState = state;
-    window.dispatchEvent(new CustomEvent('ampath-form-state', { detail: { formUuid, state } }));
+    store.setState({ [formUuid]: state });
   };
 }

--- a/packages/esm-form-entry-app/src/single-spa-props.ts
+++ b/packages/esm-form-entry-app/src/single-spa-props.ts
@@ -17,4 +17,5 @@ export type SingleSpaProps = AppProps & {
   isOffline: boolean;
   patientUuid: string;
   handlePostResponse?: (encounter: Encounter) => void;
+  showDiscardSubmitButtons?: boolean;
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [n/a] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR makes it possible to hide the submit and cancel buttons from the AMPATH form engine. Additionally it now allows for outside triggering of the onSubmit function with a window custom event, and sharing of the form engine internal `formState` via unistore

## Screenshots
No UI changes

## Related Issue
[O3-1414 ](https://issues.openmrs.org/browse/O3-1414)
TFS-330515 - "Next patient" button should save the form and allow searching for the next patient


## Other
Companion PR in Fast Data Entry coming soon
