### PR TITLE
(fix) Allergy form style fixes

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
@@ -182,170 +182,173 @@ function AllergyForm({ closeWorkspace, promptBeforeClosing, patientUuid }: Defau
         </Row>
       ) : null}
       <div className={`${styles.form} ${isTablet ? styles.tablet : styles.desktop}`}>
-        <h1 className={styles.heading}>{t('allergensAndReactions', 'Allergens and reactions')}</h1>
-        {error ? (
-          <InlineNotification
-            style={{ margin: '0rem', minWidth: '100%' }}
-            kind="error"
-            lowContrast={true}
-            title={t('errorFetchingData', 'Error fetching allergens and reactions')}
-            subtitle={t('tryReopeningTheForm', 'Please try launching the form again')}
-          />
-        ) : null}
-        <div className={`${styles.container} ${isTablet ? styles.tabletContainer : styles.desktopContainer}`}>
-          <section className={styles.section}>
-            <h2 className={styles.sectionHeading}>{t('selectAllergens', 'Select the allergens')}</h2>
-            <Tabs onSelectionChange={handleTabChange}>
-              <TabList aria-label="Allergen tabs" className={styles.tablist}>
-                {allergenTypes.map((allergenType, index) => {
-                  return (
-                    <Tab className={styles.tab} id={`tab-${index + 1}`} key={`allergen-tab-${index}`}>
-                      {allergenType}
-                    </Tab>
-                  );
-                })}
-              </TabList>
-              <TabPanels>
-                {isLoading ? (
-                  <InlineLoading style={{ margin: '1rem' }} description={t('loading', 'Loading...')} />
-                ) : (
-                  allergenTypes.map((allergenType, index) => {
-                    const allergenCategory = allergenType.toLowerCase() + 'Allergens';
+        {/* This <div> is necessary for the styling in the `.form` class to work */}
+        <div>
+          <h1 className={styles.heading}>{t('allergensAndReactions', 'Allergens and reactions')}</h1>
+          {error ? (
+            <InlineNotification
+              style={{ margin: '0rem', minWidth: '100%' }}
+              kind="error"
+              lowContrast={true}
+              title={t('errorFetchingData', 'Error fetching allergens and reactions')}
+              subtitle={t('tryReopeningTheForm', 'Please try launching the form again')}
+            />
+          ) : null}
+          <div className={`${styles.container} ${isTablet ? styles.tabletContainer : styles.desktopContainer}`}>
+            <section className={styles.section}>
+              <h2 className={styles.sectionHeading}>{t('selectAllergens', 'Select the allergens')}</h2>
+              <Tabs onSelectionChange={handleTabChange}>
+                <TabList aria-label="Allergen tabs" className={styles.tablist}>
+                  {allergenTypes.map((allergenType, index) => {
                     return (
-                      <TabPanel key={`allergen-tab-panel-${index}`}>
-                        <div className={isTablet ? styles.wrapperContainer : undefined}>
-                          <RadioButtonGroup
-                            name={`allergen-type-${index + 1}`}
-                            key={allergenCategory}
-                            orientation="vertical"
-                            onChange={(event) => setSelectedAllergen(event.toString())}
-                            valueSelected={selectedAllergen}
-                          >
-                            {allergensAndAllergicReactions?.[allergenCategory]?.map((allergen, index) => (
-                              <RadioButton
-                                key={`allergen-${index}`}
-                                className={styles.radio}
-                                id={allergen.display}
-                                labelText={allergen.display}
-                                value={allergen.uuid}
-                              />
-                            ))}
-                          </RadioButtonGroup>
-                        </div>
-                      </TabPanel>
+                      <Tab className={styles.tab} id={`tab-${index + 1}`} key={`allergen-tab-${index}`}>
+                        {allergenType}
+                      </Tab>
                     );
-                  })
+                  })}
+                </TabList>
+                <TabPanels>
+                  {isLoading ? (
+                    <InlineLoading style={{ margin: '1rem' }} description={t('loading', 'Loading...')} />
+                  ) : (
+                    allergenTypes.map((allergenType, index) => {
+                      const allergenCategory = allergenType.toLowerCase() + 'Allergens';
+                      return (
+                        <TabPanel key={`allergen-tab-panel-${index}`}>
+                          <div className={isTablet ? styles.wrapperContainer : undefined}>
+                            <RadioButtonGroup
+                              name={`allergen-type-${index + 1}`}
+                              key={allergenCategory}
+                              orientation="vertical"
+                              onChange={(event) => setSelectedAllergen(event.toString())}
+                              valueSelected={selectedAllergen}
+                            >
+                              {allergensAndAllergicReactions?.[allergenCategory]?.map((allergen, index) => (
+                                <RadioButton
+                                  key={`allergen-${index}`}
+                                  className={styles.radio}
+                                  id={allergen.display}
+                                  labelText={allergen.display}
+                                  value={allergen.uuid}
+                                />
+                              ))}
+                            </RadioButtonGroup>
+                          </div>
+                        </TabPanel>
+                      );
+                    })
+                  )}
+                </TabPanels>
+              </Tabs>
+              {selectedAllergen === otherConceptUuid ? (
+                <div className={styles.input}>
+                  <TextInput
+                    light={isTablet}
+                    id="nonCodedAllergenType"
+                    labelText={t('otherNonCodedAllergen', 'Other non-coded allergen')}
+                    onChange={(event) => setNonCodedAllergenType(event.target.value)}
+                    placeholder={t('typeAllergenName', 'Please type in the name of the allergen')}
+                  />
+                </div>
+              ) : null}
+            </section>
+            <section className={styles.section}>
+              <h2 className={styles.midSectionHeading}>{t('selectReactions', 'Select the reactions')}</h2>
+              <div className={isTablet ? styles.checkboxContainer : undefined} style={{ margin: '1rem' }}>
+                {isLoading ? (
+                  <InlineLoading description={t('loading', 'Loading...')} />
+                ) : (
+                  allergensAndAllergicReactions?.allergicReactions?.map((reaction, index) => (
+                    <Checkbox
+                      className={styles.checkbox}
+                      key={index}
+                      labelText={reaction.display}
+                      id={reaction.uuid}
+                      onChange={handleAllergicReactionChange}
+                      value={reaction.display}
+                    />
+                  ))
                 )}
-              </TabPanels>
-            </Tabs>
-            {selectedAllergen === otherConceptUuid ? (
-              <div className={styles.input}>
-                <TextInput
-                  light={isTablet}
-                  id="nonCodedAllergenType"
-                  labelText={t('otherNonCodedAllergen', 'Other non-coded allergen')}
-                  onChange={(event) => setNonCodedAllergenType(event.target.value)}
-                  placeholder={t('typeAllergenName', 'Please type in the name of the allergen')}
+              </div>
+              {allergicReactions.includes(otherConceptUuid) ? (
+                <div className={styles.input}>
+                  <TextInput
+                    light={isTablet}
+                    id="nonCodedAllergicReaction"
+                    labelText={t('otherNonCodedAllergicReaction', 'Other non-coded allergic reaction')}
+                    onChange={(event) => setNonCodedAllergicReaction(event.target.value)}
+                    placeholder={t('typeAllergicReactionName', 'Please type in the name of the allergic reaction')}
+                  />
+                </div>
+              ) : null}
+            </section>
+          </div>
+          <h1 className={styles.heading}>{t('severityAndOnsetDate', 'Severity and date of onset')}</h1>
+          <div className={`${styles.container} ${isTablet ? styles.tabletContainer : styles.desktopContainer}`}>
+            <section className={styles.section}>
+              <h2 className={styles.sectionHeading}>{t('severityOfWorstReaction', 'Severity of worst reaction')}</h2>
+              <div className={styles.wrapper}>
+                <RadioButtonGroup
+                  name="severity-of-worst-reaction"
+                  onChange={(event) => setSeverityOfWorstReaction(event.toString())}
+                  valueSelected={severityOfWorstReaction}
+                >
+                  {severityLevels.map((severity, index) => (
+                    <RadioButton
+                      id={severity.toLowerCase() + 'Severity'}
+                      key={`severity-${index}`}
+                      labelText={severity}
+                      value={(() => {
+                        switch (severity.toLowerCase()) {
+                          case 'mild':
+                            return mildReactionUuid;
+                          case 'moderate':
+                            return moderateReactionUuid;
+                          case 'severe':
+                            return severeReactionUuid;
+                          default:
+                            return '';
+                        }
+                      })()}
+                    />
+                  ))}
+                </RadioButtonGroup>
+              </div>
+            </section>
+            <section className={styles.section}>
+              <h2 className={styles.sectionHeading}>{t('dateAndComments', 'Date and comments')}</h2>
+              <div className={styles.wrapper}>
+                <DatePicker
+                  id="onsetDate"
+                  dateFormat="d/m/Y"
+                  datePickerType="single"
+                  light={!isTablet}
+                  maxDate={new Date().toISOString()}
+                  onChange={([date]) => setOnsetDate(date)}
+                  value={onsetDate}
+                >
+                  <DatePickerInput
+                    id="onsetDateInput"
+                    placeholder="dd/mm/yyyy"
+                    labelText={t('dateOfFirstOnset', 'Date of first onset')}
+                  />
+                </DatePicker>
+              </div>
+              <div className={styles.wrapper}>
+                <TextArea
+                  className={styles.textbox}
+                  cols={20}
+                  light={!isTablet}
+                  id="comments"
+                  invalidText={t('invalidComment', 'Invalid comment, try again')}
+                  labelText={t('comments', 'Comments')}
+                  onChange={(event) => setComment(event.target.value)}
+                  placeholder={t('typeAdditionalComments', 'Type any additional comments here')}
+                  rows={4}
                 />
               </div>
-            ) : null}
-          </section>
-          <section className={styles.section}>
-            <h2 className={styles.midSectionHeading}>{t('selectReactions', 'Select the reactions')}</h2>
-            <div className={isTablet ? styles.checkboxContainer : undefined} style={{ margin: '1rem' }}>
-              {isLoading ? (
-                <InlineLoading description={t('loading', 'Loading...')} />
-              ) : (
-                allergensAndAllergicReactions?.allergicReactions?.map((reaction, index) => (
-                  <Checkbox
-                    className={styles.checkbox}
-                    key={index}
-                    labelText={reaction.display}
-                    id={reaction.uuid}
-                    onChange={handleAllergicReactionChange}
-                    value={reaction.display}
-                  />
-                ))
-              )}
-            </div>
-            {allergicReactions.includes(otherConceptUuid) ? (
-              <div className={styles.input}>
-                <TextInput
-                  light={isTablet}
-                  id="nonCodedAllergicReaction"
-                  labelText={t('otherNonCodedAllergicReaction', 'Other non-coded allergic reaction')}
-                  onChange={(event) => setNonCodedAllergicReaction(event.target.value)}
-                  placeholder={t('typeAllergicReactionName', 'Please type in the name of the allergic reaction')}
-                />
-              </div>
-            ) : null}
-          </section>
-        </div>
-        <h1 className={styles.heading}>{t('severityAndOnsetDate', 'Severity and date of onset')}</h1>
-        <div className={`${styles.container} ${isTablet ? styles.tabletContainer : styles.desktopContainer}`}>
-          <section className={styles.section}>
-            <h2 className={styles.sectionHeading}>{t('severityOfWorstReaction', 'Severity of worst reaction')}</h2>
-            <div className={styles.wrapper}>
-              <RadioButtonGroup
-                name="severity-of-worst-reaction"
-                onChange={(event) => setSeverityOfWorstReaction(event.toString())}
-                valueSelected={severityOfWorstReaction}
-              >
-                {severityLevels.map((severity, index) => (
-                  <RadioButton
-                    id={severity.toLowerCase() + 'Severity'}
-                    key={`severity-${index}`}
-                    labelText={severity}
-                    value={(() => {
-                      switch (severity.toLowerCase()) {
-                        case 'mild':
-                          return mildReactionUuid;
-                        case 'moderate':
-                          return moderateReactionUuid;
-                        case 'severe':
-                          return severeReactionUuid;
-                        default:
-                          return '';
-                      }
-                    })()}
-                  />
-                ))}
-              </RadioButtonGroup>
-            </div>
-          </section>
-          <section className={styles.section}>
-            <h2 className={styles.sectionHeading}>{t('dateAndComments', 'Date and comments')}</h2>
-            <div className={styles.wrapper}>
-              <DatePicker
-                id="onsetDate"
-                dateFormat="d/m/Y"
-                datePickerType="single"
-                light={!isTablet}
-                maxDate={new Date().toISOString()}
-                onChange={([date]) => setOnsetDate(date)}
-                value={onsetDate}
-              >
-                <DatePickerInput
-                  id="onsetDateInput"
-                  placeholder="dd/mm/yyyy"
-                  labelText={t('dateOfFirstOnset', 'Date of first onset')}
-                />
-              </DatePicker>
-            </div>
-            <div className={styles.wrapper}>
-              <TextArea
-                className={styles.textbox}
-                cols={20}
-                light={!isTablet}
-                id="comments"
-                invalidText={t('invalidComment', 'Invalid comment, try again')}
-                labelText={t('comments', 'Comments')}
-                onChange={(event) => setComment(event.target.value)}
-                placeholder={t('typeAdditionalComments', 'Type any additional comments here')}
-                rows={4}
-              />
-            </div>
-          </section>
+            </section>
+          </div>
         </div>
         <ButtonSet className={isTablet ? styles.tabletButtons : styles.desktopButtons}>
           <Button className={styles.button} onClick={closeWorkspace} kind="secondary">


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the UI of the allergy form by wrapping the content of the form (sans the button set at the bottom of the form) in a `<div>`. This bit is necessary to get the styling in the `.form` class to appear as intended.

## Screenshots

> Before (note the extraneous spacing around the form sections)

<img width="601" alt="Screenshot 2022-08-30 at 16 46 53" src="https://user-images.githubusercontent.com/8509731/187454279-cf312636-bd86-4d96-9d34-ceaef972045a.png">

> After

<img width="600" alt="Screenshot 2022-08-30 at 16 44 00" src="https://user-images.githubusercontent.com/8509731/187454416-3f0ec156-dddd-4fbe-84b5-7a9c81036389.png">

