### PR TITLE
03-1623: Visit Notes widget: Items are ordered by date incorrectly.

### DIFF
--- a/packages/esm-patient-appointments-app/translations/en.json
+++ b/packages/esm-patient-appointments-app/translations/en.json
@@ -25,7 +25,6 @@
   "selectLocation": "Select a location",
   "selectService": "Select service",
   "service": "Service",
-  "serviceType": "Service type",
   "status": "Status",
   "time": "Time",
   "today": "Today",

--- a/packages/esm-patient-notes-app/src/notes/paginated-notes.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/paginated-notes.component.tsx
@@ -29,7 +29,7 @@ interface PaginatedNotes {
 const PaginatedNotes: React.FC<PaginatedNotes> = ({ notes, pageSize, pageUrl, urlLabel }) => {
   const { t } = useTranslation();
 
-  const [sortings, setSortings] = useState({ key: '', order: 'none' });
+  const [sortParams, setSortParams] = useState({ key: '', order: 'none' });
 
   const tableHeaders = [
     {
@@ -47,7 +47,7 @@ const PaginatedNotes: React.FC<PaginatedNotes> = ({ notes, pageSize, pageUrl, ur
       ? orderBy(myArray, [(obj) => new Date(obj.encounterDate).getTime()], ['desc'])
       : orderBy(myArray, [(obj) => new Date(obj.encounterDate).getTime()], ['asc']);
 
-  const { key, order } = sortings;
+  const { key, order } = sortParams;
 
   const sortedData =
     key === 'encounterDate'
@@ -58,7 +58,7 @@ const PaginatedNotes: React.FC<PaginatedNotes> = ({ notes, pageSize, pageUrl, ur
 
   function customSortRow(noteA, noteB, { sortDirection, sortStates, ...props }) {
     const { key } = props;
-    setSortings({ key, order: sortDirection });
+    setSortParams({ key, order: sortDirection });
   }
 
   const { results: paginatedNotes, goTo, currentPage } = usePagination(sortedData, pageSize);

--- a/packages/esm-patient-notes-app/src/notes/paginated-notes.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/paginated-notes.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   DataTable,
   Table,
@@ -15,6 +15,7 @@ import {
 import { formatDate, formatTime, parseDate, usePagination } from '@openmrs/esm-framework';
 import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
+import orderBy from 'lodash-es/orderBy';
 import { PatientNote } from '../types';
 import styles from './notes-overview.scss';
 
@@ -27,7 +28,8 @@ interface PaginatedNotes {
 
 const PaginatedNotes: React.FC<PaginatedNotes> = ({ notes, pageSize, pageUrl, urlLabel }) => {
   const { t } = useTranslation();
-  const { results: paginatedNotes, goTo, currentPage } = usePagination(notes, pageSize);
+
+  const [sortings, setSortings] = useState({ key: '', order: 'none' });
 
   const tableHeaders = [
     {
@@ -40,6 +42,26 @@ const PaginatedNotes: React.FC<PaginatedNotes> = ({ notes, pageSize, pageUrl, ur
     },
   ];
 
+  const sortDate = (myArray, order) =>
+    order === 'ASC'
+      ? orderBy(myArray, [(obj) => new Date(obj.encounterDate).getTime()], ['desc'])
+      : orderBy(myArray, [(obj) => new Date(obj.encounterDate).getTime()], ['asc']);
+
+  const { key, order } = sortings;
+
+  const sortedData =
+    key === 'encounterDate'
+      ? sortDate(notes, order)
+      : order === 'DESC'
+      ? orderBy(notes, [key], ['desc'])
+      : orderBy(notes, [key], ['asc']);
+
+  function customSortRow(noteA, noteB, { sortDirection, sortStates, ...props }) {
+    const { key } = props;
+    setSortings({ key, order: sortDirection });
+  }
+
+  const { results: paginatedNotes, goTo, currentPage } = usePagination(sortedData, pageSize);
   const tableRows = React.useMemo(
     () =>
       paginatedNotes?.map((note) => ({
@@ -53,7 +75,7 @@ const PaginatedNotes: React.FC<PaginatedNotes> = ({ notes, pageSize, pageUrl, ur
 
   return (
     <>
-      <DataTable rows={tableRows} headers={tableHeaders} isSortable size="sm" useZebraStyles>
+      <DataTable rows={tableRows} sortRow={customSortRow} headers={tableHeaders} isSortable size="sm" useZebraStyles>
         {({ rows, headers, getTableProps, getTableContainerProps, getHeaderProps, getRowProps }) => (
           <TableContainer {...getTableContainerProps}>
             <Table {...getTableProps()}>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds [custom sorting logic](https://react.carbondesignsystem.com/?path=/docs/components-datatable-sorting--default#custom-sorting) to the visit notes widget. The default carbon table sorting only sorts elements on that page, so if the table has pagination the default sorting won't work well.

## Screen Recording

https://user-images.githubusercontent.com/30952856/203177701-cf24068d-622f-4ec2-9465-b9ef2c20c57c.mov

## Related Issue
https://issues.openmrs.org/browse/O3-1623

