### PR TITLE
bug: fix bug with past appointments missing `appointment location`

### DIFF
--- a/packages/esm-patient-appointments-app/src/appointments/appointments-table.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-table.component.tsx
@@ -44,7 +44,7 @@ const AppointmentsTable: React.FC<AppointmentTableProps> = ({ patientAppointment
         return {
           id: appointment.uuid,
           date: formatDatetime(parseDate(appointment.startDateTime), { mode: 'wide' }),
-          location: appointment.location.name,
+          location: appointment?.location?.name ?? '--',
           service: appointment.service.name,
         };
       }),


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
- Past appointments and upcoming appointments fail because of missing appointment location. I have made the location optional

## Screenshots
<img width="1438" alt="Screenshot 2022-09-29 at 5 11 05 pm" src="https://user-images.githubusercontent.com/28008754/193055569-7313734b-668b-4737-886d-2c8182eda6c7.png">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
