### PR TITLE
O3-1641: Ability to display configurable visit attributes as tags on patient header

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -49,7 +49,7 @@ export const esmPatientChartSchema = {
   },
   visitAttributeTypes: {
     _type: Type.Array,
-    _description: 'List of visit attribute types to be shown when filling visit form',
+    _description: 'List of visit attribute types shown when filling the visit form',
     _elements: {
       uuid: {
         _type: Type.UUID,

--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -50,7 +50,6 @@ export const esmPatientChartSchema = {
   visitAttributeTypes: {
     _type: Type.Array,
     _description: 'List of visit attribute types to be shown when filling visit form',
-    _default: [],
     _elements: {
       uuid: {
         _type: Type.UUID,
@@ -58,9 +57,27 @@ export const esmPatientChartSchema = {
       },
       required: {
         _type: Type.Boolean,
-        _description: 'Either the attribute type field is required or not',
+        _description: 'Whether the attribute type field is required or not',
+        _default: false,
+      },
+      displayInThePatientBanner: {
+        _type: Type.Boolean,
+        _description: "Whether we should show this visit attribute's value in the patient banner",
+        _default: true,
       },
     },
+    _default: [
+      {
+        uuid: '57ea0cbb-064f-4d09-8cf4-e8228700491c',
+        required: false,
+        displayInThePatientBanner: true,
+      },
+      {
+        uuid: 'aac48226-d143-4274-80e0-264db4e368ee',
+        required: false,
+        displayInThePatientBanner: true,
+      },
+    ],
   },
   showServiceQueueFields: {
     _type: Type.Boolean,
@@ -101,6 +118,7 @@ export interface ChartConfig {
   visitAttributeTypes: Array<{
     uuid: string;
     required: boolean;
+    displayInThePatientBanner: boolean;
   }>;
   showServiceQueueFields: boolean;
   priorityConceptSetUuid: string;

--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -258,6 +258,14 @@ function setupOpenMRS() {
           moduleName,
         }),
       },
+      {
+        id: 'visit-attribute-tags',
+        slot: 'patient-banner-tags-slot',
+        load: getAsyncLifecycle(() => import('./patient-banner-tags/visit-attribute-tags.component'), {
+          featureName: 'visit-attribute-tags',
+          moduleName,
+        }),
+      },
     ],
   };
 }

--- a/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Tag } from '@carbon/react';
-import { formatDate } from '@openmrs/esm-framework';
+import { formatDate, useConfig } from '@openmrs/esm-framework';
+import { ChartConfig } from '../config-schema';
 import { useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
 
 interface VisitAttributeTagsProps {
@@ -10,7 +11,7 @@ interface VisitAttributeTagsProps {
 const getAttributeValue = (attributeType, value) => {
   switch (attributeType?.datatypeClassname) {
     case 'org.openmrs.customdatatype.datatype.ConceptDatatype':
-      return value;
+      return value?.display;
     case 'org.openmrs.customdatatype.datatype.FloatDatatype':
       return value;
     case 'org.openmrs.customdatatype.datatype.FreeTextDatatype':
@@ -30,14 +31,22 @@ const getAttributeValue = (attributeType, value) => {
 
 const VisitAttributeTags: React.FC<VisitAttributeTagsProps> = ({ patientUuid }) => {
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
+  const { visitAttributeTypes } = useConfig() as ChartConfig;
+
+  console.log(currentVisit?.attributes, visitAttributeTypes);
   return (
     <>
-      {currentVisit?.attributes?.map((attribute) => (
-        <Tag type="gray">{`${attribute.attributeType?.name}: ${getAttributeValue(
-          attribute?.attributeType,
-          attribute?.value,
-        )}`}</Tag>
-      ))}
+      {currentVisit?.attributes
+        ?.filter(
+          (attribute) =>
+            visitAttributeTypes.find(({ uuid }) => attribute?.attributeType?.uuid === uuid)?.displayInThePatientBanner,
+        )
+        .map((attribute) => (
+          <Tag type="gray">{`${attribute.attributeType?.name}: ${getAttributeValue(
+            attribute?.attributeType,
+            attribute?.value,
+          )}`}</Tag>
+        ))}
     </>
   );
 };

--- a/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
@@ -13,11 +13,8 @@ const getAttributeValue = (attributeType, value) => {
     case 'org.openmrs.customdatatype.datatype.ConceptDatatype':
       return value?.display;
     case 'org.openmrs.customdatatype.datatype.FloatDatatype':
-      return value;
     case 'org.openmrs.customdatatype.datatype.FreeTextDatatype':
-      return value;
     case 'org.openmrs.customdatatype.datatype.LongFreeTextDatatype':
-      return value;
     case 'org.openmrs.customdatatype.datatype.BooleanDatatype':
       return value;
     case 'org.openmrs.customdatatype.datatype.DateDatatype':

--- a/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
@@ -33,7 +33,6 @@ const VisitAttributeTags: React.FC<VisitAttributeTagsProps> = ({ patientUuid }) 
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
   const { visitAttributeTypes } = useConfig() as ChartConfig;
 
-  console.log(currentVisit?.attributes, visitAttributeTypes);
   return (
     <>
       {currentVisit?.attributes

--- a/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Tag } from '@carbon/react';
+import { formatDate } from '@openmrs/esm-framework';
+import { useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
+
+interface VisitAttributeTagsProps {
+  patientUuid: string;
+}
+
+const getAttributeValue = (attributeType, value) => {
+  switch (attributeType?.datatypeClassname) {
+    case 'org.openmrs.customdatatype.datatype.ConceptDatatype':
+      return value;
+    case 'org.openmrs.customdatatype.datatype.FloatDatatype':
+      return value;
+    case 'org.openmrs.customdatatype.datatype.FreeTextDatatype':
+      return value;
+    case 'org.openmrs.customdatatype.datatype.LongFreeTextDatatype':
+      return value;
+    case 'org.openmrs.customdatatype.datatype.BooleanDatatype':
+      return value;
+    case 'org.openmrs.customdatatype.datatype.DateDatatype':
+      return formatDate(new Date(value), {
+        mode: 'wide',
+      });
+    default:
+      return value;
+  }
+};
+
+const VisitAttributeTags: React.FC<VisitAttributeTagsProps> = ({ patientUuid }) => {
+  const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
+  return (
+    <>
+      {currentVisit?.attributes?.map((attribute) => (
+        <Tag type="gray">{`${attribute.attributeType?.name}: ${getAttributeValue(
+          attribute?.attributeType,
+          attribute?.value,
+        )}`}</Tag>
+      ))}
+    </>
+  );
+};
+
+export default VisitAttributeTags;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR supports showing visit attributes, which are recorded when starting a visit, on the patient banner as tags.
The user can configure whether to show a visit attribute on the patient banner or not using the below mentioned configuration:

```
"@openmrs/esm-patient-chart-app": {
  "visitAttributeTypes": Array<{
    "uuid": (string) UUID of the visit attribute type whose field is to be shown in the start visit form,
    "required": (boolean) Whether filling the visit attribute type field is required or not,
    "displayInThePatientBanner": (boolean) Whether the visit attribute's value should be shown in the patient banner or not
  }>
}
```

## Screenshots
![image](https://user-images.githubusercontent.com/51502471/203769324-5688c92d-6418-42ae-a9e7-2ec1d9149b1e.png)
![image](https://user-images.githubusercontent.com/51502471/203769492-01b75465-afc6-4b3b-ae60-9232930cb9af.png)


## Related Issue
https://issues.openmrs.org/browse/O3-1641

## Other
Dependent on https://github.com/openmrs/openmrs-esm-core/pull/575
