### PR TITLE
(fix) Fix vitals header flagging logic

### DIFF
--- a/packages/esm-patient-programs-app/translations/en.json
+++ b/packages/esm-patient-programs-app/translations/en.json
@@ -8,6 +8,7 @@
   "chooseLocation": "Choose a location",
   "chooseProgram": "Choose a program",
   "completedOn": "Completed on",
+  "configurePrograms": "Please configure programs to continue.",
   "dateCompleted": "Date completed",
   "dateEnrolled": "Date enrolled",
   "discontinue": "Discontinue",

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
@@ -9,9 +9,9 @@ import { launchPatientWorkspace, useVitalsConceptMetadata } from '@openmrs/esm-p
 import { ConfigObject } from '../../config-schema';
 import { patientVitalsBiometricsFormWorkspace } from '../../constants';
 import {
-  assessAllValues,
   assessValue,
   getReferenceRangesForConcept,
+  hasAbnormalValues,
   interpretBloodPressure,
   useVitals,
 } from '../vitals.resource';
@@ -47,21 +47,18 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
 
   if (!isLoading && latestVitals && Object.keys(latestVitals).length && conceptMetadata?.length) {
     const isNotRecordedToday = !dayjs(latestVitals?.date).isToday();
-    const hasAbnormalValues = assessAllValues(latestVitals, config, conceptMetadata).some(
-      (value) => value !== 'normal',
-    );
 
     return (
       <div
         className={`${
-          latestVitals && hasAbnormalValues && isNotRecordedToday
+          Object.keys(latestVitals).length && hasAbnormalValues(latestVitals) && isNotRecordedToday
             ? styles['warning-background']
             : styles['default-background']
         }`}
       >
         <div className={styles['vitals-header']} role="button" tabIndex={0} onClick={toggleDetailsPanel}>
           <span className={styles.container}>
-            {hasAbnormalValues && isNotRecordedToday ? (
+            {hasAbnormalValues(latestVitals) && isNotRecordedToday ? (
               <WarningFilled
                 size={20}
                 title={'WarningFilled'}
@@ -107,7 +104,9 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
         {showDetailsPanel ? (
           <div
             className={
-              hasAbnormalValues && isNotRecordedToday ? `${styles['warning-border']}` : `${styles['default-border']}`
+              hasAbnormalValues(latestVitals) && isNotRecordedToday
+                ? `${styles['warning-border']}`
+                : `${styles['default-border']}`
             }
           >
             <div className={styles.row}>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
@@ -74,6 +74,7 @@ describe('VitalsHeader: ', () => {
     expect(screen.getByText(/Last recorded/i)).toBeInTheDocument();
     expect(screen.getByText(/19 — May — 2021/i)).toBeInTheDocument();
     expect(screen.getByText(/Record vitals/i)).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /warning/i })).toBeInTheDocument();
 
     const expandButton = screen.getByTitle(/ChevronDown/);
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
@@ -229,14 +229,12 @@ export function assessValue(value: number, range: ObsMetaInfo): ObservationInter
   return 'normal';
 }
 
-export function assessAllValues(
-  vitals: PatientVitals,
-  config: ConfigObject,
-  conceptMetadata: Array<ConceptMetadata>,
-): Array<ObservationInterpretation> {
-  return Object.entries(vitals).map((key, value) => {
-    return assessValue(value, getReferenceRangesForConcept(config.concepts[`${key[0]}Uuid`], conceptMetadata));
-  });
+export function hasAbnormalValues(vitals: PatientVitals): boolean {
+  const interpretations = Object.entries(vitals)
+    .filter(([key]) => key.match(/interpretation/i))
+    .map(([, value]) => value);
+
+  return interpretations.some((value) => value !== 'normal');
 }
 
 export function getReferenceRangesForConcept(


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the logic used to determine whether to show a warning background in the vitals header. Presently, that logic fails because of a bug in the `assessAllValues` function where the key-value pairs that get iterated over do not get correctly destructured from the source `Object.entries` array. I've replaced this function entirely with a function that only looks at the interpretation results for each vital sign and returns a boolean depending on whether any vital signs with abnormal interpretations exist.

## Screenshots

> Before
<img width="1148" alt="Screenshot 2022-08-29 at 14 10 12" src="https://user-images.githubusercontent.com/8509731/187189446-f4794b8a-c4e1-4b7a-a18f-3f8fef7b531d.png">

> After
<img width="1149" alt="Screenshot 2022-08-29 at 14 09 23" src="https://user-images.githubusercontent.com/8509731/187189457-73bc15fc-9ec1-4101-b2d3-f60be310a6c8.png">



