### PR TITLE
(feat) Automatically revalidate order data after form submission

### DIFF
--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -28,8 +28,8 @@ export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any', 
 
   return {
     data: data ? drugOrders : null,
+    error: error,
     isLoading: !data && !error,
-    isError: error,
     isValidating,
   };
 }

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -18,13 +18,14 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
 
   const {
     data: activeOrders,
-    isError: isErrorActiveOrders,
+    error: activeOrdersError,
     isLoading: isLoadingActiveOrders,
     isValidating: isValidatingActiveOrders,
   } = usePatientOrders(patientUuid, 'ACTIVE', config.careSettingUuid);
+
   const {
     data: pastOrders,
-    isError: isErrorPastOrders,
+    error: pastOrdersError,
     isLoading: isLoadingPastOrders,
     isValidating: isValidatingPastOrders,
   } = usePatientOrders(patientUuid, 'any', config.careSettingUuid);
@@ -37,7 +38,9 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
           const headerTitle = t('activeMedicationsHeaderTitle', 'active medications');
 
           if (isLoadingActiveOrders) return <DataTableSkeleton role="progressbar" />;
-          if (isErrorActiveOrders) return <ErrorState error={isErrorActiveOrders} headerTitle={headerTitle} />;
+
+          if (activeOrdersError) return <ErrorState error={activeOrdersError} headerTitle={headerTitle} />;
+
           if (activeOrders?.length) {
             return (
               <MedicationsDetailsTable
@@ -51,6 +54,7 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
               />
             );
           }
+
           return <EmptyState displayText={displayText} headerTitle={headerTitle} />;
         })()}
       </div>
@@ -60,7 +64,9 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
           const headerTitle = t('pastMedicationsHeaderTitle', 'past medications');
 
           if (isLoadingPastOrders) return <DataTableSkeleton role="progressbar" />;
-          if (isErrorPastOrders) return <ErrorState error={isErrorPastOrders} headerTitle={headerTitle} />;
+
+          if (pastOrdersError) return <ErrorState error={pastOrdersError} headerTitle={headerTitle} />;
+
           if (pastOrders?.length) {
             return (
               <MedicationsDetailsTable
@@ -74,6 +80,7 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
               />
             );
           }
+
           return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchOrderBasket} />;
         })()}
       </div>

--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
@@ -22,7 +22,7 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, show
 
   const {
     data: activePatientOrders,
-    isError,
+    error,
     isLoading,
     isValidating,
   } = usePatientOrders(patientUuid, 'ACTIVE', config.careSettingUuid);
@@ -32,7 +32,9 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, show
   }, []);
 
   if (isLoading) return <DataTableSkeleton role="progressbar" />;
-  if (isError) return <ErrorState error={isError} headerTitle={headerTitle} />;
+
+  if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
+
   if (activePatientOrders?.length) {
     return (
       // FIX
@@ -50,6 +52,7 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, show
       </Provider>
     );
   }
+
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchOrderBasket} />;
 };
 

--- a/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
@@ -17,8 +17,8 @@ import { ArrowLeft } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
 import { isDesktop, useLayoutType } from '@openmrs/esm-framework';
 import { OrderBasketItem } from '../types/order-basket-item';
-import styles from './medication-order-form.scss';
 import { useOrderConfig } from '../api/order-config';
+import styles from './medication-order-form.scss';
 
 export interface MedicationOrderFormProps {
   initialOrderBasketItem: OrderBasketItem;

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-item-list.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-item-list.component.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import { Layer, Tile } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import { useLayoutType } from '@openmrs/esm-framework';
-import { Tile } from '@carbon/react';
-import OrderBasketItemTile from './order-basket-item.component';
 import { OrderBasketItem } from '../types/order-basket-item';
+import OrderBasketItemTile from './order-basket-item.component';
 import styles from './order-basket-item-list.scss';
 
 export interface OrderBasketItemListProps {
@@ -27,13 +27,15 @@ export default function OrderBasketItemList({
   return (
     <div className={isTablet ? `${styles.orderBasketContainerTablet}` : `${styles.orderBasketContainerDesktop}`}>
       {orderBasketItems.length === 0 && (
-        <Tile className={isTablet ? `${styles.tabletTile}` : `${styles.desktopTile}`}>
-          <div className={isTablet ? styles.tabletHeading : styles.desktopHeading}>
-            <h4>{t('orderBasket', 'Order Basket')}</h4>
-          </div>
-          <p className={styles.content}>{t('emptyOrderBasket', 'Your basket is empty')}</p>
-          <p className={styles.actionText}>{t('searchForAnOrder', 'Search for an order above')}</p>
-        </Tile>
+        <Layer>
+          <Tile className={isTablet ? `${styles.tabletTile}` : `${styles.desktopTile}`}>
+            <div className={isTablet ? styles.tabletHeading : styles.desktopHeading}>
+              <h4>{t('orderBasket', 'Order Basket')}</h4>
+            </div>
+            <p className={styles.content}>{t('emptyOrderBasket', 'Your basket is empty')}</p>
+            <p className={styles.actionText}>{t('searchForAnOrder', 'Search for an order above')}</p>
+          </Tile>
+        </Layer>
       )}
 
       {newOrderBasketItems.length > 0 && (

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket.component.tsx
@@ -1,20 +1,20 @@
 import React, { useEffect, useState } from 'react';
-import OrderBasketSearch from './order-basket-search.component';
-import MedicationOrderForm from './medication-order-form.component';
-import OrderBasketItemList from './order-basket-item-list.component';
-import MedicationsDetailsTable from '../components/medications-details-table.component';
-import { Button, ButtonSet, DataTableSkeleton, InlineLoading } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { OrderBasketItem } from '../types/order-basket-item';
-import { createEmptyEncounter, getCurrentOrderBasketEncounter, usePatientOrders } from '../api/api';
-import { createErrorHandler, showToast, useConfig, useLayoutType, useSession } from '@openmrs/esm-framework';
-import { orderDrugs } from './drug-ordering';
-import { connect } from 'unistore/react';
-import { OrderBasketStore, OrderBasketStoreActions, orderBasketStoreActions } from '../medications/order-basket-store';
-import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
-import { ConfigObject } from '../config-schema';
-import styles from './order-basket.scss';
 import { useSWRConfig } from 'swr';
+import { connect } from 'unistore/react';
+import { Button, ButtonSet, DataTableSkeleton, InlineLoading } from '@carbon/react';
+import { createErrorHandler, showToast, useConfig, useLayoutType, useSession } from '@openmrs/esm-framework';
+import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
+import { orderDrugs } from './drug-ordering';
+import { ConfigObject } from '../config-schema';
+import { createEmptyEncounter, getCurrentOrderBasketEncounter, usePatientOrders } from '../api/api';
+import { OrderBasketItem } from '../types/order-basket-item';
+import { OrderBasketStore, OrderBasketStoreActions, orderBasketStoreActions } from '../medications/order-basket-store';
+import MedicationOrderForm from './medication-order-form.component';
+import MedicationsDetailsTable from '../components/medications-details-table.component';
+import OrderBasketItemList from './order-basket-item-list.component';
+import OrderBasketSearch from './order-basket-search.component';
+import styles from './order-basket.scss';
 
 export interface OrderBasketProps {
   closeWorkspace(): void;

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket.component.tsx
@@ -41,7 +41,7 @@ const OrderBasket = connect<OrderBasketProps, OrderBasketStoreActions, OrderBask
   const sessionObject = useSession();
   const {
     data: activePatientOrders,
-    isError,
+    error,
     isLoading: isLoadingOrders,
     isValidating,
   } = usePatientOrders(patientUuid, 'ACTIVE', config.careSettingUuid);
@@ -163,7 +163,9 @@ const OrderBasket = connect<OrderBasketProps, OrderBasketStoreActions, OrderBask
           />
           {(() => {
             if (isLoadingOrders) return <DataTableSkeleton role="progressbar" />;
-            if (isError) return <ErrorState error={isError} headerTitle={headerTitle} />;
+
+            if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
+
             if (activePatientOrders?.length) {
               return (
                 <MedicationsDetailsTable
@@ -177,6 +179,7 @@ const OrderBasket = connect<OrderBasketProps, OrderBasketStoreActions, OrderBask
                 />
               );
             }
+
             return <EmptyState displayText={displayText} headerTitle={headerTitle} />;
           })()}
         </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR is a follow-up to https://github.com/openmrs/openmrs-esm-patient-chart/pull/774. It adds a call to SWR's `mutate` function to the orders form submission handler so that when the form gets submitted successfully, a revalidation request gets broadcasted to SWR hooks using the same key. This means the user does not need to reload the patient chart to see newly created orders (as @samuelmale showed in the video demo in #774).

This PR also wraps an empty state `Tile` in the OrderBasketItemList component with the `Layer` component. This harmonizes its look and feel with that of the other empty states in the app.
