### PR TITLE
O3-1619: Closing the patient chart should close any open workspaces.

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -22,7 +22,7 @@ import {
   navigate,
   useConfig,
 } from '@openmrs/esm-framework';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { launchPatientWorkspace, useWorkspaces } from '@openmrs/esm-patient-common-lib';
 import VisitHeaderSideMenu from './visit-header-side-menu.component';
 import styles from './visit-header.scss';
 import { MappedQueuePriority, MappedVisitQueueEntry, useVisitQueueEntries } from '../visit/queue-entry/queue.resource';
@@ -128,11 +128,16 @@ const VisitHeader: React.FC = () => {
 
   const originPage = localStorage.getItem('fromPage');
 
-  const onClosePatientChart = useCallback(() => {
+  const { workspaces } = useWorkspaces();
+
+  const onClosePatientChart = React.useCallback(() => {
     originPage ? navigate({ to: `${window.spaBase}/${originPage}` }) : navigate({ to: `${window.spaBase}/home` });
     setShowVisitHeader((prevState) => !prevState);
     localStorage.removeItem('fromPage');
-  }, [originPage]);
+    workspaces.forEach((workspace) => {
+      workspace.closeWorkspace();
+    });
+  }, [originPage, workspaces]);
 
   const render = useCallback(() => {
     if (!showVisitHeader) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, when you have an open workspace and close/leave the patient chart, when you click on a patient again, the workspace is still open. We should close the workspaces once one leaves the patient chart. 
cc @hadijahkyampeire 

## Screenshots
<!-- Required if you are making UI changes. -->
https://user-images.githubusercontent.com/58003327/202601671-87f1d8d9-7970-4241-87bb-b2b5080c7312.mov

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-1619

## Other
<!-- Anything not covered above -->
