### PR TITLE
feat(form-entry-app): Add a hook to handle the encounter before it's created

### DIFF
--- a/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.ts
@@ -51,7 +51,7 @@ export class FormSubmissionService {
           this.deepClearInitialNodeValues(form.rootNode);
         }
 
-        const encounterCreate = this.buildEncounterPayload(form);
+        const encounterCreate = this.onEncounterCreate(this.buildEncounterPayload(form));
         const personUpdate = this.buildPersonUpdatePayload(form);
 
         return isOfflineSubmission
@@ -76,6 +76,12 @@ export class FormSubmissionService {
         this.deepClearInitialNodeValues(child as NodeBase);
       }
     }
+  }
+
+  private onEncounterCreate(encounterCreate: EncounterCreate): EncounterCreate {
+    const handleEncounterCreate = this.singleSpaPropsService.getProp('handleEncounterCreate');
+    if (handleEncounterCreate && typeof handleEncounterCreate === 'function') handleEncounterCreate(encounterCreate);
+    return encounterCreate;
   }
 
   private submitPayloadOffline(

--- a/packages/esm-form-entry-app/src/single-spa-props.ts
+++ b/packages/esm-form-entry-app/src/single-spa-props.ts
@@ -1,6 +1,6 @@
 import { ReplaySubject } from 'rxjs';
 import { AppProps } from 'single-spa';
-import { Encounter } from './app/types';
+import { Encounter, EncounterCreate } from './app/types';
 
 export const singleSpaPropsSubject = new ReplaySubject<SingleSpaProps>(1);
 
@@ -16,6 +16,7 @@ export type SingleSpaProps = AppProps & {
   patient: any;
   isOffline: boolean;
   patientUuid: string;
+  handleEncounterCreate?: (encounter: EncounterCreate) => void;
   handlePostResponse?: (encounter: Encounter) => void;
   showDiscardSubmitButtons?: boolean;
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
@ZacButko I think this is the hook you mentioned needing?

Always a wrapping component to add a handler to handle the form-engine's `EncounterCreate` object. Basically, allows a wrapper to modify the encounter that will be created before it's created.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
