### PR TITLE
(feat) Manually Trigger Form Validation

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -225,6 +225,8 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
       this.changeState('readyWithValidationErrors');
     }
 
+    this.onValidate(this.form.valid);
+
     return this.form.valid;
   }
 
@@ -252,13 +254,22 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
     if (handlePostResponse && typeof handlePostResponse === 'function') handlePostResponse(encounter);
   }
 
+  public onValidate(valid: boolean): void {
+    const handleOnValidate = this.singleSpaPropsService.getProp('handleOnValidate');
+    if (handleOnValidate && typeof handleOnValidate === 'function') handleOnValidate(valid);
+  }
+
   @HostListener('window:ampath-form-action', ['$event'])
   onFormAction(event) {
     const formUuid = this.singleSpaPropsService.getPropOrThrow('formUuid');
-    if (event.detail?.formUuid === formUuid) {
+    const patientUuid = this.singleSpaPropsService.getPropOrThrow('patientUuid');
+    if (event.detail?.formUuid === formUuid && event.detail?.patientUuid === patientUuid) {
       switch (event.detail?.action) {
         case 'onSubmit':
           this.onSubmit();
+          break;
+        case 'validateForm':
+          this.validateForm();
           break;
         default:
           break;

--- a/packages/esm-form-entry-app/src/single-spa-props.ts
+++ b/packages/esm-form-entry-app/src/single-spa-props.ts
@@ -18,5 +18,6 @@ export type SingleSpaProps = AppProps & {
   patientUuid: string;
   handleEncounterCreate?: (encounter: EncounterCreate) => void;
   handlePostResponse?: (encounter: Encounter) => void;
+  handleOnValidate?: (valid: boolean) => void;
   showDiscardSubmitButtons?: boolean;
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This allows triggering the @openmrs/esm-form-entry-app validation function by sending a window event like

```javascipt
window.dispatchEvent(
  new CustomEvent("ampath-form-action", {
    detail: {
      formUuid: activeFormUuid,
      patientUuid: activePatientUuid,
      action: "validateForm",
    },
  })
);
```

It also allows for the result of the validation to be listened to by passing a prop `handleOnValidate` to the extension-slot

## Screenshots

## Related Issue
Need this for Group Sessions since we need to create a visit. Workflow will go
1. validate form
2. if valid form, start a visit using saved metadata
3. Submit form using new visitUuid

## Other
<!-- Anything not covered above -->
