### PR TITLE
(fix) Tweak the empty state text showed when filtering encounters

### DIFF
--- a/__mocks__/visits.mock.ts
+++ b/__mocks__/visits.mock.ts
@@ -400,10 +400,10 @@ export const mockEncounters = [
   {
     id: 'ff9a0035-8698-47dc-b608-bd6ec2646e5c',
     datetime: '2021-07-05T10:07:18.000+0000',
-    encounterType: 'Visit Note',
+    encounterType: 'Consultation',
     form: {
-      uuid: 'c75f120a-04ec-11e3-8780-2b40bef9a44b',
-      display: 'Visit Note',
+      uuid: '9e1a0c68-ca19-3482-9ffb-0a6b4e591c2a',
+      display: 'Covid 19',
     },
     obs: [],
     provider: 'Dennis The Doctor',

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
@@ -142,7 +142,7 @@ const EncountersTable: React.FC<EncountersTableProps> = ({ showAllEncounters, en
             <div className={styles.tileContainer}>
               <Tile className={styles.tile}>
                 <div className={styles.tileContent}>
-                  <p className={styles.content}>{t('noPatientsToDisplay', 'No patients to display')}</p>
+                  <p className={styles.content}>{t('noEncountersToDisplay', 'No encounters to display')}</p>
                   <p className={styles.helper}>{t('checkFilters', 'Check the filters above')}</p>
                 </div>
               </Tile>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DataTable,
@@ -21,9 +21,9 @@ import {
 } from '@carbon/react';
 import { formatDatetime, parseDate, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { ErrorState, EmptyState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
-import styles from './encounters-table.scss';
 import EncounterObservations from '../encounter-observations';
 import { useEncounters } from '../visit.resource';
+import styles from './encounters-table.scss';
 
 interface Encounter {
   datetime?: string;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.test.tsx
@@ -45,8 +45,6 @@ describe('EncounterList', () => {
   });
 
   it("renders a tabular overview of the patient's clinical encounters", async () => {
-    const user = userEvent.setup();
-
     testProps.encounters = mockEncounters2;
 
     mockedUsePagination.mockImplementationOnce(() => ({
@@ -58,6 +56,29 @@ describe('EncounterList', () => {
     renderEncountersTable();
 
     expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  it('filters the encounter list when a user types into the searchbox', async () => {
+    const user = userEvent.setup();
+
+    mockedUsePagination.mockImplementationOnce(() => ({
+      currentPage: 1,
+      goTo: () => {},
+      results: mockEncounters2,
+    }));
+
+    renderEncountersTable();
+
+    const searchbox = screen.getByRole('searchbox');
+    expect(searchbox).toBeInTheDocument();
+
+    await user.type(searchbox, 'Consultation');
+    expect(screen.getByText(/consultation/i)).toBeInTheDocument();
+
+    await user.type(searchbox, 'Triage');
+
+    expect(screen.getByText(/no encounters to display/i)).toBeInTheDocument();
+    expect(screen.getByText(/check the filters above/i)).toBeInTheDocument();
   });
 });
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -27,8 +27,8 @@ import { Edit } from '@carbon/react/icons';
 import { formatDatetime, formatTime, parseDate, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { formEntrySub, launchPatientWorkspace, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import { MappedEncounter } from '../visit-summary.component';
-import styles from './visits-table.scss';
 import EncounterObservations from '../../encounter-observations';
+import styles from './visits-table.scss';
 
 interface VisitTableProps {
   visits: Array<MappedEncounter>;
@@ -244,7 +244,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
             <div className={styles.tileContainer}>
               <Tile className={styles.tile}>
                 <div className={styles.tileContent}>
-                  <p className={styles.content}>{t('noPatientsToDisplay', 'No patients to display')}</p>
+                  <p className={styles.content}>{t('noEncountersToDisplay', 'No encounters to display')}</p>
                   <p className={styles.helper}>{t('checkFilters', 'Check the filters above')}</p>
                 </div>
               </Tile>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -70,11 +70,12 @@ describe('EncounterList', () => {
     const expectedTableRows = [
       /18-Jan-2022, 04:25 PM Facility Visit Admission/,
       /03-Aug-2021, 12:47 AM Facility Visit Visit Note User One/,
-      /05-Jul-2021, 10:07 AM Facility Visit Visit Note Dennis The Doctor/,
+      /05-Jul-2021, 10:07 AM Facility Visit Consultation Dennis The Doctor/,
     ];
     expectedTableRows.forEach((row) => {
       expect(screen.getByRole('row', { name: new RegExp(row, 'i') })).toBeInTheDocument();
     });
+
     expect(screen.getByRole('button', { name: /previous page/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: /expand current row/i }).length).toEqual(3);
@@ -92,18 +93,16 @@ describe('EncounterList', () => {
     await waitFor(() => user.click(encounterTypeFilter));
     await waitFor(() => user.click(screen.getByRole('option', { name: /all/i })));
 
-    expect(screen.getAllByText(/visit note/i).length).toEqual(2);
-
     // filter table by typing in the searchbox
-    await waitFor(() => user.type(searchbox, 'Dennis'));
+    await waitFor(() => user.type(searchbox, 'Visit Note'));
 
-    expect(screen.getByText(/dennis/i)).toBeInTheDocument();
-    expect(screen.queryByText(/user one/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/visit note/i)).toBeInTheDocument();
+    expect(screen.queryByText(/consultation/i)).not.toBeInTheDocument();
 
     await waitFor(() => user.clear(searchbox));
-    await waitFor(() => user.type(searchbox, 'luke skywalker'));
+    await waitFor(() => user.type(searchbox, 'triage'));
 
-    expect(screen.getByText(/no patients to display/i)).toBeInTheDocument();
+    expect(screen.getByText(/no encounters to display/i)).toBeInTheDocument();
     expect(screen.getByText(/check the filters above/i)).toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -4,10 +4,10 @@ import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { formatDatetime, OpenmrsResource, parseDate, useConfig } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { Observation, useVisits } from './visit.resource';
+import { EncountersTableLifecycle } from './encounters-table/encounters-table.component';
 import VisitsTable from './past-visits-components/visits-table';
 import VisitSummary from './past-visits-components/visit-summary.component';
 import styles from './visit-detail-overview.scss';
-import { EncountersTableLifecycle } from './encounters-table/encounters-table.component';
 
 interface VisitOverviewComponentProps {
   patientUuid: string;

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -65,6 +65,7 @@
   "noActiveVisitText": "You can't add data to the patient chart without an active visit. Choose from one of the options below to continue.",
   "noDiagnosesFound": "No diagnoses found",
   "noEncountersFound": "No encounters found",
+  "noEncountersToDisplay": "No encounters to display",
   "noMedicationsFound": "No medications found",
   "noNotesFound": "No notes found",
   "noObservationsFound": "No observations found",

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -69,7 +69,6 @@
   "noMedicationsFound": "No medications found",
   "noNotesFound": "No notes found",
   "noObservationsFound": "No observations found",
-  "noPatientsToDisplay": "No patients to display",
   "notes": "Notes",
   "openAnyway": "Open anyway",
   "orderDurationAndUnit": "for {duration} {durationUnit}",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes the empty state text displayed when filtering encounter lists in the visit summary dashboard. Also adds a spec that tests the search functionality. 

## Video

https://user-images.githubusercontent.com/8509731/200811459-791408ed-d2a5-4fa3-beb2-cf1f7a9d307c.mp4


