### PR TITLE
Added possibility to display Graph view by default through the configuration

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/config-schema.ts
+++ b/packages/esm-generic-patient-widgets-app/src/config-schema.ts
@@ -47,6 +47,11 @@ export const configSchema = {
       _default: 5,
     },
   },
+  showGraphByDefault: {
+    _type: Type.Boolean,
+    _description: 'Displayed graph by default',
+    _default: true,
+  },
 };
 
 export interface ConfigObject {
@@ -60,4 +65,5 @@ export interface ConfigObject {
   table: {
     pageSize: number;
   };
+  showGraphByDefault: boolean;
 }

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
@@ -17,7 +17,7 @@ interface ObsSwitchableProps {
 const ObsSwitchable: React.FC<ObsSwitchableProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const config = useConfig() as ConfigObject;
-  const [chartView, setChartView] = React.useState<boolean>();
+  const [chartView, setChartView] = React.useState<boolean>(config.showGraphByDefault);
 
   const { data: obss, error, isLoading, isValidating } = useObs(patientUuid);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Support a configurable way, per widget,  to display graph view by default.

## Screenshots
<img width="855" alt="image" src="https://user-images.githubusercontent.com/106243905/192817154-64c5bf36-e822-4cd5-95f8-a226583bcd86.png">

## Related Issue
NA

## Other
The left side of the graph view will be tackled in another ticket.
