### PR TITLE
(feat) Notify the user when programs have not been configured

### DIFF
--- a/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
@@ -172,7 +172,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ closeWorkspace, patientUuid
             style={{ minWidth: '100%', margin: '0rem', padding: '0rem' }}
             kind={'error'}
             lowContrast
-            subtitle={t('noProgramsConfigured', 'Please configure programs to continue.')}
+            subtitle={t('configurePrograms', 'Please configure programs to continue.')}
             title={t('noProgramsConfigured', 'No programs configured')}
           />
         ) : null}

--- a/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
@@ -1,10 +1,23 @@
 import React, { SyntheticEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSWRConfig } from 'swr';
 import dayjs from 'dayjs';
 import filter from 'lodash-es/filter';
 import includes from 'lodash-es/includes';
 import map from 'lodash-es/map';
-import { useSWRConfig } from 'swr';
+import {
+  Button,
+  ButtonSet,
+  DatePicker,
+  DatePickerInput,
+  Form,
+  FormGroup,
+  InlineNotification,
+  Layer,
+  Select,
+  SelectItem,
+  Stack,
+} from '@carbon/react';
 import {
   createErrorHandler,
   showNotification,
@@ -14,17 +27,7 @@ import {
   useLayoutType,
   parseDate,
 } from '@openmrs/esm-framework';
-import {
-  Button,
-  ButtonSet,
-  DatePicker,
-  DatePickerInput,
-  Form,
-  FormGroup,
-  Select,
-  SelectItem,
-  Stack,
-} from '@carbon/react';
+import { DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import {
   createProgramEnrollment,
   useAvailablePrograms,
@@ -32,7 +35,6 @@ import {
   customRepresentation,
   updateProgramEnrollment,
 } from './programs.resource';
-import { DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import styles from './programs-form.scss';
 
 interface ProgramsFormProps extends DefaultWorkspaceProps {
@@ -48,6 +50,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ closeWorkspace, patientUuid
 
   const { data: availablePrograms } = useAvailablePrograms();
   const { data: enrollments } = useEnrollments(patientUuid);
+
   const currentEnrollment = programEnrollmentId && enrollments.filter((e) => e.uuid == programEnrollmentId)[0];
   const currentProgram = currentEnrollment
     ? {
@@ -59,6 +62,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ closeWorkspace, patientUuid
   const eligiblePrograms = currentProgram
     ? [currentProgram]
     : filter(availablePrograms, (program) => !includes(map(enrollments, 'program.uuid'), program.uuid));
+
   const [completionDate, setCompletionDate] = React.useState<Date>(
     currentEnrollment?.dateCompleted ? parseDate(currentEnrollment.dateCompleted) : null,
   );
@@ -163,71 +167,148 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ closeWorkspace, patientUuid
   return (
     <Form className={styles.form} onSubmit={handleSubmit}>
       <Stack className={styles.formContainer} gap={7}>
+        {!eligiblePrograms.length ? (
+          <InlineNotification
+            style={{ minWidth: '100%', margin: '0rem', padding: '0rem' }}
+            kind={'error'}
+            lowContrast
+            subtitle={t('noProgramsConfigured', 'Please configure programs to continue.')}
+            title={t('noProgramsConfigured', 'No programs configured')}
+          />
+        ) : null}
         <FormGroup style={{ maxWidth: '50%' }} legendText={t('programName', 'Program name')}>
           <div className={styles.selectContainer}>
-            <Select
-              id="program"
-              invalidText={t('required', 'Required')}
-              labelText=""
-              light={isTablet}
-              onChange={(event) => setSelectedProgram(event.target.value)}
-            >
-              {!selectedProgram ? <SelectItem text={t('chooseProgram', 'Choose a program')} value="" /> : null}
-              {eligiblePrograms?.length > 0 &&
-                eligiblePrograms.map((program) => (
-                  <SelectItem key={program.uuid} text={program.display} value={program.uuid}>
-                    {program.display}
-                  </SelectItem>
-                ))}
-            </Select>
+            {isTablet ? (
+              <Layer>
+                <Select
+                  id="program"
+                  invalidText={t('required', 'Required')}
+                  labelText=""
+                  onChange={(event) => setSelectedProgram(event.target.value)}
+                >
+                  {!selectedProgram ? <SelectItem text={t('chooseProgram', 'Choose a program')} value="" /> : null}
+                  {eligiblePrograms?.length > 0 &&
+                    eligiblePrograms.map((program) => (
+                      <SelectItem key={program.uuid} text={program.display} value={program.uuid}>
+                        {program.display}
+                      </SelectItem>
+                    ))}
+                </Select>
+              </Layer>
+            ) : (
+              <Select
+                id="program"
+                invalidText={t('required', 'Required')}
+                labelText=""
+                onChange={(event) => setSelectedProgram(event.target.value)}
+              >
+                {!selectedProgram ? <SelectItem text={t('chooseProgram', 'Choose a program')} value="" /> : null}
+                {eligiblePrograms?.length > 0 &&
+                  eligiblePrograms.map((program) => (
+                    <SelectItem key={program.uuid} text={program.display} value={program.uuid}>
+                      {program.display}
+                    </SelectItem>
+                  ))}
+              </Select>
+            )}
           </div>
         </FormGroup>
         <FormGroup style={{ maxWidth: '50%' }} legendText={t('dateEnrolled', 'Date enrolled')}>
-          <DatePicker
-            id="enrollmentDate"
-            datePickerType="single"
-            dateFormat="d/m/Y"
-            light={isTablet}
-            maxDate={new Date().toISOString()}
-            placeholder="dd/mm/yyyy"
-            onChange={([date]) => setEnrollmentDate(date)}
-            value={enrollmentDate}
-          >
-            <DatePickerInput id="enrollmentDateInput" labelText="" />
-          </DatePicker>
+          {isTablet ? (
+            <Layer>
+              <DatePicker
+                id="enrollmentDate"
+                datePickerType="single"
+                dateFormat="d/m/Y"
+                maxDate={new Date().toISOString()}
+                placeholder="dd/mm/yyyy"
+                onChange={([date]) => setEnrollmentDate(date)}
+                value={enrollmentDate}
+              >
+                <DatePickerInput id="enrollmentDateInput" labelText="" />
+              </DatePicker>
+            </Layer>
+          ) : (
+            <DatePicker
+              id="enrollmentDate"
+              datePickerType="single"
+              dateFormat="d/m/Y"
+              maxDate={new Date().toISOString()}
+              placeholder="dd/mm/yyyy"
+              onChange={([date]) => setEnrollmentDate(date)}
+              value={enrollmentDate}
+            >
+              <DatePickerInput id="enrollmentDateInput" labelText="" />
+            </DatePicker>
+          )}
         </FormGroup>
         <FormGroup style={{ width: '50%' }} legendText={t('dateCompleted', 'Date completed')}>
-          <DatePicker
-            id="completionDate"
-            datePickerType="single"
-            dateFormat="d/m/Y"
-            light={isTablet}
-            minDate={new Date(enrollmentDate).toISOString()}
-            maxDate={new Date().toISOString()}
-            placeholder="dd/mm/yyyy"
-            onChange={([date]) => setCompletionDate(date)}
-            value={completionDate}
-          >
-            <DatePickerInput id="completionDateInput" labelText="" />
-          </DatePicker>
+          {isTablet ? (
+            <Layer>
+              <DatePicker
+                id="completionDate"
+                datePickerType="single"
+                dateFormat="d/m/Y"
+                minDate={new Date(enrollmentDate).toISOString()}
+                maxDate={new Date().toISOString()}
+                placeholder="dd/mm/yyyy"
+                onChange={([date]) => setCompletionDate(date)}
+                value={completionDate}
+              >
+                <DatePickerInput id="completionDateInput" labelText="" />
+              </DatePicker>
+            </Layer>
+          ) : (
+            <DatePicker
+              id="completionDate"
+              datePickerType="single"
+              dateFormat="d/m/Y"
+              minDate={new Date(enrollmentDate).toISOString()}
+              maxDate={new Date().toISOString()}
+              placeholder="dd/mm/yyyy"
+              onChange={([date]) => setCompletionDate(date)}
+              value={completionDate}
+            >
+              <DatePickerInput id="completionDateInput" labelText="" />
+            </DatePicker>
+          )}
         </FormGroup>
         <FormGroup style={{ width: '50%' }} legendText={t('enrollmentLocation', 'Enrollment location')}>
-          <Select
-            id="location"
-            invalidText="Required"
-            labelText=""
-            light={isTablet}
-            onChange={(event) => setUserLocation(event.target.value)}
-            value={userLocation}
-          >
-            {!userLocation ? <SelectItem text={t('chooseLocation', 'Choose a location')} value="" /> : null}
-            {availableLocations?.length > 0 &&
-              availableLocations.map((location) => (
-                <SelectItem key={location.uuid} text={location.display} value={location.uuid}>
-                  {location.display}
-                </SelectItem>
-              ))}
-          </Select>
+          {isTablet ? (
+            <Layer>
+              <Select
+                id="location"
+                invalidText="Required"
+                labelText=""
+                onChange={(event) => setUserLocation(event.target.value)}
+                value={userLocation}
+              >
+                {!userLocation ? <SelectItem text={t('chooseLocation', 'Choose a location')} value="" /> : null}
+                {availableLocations?.length > 0 &&
+                  availableLocations.map((location) => (
+                    <SelectItem key={location.uuid} text={location.display} value={location.uuid}>
+                      {location.display}
+                    </SelectItem>
+                  ))}
+              </Select>
+            </Layer>
+          ) : (
+            <Select
+              id="location"
+              invalidText="Required"
+              labelText=""
+              onChange={(event) => setUserLocation(event.target.value)}
+              value={userLocation}
+            >
+              {!userLocation ? <SelectItem text={t('chooseLocation', 'Choose a location')} value="" /> : null}
+              {availableLocations?.length > 0 &&
+                availableLocations.map((location) => (
+                  <SelectItem key={location.uuid} text={location.display} value={location.uuid}>
+                    {location.display}
+                  </SelectItem>
+                ))}
+            </Select>
+          )}
         </FormGroup>
       </Stack>
       <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>

--- a/packages/esm-patient-programs-app/translations/en.json
+++ b/packages/esm-patient-programs-app/translations/en.json
@@ -21,6 +21,7 @@
   "fullyEnrolled": "Enrolled in all programs",
   "location": "Location",
   "noEligibleEnrollments": "There are no more programs left to enroll this patient in",
+  "noProgramsConfigured": "No programs configured",
   "programEnrollments": "Program enrollments",
   "programEnrollmentSaveError": "Error saving program enrollment",
   "programName": "Program name",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This pull request modifies the logic of the `ProgramsForm` component to render an error notification when programs have not been configured in the system. This communicates to the user that they cannot enrol a patient into a program before programs get configured in the system. 

Further, this PR also tweaks the appearance of some UI elements in tablet mode, replacing the `light` prop (from Carbon v10) with the new `Layer` component.

## Screenshots

> On desktop
<img width="1558" alt="Screenshot 2022-08-23 at 16 38 43" src="https://user-images.githubusercontent.com/8509731/186242253-0b3eda12-7013-47ed-a13b-9147d7f65ff5.png">

> On tablet
<img width="894" alt="Screenshot 2022-08-23 at 21 49 24" src="https://user-images.githubusercontent.com/8509731/186242357-22357c46-770b-4d13-8c19-22fd23778384.png">
