### PR TITLE
(fix) Arrange encounters in the visits summary in reverse chronological order

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -62,7 +62,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
   const tableHeaders = [
     {
       id: 1,
-      header: showAllEncounters ? t('dateAndTime', 'Date & time') : t('time', 'Time'),
+      header: t('dateAndTime', 'Date & time'),
       key: 'datetime',
     },
     {
@@ -95,9 +95,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
   const tableRows = React.useMemo(() => {
     return (filteredRows.length ? filteredRows : paginatedEncounters)?.map((encounter) => ({
       ...encounter,
-      datetime: showAllEncounters
-        ? formatDatetime(parseDate(encounter?.datetime))
-        : formatTime(parseDate(encounter?.datetime)),
+      datetime: formatDatetime(parseDate(encounter?.datetime))
     }));
   }, [filteredRows, showAllEncounters, paginatedEncounters]);
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -95,7 +95,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
   const tableRows = React.useMemo(() => {
     return (filteredRows.length ? filteredRows : paginatedEncounters)?.map((encounter) => ({
       ...encounter,
-      datetime: formatDatetime(parseDate(encounter?.datetime))
+      datetime: formatDatetime(parseDate(encounter?.datetime)),
     }));
   }, [filteredRows, showAllEncounters, paginatedEncounters]);
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -97,7 +97,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
       ...encounter,
       datetime: formatDatetime(parseDate(encounter?.datetime)),
     }));
-  }, [filteredRows, showAllEncounters, paginatedEncounters]);
+  }, [filteredRows, paginatedEncounters]);
 
   const handleEncounterTypeChange = ({ selectedItem }) => {
     setFilter(selectedItem);

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.scss
@@ -1,6 +1,7 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @import '~@openmrs/esm-styleguide/src/vars';
+@import "../../../../root.scss";
 
 .tableContainer {
   padding: 0;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary

- Use `Date and Time` on the `Encounters Table` in the summary
- Apply the styles for `No encounters found`

## Screenshots

- Table with Date and Time
### Before
![Untitled](https://user-images.githubusercontent.com/30952856/200692542-5f301005-5947-48d8-a598-50b87a14da61.png)
### After
<img width="1092" alt="Screenshot 2022-11-09 at 01 19 11" src="https://user-images.githubusercontent.com/30952856/200691939-193bc449-06a7-412a-92d1-623dae17778c.png">

- Font-fix
### Before:
![image-2022-11-08-18-35-52-573](https://user-images.githubusercontent.com/30952856/200692239-df59b0e8-7c83-44ce-a57e-17767f50ff2f.png)
### After:
<img width="683" alt="Screenshot 2022-11-09 at 01 16 52" src="https://user-images.githubusercontent.com/30952856/200691945-95477c52-149b-4297-a70a-2a34586d3384.png">


## Related Issues
- [Visit encounters should be displayed in descending order and with dates](https://issues.openmrs.org/browse/O3-1582)
- [Incorrect font for 'No encounters found'](https://issues.openmrs.org/browse/O3-1587)
