### PR TITLE
(fix) Reorder items in ProgramsOverview card header

### DIFF
--- a/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
@@ -107,6 +107,7 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ basePath, patientUu
     return (
       <div className={styles.widgetCard}>
         <CardHeader title={headerTitle}>
+          <span>{isValidating ? <InlineLoading /> : null}</span>
           {config.hideAddProgramButton ? null : (
             <Button
               kind="ghost"
@@ -118,7 +119,6 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ basePath, patientUu
               {t('add', 'Add')}
             </Button>
           )}
-          <span>{isValidating ? <InlineLoading /> : null}</span>
         </CardHeader>
         {availablePrograms?.length && eligiblePrograms?.length === 0 && (
           <InlineNotification


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary

Reorders the contents of the `CardHeader` element in the `ProgramsOverview` component as follows:

- Moves the `InlineLoading` spinner component to the centre of the card header.
- Moves the `Add +` button to the rightmost end of the card header.

## Screenshots

<img width="931" alt="Screenshot 2022-11-08 at 23 01 31" src="https://user-images.githubusercontent.com/8509731/200663382-2cab9716-8537-435f-9111-8dea06d5c489.png">

