### PR TITLE
(fix) Medication.durationUnits as a nullable attribute notably for synthetic data entry

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -295,8 +295,8 @@ function OrderBasketItemActions({
         startDate: medication.dateActivated,
         duration: medication.duration,
         durationUnit: {
-          uuid: medication.durationUnits.uuid,
-          display: medication.durationUnits.display,
+          uuid: medication.durationUnits?.uuid,
+          display: medication.durationUnits?.display,
         },
         pillsDispensed: medication.quantity,
         numRefills: medication.numRefills,
@@ -345,8 +345,8 @@ function OrderBasketItemActions({
         asNeededCondition: medication.asNeededCondition,
         duration: medication.duration,
         durationUnit: {
-          uuid: medication.durationUnits.uuid,
-          display: medication.durationUnits.display,
+          uuid: medication.durationUnits?.uuid,
+          display: medication.durationUnits?.display,
         },
         pillsDispensed: medication.quantity,
         numRefills: medication.numRefills,
@@ -395,8 +395,8 @@ function OrderBasketItemActions({
         asNeededCondition: medication.asNeededCondition,
         duration: medication.duration,
         durationUnit: {
-          uuid: medication.durationUnits.uuid,
-          display: medication.durationUnits.display,
+          uuid: medication.durationUnits?.uuid,
+          display: medication.durationUnits?.display,
         },
         pillsDispensed: medication.quantity,
         numRefills: medication.numRefills,


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This is a minor followup commit that fixes an issue with Order entries missing the `durationUnits`. Well in an ideal production  setting, this shouldn't be possible but when dealing synthetic data, it's a necessary change.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
