### PR TITLE
Support for rendering values from older to newer on generic widgets

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/config-schema.ts
+++ b/packages/esm-generic-patient-widgets-app/src/config-schema.ts
@@ -11,7 +11,7 @@ export const configSchema = {
     _description: 'Displayed in messages about this data',
     _default: 'results',
   },
-  dateAxisReverse: {
+  graphOldestFirst: {
     _type: Type.Boolean,
     _description: 'Show graph values from most oldest to recent',
     _default: false,
@@ -57,7 +57,7 @@ export const configSchema = {
 export interface ConfigObject {
   title: string;
   resultsName: string;
-  dateAxisReverse: boolean;
+  graphOldestFirst: boolean;
   data: Array<{
     concept: string;
     label: string;

--- a/packages/esm-generic-patient-widgets-app/src/config-schema.ts
+++ b/packages/esm-generic-patient-widgets-app/src/config-schema.ts
@@ -11,6 +11,11 @@ export const configSchema = {
     _description: 'Displayed in messages about this data',
     _default: 'results',
   },
+  dateAxisReverse: {
+    _type: Type.Boolean,
+    _description: 'Show graph values from most oldest to recent',
+    _default: false,
+  },
   data: {
     _type: Type.Array,
     _elements: {
@@ -52,6 +57,7 @@ export const configSchema = {
 export interface ConfigObject {
   title: string;
   resultsName: string;
+  dateAxisReverse: boolean;
   data: Array<{
     concept: string;
     label: string;

--- a/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
@@ -33,17 +33,20 @@ const ObsGraph: React.FC<ObsGraphProps> = ({ patientUuid }) => {
     uuid: config.data[0]?.concept,
   });
 
-  const chartData = useMemo(
-    () =>
-      obss
-        .filter((obs) => obs.conceptUuid === selectedConcept.uuid && obs.dataType === 'Number')
-        .map((obs) => ({
-          group: selectedConcept.label,
-          key: formatDate(new Date(obs.issued), { year: false, time: false }),
-          value: obs.valueQuantity.value,
-        })),
-    [obss, selectedConcept.uuid, selectedConcept.label],
-  );
+  const chartData = useMemo(() => {
+    let chartRecords = obss
+      .filter((obs) => obs.conceptUuid === selectedConcept.uuid && obs.dataType === 'Number')
+      .map((obs) => ({
+        group: selectedConcept.label,
+        key: formatDate(new Date(obs.issued), { year: false, time: false }),
+        value: obs.valueQuantity.value,
+      }));
+
+    if (config?.dateAxisReverse) {
+      chartRecords.reverse();
+    }
+    return chartRecords;
+  }, [obss, config.dateAxisReverse, selectedConcept.uuid, selectedConcept.label]);
 
   const chartColors = Object.fromEntries(config.data.map((d) => [d.label, d.color]));
 

--- a/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
@@ -34,7 +34,7 @@ const ObsGraph: React.FC<ObsGraphProps> = ({ patientUuid }) => {
   });
 
   const chartData = useMemo(() => {
-    let chartRecords = obss
+    const chartRecords = obss
       .filter((obs) => obs.conceptUuid === selectedConcept.uuid && obs.dataType === 'Number')
       .map((obs) => ({
         group: selectedConcept.label,
@@ -42,7 +42,7 @@ const ObsGraph: React.FC<ObsGraphProps> = ({ patientUuid }) => {
         value: obs.valueQuantity.value,
       }));
 
-    if (config?.graphOldestFirst) {
+    if (config.graphOldestFirst) {
       chartRecords.reverse();
     }
     return chartRecords;

--- a/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
@@ -42,11 +42,11 @@ const ObsGraph: React.FC<ObsGraphProps> = ({ patientUuid }) => {
         value: obs.valueQuantity.value,
       }));
 
-    if (config?.dateAxisReverse) {
+    if (config?.graphOldestFirst) {
       chartRecords.reverse();
     }
     return chartRecords;
-  }, [obss, config.dateAxisReverse, selectedConcept.uuid, selectedConcept.label]);
+  }, [obss, config.graphOldestFirst, selectedConcept.uuid, selectedConcept.label]);
 
   const chartColors = Object.fromEntries(config.data.map((d) => [d.label, d.color]));
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
As a developer, I want it to be possible to use a configuration to invert the order of the values. By inverting the data, it will be possible to render the values from the oldest to the most recent.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![image](https://user-images.githubusercontent.com/94977371/191554247-deb7b1c4-c940-4180-a3b5-02084a9e0ff1.png)

After (with dateAxisReverse config set to true):
![image](https://user-images.githubusercontent.com/94977371/191554117-223b6cc3-7340-40b2-99c2-61298a3158e0.png)

## Related Issue
None
## Other
<!-- Anything not covered above -->
None
