### PR TITLE
Restore normal display to diagnoses in past-visits-component

### DIFF
--- a/__mocks__/visits.mock.ts
+++ b/__mocks__/visits.mock.ts
@@ -252,34 +252,19 @@ export const visitOverviewDetailMockDataNotEmpty = {
             uuid: '95f6471b-9a65-4dc3-b6ab-0d8bd3299ff0',
             encounterDatetime: '2021-09-08T03:09:37.000+0000',
             orders: [],
-            obs: [
+            diagnoses: [
               {
+                display: 'Malaria, confirmed',
+                rank: 1,
                 uuid: 'ec5bd62a-38c6-4d03-b51c-4554468f3169',
-                concept: {
-                  uuid: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-                  display: 'Visit Diagnoses',
-                  conceptClass: { uuid: '8d492594-c2cc-11de-8d13-0010c6dffd0f', display: 'ConvSet' },
-                },
-                display: 'Visit Diagnoses: Primary, Presumed diagnosis, Malaria, confirmed',
-                groupMembers: [
-                  {
-                    uuid: '3d12c806-bb89-4c16-a54e-77a29493ebc5',
-                    concept: { uuid: '159946AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Diagnosis order' },
-                    value: { uuid: '159943AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Primary' },
-                  },
-                  {
-                    uuid: '604b4f8e-f13b-4b90-b78d-79b75cf9c29a',
-                    concept: { uuid: '159394AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Diagnosis certainty' },
-                    value: { uuid: '159393AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Presumed diagnosis' },
-                  },
-                  {
-                    uuid: 'db7e1d38-a22a-486f-b7d9-31ef9c87f58e',
-                    concept: { uuid: '1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'PROBLEM LIST' },
-                    value: { uuid: '160148AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Malaria, confirmed' },
-                  },
-                ],
-                value: null,
               },
+              {
+                display: 'HUMAN IMMUNODEFICIENCY VIRUS (HIV) DISEASE',
+                rank: 2,
+                uuid: 'f1381ba6-f876-4ca8-96c8-309127372b95',
+              },
+            ],
+            obs: [
               {
                 uuid: '70fb26b6-78bf-4bb7-bea1-9d371a918759',
                 concept: {
@@ -290,36 +275,6 @@ export const visitOverviewDetailMockDataNotEmpty = {
                 display: 'Text of encounter note: Patient seems very unwell\r\n',
                 groupMembers: null,
                 value: 'Patient seems very unwell\r\n',
-              },
-              {
-                uuid: 'f1381ba6-f876-4ca8-96c8-309127372b95',
-                concept: {
-                  uuid: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-                  display: 'Visit Diagnoses',
-                  conceptClass: { uuid: '8d492594-c2cc-11de-8d13-0010c6dffd0f', display: 'ConvSet' },
-                },
-                display: 'Visit Diagnoses: Secondary, HUMAN IMMUNODEFICIENCY VIRUS (HIV) DISEASE, Presumed diagnosis',
-                groupMembers: [
-                  {
-                    uuid: 'c4e3a836-d188-4145-a1bc-67a4fe46cf5c',
-                    concept: { uuid: '159946AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Diagnosis order' },
-                    value: { uuid: '159944AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Secondary' },
-                  },
-                  {
-                    uuid: '692f513a-c744-4ced-bca1-d01e4186b7f5',
-                    concept: { uuid: '1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'PROBLEM LIST' },
-                    value: {
-                      uuid: '138405AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-                      display: 'HUMAN IMMUNODEFICIENCY VIRUS (HIV) DISEASE',
-                    },
-                  },
-                  {
-                    uuid: '4bc57d87-8271-477d-93f7-f6f2493b9e7b',
-                    concept: { uuid: '159394AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Diagnosis certainty' },
-                    value: { uuid: '159393AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Presumed diagnosis' },
-                  },
-                ],
-                value: null,
               },
             ],
             encounterType: { uuid: 'd7151f82-c1f3-4152-a605-2f9ea7414a79', display: 'Visit Note' },

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tab, Tabs, TabList, TabPanel, TabPanels, Tag } from '@carbon/react';
 import { formatTime, OpenmrsResource, parseDate, useConfig, useLayoutType } from '@openmrs/esm-framework';
-import { Order, Encounter, Note, Observation, OrderItem } from '../visit.resource';
+import { Order, Encounter, Note, Observation, OrderItem, Diagnosis } from '../visit.resource';
 import VisitsTable from './visits-table/visits-table.component';
 import MedicationSummary from './medications-summary.component';
 import NotesSummary from './notes-summary.component';
@@ -55,16 +55,22 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ encounters, patientUuid }) 
         })),
       );
 
+      //Check if there is a diagnosis associated with this encounter
+      if (enc.hasOwnProperty('diagnoses')) {
+        if (enc.diagnoses.length > 0) {
+          enc.diagnoses.forEach((diagnosis: Diagnosis) => {
+            // Putting all the diagnoses in a single array.
+            diagnoses.push({
+              diagnosis: diagnosis.display,
+              order: diagnosis.rank === 1 ? 'Primary' : 'Secondary',
+            });
+          });
+        }
+      }
+
       // Check for Visit Diagnoses and Notes
       enc.obs.forEach((obs: Observation) => {
-        if (obs.concept.uuid === config.visitDiagnosisConceptUuid) {
-          // Putting all the diagnoses in a single array.
-          diagnoses.push({
-            diagnosis: obs.groupMembers?.find((mem) => mem.concept.uuid === config.problemListConceptUuid).value
-              .display,
-            order: obs.groupMembers?.find((mem) => mem.concept.uuid === config.diagnosisOrderConceptUuid).value.display,
-          });
-        } else if (config.notesConceptUuids?.includes(obs.concept.uuid)) {
+        if (config.notesConceptUuids?.includes(obs.concept.uuid)) {
           // Putting all notes in a single array.
           notes.push({
             note: obs.value,
@@ -78,14 +84,9 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ encounters, patientUuid }) 
         }
       });
     });
+
     return [diagnoses, notes, medications];
-  }, [
-    config.diagnosisOrderConceptUuid,
-    config.notesConceptUuids,
-    config.problemListConceptUuid,
-    config.visitDiagnosisConceptUuid,
-    encounters,
-  ]);
+  }, [config.notesConceptUuids, encounters]);
 
   return (
     <div className={styles.summaryContainer}>
@@ -93,7 +94,7 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ encounters, patientUuid }) 
       <div className={styles.diagnosesList}>
         {diagnoses.length > 0 ? (
           diagnoses.map((diagnosis, i) => (
-            <Tag key={i} type={diagnosis.order === 'Primary' ? 'blue' : 'red'}>
+            <Tag key={i} type={diagnosis.order === 'Primary' ? 'red' : 'blue'}>
               {diagnosis.diagnosis}
             </Tag>
           ))

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -3,7 +3,7 @@ import { openmrsFetch, OpenmrsResource, Visit } from '@openmrs/esm-framework';
 
 export function useVisits(patientUuid: string) {
   const customRepresentation =
-    'custom:(uuid,encounters:(uuid,form:(uuid,display),encounterDatetime,' +
+    'custom:(uuid,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis),form:(uuid,display),encounterDatetime,' +
     'orders:full,' +
     'obs:(uuid,concept:(uuid,display,conceptClass:(uuid,display)),' +
     'display,groupMembers:(uuid,concept:(uuid,display),' +
@@ -78,6 +78,7 @@ export function usePastVisits(patientUuid: string) {
 
 export interface Encounter {
   uuid: string;
+  diagnoses: Array<Diagnosis>;
   encounterDatetime: string;
   encounterProviders: Array<{
     uuid: string;
@@ -209,6 +210,24 @@ export interface OrderItem {
   provider: {
     name: string;
     role: string;
+  };
+}
+
+export interface Diagnosis {
+  certainty: string;
+  display: string;
+  encounter: OpenmrsResource;
+  links: Array<any>;
+  patient: OpenmrsResource;
+  rank: number;
+  resourceVersion: string;
+  uuid: string;
+  voided: boolean;
+  diagnosis: {
+    coded: {
+      display: string;
+      links: Array<any>;
+    };
   };
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
Added parameter to Url to retrieve the necessary data to display the diagnoses correctly. 
Changes were made to the mock data so the tests are aligned with the modification.

## Screenshots
<img width="722" alt="image" src="https://user-images.githubusercontent.com/106243905/200612468-dc9871a7-0cf6-4411-a032-703d5b4ec2ca.png">

## Related Issue
This issue is related to this development.
[Visit Note - Add Ability to Mark Primary and Secondary Diagnoses](https://github.com/openmrs/openmrs-esm-patient-chart/pull/757)
