### PR TITLE
(fix) Remove extraneous margin around the biometrics section of the form

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -283,7 +283,7 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
             </Column>
           </Row>
         </Stack>
-        <Stack className={`${styles.spacer} ${styles.grid}`}>
+        <Stack className={styles.spacer}>
           <Column className={styles.column}>
             <p className={styles.vitalsTitle}>{t('recordBiometrics', 'Record biometrics')}</p>
           </Column>
@@ -340,7 +340,7 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
                   },
                 ]}
                 unitSymbol={biometricsUnitsSymbols['bmiUnit']}
-                disabled={true}
+                disabled
                 inputIsNormal={isBMIInNormalRange(patientBMI)}
               />
             </Column>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes a style rule from the biometrics section of the form that led to an extraneous amount of margin being applied to the biometrics section of the form (see the before and after screenshots below).

## Screenshots

> Before
<img width="927" alt="Screenshot 2022-08-31 at 12 55 38" src="https://user-images.githubusercontent.com/8509731/187652421-64ae24b5-a2fa-4408-ae6d-66ec40cd5f0b.png">

> After
<img width="927" alt="Screenshot 2022-08-31 at 12 49 52" src="https://user-images.githubusercontent.com/8509731/187650840-7a6fbf78-b5d5-489b-b0af-fb15f02fa0f5.png">
