### PR TITLE
fix: Adjust `top-of-all-patient-dashboard-slot` appears before dashboard title

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
@@ -53,8 +53,8 @@ export function DashboardView({ dashboard, patientUuid, patient }: DashboardView
 
   return (
     <>
-      {dashboard.title && <h1 className={styles.dashboardTitle}>{dashboard.title}</h1>}
       <ExtensionSlot state={state} extensionSlotName="top-of-all-patient-dashboards-slot" />
+      {dashboard.title && <h1 className={styles.dashboardTitle}>{dashboard.title}</h1>}
       <ExtensionSlot
         key={dashboard.slot}
         extensionSlotName={dashboard.slot}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screen
![Screenshot from 2022-09-07 23-02-46](https://user-images.githubusercontent.com/28008754/188966725-9ba55b6d-15ba-4200-b578-ec580bbd5b5b.png)
shots


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
