### PR TITLE
(fix) Split requests when fetching labels from concept dictionary to avoid HTTP 414 URI Too Long

### DIFF
--- a/packages/esm-form-entry-app/src/app/services/concept.service.ts
+++ b/packages/esm-form-entry-app/src/app/services/concept.service.ts
@@ -1,4 +1,4 @@
-import { forkJoin, Observable, of } from 'rxjs';
+import { forkJoin, Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
@@ -32,7 +32,10 @@ export class ConceptService {
   public searchBulkConceptByUUID(conceptUuids: Array<string>, lang: string): Observable<Array<ConceptMetadata>> {
     const chunkSize = 100;
     const observablesArray = [];
-    const slicedConceptUuids = conceptUuids.reduceRight((acc, currentValue, i, array) => [...acc, array.splice(0, chunkSize)], []);
+    const slicedConceptUuids = conceptUuids.reduceRight(
+      (acc, currentValue, i, array) => [...acc, array.splice(0, chunkSize)],
+      [],
+    );
 
     for (const conceptUuidsChunk of slicedConceptUuids) {
       observablesArray.push(

--- a/packages/esm-form-entry-app/src/app/services/concept.service.ts
+++ b/packages/esm-form-entry-app/src/app/services/concept.service.ts
@@ -1,4 +1,4 @@
-import {forkJoin, forkJoin as observableForkJoin, Observable, of} from 'rxjs';
+import { forkJoin, Observable, of } from 'rxjs';
 import { Injectable } from '@angular/core';
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';

--- a/packages/esm-form-entry-app/src/app/services/concept.service.ts
+++ b/packages/esm-form-entry-app/src/app/services/concept.service.ts
@@ -30,7 +30,7 @@ export class ConceptService {
   }
 
   public searchBulkConceptByUUID(conceptUuids: Array<string>, lang: string): Observable<Array<ConceptMetadata>> {
-    const chunkSize = 50;
+    const chunkSize = 100;
     const observablesArray = [];
     const slicedConceptUuids = conceptUuids.reduceRight((acc, currentValue, i, array) => [...acc, array.splice(0, chunkSize)], []);
 


### PR DESCRIPTION
Split requests when fetching labels from concept dictionary to avoid HTTP 414 URI Too Long

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Split requests to fetch 50 concepts at a time instead of having a single request with a huge url that can get rejected depending on limits