### PR TITLE
O3-1613: UI improvements in the orders view (medication orders)

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -84,8 +84,8 @@ const MedicationsDetailsTable = connect<
           <div className={styles.medicationRecord}>
             <div>
               <p className={styles.bodyLong01}>
-                <strong>{capitalize(medication.drug?.name)}</strong> &mdash; {medication.drug?.strength.toLowerCase()}{' '}
-                &mdash; {medication.doseUnits?.display.toLowerCase()}
+                <strong>{capitalize(medication.drug?.concept?.display)}</strong> &mdash;{' '}
+                {medication.drug?.strength.toLowerCase()} &mdash; {medication.drug.dosageForm.display.toLowerCase()}
               </p>
               <p className={styles.bodyLong01}>
                 <span className={styles.label01}>{t('dose', 'Dose').toUpperCase()}</span>{' '}

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -55,7 +55,7 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
             );
           }
 
-          return <EmptyState displayText={displayText} headerTitle={headerTitle} />;
+          return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchOrderBasket} />;
         })()}
       </div>
       <div style={{ marginTop: '1.5rem' }}>
@@ -81,7 +81,7 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
             );
           }
 
-          return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchOrderBasket} />;
+          return <EmptyState displayText={displayText} headerTitle={headerTitle} />;
         })()}
       </div>
     </>

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-item-list.test.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-item-list.test.tsx
@@ -33,7 +33,7 @@ describe('OrderBasketItemList: ', () => {
     const orderBasketItem = screen.getByRole('listitem');
     expect(orderBasketItem).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /item\(s\) already in your basket/i })).toBeInTheDocument();
-    expect(getByTextWithMarkup(/New\s*Aspirin — 81 mg — Tablet/)).toBeInTheDocument();
+    expect(getByTextWithMarkup(/New\s*Aspirin — 81mg — Tablet/)).toBeInTheDocument();
     expect(getByTextWithMarkup(/DOSE 81 mg — Oral — Once daily — REFILLS 0 QUANTITY 0/)).toBeInTheDocument();
 
     const removeFromBasketButton = screen.getByRole('button', { name: /remove from basket/i });
@@ -51,7 +51,7 @@ describe('OrderBasketItemList: ', () => {
     renderOrderBasketItemList();
 
     expect(screen.getByRole('heading', { name: /order\(s\) being renewed/i })).toBeInTheDocument();
-    expect(getByTextWithMarkup(/Renew\s*Aspirin — 81 mg — Tablet/)).toBeInTheDocument();
+    expect(getByTextWithMarkup(/Renew\s*Aspirin — 81mg — Tablet/)).toBeInTheDocument();
     expect(getByTextWithMarkup(/DOSE 81 mg — Oral — Once daily — REFILLS 0 QUANTITY 0/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /remove from basket/i })).toBeInTheDocument();
   });
@@ -62,7 +62,7 @@ describe('OrderBasketItemList: ', () => {
     renderOrderBasketItemList();
 
     expect(screen.getByRole('heading', { name: /order\(s\) being modified \(revised\)/i })).toBeInTheDocument();
-    expect(getByTextWithMarkup(/Modify\s*Aspirin — 81 mg — Tablet/)).toBeInTheDocument();
+    expect(getByTextWithMarkup(/Modify\s*Aspirin — 81mg — Tablet/)).toBeInTheDocument();
     expect(getByTextWithMarkup(/DOSE 81 mg — Oral — Once daily — REFILLS 0 QUANTITY 0/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /remove from basket/i })).toBeInTheDocument();
   });
@@ -73,7 +73,7 @@ describe('OrderBasketItemList: ', () => {
     renderOrderBasketItemList();
 
     expect(screen.getByRole('heading', { name: /discontinued order\(s\)/i })).toBeInTheDocument();
-    expect(getByTextWithMarkup(/Discontinue\s*Aspirin — 81 mg — Tablet/)).toBeInTheDocument();
+    expect(getByTextWithMarkup(/Discontinue\s*Aspirin — 81mg — Tablet/)).toBeInTheDocument();
     expect(getByTextWithMarkup(/DOSE 81 mg — Oral — Once daily — REFILLS 0 QUANTITY 0/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /remove from basket/i })).toBeInTheDocument();
   });

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-item.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-item.component.tsx
@@ -39,8 +39,7 @@ export default function OrderBasketItemTile({ orderBasketItem, onItemClick, onRe
             <span className={styles.drugName}>{orderBasketItem.drug.concept.display}</span>
             <span className={styles.dosageInfo}>
               {' '}
-              &mdash; {orderBasketItem.dosage.value} {orderBasketItem.unit.value} &mdash;{' '}
-              {orderBasketItem.drug.dosageForm.display}
+              &mdash; {orderBasketItem.drug.strength} &mdash; {orderBasketItem.drug.dosageForm.display}
             </span>
           </>
         )}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR addresses the following changes in the UI

1. The order item in the order basket was not properly showing the drug strength and was showing the dosage ordered.
#### Before
<img width="688" alt="image" src="https://user-images.githubusercontent.com/51502471/201021360-6655807e-20d6-49bc-81f3-fb7565b9d7ed.png">

#### Now
<img width="686" alt="image" src="https://user-images.githubusercontent.com/51502471/201021570-7d09ed2c-07e4-4946-9f41-2b482f082783.png">

2. The empty state of past medications had the "Record medication", which is now shifted to the active medication's Empty state.
#### Before
<img width="1363" alt="image" src="https://user-images.githubusercontent.com/51502471/201022079-3884626e-165d-42a7-beeb-ccbbde5cbc03.png">

#### Now
<img width="1357" alt="image" src="https://user-images.githubusercontent.com/51502471/201021903-ce28a5d7-794a-41fd-b076-231b0a7cb3c2.png">

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
