### PR TITLE
(fix) Add back in webpack for dev servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "systemjs-webpack-interop": "^2.3.7",
     "turbo": "^1.1.10",
     "typescript": "^4.0.3",
-    "webpack": "^5.36.2",
+    "webpack": "^5.74.0",
     "webpack-cli": "^4.7.0"
   },
   "resolutions": {

--- a/packages/esm-generic-patient-widgets-app/package.json
+++ b/packages/esm-generic-patient-widgets-app/package.json
@@ -48,5 +48,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-allergies-app/package.json
+++ b/packages/esm-patient-allergies-app/package.json
@@ -47,5 +47,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-appointments-app/package.json
+++ b/packages/esm-patient-appointments-app/package.json
@@ -46,5 +46,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-attachments-app/package.json
+++ b/packages/esm-patient-attachments-app/package.json
@@ -49,5 +49,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-banner-app/package.json
+++ b/packages/esm-patient-banner-app/package.json
@@ -47,5 +47,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-biometrics-app/package.json
+++ b/packages/esm-patient-biometrics-app/package.json
@@ -48,5 +48,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-chart-app/package.json
+++ b/packages/esm-patient-chart-app/package.json
@@ -54,6 +54,7 @@
     "@openmrs/esm-patient-common-lib": "^4.0.0",
     "@types/uuid": "^8.3.0",
     "single-spa": "5",
-    "single-spa-react": "^4.6.1"
+    "single-spa-react": "^4.6.1",
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-conditions-app/package.json
+++ b/packages/esm-patient-conditions-app/package.json
@@ -47,5 +47,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-forms-app/package.json
+++ b/packages/esm-patient-forms-app/package.json
@@ -47,5 +47,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-immunizations-app/package.json
+++ b/packages/esm-patient-immunizations-app/package.json
@@ -46,5 +46,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-medications-app/package.json
+++ b/packages/esm-patient-medications-app/package.json
@@ -47,5 +47,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-notes-app/package.json
+++ b/packages/esm-patient-notes-app/package.json
@@ -46,5 +46,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-programs-app/package.json
+++ b/packages/esm-patient-programs-app/package.json
@@ -47,5 +47,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-test-results-app/package.json
+++ b/packages/esm-patient-test-results-app/package.json
@@ -47,5 +47,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-vitals-app/package.json
+++ b/packages/esm-patient-vitals-app/package.json
@@ -48,5 +48,8 @@
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4413,6 +4413,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.0.3
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 3.x
     "@openmrs/esm-patient-common-lib": 3.x
@@ -4459,6 +4460,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.0.3
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 3.x
     "@openmrs/esm-patient-common-lib": 3.x
@@ -4477,6 +4479,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.0.3
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 3.x
     "@openmrs/esm-patient-common-lib": 3.x
@@ -4498,6 +4501,7 @@ __metadata:
     lodash-es: ^4.17.15
     react-grid-gallery: ^0.5.5
     react-html5-camera-photo: ^1.5.4
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 3.x
     "@openmrs/esm-patient-common-lib": 3.x
@@ -4517,6 +4521,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.0.3
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     "@openmrs/esm-patient-common-lib": 4.x
@@ -4538,6 +4543,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.4.4
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     "@openmrs/esm-patient-common-lib": 4.x
@@ -4559,6 +4565,7 @@ __metadata:
     single-spa: 5
     single-spa-react: ^4.6.1
     uuid: ^8.3.2
+    webpack: ^5.74.0
   peerDependencies:
     "@carbon/react": 1.x
     "@openmrs/esm-framework": 4.x
@@ -4628,7 +4635,7 @@ __metadata:
     systemjs-webpack-interop: ^2.3.7
     turbo: ^1.1.10
     typescript: ^4.0.3
-    webpack: ^5.36.2
+    webpack: ^5.74.0
     webpack-cli: ^4.7.0
   languageName: unknown
   linkType: soft
@@ -4655,6 +4662,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.0.3
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     "@openmrs/esm-patient-common-lib": 4.x
@@ -4674,6 +4682,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.0.3
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     "@openmrs/esm-patient-common-lib": 4.x
@@ -4693,6 +4702,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.0.3
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     "@openmrs/esm-patient-common-lib": 4.x
@@ -4712,6 +4722,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.0.3
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     "@openmrs/esm-patient-common-lib": 4.x
@@ -4730,6 +4741,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.0.3
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     "@openmrs/esm-patient-common-lib": 4.x
@@ -4749,6 +4761,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.0.3
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     "@openmrs/esm-patient-common-lib": 4.x
@@ -4769,6 +4782,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.6.1
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     "@openmrs/esm-patient-common-lib": 4.x
@@ -4788,6 +4802,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": ^4.0.0
     d3: ^7.6.1
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     "@openmrs/esm-patient-common-lib": 4.x
@@ -23893,7 +23908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.36.2, webpack@npm:^5.64.0, webpack@npm:^5.74.0":
+"webpack@npm:^5.64.0, webpack@npm:^5.74.0":
   version: 5.74.0
   resolution: "webpack@npm:5.74.0"
   dependencies:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Due to Yarn 3 upgrade dev dependencies for packages in the monorepo need to be explicitly stated. This adds webpack as a dev dependency so that the `yarn serve` command will work.

## Screenshots

## Related Issue

## Other
