### PR TITLE
Support to hide the add button on programs widget

### DIFF
--- a/packages/esm-patient-programs-app/src/config-schema.ts
+++ b/packages/esm-patient-programs-app/src/config-schema.ts
@@ -5,8 +5,13 @@ export const configSchema = {
     _type: Type.String,
     _default: '',
   },
+  hideAddProgramButton: {
+    _type: Type.Boolean,
+    _default: false,
+  },
 };
 
 export interface ConfigObject {
   customUrl: string;
+  hideAddProgramButton: boolean;
 }

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -96,15 +96,17 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
       <div className={styles.widgetCard}>
         <CardHeader title={headerTitle}>
           <span>{isValidating ? <InlineLoading /> : null}</span>
-          <Button
-            kind="ghost"
-            renderIcon={(props) => <Add size={16} {...props} />}
-            iconDescription="Add programs"
-            onClick={launchProgramsForm}
-            disabled={availablePrograms?.length && eligiblePrograms?.length === 0}
-          >
-            {t('add', 'Add')}
-          </Button>
+          {config.hideAddProgramButton ? null : (
+            <Button
+              kind="ghost"
+              renderIcon={(props) => <Add size={16} {...props} />}
+              iconDescription="Add programs"
+              onClick={launchProgramsForm}
+              disabled={availablePrograms?.length && eligiblePrograms?.length === 0}
+            >
+              {t('add', 'Add')}
+            </Button>
+          )}
         </CardHeader>
         {availablePrograms?.length && eligiblePrograms?.length === 0 ? (
           <InlineNotification

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
@@ -107,16 +107,18 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ basePath, patientUu
     return (
       <div className={styles.widgetCard}>
         <CardHeader title={headerTitle}>
+          {config.hideAddProgramButton ? null : (
+            <Button
+              kind="ghost"
+              renderIcon={(props) => <Add size={16} {...props} />}
+              iconDescription="Add programs"
+              onClick={launchProgramsForm}
+              disabled={availablePrograms?.length && eligiblePrograms?.length === 0}
+            >
+              {t('add', 'Add')}
+            </Button>
+          )}
           <span>{isValidating ? <InlineLoading /> : null}</span>
-          <Button
-            kind="ghost"
-            renderIcon={(props) => <Add size={16} {...props} />}
-            iconDescription="Add programs"
-            onClick={launchProgramsForm}
-            disabled={availablePrograms?.length && eligiblePrograms?.length === 0}
-          >
-            {t('add', 'Add')}
-          </Button>
         </CardHeader>
         {availablePrograms?.length && eligiblePrograms?.length === 0 && (
           <InlineNotification


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
With this development, the developer could hide the add button on care programs. This problem came up because in some cases the patient is enrolled automatically.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
<img width="1461" alt="image" src="https://user-images.githubusercontent.com/94977371/191715032-53524373-2164-40b3-b5ee-879a960c33eb.png">

After (with hideAddProgramButton prop set to true)
<img width="1460" alt="image" src="https://user-images.githubusercontent.com/94977371/191717926-730a718f-e86c-41fc-8fa6-a3b533d0e7bc.png">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
