### PR TITLE
03-1578: Patient chart background changes to dark grey when the window size is expanded.

### DIFF
--- a/packages/esm-patient-chart-app/src/root.scss
+++ b/packages/esm-patient-chart-app/src/root.scss
@@ -11,12 +11,15 @@
   &>nav {
     overflow-y: scroll;
     padding-bottom: 3rem;
-    scrollbar-width: none; 
+    scrollbar-width: none;
   }
 
   ::-webkit-scrollbar {
     width: 0px;
     background-color: transparent
+  }
+  :global(.cds--side-nav__overlay-active) {
+    background-color: transparent;
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
- Override the active overlay gray background

## Recording

https://user-images.githubusercontent.com/30952856/200083260-0c50893c-3cc4-43be-a994-89320c34cd3f.mov

## Ticket 
https://issues.openmrs.org/browse/O3-1578

