### PR TITLE
(feat) Configure Show All Encounters

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -32,6 +32,11 @@ export const esmPatientChartSchema = {
     _default: '/etl-latest/etl/patient/',
     _description: 'Custom URL to load resources required for showing recommended visit types',
   },
+  showAllEncountersTab: {
+    _type: Type.Boolean,
+    _description: 'Shows the All Encounters Tab of Patient Visits section in Patient Chart',
+    _default: false,
+  },
 };
 
 export interface ChartConfig {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import {
   DataTable,
   DataTableHeader,
-  Dropdown,
   Table,
   TableBody,
   TableCell,
@@ -18,11 +17,13 @@ import {
   TableToolbarContent,
   TableToolbarSearch,
   Tile,
+  InlineLoading,
 } from '@carbon/react';
-import { formatDatetime, formatTime, parseDate, useLayoutType, usePagination } from '@openmrs/esm-framework';
-import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
+import { formatDatetime, parseDate, useLayoutType, usePagination, ErrorState } from '@openmrs/esm-framework';
+import { EmptyState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import styles from './encounters-table.scss';
 import EncounterObservations from '../encounter-observations';
+import { useEncounters } from '../visit.resource';
 
 interface Encounter {
   datetime?: string;
@@ -162,4 +163,24 @@ const EncountersTable: React.FC<EncountersTableProps> = ({ showAllEncounters, en
   );
 };
 
+const EncountersTableLifecycle = ({ patientUuid }) => {
+  const { t } = useTranslation();
+  const { encounters, error, isLoading } = useEncounters(patientUuid);
+
+  if (isLoading) {
+    return <InlineLoading description={t('loading', 'Loading...')} role="progressbar" />;
+  }
+
+  if (error) {
+    return <ErrorState headerTitle={t('encounters', 'encounters')} error={error} />;
+  }
+
+  if (!encounters?.length) {
+    return <EmptyState headerTitle={t('encounters', 'encounters')} displayText={t('Encounters', 'Encounters')} />;
+  }
+
+  return <EncountersTable encounters={encounters} showAllEncounters />;
+};
+
 export default EncountersTable;
+export { EncountersTableLifecycle };

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
@@ -19,8 +19,8 @@ import {
   Tile,
   InlineLoading,
 } from '@carbon/react';
-import { formatDatetime, parseDate, useLayoutType, usePagination, ErrorState } from '@openmrs/esm-framework';
-import { EmptyState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
+import { formatDatetime, parseDate, useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { ErrorState, EmptyState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import styles from './encounters-table.scss';
 import EncounterObservations from '../encounter-observations';
 import { useEncounters } from '../visit.resource';

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { InlineLoading, Tab, Tabs, TabList, TabPanel, TabPanels } from '@carbon/react';
-import { EmptyState } from '@openmrs/esm-patient-common-lib';
-import { formatDatetime, OpenmrsResource, parseDate, ErrorState, useConfig } from '@openmrs/esm-framework';
+import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
+import { formatDatetime, OpenmrsResource, parseDate, useConfig } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { Observation, useVisits } from './visit.resource';
 import VisitsTable from './past-visits-components/visits-table';

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -33,9 +33,9 @@ describe('VisitDetailOverview', () => {
 
     await waitForLoadingToFinish();
 
-    expect(screen.getByRole('heading', { name: /encounters/i })).toBeInTheDocument();
-    expect(screen.getByTitle(/Empty data illustration/i)).toBeInTheDocument();
-    expect(screen.getByText(/There are no encounters to display for this patient/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /visits/i })).toBeInTheDocument();
+    expect(screen.getAllByTitle(/Empty data illustration/i)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/There are no visits to display for this patient/i)[0]).toBeInTheDocument();
   });
 
   it('renders an error state view if there was a problem fetching encounter data', async () => {
@@ -54,9 +54,9 @@ describe('VisitDetailOverview', () => {
     await waitForLoadingToFinish();
 
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /encounters/i })).toBeInTheDocument();
-    expect(screen.getByText(/Error 401: Unauthorized/i)).toBeInTheDocument();
-    expect(screen.getByText(/Sorry, there was a problem displaying this information/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /visits/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/Error 401: Unauthorized/i)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/Sorry, there was a problem displaying this information/i)[0]).toBeInTheDocument();
   });
 
   it(`renders a summary of the patient's visits and encounters when data is available`, async () => {
@@ -68,13 +68,13 @@ describe('VisitDetailOverview', () => {
 
     await waitForLoadingToFinish();
 
-    const allEncountersTab = screen.getByRole('tab', { name: /all encounters/i });
+    const allVisitsTab = screen.getByRole('tab', { name: /all visits/i });
     const visitSummariesTab = screen.getByRole('tab', { name: /visit summaries/i });
 
     expect(visitSummariesTab).toBeInTheDocument();
-    expect(allEncountersTab).toBeInTheDocument();
+    expect(allVisitsTab).toBeInTheDocument();
     expect(visitSummariesTab).toHaveAttribute('aria-selected', 'true');
-    expect(allEncountersTab).toHaveAttribute('aria-selected', 'false');
+    expect(allVisitsTab).toHaveAttribute('aria-selected', 'false');
     expect(screen.getByRole('tab', { name: /notes/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /tests/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /medications/i })).toBeInTheDocument();
@@ -86,9 +86,9 @@ describe('VisitDetailOverview', () => {
     expect(screen.getByText(/no notes found/i)).toBeInTheDocument();
     expect(screen.getByText(/no medications found/i)).toBeInTheDocument();
 
-    await waitFor(() => user.click(allEncountersTab));
+    await waitFor(() => user.click(allVisitsTab));
 
-    expect(allEncountersTab).toHaveAttribute('aria-selected', 'true');
+    expect(allVisitsTab).toHaveAttribute('aria-selected', 'true');
     expect(visitSummariesTab).toHaveAttribute('aria-selected', 'false');
   });
 });

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -28,7 +28,9 @@
   "editPastVisit": "Edit Past Visit",
   "editThisEncounter": "Edit this encounter",
   "encounters": "Encounters",
+  "Encounters": "Encounters",
   "encounterType": "Encounter type",
+  "end": "End",
   "endActiveVisit": "End active visit",
   "endDate": "End date",
   "endVisit": "End Visit",
@@ -76,6 +78,7 @@
   "selectVisitType": "Please select a Visit Type",
   "showAllDetails": "Show all details",
   "showLess": "Show less",
+  "start": "Start",
   "startDate": "Start date",
   "startNewVisit": "Start new visit",
   "startVisit": "Start visit",
@@ -89,11 +92,11 @@
   "visitEnded": "Visit ended",
   "visitEndSuccessfully": "Ended current visit successfully",
   "visitLocation": "Visit Location",
+  "visits": "visits",
+  "Visits": "Visits",
   "visitStarted": "Visit started",
   "visitStartedSuccessfully": "",
   "visitSummaries": "Visit summaries",
   "visitType": "Visit type",
-  "workspaceModalText": "Launching a new form in the workspace could cause you to lose unsaved work on the {formName} form.",
-  "start": "Start",
-  "end":"End"
+  "workspaceModalText": "Launching a new form in the workspace could cause you to lose unsaved work on the {formName} form."
 }

--- a/packages/esm-patient-medications-app/src/config-schema.ts
+++ b/packages/esm-patient-medications-app/src/config-schema.ts
@@ -27,7 +27,7 @@ export const configSchema = {
   quantityUnitsUuid: {
     _type: Type.ConceptUuid,
     _description:
-      'Concept to be used as order quantity units default value. This is necessary because this datapoint isn\'t captured on the dispensing form but the datamodel requires this attribute to issue an order',
+      "Concept to be used as order quantity units default value. This is necessary because this datapoint isn't captured on the dispensing form but the datamodel requires this attribute to issue an order",
     _default: '162399AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   },
   clinicianEncounterRole: {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This makes it so that the all encounters tab of patient-chart visits section is turned off by default, and can be set in configuration to be on.

Additionally, it separates out the All Visits tab from the All Encounters tab, so that patients with encounters but not visits will be able to find their data

## Screenshots
Default configuration is off: 

![Screen Shot 2022-10-07 at 5 16 46 AM](https://user-images.githubusercontent.com/5445264/194566244-d7f34c4f-90a7-4b43-8b44-bd222e05b31b.png)

Configuring on shows the All Encounters tab: 

![Screen Shot 2022-10-07 at 5 16 27 AM](https://user-images.githubusercontent.com/5445264/194566254-2437b3f9-19f2-4027-b338-396e6e449fad.png)

Data shown on all encounters
![Screen Shot 2022-10-07 at 4 38 34 AM](https://user-images.githubusercontent.com/5445264/194566280-5759320d-46a2-423f-8de5-2c9eedeaac4e.png)

<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
