### PR TITLE
O3-1612: Medications tables should only fetch drugOrders.

### DIFF
--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -1,6 +1,7 @@
 import useSWR from 'swr';
-import { ConfigObject, openmrsFetch, Session } from '@openmrs/esm-framework';
+import { openmrsFetch, Session, useConfig } from '@openmrs/esm-framework';
 import { OrderPost, PatientMedicationFetchResponse } from '../types/order';
+import { ConfigObject } from '../config-schema';
 
 /**
  * Fast, lighweight, reusable data fetcher with built-in cache invalidation that
@@ -9,6 +10,7 @@ import { OrderPost, PatientMedicationFetchResponse } from '../types/order';
  * @param status The status/the kind of orders to be fetched.
  */
 export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any', careSettingUuid: string) {
+  const { drugOrderTypeUUID } = useConfig() as ConfigObject;
   const customRepresentation =
     'custom:(uuid,dosingType,orderNumber,accessionNumber,' +
     'patient:ref,action,careSetting:ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,' +
@@ -18,7 +20,7 @@ export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any', 
     'duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)';
 
   const { data, error, isValidating } = useSWR<{ data: PatientMedicationFetchResponse }, Error>(
-    `/ws/rest/v1/order?patient=${patientUuid}&careSetting=${careSettingUuid}&status=${status}&v=${customRepresentation}`,
+    `/ws/rest/v1/order?patient=${patientUuid}&careSetting=${careSettingUuid}&status=${status}&orderType=${drugOrderTypeUUID}&v=${customRepresentation}`,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-medications-app/src/config-schema.ts
+++ b/packages/esm-patient-medications-app/src/config-schema.ts
@@ -35,6 +35,11 @@ export const configSchema = {
     _description: 'Encounter role required by clinician to dispense medication(s)',
     _default: '240b26f9-dd88-4172-823d-4a8bfeb7841f',
   },
+  drugOrderTypeUUID: {
+    _type: Type.UUID,
+    _description: "UUID for the 'Drug' order type to fetch medications",
+    _default: '131168f4-15f5-102d-96e4-000c29c2a5d7',
+  },
 };
 
 export interface ConfigObject {
@@ -47,4 +52,5 @@ export interface ConfigObject {
     uuid: string;
     display: string;
   };
+  drugOrderTypeUUID: string;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary

Medications tables in the orders view should only fetch Drug orders (orders having orderType = DrugOrder). I have added orderType when fetching medications for a patient.

More description can be found in the ticket mentioned below.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-1612

## Other
<!-- Anything not covered above -->
