### PR TITLE
Remove the yarn start-all script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,6 @@ yarn start --sources 'packages/esm-patient-<insert-package-name>-app'
 
 This command uses the [openmrs](https://www.npmjs.com/package/openmrs) tooling to fire up a dev server running `esm-patient-chart` as well as the specified microfrontend.
 
-To start a dev server running all the packages, run:
-
-```bash
-yarn start-all
-```
-
-Note that this is very resource-intensive. 
 
 There are two approaches for working on multiple microfrontends simultaneously.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   ],
   "scripts": {
     "start": "openmrs develop --sources packages/esm-patient-chart-app/",
-    "start-all": "openmrs develop --sources 'packages/esm-*-app/'",
     "ci:publish": "lerna publish from-package --yes",
     "ci:prepublish": "lerna publish from-package --no-git-reset --yes --dist-tag next",
     "release": "lerna version --no-git-tag-version",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Just removes the `yarn start-all` command because it freezes dev's computers as it is resource intensive and most likely no one will even need to run all apps at once.
- Also removed its reference from the ReadMe.


