### PR TITLE
(feat) Remove top border from pagination component

### DIFF
--- a/packages/esm-patient-common-lib/src/pagination/pagination.scss
+++ b/packages/esm-patient-common-lib/src/pagination/pagination.scss
@@ -9,7 +9,6 @@
 .desktop, .tablet {
   @include type.type-style('body-compact-01');
   display: flex;
-  border-top: 1px solid #e0e0e0;
   justify-content: space-between;
   color: $text-02;
   background-color: $ui-02;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The top border on the pagination component is no longer required following https://github.com/openmrs/openmrs-esm-core/pull/569. This is the final piece in getting Datatable-based overview widgets in line with the latest [designs](https://zpl.io/Am0lJkP).

## Screenshots

> Before 

<img width="962" alt="Screenshot 2022-11-14 at 21 58 29" src="https://user-images.githubusercontent.com/8509731/201743788-3c9ef53b-28fd-451f-bd9c-d78f5f76ffef.png">

> After

<img width="966" alt="Screenshot 2022-11-14 at 21 58 19" src="https://user-images.githubusercontent.com/8509731/201743807-73de033a-d4ec-4ad6-9478-6b88cea71118.png">

