### PR TITLE
(fix) add __VERSION__ constant for form-entry-app

### DIFF
--- a/packages/esm-form-entry-app/extra-webpack.config.js
+++ b/packages/esm-form-entry-app/extra-webpack.config.js
@@ -19,9 +19,9 @@ function getFrameworkVersion() {
   }
 }
 
-const mode = argv.mode || process.env.NODE_ENV || "development";
-
 module.exports = (angularWebpackConfig, options) => {
+  const mode = options.mode || process.env.NODE_ENV || "development";
+
   const filename = basename(browser || main);
   const frameworkVersion = getFrameworkVersion();
   const singleSpaWebpackConfig = singleSpaAngularWebpack(angularWebpackConfig, options);

--- a/packages/esm-form-entry-app/extra-webpack.config.js
+++ b/packages/esm-form-entry-app/extra-webpack.config.js
@@ -3,7 +3,12 @@ const { StatsWriterPlugin } = require('webpack-stats-plugin');
 const { basename } = require('path');
 const singleSpaAngularWebpack = require('single-spa-angular/lib/webpack').default;
 
-const packageJson = require('./package.json');
+const {
+  version,
+  peerDependencies,
+  browser,
+  main,
+} = require('./package.json');
 
 function getFrameworkVersion() {
   try {
@@ -14,20 +19,23 @@ function getFrameworkVersion() {
   }
 }
 
+const mode = argv.mode || process.env.NODE_ENV || "development";
+
 module.exports = (angularWebpackConfig, options) => {
-  const filename = basename(packageJson.browser || packageJson.main);
+  const filename = basename(browser || main);
   const frameworkVersion = getFrameworkVersion();
   const singleSpaWebpackConfig = singleSpaAngularWebpack(angularWebpackConfig, options);
 
   singleSpaWebpackConfig.output.filename = filename;
 
-  for (const dependency of Object.keys(packageJson.peerDependencies)) {
+  for (const dependency of Object.keys(peerDependencies)) {
     singleSpaWebpackConfig.externals.push(dependency);
   }
 
   singleSpaWebpackConfig.plugins.push(
     new IgnorePlugin(/^\.\/locale$/, /moment$/),
     new DefinePlugin({
+      __VERSION__: mode === production ? JSON.stringify(version) : JSON.stringify(inc(version, 'prerelease', 'local')),
       'process.env.FRAMEWORK_VERSION': JSON.stringify(frameworkVersion),
     }),
     new StatsWriterPlugin({

--- a/packages/esm-form-entry-app/extra-webpack.config.js
+++ b/packages/esm-form-entry-app/extra-webpack.config.js
@@ -35,7 +35,7 @@ module.exports = (angularWebpackConfig, options) => {
   singleSpaWebpackConfig.plugins.push(
     new IgnorePlugin(/^\.\/locale$/, /moment$/),
     new DefinePlugin({
-      __VERSION__: mode === production ? JSON.stringify(version) : JSON.stringify(inc(version, 'prerelease', 'local')),
+      __VERSION__: mode === "production" ? JSON.stringify(version) : JSON.stringify(inc(version, 'prerelease', 'local')),
       'process.env.FRAMEWORK_VERSION': JSON.stringify(frameworkVersion),
     }),
     new StatsWriterPlugin({

--- a/packages/esm-form-entry-app/extra-webpack.config.js
+++ b/packages/esm-form-entry-app/extra-webpack.config.js
@@ -1,5 +1,6 @@
 const { IgnorePlugin, DefinePlugin } = require('webpack');
 const { StatsWriterPlugin } = require('webpack-stats-plugin');
+const { inc } = require('semver'); 
 const { basename } = require('path');
 const singleSpaAngularWebpack = require('single-spa-angular/lib/webpack').default;
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
I forgot that form-entry-app uses it's own custom webpack configuration... This adds the `__VERSION__` constant to that app.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
