### PR TITLE
Fixed extension slot declaration in esm-generic-patient-widgets-app

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/index.ts
+++ b/packages/esm-generic-patient-widgets-app/src/index.ts
@@ -19,7 +19,7 @@ function setupOpenMRS() {
     moduleName,
   };
 
-  defineExtensionConfigSchema('obs-by-encounter-widget', configSchema);
+  defineExtensionConfigSchema(moduleName, configSchema);
 
   return {
     extensions: [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
There was a problem in the declaration of the extension slot in esm-generic-patient-widgets-app, this was fixed, enabling the display of the obs tables.
