### PR TITLE
(feat) Arrange visit notes in reverse chronological order

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -37,6 +37,10 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, showAddNote, pag
     }
   }, [currentVisit]);
 
+  const sortedNotes = visitNotes?.sort(
+    (noteA, noteB) => new Date(noteB.encounterDate).getTime() - new Date(noteA.encounterDate).getTime(),
+  );
+
   return (
     <>
       {(() => {
@@ -58,7 +62,7 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, showAddNote, pag
                   </Button>
                 )}
               </CardHeader>
-              <PaginatedNotes notes={visitNotes} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />
+              <PaginatedNotes notes={sortedNotes} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />
             </div>
           );
         return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchVisitNoteForm} />;

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -37,10 +37,6 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, showAddNote, pag
     }
   }, [currentVisit]);
 
-  const sortedNotes = visitNotes?.sort(
-    (noteA, noteB) => new Date(noteB.encounterDate).getTime() - new Date(noteA.encounterDate).getTime(),
-  );
-
   return (
     <>
       {(() => {
@@ -62,7 +58,7 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, showAddNote, pag
                   </Button>
                 )}
               </CardHeader>
-              <PaginatedNotes notes={sortedNotes} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />
+              <PaginatedNotes notes={visitNotes} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />
             </div>
           );
         return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchVisitNoteForm} />;

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.component.tsx
@@ -12,7 +12,7 @@ interface NotesOverviewProps {
 const NotesOverview: React.FC<NotesOverviewProps> = ({ patientUuid, patient, showAddNote, basePath }) => {
   const pageSize = 5;
   const { t } = useTranslation();
-  const pageUrl = window.spaBase + basePath + '/forms';
+  const pageUrl = `\${openmrsSpaBase}/patient/${patient.id}/chart/Forms & Notes`;
   const urlLabel = t('seeAll', 'See all');
 
   return (

--- a/packages/esm-patient-notes-app/src/notes/paginated-notes.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/paginated-notes.component.tsx
@@ -46,7 +46,7 @@ const PaginatedNotes: React.FC<PaginatedNotes> = ({ notes, pageSize, pageUrl, ur
         ...note,
         id: `${note.id}`,
         encounterDate: formatDate(parseDate(note.encounterDate), { mode: 'wide' }),
-        diagnoses: note.diagnoses,
+        diagnoses: note.diagnoses ? note.diagnoses : '--',
       })),
     [paginatedNotes],
   );

--- a/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
@@ -51,7 +51,9 @@ export function useVisitNotes(patientUuid: string): UseVisitNotes {
     encounterProviderRole: note?.encounterProviders[0]?.encounterRole?.display,
   });
 
-  const formattedVisitNotes = data?.data?.results?.map(mapNoteProperties);
+  const formattedVisitNotes = data?.data?.results
+    ?.map(mapNoteProperties)
+    ?.sort((noteA, noteB) => new Date(noteB.encounterDate).getTime() - new Date(noteA.encounterDate).getTime());
 
   return {
     visitNotes: data ? formattedVisitNotes : null,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
- Sort visit notes in descending order by `encounterDate`

## Recording showing `Dev3(Unsorted)` and `Fixed local`

https://user-images.githubusercontent.com/30952856/201225923-76b49012-4f2a-4aeb-8be1-b365a44a39bf.mov

## Related Issue
[‘Visit notes’ encounters should be in descending order by date](https://issues.openmrs.org/browse/O3-1609)

