### PR TITLE
03-1566: Left Nav Highlight disappears on click and is stuck on 1st page

### DIFF
--- a/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
@@ -10,7 +10,7 @@ export interface DashboardExtensionProps {
 }
 
 export const DashboardExtension = ({ title, basePath }: DashboardExtensionProps) => {
-  const location = window.location ?? { pathname: '' };
+  const location = useLocation();
   const navLink = useMemo(() => decodeURIComponent(last(location.pathname.split('/'))), [location.pathname]);
 
   const activeClassName = title === navLink ? 'active-left-nav-link' : 'non-active';

--- a/packages/esm-patient-common-lib/src/dashboards/createDashboardLink.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/createDashboardLink.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import { DashboardLinkConfig } from '../types';
 import { DashboardExtension } from './DashboardExtension';
 
 export const createDashboardLink = (db: DashboardLinkConfig) => {
   return ({ basePath }: { basePath: string }) => {
-    return <DashboardExtension title={db.title} basePath={basePath} />;
+    return (
+      <BrowserRouter>
+        <DashboardExtension title={db.title} basePath={basePath} />
+      </BrowserRouter>
+    );
   };
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
- Wrap the dashboard extension in BrowserRouter and use the react-router location so as to ensure immediate updates.

## Screenshots
Before(bug in dev3)

https://user-images.githubusercontent.com/30952856/199488853-9d5e295f-5007-4398-8555-4c4e13a01aaa.mp4

Fix with this PR

https://user-images.githubusercontent.com/30952856/199488943-112da047-0ee1-45f7-bcb8-ecf5f0bed3ca.mp4


## Related Issue
[Left Nav Highlight disappears on click and is stuck on 1st page](https://issues.openmrs.org/browse/O3-1566)

## Other
- We have some delay because of rendering in extensions
