### PR TITLE
feat: Add current date appointments and fix issue with displaying past and upcoming appointments

### DIFF
--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
@@ -74,7 +74,10 @@ const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
                 <Tile className={styles.tile}>
                   <EmptyDataIllustration />
                   <p className={styles.content}>
-                    {t('noCurrentAppointments', 'There are current appointments to display for this patient')}
+                    {t(
+                      'noCurrentAppointments',
+                      'There are no appointments scheduled for today to display for this patient',
+                    )}
                   </p>
                 </Tile>
               </Layer>

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
@@ -14,8 +14,9 @@ interface AppointmentsBaseProps {
 }
 
 enum AppointmentTypes {
-  UPCOMING = 0,
-  PAST = 1,
+  TODAY = 0,
+  UPCOMING = 1,
+  PAST = 2,
 }
 
 const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
@@ -48,6 +49,7 @@ const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
           ) : null}
           <div className={styles.contentSwitcherWrapper}>
             <ContentSwitcher size="md" onChange={({ index }) => setContentSwitcherValue(index)}>
+              <Switch name={'today'} text={t('today', 'Today')} />
               <Switch name={'upcoming'} text={t('upcoming', 'Upcoming')} />
               <Switch name={'past'} text={t('past', 'Past')} />
             </ContentSwitcher>
@@ -63,6 +65,21 @@ const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
           </div>
         </CardHeader>
         {(() => {
+          if (contentSwitcherValue === AppointmentTypes.TODAY) {
+            if (appointmentsData.todaysAppointments?.length) {
+              return <AppointmentsTable patientAppointments={appointmentsData?.todaysAppointments} />;
+            }
+            return (
+              <Layer>
+                <Tile className={styles.tile}>
+                  <EmptyDataIllustration />
+                  <p className={styles.content}>
+                    {t('noCurrentAppointments', 'There are current appointments to display for this patient')}
+                  </p>
+                </Tile>
+              </Layer>
+            );
+          }
           if (contentSwitcherValue === AppointmentTypes.UPCOMING) {
             if (appointmentsData.upcomingAppointments?.length) {
               return <AppointmentsTable patientAppointments={appointmentsData?.upcomingAppointments} />;

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.test.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.test.tsx
@@ -88,7 +88,9 @@ describe('AppointmensOverview', () => {
     expect(screen.getByRole('tablist')).toContainElement(upcomingAppointmentsTab);
     expect(screen.getByRole('tablist')).toContainElement(pastAppointmentsTab);
     expect(screen.getByTitle(/Empty data illustration/i)).toBeInTheDocument();
-    expect(screen.getByText(/There are current appointments to display for this patient/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/There are no appointments scheduled for today to display for this patient/i),
+    ).toBeInTheDocument();
 
     await waitFor(() => user.click(pastAppointmentsTab));
     expect(screen.getByRole('table')).toBeInTheDocument();

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.test.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.test.tsx
@@ -88,7 +88,7 @@ describe('AppointmensOverview', () => {
     expect(screen.getByRole('tablist')).toContainElement(upcomingAppointmentsTab);
     expect(screen.getByRole('tablist')).toContainElement(pastAppointmentsTab);
     expect(screen.getByTitle(/Empty data illustration/i)).toBeInTheDocument();
-    expect(screen.getByText(/There are no upcoming appointments to display for this patient/i)).toBeInTheDocument();
+    expect(screen.getByText(/There are current appointments to display for this patient/i)).toBeInTheDocument();
 
     await waitFor(() => user.click(pastAppointmentsTab));
     expect(screen.getByRole('table')).toBeInTheDocument();

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-table.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-table.component.tsx
@@ -34,6 +34,7 @@ const AppointmentsTable: React.FC<AppointmentTableProps> = ({ patientAppointment
       { key: 'date', header: t('date', 'Date') },
       { key: 'location', header: t('location', 'Location') },
       { key: 'service', header: t('service', 'Service') },
+      { key: 'status', header: t('status', 'Status') },
     ],
     [t],
   );
@@ -46,6 +47,7 @@ const AppointmentsTable: React.FC<AppointmentTableProps> = ({ patientAppointment
           date: formatDatetime(parseDate(appointment.startDateTime), { mode: 'wide' }),
           location: appointment?.location?.name ?? '--',
           service: appointment.service.name,
+          status: appointment.status,
         };
       }),
     [paginatedAppointments],

--- a/packages/esm-patient-appointments-app/translations/en.json
+++ b/packages/esm-patient-appointments-app/translations/en.json
@@ -25,11 +25,8 @@
   "selectLocation": "Select a location",
   "selectService": "Select service",
   "service": "Service",
-<<<<<<< HEAD
-=======
   "serviceType": "Service type",
   "status": "Status",
->>>>>>> 7059ddd (code review)
   "time": "Time",
   "today": "Today",
   "upcoming": "Upcoming"

--- a/packages/esm-patient-appointments-app/translations/en.json
+++ b/packages/esm-patient-appointments-app/translations/en.json
@@ -15,7 +15,7 @@
   "discard": "Discard",
   "loading": "Loading",
   "location": "Location",
-  "noCurrentAppointments": "There are current appointments to display for this patient",
+  "noCurrentAppointments": "There are no appointments scheduled for today to display for this patient",
   "noPastAppointments": "There are no past appointments to display for this patient",
   "note": "Note",
   "noUpcomingAppointments": "There are no upcoming appointments to display for this patient",
@@ -25,6 +25,11 @@
   "selectLocation": "Select a location",
   "selectService": "Select service",
   "service": "Service",
+<<<<<<< HEAD
+=======
+  "serviceType": "Service type",
+  "status": "Status",
+>>>>>>> 7059ddd (code review)
   "time": "Time",
   "today": "Today",
   "upcoming": "Upcoming"

--- a/packages/esm-patient-appointments-app/translations/en.json
+++ b/packages/esm-patient-appointments-app/translations/en.json
@@ -15,6 +15,7 @@
   "discard": "Discard",
   "loading": "Loading",
   "location": "Location",
+  "noCurrentAppointments": "There are current appointments to display for this patient",
   "noPastAppointments": "There are no past appointments to display for this patient",
   "note": "Note",
   "noUpcomingAppointments": "There are no upcoming appointments to display for this patient",
@@ -25,5 +26,6 @@
   "selectService": "Select service",
   "service": "Service",
   "time": "Time",
+  "today": "Today",
   "upcoming": "Upcoming"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR addresses two issues:

- Fixes the display of `Past` and `Upcoming` appointments in the UI. Presently, appointments with UTC dates are displayed incorrectly.
- Adds a `Today` tab to the content switcher that displays appointments for the present day. This information is useful in a clinical setup.

## Screenshots
<img width="746" alt="Screenshot 2022-11-11 at 8 50 14 am" src="https://user-images.githubusercontent.com/28008754/201273935-4b640382-a00f-442d-9dd9-4aa40f0c66ea.png">

