### PR TITLE
O3-1586: Fix the identifiers UI in the patient banner

### DIFF
--- a/packages/esm-patient-chart-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-chart-app/src/banner/patient-banner.component.tsx
@@ -121,7 +121,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
               {patient?.identifier?.length
                 ? patient?.identifier.map(({ value, type }) => (
                     <span className={styles.identifierTag}>
-                      <Tag className={styles.tag} key={value} type="gray" title={type.text}>
+                      <Tag key={value} className={styles.tag} type="gray" title={type.text}>
                         {type.text}
                       </Tag>
                       {value}

--- a/packages/esm-patient-chart-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-chart-app/src/banner/patient-banner.component.tsx
@@ -6,6 +6,7 @@ import { ExtensionSlot, age, formatDate, parseDate } from '@openmrs/esm-framewor
 import ContactDetails from './contact-details/contact-details.component';
 import CustomOverflowMenuComponent from './ui-components/overflow-menu.component';
 import styles from './patient-banner.scss';
+
 interface PatientBannerProps {
   patient: fhir.Patient;
   patientUuid: string;
@@ -120,11 +121,10 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
               {patient?.identifier?.length
                 ? patient?.identifier.map(({ value, type }) => (
                     <span className={styles.identifierTag}>
-                      <Tag key={value} type="gray" title={type.text}>
+                      <Tag className={styles.tag} key={value} type="gray" title={type.text}>
                         {type.text}
                       </Tag>
                       {value}
-                      &#183;
                     </span>
                   ))
                 : ''}

--- a/packages/esm-patient-chart-app/src/banner/patient-banner.scss
+++ b/packages/esm-patient-chart-app/src/banner/patient-banner.scss
@@ -60,6 +60,20 @@
 .identifiers {
   @include type.type-style("body-compact-02");
   color: $ui-04;
+  display: flex;
+
+  span:not(:first-child) {
+    margin: 0rem 0.75rem;
+  }
+}
+
+.identifierTag {
+  display: flex;
+  align-items: center;
+}
+
+.tag {
+  margin: 0.25rem 0.25rem 0.25rem 0rem;
 }
 
 .tooltipPadding {

--- a/packages/esm-patient-vitals-app/translations/en.json
+++ b/packages/esm-patient-vitals-app/translations/en.json
@@ -6,6 +6,7 @@
   "bmiCalc": "BMI (calc.)",
   "bp": "BP",
   "chartView": "Chart View",
+  "checkForValidity": "Some of the values entered are invalid",
   "diastolic": "diastolic",
   "discard": "Discard",
   "goToSummary": "Go to Summary",
@@ -38,6 +39,5 @@
   "vitalsAndBiometricsSaveError": "Error saving vitals and biometrics",
   "vitalSignDisplayed": "Vital Sign Displayed",
   "vitalSigns": "Vital signs",
-  "weight": "Weight",
-  "checkForValidity": "Some of the values entered are invalid"
+  "weight": "Weight"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes a few issues in the patient banner identifiers UI:

- Removes the left padding on the identifier tag.
- Applies some margin between tags when multiple identifiers are present.
- Aligns the tag and its associated identifiers in a center-aligned flex container.
- Removes the interpunct between identifiers.

## Screenshots

> Before
<img width="871" alt="Screenshot 2022-11-14 at 23 22 27" src="https://user-images.githubusercontent.com/8509731/201998174-313483e5-9829-445f-ad6d-09cb9aec7387.png">

> After
<img width="863" alt="Screenshot 2022-11-14 at 23 21 44" src="https://user-images.githubusercontent.com/8509731/201998194-db73787c-20f8-4bb3-b9a6-87f328d91884.png">

## Related Issue

https://issues.openmrs.org/browse/O3-1586