### PR TITLE
Possibility to add an ExtensionSlot under graph

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tab, Tabs, TabList } from '@carbon/react';
 import { LineChart } from '@carbon/charts-react';
-import { formatDate, useConfig } from '@openmrs/esm-framework';
+import { ExtensionSlot, formatDate, useConfig } from '@openmrs/esm-framework';
 import { useObs } from '../resources/useObs';
 import styles from './obs-graph.scss';
 
@@ -71,38 +71,45 @@ const ObsGraph: React.FC<ObsGraphProps> = ({ patientUuid }) => {
   };
 
   return (
-    <div className={styles.graphContainer}>
-      <div className={styles.conceptPickerTabs}>
-        <label className={styles.conceptLabel} htmlFor="concept-tab-group">
-          {t('displaying', 'Displaying')}
-        </label>
-        <Tabs id="concept-tab-group" className={styles.verticalTabs} type="default">
-          <TabList className={styles.tablist} aria-label="Obs tabs">
-            {config.data.map(({ concept, label }, index) => {
-              return (
-                <Tab
-                  key={index}
-                  className={`${styles.tab} ${styles.bodyLong01} ${
-                    selectedConcept.label === label && styles.selectedTab
-                  }`}
-                  onClick={() =>
-                    setSelectedConcept({
-                      label,
-                      uuid: concept,
-                    })
-                  }
-                >
-                  {label}
-                </Tab>
-              );
-            })}
-          </TabList>
-        </Tabs>
+    <>
+      <div className={styles.graphContainer}>
+        <div className={styles.conceptPickerTabs}>
+          <label className={styles.conceptLabel} htmlFor="concept-tab-group">
+            {t('displaying', 'Displaying')}
+          </label>
+          <Tabs id="concept-tab-group" className={styles.verticalTabs} type="default">
+            <TabList className={styles.tablist} aria-label="Obs tabs">
+              {config.data.map(({ concept, label }, index) => {
+                return (
+                  <Tab
+                    key={index}
+                    className={`${styles.tab} ${styles.bodyLong01} ${
+                      selectedConcept.label === label && styles.selectedTab
+                    }`}
+                    onClick={() =>
+                      setSelectedConcept({
+                        label,
+                        uuid: concept,
+                      })
+                    }
+                  >
+                    {label}
+                  </Tab>
+                );
+              })}
+            </TabList>
+          </Tabs>
+        </div>
+        <div className={styles.lineChartContainer}>
+          <LineChart data={chartData.flat()} options={chartOptions} />
+        </div>
       </div>
-      <div className={styles.lineChartContainer}>
-        <LineChart data={chartData.flat()} options={chartOptions} />
-      </div>
-    </div>
+      {config.interpretationSlot ? (
+        <div>
+          <ExtensionSlot extensionSlotName={config.interpretationSlot} style={{ gridTemplateColumns: '1fr' }} />
+        </div>
+      ) : null}
+    </>
   );
 };
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Adds an extension slot named `interpretationSlot` below the obs graph.

## Screenshots
<img width="1109" alt="image" src="https://user-images.githubusercontent.com/106243905/197566526-489d704c-3b4d-468e-8835-181846e169e1.png">

## Related Issue
NA
