### PR TITLE
(chore)Husky fix: Replaced prepare with postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "release": "lerna version --no-git-tag-version",
     "verify": "turbo run lint && turbo run typescript && yarn run test",
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx}\"",
-    "prepare": "husky install",
+    "postinstall": "husky install",
     "test": "cross-env TZ=UTC jest --config jest.config.json --verbose false --passWithNoTests",
     "test-watch": "cross-env TZ=UTC jest --watch --config jest.config.json",
     "coverage": "yarn test --coverage"
@@ -44,7 +44,7 @@
     "eslint-config-prettier": "^8.2.0",
     "eslint-config-ts-react-important-stuff": "^3.0.0",
     "eslint-plugin-prettier": "^3.3.1",
-    "husky": "^6.0.0",
+    "husky": "^8.0.1",
     "i18next": "^19.7.0",
     "i18next-parser": "^5.4.0",
     "identity-obj-proxy": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4471,7 +4471,7 @@ __metadata:
     eslint-config-prettier: ^8.2.0
     eslint-config-ts-react-important-stuff: ^3.0.0
     eslint-plugin-prettier: ^3.3.1
-    husky: ^6.0.0
+    husky: ^8.0.1
     i18next: ^19.7.0
     i18next-parser: ^5.4.0
     identity-obj-proxy: ^3.0.0
@@ -13328,12 +13328,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"husky@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "husky@npm:6.0.0"
+"husky@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "husky@npm:8.0.1"
   bin:
     husky: lib/bin.js
-  checksum: db6da76a670b2cd1e967990decfd291e6f35a5aee4d362208a51771474d3b4896d526acb4bf0413c2d7154716e42a4d8b6cc19f2bb108e48d1f554624c723a00
+  checksum: 943a73a13d0201318fd30e83d299bb81d866bd245b69e6277804c3b462638dc1921694cb94c2b8c920a4a187060f7d6058d3365152865406352e934c5fff70dc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
According to the statement on the Husky website [here](https://typicode.github.io/husky/#/?id=install), it states that
```
Yarn 2+ doesn't support prepare lifecycle script, so husky needs to be installed differently (this doesn't apply to Yarn 1 though). See [Yarn 2+ install](https://typicode.github.io/husky/#/?id=yarn-2).
```
Hence I have incorporated the changes according to the instructions [here](https://typicode.github.io/husky/#/?id=yarn-2).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
