### PR TITLE
Patient chart widget additions to patient search banner

### DIFF
--- a/packages/esm-patient-chart-app/src/actions-buttons/add-past-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/add-past-visit.component.tsx
@@ -19,7 +19,7 @@ const AddPastVisitOverflowMenuItem: React.FC<AddPastVisitOverflowMenuItemProps> 
       launchPatientChart,
       closeModal: () => dispose(),
     });
-  }, [patientUuid]);
+  }, [patientUuid, launchPatientChart]);
 
   return (
     <li className="bx--overflow-menu-options__option">

--- a/packages/esm-patient-chart-app/src/actions-buttons/add-past-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/add-past-visit.component.tsx
@@ -2,16 +2,24 @@ import { showModal } from '@openmrs/esm-framework';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-interface AddPastVisitOverflowMenuItemProps {}
+interface AddPastVisitOverflowMenuItemProps {
+  patientUuid?: string;
+  launchPatientChart?: boolean;
+}
 
-const AddPastVisitOverflowMenuItem: React.FC<AddPastVisitOverflowMenuItemProps> = () => {
+const AddPastVisitOverflowMenuItem: React.FC<AddPastVisitOverflowMenuItemProps> = ({
+  patientUuid,
+  launchPatientChart,
+}) => {
   const { t } = useTranslation();
 
   const openModal = useCallback(() => {
     const dispose = showModal('start-visit-dialog', {
+      patientUuid,
+      launchPatientChart,
       closeModal: () => dispose(),
     });
-  }, []);
+  }, [patientUuid]);
 
   return (
     <li className="bx--overflow-menu-options__option">

--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -182,6 +182,14 @@ function setupOpenMRS() {
           moduleName,
         }),
       },
+      {
+        id: 'start-visit-button-patient-search',
+        slot: 'start-visit-button-slot',
+        load: getAsyncLifecycle(() => import('./visit/start-visit-button.component'), {
+          featureName: 'start-visit-button-patient-search',
+          moduleName,
+        }),
+      },
     ],
   };
 }

--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -80,6 +80,14 @@ function setupOpenMRS() {
         }),
       },
       {
+        name: 'stop-visit-button-patient-search',
+        slot: 'patient-search-actions-slot',
+        load: getAsyncLifecycle(() => import('./actions-buttons/stop-visit.component'), {
+          featureName: 'patient-actions-slot',
+          moduleName,
+        }),
+      },
+      {
         name: 'cancel-visit-button',
         slot: 'patient-actions-slot',
         load: getAsyncLifecycle(() => import('./actions-buttons/cancel-visit.component'), {
@@ -88,8 +96,24 @@ function setupOpenMRS() {
         }),
       },
       {
+        name: 'cancel-visit-button',
+        slot: 'patient-search-actions-slot',
+        load: getAsyncLifecycle(() => import('./actions-buttons/cancel-visit.component'), {
+          featureName: 'patient-actions-slot',
+          moduleName,
+        }),
+      },
+      {
         name: 'add-past-visit-button',
         slot: 'patient-actions-slot',
+        load: getAsyncLifecycle(() => import('./actions-buttons/add-past-visit.component'), {
+          featureName: 'patient-actions-slot',
+          moduleName,
+        }),
+      },
+      {
+        name: 'add-past-visit-button',
+        slot: 'patient-search-actions-slot',
         load: getAsyncLifecycle(() => import('./actions-buttons/add-past-visit.component'), {
           featureName: 'patient-actions-slot',
           moduleName,

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
@@ -19,7 +19,8 @@ const StartVisitButton = ({ patientUuid }) => {
     navigate({
       to: `\${openmrsSpaBase}/patient/${patientUuid}/chart`,
     });
-  }, [launchPatientChartWithWorkspaceOpen, patientUuid]);
+  }, [patientUuid, navigate]);
+
   return (
     <Button kind="primary" onClick={handleStartVisit}>
       {t('startVisit', 'Start visit')}

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
@@ -19,7 +19,7 @@ const StartVisitButton = ({ patientUuid }) => {
     navigate({
       to: `\${openmrsSpaBase}/patient/${patientUuid}/chart`,
     });
-  }, [patientUuid, navigate]);
+  }, [patientUuid]);
 
   return (
     <Button kind="primary" onClick={handleStartVisit}>

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
@@ -1,0 +1,30 @@
+import { navigate } from '@openmrs/esm-framework';
+import { launchPatientChartWithWorkspaceOpen } from '@openmrs/esm-patient-common-lib';
+import { Button } from 'carbon-components-react';
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface StartVisitButtonProps {
+  patientUuid: string;
+}
+
+const StartVisitButton = ({ patientUuid }) => {
+  const { t } = useTranslation();
+
+  const handleStartVisit = useCallback(() => {
+    launchPatientChartWithWorkspaceOpen({
+      patientUuid,
+      workspaceName: 'start-visit-workspace-form',
+    });
+    navigate({
+      to: `\${openmrsSpaBase}/patient/${patientUuid}/chart`,
+    });
+  }, [launchPatientChartWithWorkspaceOpen, patientUuid]);
+  return (
+    <Button kind="primary" onClick={handleStartVisit}>
+      {t('startVisit', 'Start visit')}
+    </Button>
+  );
+};
+
+export default StartVisitButton;

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -122,7 +122,7 @@ const StartVisitForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWor
           },
         );
     },
-    [closeWorkspace, patientUuid, selectedLocation, t, timeFormat, visitDate, visitTime, visitType],
+    [closeWorkspace, patientUuid, selectedLocation, t, timeFormat, visitDate, visitTime, visitType, mutate],
   );
 
   const handleOnChange = () => {

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.component.tsx
@@ -44,7 +44,7 @@ const CancelVisitDialog: React.FC<CancelVisitDialogProps> = ({ patientUuid, clos
         setSubmitting(false);
       },
     );
-  }, []);
+  }, [closeModal, currentVisit.uuid, mutate, t]);
 
   return (
     <div>

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.component.tsx
@@ -1,27 +1,48 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ModalBody, ModalHeader, ModalFooter } from 'carbon-components-react';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { launchPatientChartWithWorkspaceOpen, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import styles from './start-visit-dialog.scss';
 
 interface StartVisitDialogProps {
   patientUuid: string;
   closeModal: () => void;
   visitType: string;
+  launchPatientChart?: boolean;
 }
 
-const StartVisitDialog: React.FC<StartVisitDialogProps> = ({ patientUuid, closeModal, visitType }) => {
+const StartVisitDialog: React.FC<StartVisitDialogProps> = ({
+  patientUuid,
+  closeModal,
+  visitType,
+  launchPatientChart,
+}) => {
   const { t } = useTranslation();
 
   const handleEditPastVisit = useCallback(() => {
-    launchPatientWorkspace('past-visits-overview');
+    if (launchPatientChart) {
+      launchPatientChartWithWorkspaceOpen({
+        patientUuid,
+        workspaceName: 'past-visits-overview',
+      });
+    } else {
+      launchPatientWorkspace('past-visits-overview');
+    }
     closeModal();
-  }, [closeModal]);
+  }, [closeModal, patientUuid, launchPatientChart]);
 
   const handleStartNewVisit = useCallback(() => {
-    launchPatientWorkspace('start-visit-workspace-form');
+    if (launchPatientChart) {
+      launchPatientChartWithWorkspaceOpen({
+        patientUuid,
+        workspaceName: 'start-visit-workspace-form',
+      });
+    } else {
+      launchPatientWorkspace('start-visit-workspace-form');
+    }
+
     closeModal();
-  }, [closeModal]);
+  }, [closeModal, patientUuid, launchPatientChart]);
 
   const modalHeaderText =
     visitType === 'past' ? t('addPastVisit', 'Add a past visit') : t('noActiveVisit', 'No active visit');

--- a/packages/esm-patient-chart-app/src/workspace/workspace-renderer.component.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-renderer.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { useLayoutType } from '@openmrs/esm-framework';
 import { OpenWorkspace, useWorkspaceWindowSize } from '@openmrs/esm-patient-common-lib';
 import { mountRootParcel } from 'single-spa';
@@ -31,7 +31,7 @@ export function WorkspaceRenderer({ workspace, patientUuid, active }: WorkspaceR
     };
   }, [workspace]);
 
-  const props = React.useMemo(
+  const props = useMemo(
     () =>
       workspace && {
         closeWorkspace: workspace.closeWorkspace,
@@ -39,7 +39,7 @@ export function WorkspaceRenderer({ workspace, patientUuid, active }: WorkspaceR
         patientUuid,
         ...workspace.additionalProps,
       },
-    [workspace, workspace.additionalProps, workspace.closeWorkspace, workspace.promptBeforeClosing, patientUuid],
+    [workspace, patientUuid],
   );
 
   return (

--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.component.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.component.tsx
@@ -45,7 +45,7 @@ const WorkspaceWindow: React.FC<RouteComponentProps<ContextWorkspaceParams>> = (
     if (active && hidden) {
       updateWindowSize('normal');
     }
-  }, [workspaces]);
+  }, [workspaces, active, hidden, updateWindowSize]);
 
   useBodyScrollLock(active && !isDesktop(layout));
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I have added the below listed extension for the use in the patient search application banner.

- [x] Start visit button in the banner, which when clicked, navigates to the patient chart and opens the `start-visit-workspace-form`.
- [x] Add past visit, to add and edit the past visits of the patient.
- [x] End visit button in the patient search banner action buttons (only visible if the patient has active visit)
- [x] Cancel visit button in the patient search banner actions button (only visible if the patient has active visit)


## Screenshots
<img width="610" alt="image" src="https://user-images.githubusercontent.com/51502471/182355226-3e1eee3e-cf2d-42ae-b914-0b893643ed99.png">

<img width="1671" alt="image" src="https://user-images.githubusercontent.com/51502471/182355146-dbb9f5af-aff9-488b-91f0-2cb2d2991b1e.png">

### Patient actions when a patient has active visit
<img width="618" alt="image" src="https://user-images.githubusercontent.com/51502471/182362344-0ddfda16-e407-47ab-a82d-b49102b9bfad.png">

### Add past visit modal
<img width="839" alt="image" src="https://user-images.githubusercontent.com/51502471/182362421-89719ce3-7981-49fd-bf50-3fdeacf7c7c5.png">



## Related Issue
https://issues.openmrs.org/browse/O3-1284

## Other
Relates with https://github.com/openmrs/openmrs-esm-patient-management/pull/287
