### PR TITLE
(feat) Add enrolment location empty state display

### DIFF
--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -77,7 +77,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
       return {
         id: program.uuid,
         display: program.display,
-        location: program.location?.display,
+        location: program.location?.display ?? '--',
         dateEnrolled: formatDatetime(new Date(program.dateEnrolled)),
         status: program.dateCompleted
           ? `${t('completedOn', 'Completed On')} ${formatDate(new Date(program.dateCompleted))}`

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
@@ -90,7 +90,7 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ basePath, patientUu
     return paginatedEnrollments?.map((enrollment: ConfigurableProgram) => ({
       id: enrollment.uuid,
       display: enrollment.display,
-      location: enrollment.location?.display,
+      location: enrollment.location?.display ?? '--',
       dateEnrolled: enrollment.dateEnrolled ? formatDatetime(new Date(enrollment.dateEnrolled)) : '--',
       status: isConfigurable
         ? capitalize(enrollment.enrollmentStatus)


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Adds an empty state for the enrolment location to the Programs widget datatable.

## Screenshots

<img width="1225" alt="enrolment-location-empty-state" src="https://user-images.githubusercontent.com/8509731/200919970-c5feea97-937a-4d81-b86c-50d161aeb928.png">

