### PR TITLE
(feat) add the ability to load custom data sources into the AMPATH form engine

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,20 +11,19 @@
         "paths": [
           {
             "name": "lodash",
-            "message": "Import specific methods from `lodash-es`. e.g. `import map from 'lodash-es/map'`"
+            "message": "Import specific methods from `lodash`. e.g. `import map from 'lodash/map'`"
           },
           {
             "name": "lodash-es",
-            "message": "Import specific methods from `lodash-es`. e.g. `import map from 'lodash-es/map'`"
-          }
-        ],
-        "patterns": [
+            "importNames": ["default"],
+            "message": "Import specific methods from `lodash-es`. e.g. `import { map } from 'lodash-es'`"
+          },
           {
-            "group": ["carbon-components-react"],
+            "name": "carbon-components-react",
             "message": "Import from `@carbon/react` directly. e.g. `import { Toggle } from '@carbon/react'`"
           },
           {
-            "group": ["@carbon/icons-react"],
+            "name": "@carbon/icons-react",
             "message": "Import from `@carbon/react/icons`. e.g. `import { ChevronUp } from '@carbon/react/icons'`"
           }
         ]

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -1,7 +1,7 @@
 import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { Form } from '@ampath-kenya/ngx-formentry';
 import { Observable, forkJoin, from, throwError, of, Subscription } from 'rxjs';
-import { catchError, map, mergeMap, take } from 'rxjs/operators';
+import { catchError, concatAll, map, mergeMap, take } from 'rxjs/operators';
 import { OpenmrsEsmApiService } from '../openmrs-api/openmrs-esm-api.service';
 import { FormSchemaService } from '../form-schema/form-schema.service';
 import { FormSubmissionService } from '../form-submission/form-submission.service';
@@ -70,7 +70,8 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
     this.launchFormSubscription = this.loadAllFormDependencies()
       .pipe(
         take(1),
-        map((createFormParams) => this.formCreationService.initAndCreateForm(createFormParams)),
+        map((createFormParams) => from(this.formCreationService.initAndCreateForm(createFormParams))),
+        concatAll(),
         mergeMap((form) => {
           const unlabeledConcepts = FormSchemaService.getUnlabeledConceptIdentifiersFromSchema(form.schema);
           return this.conceptService

--- a/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
@@ -6,9 +6,8 @@ import { ConfigResourceService } from '../services/config-resource.service';
 import { MonthlyScheduleResourceService } from '../services/monthly-scheduled-resource.service';
 import { SingleSpaPropsService } from '../single-spa-props/single-spa-props.service';
 import { Encounter, FormSchema } from '../types';
-import type { NodeBase } from '@ampath-kenya/ngx-formentry/form-entry/form-factory/form-node';
 import { LoggedInUser } from '@openmrs/esm-framework';
-import type { FeWrapperComponent } from '../fe-wrapper/fe-wrapper.component';
+import { isFunction } from 'lodash-es';
 
 /**
  * Data required for creating a {@link Form} instance.
@@ -33,6 +32,8 @@ export interface CreateFormParams {
    */
   previousEncounter?: Encounter;
 }
+
+const loadedCustomDataSources: Record<string, unknown> = {};
 
 /**
  * A service solely created for the {@link FeWrapperComponent}.
@@ -63,10 +64,10 @@ export class FormCreationService {
    * @param createFormParams Data used for building the initial form.
    * @returns The new {@link Form} instance.
    */
-  public initAndCreateForm(createFormParams: CreateFormParams) {
+  public async initAndCreateForm(createFormParams: CreateFormParams) {
     const { formSchema, encounter } = createFormParams;
 
-    this.wireDataSources(createFormParams);
+    await this.wireDataSources(createFormParams);
 
     const form = this.formFactory.createForm(formSchema, this.dataSources.dataSources);
     this.setUpWHOCascading(form);
@@ -111,11 +112,97 @@ export class FormCreationService {
     this.dataSources.registerDataSource('rawPrevEnc', createFormParams.previousEncounter, false);
     this.dataSources.registerDataSource('userLocation', createFormParams.user.sessionLocation);
 
-    // Data sources which are configurable.
-    const configurableDataSources = this.configResourceService.getConfig().dataSources;
-    if (configurableDataSources.monthlySchedule) {
+    // TODO monthlySchedule should be converted to a "standard" configurableDataSource
+    const config = this.configResourceService.getConfig();
+    if (config.dataSources.monthlySchedule) {
       this.dataSources.registerDataSource('monthlyScheduleResourceService', this.monthlyScheduleResourceService);
     }
+
+    // Load configurable data sources which are configurable.
+    return Promise.all([
+      config.customDataSources.map(async ({ name, moduleName, moduleExport }) => {
+        let silent = false;
+        // for now, these data sources are not reloaded between runs
+        if (loadedCustomDataSources.hasOwnProperty(name)) {
+          const module = loadedCustomDataSources[name];
+          if (module) {
+            this.dataSources.registerDataSource(name, loadedCustomDataSources[name]);
+            return Promise.resolve();
+          } else {
+            // if module is not defined at this point, an error would've been logged the first time it was loaded
+            silent = true;
+          }
+        }
+
+        if (moduleName === '') {
+          if (!silent) {
+            console.warn(
+              `A custom data source ${name} has a blank module name. A module name must be provided to register a data source correctly.`,
+            );
+          }
+          loadedCustomDataSources[name] = undefined;
+          return Promise.resolve();
+        }
+
+        const slug = slugify(moduleName);
+        if (window.hasOwnProperty(slug)) {
+          const moduleEntry: Record<string, unknown> = window[slug] as unknown as Record<string, unknown>;
+          if (
+            !(typeof moduleEntry === 'object') ||
+            !moduleEntry.hasOwnProperty('init') ||
+            !isFunction(moduleEntry.init) ||
+            !moduleEntry.hasOwnProperty('get') ||
+            !isFunction(moduleEntry.get)
+          ) {
+            if (!silent) {
+              console.error(
+                `esm-form-app is configured to use the datasource ${name} from the module ${moduleName}, but the version of ${moduleName} loaded is not in the expected format. Please ensure that the version of ${moduleName} you are loading is built as a Webpack module.`,
+              );
+            }
+            loadedCustomDataSources[name] = undefined;
+            return Promise.resolve();
+          }
+
+          try {
+            const factory: () => Record<string, unknown> = await moduleEntry.get('./start');
+            const module = factory();
+
+            if (!(typeof module === 'object') || !module.hasOwnProperty(moduleExport)) {
+              if (!silent) {
+                console.error(
+                  `esm-form-entry-app could not load the module ${moduleName} for the datasource ${name} because the module did not have the expected ${
+                    moduleExport == 'default' ? 'default export' : `export ${moduleExport}`
+                  }.`,
+                );
+              }
+              loadedCustomDataSources[name] = undefined;
+              return Promise.resolve();
+            }
+
+            loadedCustomDataSources[name] = module[moduleExport];
+            this.dataSources.registerDataSource(name, module[moduleExport]);
+            return Promise.resolve();
+          } catch (e) {
+            if (!silent) {
+              console.error(
+                `esm-form-entry-app could not load the datasource ${name} because ${moduleName} did not export the expected entry "./start". Please check the Webpack configuration for ${moduleName}.`,
+                e,
+              );
+            }
+            loadedCustomDataSources[name] = undefined;
+            return Promise.resolve();
+          }
+        } else {
+          if (!silent) {
+            console.error(
+              `esm-form-entry-app is configured to use the datasource ${name}, but the corresponding module ${moduleName} has not been loaded. Most likely, this means that ${moduleName} is not in your importmap or was not loaded prior to ending up here.`,
+            );
+          }
+          loadedCustomDataSources[name] = undefined;
+          return Promise.resolve();
+        }
+      }),
+    ]);
   }
 
   private setUpWHOCascading(form: Form) {
@@ -205,4 +292,8 @@ export class FormCreationService {
       this.encounterAdapter.populateForm(form, encounter);
     }
   }
+}
+
+function slugify(name) {
+  return name.replace(/[\/\-@]/g, '_');
 }

--- a/packages/esm-form-entry-app/src/app/services/concept.service.ts
+++ b/packages/esm-form-entry-app/src/app/services/concept.service.ts
@@ -36,7 +36,7 @@ export class ConceptService {
     for (const relativeConceptLabelUrl of relativeConceptLabelUrls) {
       observablesArray.push(
         this.http
-          .get<ListResult<ConceptMetadata>>(this.getUrl() + relativeConceptLabelUrl, {
+          .get<ListResult<ConceptMetadata>>(this.windowRef.openmrsRestBase + relativeConceptLabelUrl, {
             headers: this.headers,
           })
           .pipe(
@@ -61,7 +61,7 @@ export class ConceptService {
    */
   public static getRelativeConceptLabelUrls(conceptUuids: Array<string>, lang: string) {
     const chunkSize = 100;
-    return conceptUuids
+    return [...new Set(conceptUuids)]
       .reduceRight((acc, _, __, array) => [...acc, array.splice(0, chunkSize)], [])
       .map((uuidPartition) => `?references=${uuidPartition.join(',')}`);
   }

--- a/packages/esm-form-entry-app/src/app/types/index.ts
+++ b/packages/esm-form-entry-app/src/app/types/index.ts
@@ -191,9 +191,16 @@ export interface MonthlyScheduleParams {
 }
 
 export interface FormEntryConfig {
+  /** @deprecated use customDataSources instead */
   dataSources: {
+    /** @deprecated should be converted to customDataSource */
     monthlySchedule: boolean;
   };
+  customDataSources: {
+    name: string;
+    moduleName: string;
+    moduleExport: 'default' | string;
+  }[];
   appointmentsResourceUrl: string;
 }
 

--- a/packages/esm-form-entry-app/src/config-schema.ts
+++ b/packages/esm-form-entry-app/src/config-schema.ts
@@ -1,12 +1,38 @@
-import { Type } from '@openmrs/esm-framework';
+import { Type, validator } from '@openmrs/esm-framework';
 
 export const configSchema = {
+  /** @deprecated use customDataSources instead */
   dataSources: {
     monthlySchedule: {
       _type: 'Boolean',
       _default: false,
       _description:
         'Whether to use monthly scheduled appointment data source in form-entry engine. Requires `appointmentsResourceUrl`.',
+    },
+  },
+  customDataSources: {
+    _type: Type.Array,
+    _default: [],
+    _elements: {
+      name: {
+        _type: Type.String,
+        _default: 'customDataSource',
+        _description: 'The name of the data source. This is how the data source is referenced inside the form.',
+        _validators: [validator((val) => val !== '', 'Must have a value')],
+      },
+      moduleName: {
+        _type: Type.String,
+        _default: '',
+        _description:
+          'The specifier for the module, e.g., "@myOrg/myGreatDataSource". This module should be defined in your import map and will be loaded for all forms.',
+        _validators: [validator((val) => val !== '', 'Must have a value')],
+      },
+      moduleExport: {
+        _type: Type.String,
+        _default: 'default',
+        _description:
+          'The property of the module to be exposed as the data source. This is the name of the exported JS object. For example, setting this to "ageFactory" will use the attribute named "ageFactory". The default value, "default", will point to the default export, if your JS module has one.',
+      },
     },
   },
   appointmentsResourceUrl: {

--- a/packages/esm-form-entry-app/src/declarations.d.ts
+++ b/packages/esm-form-entry-app/src/declarations.d.ts
@@ -1,0 +1,3 @@
+declare module '*.css';
+declare module '*.scss';
+declare const __webpack_share_scopes__;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This a proposal for how to support loading arbitrary custom data sources into the AMPATH form engine. Essentially, this works by having the user specify what custom data sources they want to load through the configuration of the esm-form-entry-app. I've also built a quick example [available here](https://github.com/openmrs/openmrs-esm-custom-data-source-example) of what a data source might look like that also has an example configuration.

This implementation depends on the 4.0 app shell, assumes that all custom data sources are available on the import map, and are loaded as part of the app shell. Among other things, this code _does not_  call `init()` on the module which is necessary for a federated module to be loaded properly.[^1] Custom data sources are assumed to be federated modules and this does not support loading any other type of module packaging. In the 4.0 app shell, this should be a non-issue since all modules are federated.

Limitations: For now, a custom data source is loaded only once, so it is best if data sources do not statically store possibly changable data (e.g. state of the current user, patient or visit—it's fine to have functions that look these things up though).

@denniskigen @enyachoke I'd particularly welcome your feedback on this as I'm not 100% sure I've completely understood data sources here, i.e., among other things, I'm not entirely sure I understand the point of the `unWrap` parameter and if I should add that to the configuration or not. I'm also assuming that implementations can somehow take advantage of these data sources, but it's a bit obscure to me how to do so.

Future work: If someone starts building a large number of these custom data sources there may need to be more optimisations done, i.e., to figure out which data sources are actually required by each form. But for right now, that didn't feel necessary.

PS While there's a few things going on here, the core of the implementation is just this:

```ts
this.dataSources.registerDataSource(name,
	(await window[slugify(moduleName)].get('./start'))();
);
```

[^1]: The technical reason for this is that the global object for tracking module scopes, `__webpack_share_scopes__`, is only made available in Webpack 5, but esm-form-entry-app is built using Webpack 4. By loading things through the app shell, the module will be properly initialized, and once that's done the module itself can be accessed by calling `get()` with no dependencies on Webpack-injected code. Once we can upgrade AMPATH forms and esm-form-entry-app to Angular 12+ this caveat can go away.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
