### PR TITLE
(chore) use @openmrs/ngx-formentry instead of @ampath-kenya/ngx-formentry

### DIFF
--- a/packages/esm-form-entry-app/package.json
+++ b/packages/esm-form-entry-app/package.json
@@ -35,7 +35,6 @@
     "url": "https://github.com/openmrs/openmrs-esm-patient-chart/issues"
   },
   "dependencies": {
-    "@ampath-kenya/ngx-formentry": "next",
     "@angular-extensions/elements": "11.0.1",
     "@angular/animations": "~11.2.14",
     "@angular/cdk": "~11.2.13",
@@ -48,6 +47,7 @@
     "@angular/router": "~11.2.14",
     "@carbon/styles": "^1.8.0",
     "@ng-select/ng-select": "^6.1.0",
+    "@openmrs/ngx-formentry": "next",
     "hammerjs": "^2.0.8",
     "jspdf": "^1.5.3",
     "moment": "^2.17.1",

--- a/packages/esm-form-entry-app/src/app/app.component.spec.ts
+++ b/packages/esm-form-entry-app/src/app/app.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 import { FeWrapperComponent } from './fe-wrapper/fe-wrapper.component';
-import { FormEntryModule } from '@ampath-kenya/ngx-formentry';
+import { FormEntryModule } from '@openmrs/ngx-formentry';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FormSchemaService } from './form-schema/form-schema.service';
 import { OpenmrsApiModule } from './openmrs-api/openmrs-api.module';

--- a/packages/esm-form-entry-app/src/app/app.module.ts
+++ b/packages/esm-form-entry-app/src/app/app.module.ts
@@ -6,7 +6,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { EmptyRouteComponent } from './empty-route/empty-route.component';
 import { FeWrapperComponent } from './fe-wrapper/fe-wrapper.component';
-import { FormEntryModule } from '@ampath-kenya/ngx-formentry';
+import { FormEntryModule } from '@openmrs/ngx-formentry';
 import { ReactiveFormsModule } from '@angular/forms';
 import { OpenmrsApiModule } from './openmrs-api/openmrs-api.module';
 import { FormSchemaService } from './form-schema/form-schema.service';

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.spec.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.spec.ts
@@ -3,7 +3,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { FeWrapperComponent } from './fe-wrapper.component';
-import { FormEntryModule } from '@ampath-kenya/ngx-formentry';
+import { FormEntryModule } from '@openmrs/ngx-formentry';
 import { ReactiveFormsModule } from '@angular/forms';
 import { OpenmrsEsmApiService } from '../openmrs-api/openmrs-esm-api.service';
 import { of } from 'rxjs';

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
-import { Form } from '@ampath-kenya/ngx-formentry';
+import { Form } from '@openmrs/ngx-formentry';
 import { Observable, forkJoin, from, throwError, of, Subscription } from 'rxjs';
 import { catchError, concatAll, map, mergeMap, take } from 'rxjs/operators';
 import { OpenmrsEsmApiService } from '../openmrs-api/openmrs-esm-api.service';

--- a/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
@@ -1,4 +1,4 @@
-import { DataSources, EncounterAdapter, Form, FormFactory } from '@ampath-kenya/ngx-formentry';
+import { DataSources, EncounterAdapter, Form, FormFactory } from '@openmrs/ngx-formentry';
 import { Injectable } from '@angular/core';
 import * as moment from 'moment';
 import { FormDataSourceService } from '../form-data-source/form-data-source.service';

--- a/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.spec.ts
@@ -1,10 +1,10 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 import { FormSchemaService } from './form-schema.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormResourceService } from '../openmrs-api/form-resource.service';
 import { LocalStorageService } from '../local-storage/local-storage.service';
-import { FormSchemaCompiler } from '@ampath-kenya/ngx-formentry';
+import { FormSchemaCompiler } from '@openmrs/ngx-formentry';
 
 describe('Service: FormSchemaService', () => {
   let formSchemaService: FormSchemaService;

--- a/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts
@@ -3,7 +3,7 @@ import { ReplaySubject, Observable, Subject, of, forkJoin } from 'rxjs';
 import { concat, first, map, take, tap } from 'rxjs/operators';
 
 import { FormResourceService } from '../openmrs-api/form-resource.service';
-import { FormSchemaCompiler } from '@ampath-kenya/ngx-formentry';
+import { FormSchemaCompiler } from '@openmrs/ngx-formentry';
 import { LocalStorageService } from '../local-storage/local-storage.service';
 import { FormSchema, Questions } from '../types';
 

--- a/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.spec.ts
@@ -5,7 +5,7 @@ import { throwError as observableThrowError, of } from 'rxjs';
 import { FormSubmissionService } from './form-submission.service';
 import { OpenmrsApiModule } from '../openmrs-api/openmrs-api.module';
 import { EncounterResourceService } from '../openmrs-api/encounter-resource.service';
-import { PersonAttribuAdapter, Form, EncounterAdapter, FormEntryModule } from '@ampath-kenya/ngx-formentry';
+import { PersonAttribuAdapter, Form, EncounterAdapter, FormEntryModule } from '@openmrs/ngx-formentry';
 import { PersonResourceService } from '../openmrs-api/person-resource.service';
 import { FormDataSourceService } from '../form-data-source/form-data-source.service';
 import { LocalStorageService } from '../local-storage/local-storage.service';

--- a/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 
 import { forkJoin, Observable, of, from } from 'rxjs';
-import { catchError, map, mergeMap } from 'rxjs/operators';
-import { EncounterAdapter, PersonAttribuAdapter, Form } from '@ampath-kenya/ngx-formentry';
+import { catchError, mergeMap } from 'rxjs/operators';
+import { EncounterAdapter, PersonAttribuAdapter, Form } from '@openmrs/ngx-formentry';
+import { NodeBase } from '@openmrs/ngx-formentry/form-entry/form-factory/form-node';
 import { EncounterResourceService } from '../openmrs-api/encounter-resource.service';
 import { PersonResourceService } from '../openmrs-api/person-resource.service';
 import { FormDataSourceService } from '../form-data-source/form-data-source.service';
@@ -18,7 +19,6 @@ import cloneDeep from 'lodash-es/cloneDeep';
 import { mutateEncounterCreateToPartialEncounter } from '../offline/syncItemMutation';
 import { SingleSpaPropsService } from '../single-spa-props/single-spa-props.service';
 import { v4 } from 'uuid';
-import { NodeBase } from '@ampath-kenya/ngx-formentry/form-entry/form-factory/form-node';
 
 /**
  * The result of submitting a form via the {@link FormSubmissionService.submitPayload} function.

--- a/packages/esm-form-entry-app/src/app/offline/caching.ts
+++ b/packages/esm-form-entry-app/src/app/offline/caching.ts
@@ -1,4 +1,3 @@
-import { FormSchemaCompiler } from '@ampath-kenya/ngx-formentry';
 import {
   makeUrl,
   messageOmrsServiceWorker,
@@ -7,6 +6,7 @@ import {
   setupDynamicOfflineDataHandler,
   subscribePrecacheStaticDependencies,
 } from '@openmrs/esm-framework';
+import { FormSchemaCompiler } from '@openmrs/ngx-formentry';
 import escapeRegExp from 'lodash-es/escapeRegExp';
 import { FormSchemaService } from '../form-schema/form-schema.service';
 import { FormEncounter, FormSchema } from '../types';

--- a/packages/esm-form-entry-app/src/app/types/index.ts
+++ b/packages/esm-form-entry-app/src/app/types/index.ts
@@ -1,4 +1,4 @@
-import { Form } from '@ampath-kenya/ngx-formentry';
+import { Form } from '@openmrs/ngx-formentry';
 
 interface OpenMRSResource {
   display: string;

--- a/packages/esm-form-entry-app/src/styles.css
+++ b/packages/esm-form-entry-app/src/styles.css
@@ -1,6 +1,3 @@
 /* You can add global styles to this file, and also import other style files */
-/* @import '~@ampath-kenya/scoped-bootstrap/dist/css/bootstrap.min.css';
-@import "~@angular/material/prebuilt-themes/indigo-pink.css";
-@import '~carbon-components/css/carbon-components.css'; */
-@import "~@ampath-kenya/ngx-formentry/styles/ngx-formentry.css";
-@import "~@ampath-kenya/ngx-formentry/styles/picker.min.css";
+@import "~@openmrs/ngx-formentry/styles/ngx-formentry.css";
+@import "~@openmrs/ngx-formentry/styles/picker.min.css";

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,34 +12,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ampath-kenya/ngx-formentry@npm:next":
-  version: 3.0.0-alpha22
-  resolution: "@ampath-kenya/ngx-formentry@npm:3.0.0-alpha22"
-  dependencies:
-    tslib: ^2.0.0
-  peerDependencies:
-    "@angular-extensions/elements": ^12.6.0
-    "@angular/animations": ">=11.2.14 <=12.0.4"
-    "@angular/cdk": ">=11.2.13 <=12.0.4"
-    "@angular/common": ">=11.2.14 <=12.0.4"
-    "@angular/compiler": ">=11.2.14 <=12.0.4"
-    "@angular/core": ">=11.2.14 <=12.0.4"
-    "@angular/forms": ">=11.2.14 <=12.0.4"
-    "@carbon/styles": ^1.9.0
-    "@ng-select/ng-select": ^6.1.0
-    hammerjs: ^2.0.8
-    lodash: ^4.17.4
-    moment: ^2.17.1
-    ngx-file-uploader: ^0.0.18
-    ngx-webcam: ^0.2.2
-    reflect-metadata: ^0.1.9
-    shelljs: ^0.7.0
-    slick-carousel: ^1.6.0
-    tree-model: ^1.0.5
-  checksum: 30fc5f89167263b3f9fcbfc89d207268534239a6fb72143a513fd7b32f1bbd965ed3e05a607c54eb13770dfb3065338905d1aea3fc15ecaef51df3c0f98ca93e
-  languageName: node
-  linkType: hard
-
 "@ampproject/remapping@npm:^2.1.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -4356,7 +4328,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-form-entry-app@workspace:packages/esm-form-entry-app"
   dependencies:
-    "@ampath-kenya/ngx-formentry": next
     "@angular-builders/custom-webpack": ~11.1.1
     "@angular-devkit/build-angular": ~0.1102.14
     "@angular-extensions/elements": 11.0.1
@@ -4375,6 +4346,7 @@ __metadata:
     "@angular/router": ~11.2.14
     "@carbon/styles": ^1.8.0
     "@ng-select/ng-select": ^6.1.0
+    "@openmrs/ngx-formentry": next
     "@types/jasmine": ~3.6.0
     "@types/jasminewd2": ~2.0.3
     "@types/webpack-env": ^1.17.0
@@ -4887,6 +4859,34 @@ __metadata:
     i18next: 19.x
     rxjs: 6.x
   checksum: 6d6a54e06c1f41086b48079017f708aa0121be1acee0ddb1f827a925f550b8661c9e385a5200f1eda49b523abee2195785a95d9c26b670c80cfcd57632342a16
+  languageName: node
+  linkType: hard
+
+"@openmrs/ngx-formentry@npm:next":
+  version: 3.0.1-pre.8
+  resolution: "@openmrs/ngx-formentry@npm:3.0.1-pre.8"
+  dependencies:
+    tslib: ^2.0.0
+  peerDependencies:
+    "@angular-extensions/elements": ^12.6.0
+    "@angular/animations": ">=11.2.14 <=12.0.4"
+    "@angular/cdk": ">=11.2.13 <=12.0.4"
+    "@angular/common": ">=11.2.14 <=12.0.4"
+    "@angular/compiler": ">=11.2.14 <=12.0.4"
+    "@angular/core": ">=11.2.14 <=12.0.4"
+    "@angular/forms": ">=11.2.14 <=12.0.4"
+    "@ng-select/ng-select": ^6.1.0
+    carbon-components: ^10.36.0
+    hammerjs: ^2.0.8
+    lodash: ^4.17.4
+    moment: ^2.17.1
+    ngx-file-uploader: ^0.0.18
+    ngx-webcam: ^0.2.2
+    reflect-metadata: ^0.1.9
+    shelljs: ^0.7.0
+    slick-carousel: ^1.6.0
+    tree-model: ^1.0.5
+  checksum: cadfa041364bf3593cfcfe8f3d542efbbc7e5d8f260c5fe956233d7081044bbd05974e98d04fad6e597ad6ec2a18bf02c44dc62fc8558f276cccd3668ede113f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This is just switching the form-entry-app from using the AMPATH version of the formentry tool to the community version hosted [here](https://github.com/openmrs/openmrs-ngx-formentry).

This is just a name change.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
