### PR TITLE
O3-1634: UI Fixes for Test results viewer in Tablet and Small Desktop

### DIFF
--- a/packages/esm-patient-common-lib/src/types/test-results.ts
+++ b/packages/esm-patient-common-lib/src/types/test-results.ts
@@ -15,7 +15,7 @@ export interface ObsRecord {
 
 export interface ObsMetaInfo {
   [_: string]: any;
-  assessValue?: (value: number) => OBSERVATION_INTERPRETATION;
+  assessValue?: (value: string) => OBSERVATION_INTERPRETATION;
 }
 
 export interface ConceptRecord {

--- a/packages/esm-patient-test-results-app/src/filter/filter-types.ts
+++ b/packages/esm-patient-test-results-app/src/filter/filter-types.ts
@@ -47,7 +47,7 @@ export interface ReducerAction {
 
 export interface ObservationData {
   obsDatetime: string;
-  value: number;
+  value: string;
   interpretation: OBSERVATION_INTERPRETATION;
 }
 export interface TestData {

--- a/packages/esm-patient-test-results-app/src/grouped-timeline/grouped-timeline.tsx
+++ b/packages/esm-patient-test-results-app/src/grouped-timeline/grouped-timeline.tsx
@@ -276,8 +276,8 @@ export const GroupedTimeline = () => {
   }
   if (activeTests && timelineData && loaded) {
     return (
-      <div className={styles.timelineHeader} style={{ top: tablet ? '7rem' : '6.5rem' }}>
-        <div className={styles.timelineHeader} style={{ top: tablet ? '7rem' : '6.5rem' }}>
+      <div className={styles.timelineHeader} style={{ top: '6.5rem' }}>
+        <div className={styles.timelineHeader} style={{ top: '6.5rem' }}>
           <div className={styles.dateHeaderContainer}>
             <PanelNameCorner showShadow={true} panelName={panelName} />
             <DateHeaderGrid

--- a/packages/esm-patient-test-results-app/src/grouped-timeline/grouped-timeline.tsx
+++ b/packages/esm-patient-test-results-app/src/grouped-timeline/grouped-timeline.tsx
@@ -28,8 +28,22 @@ const PanelNameCorner: React.FC<PanelNameCornerProps> = ({ showShadow, panelName
   <TimeSlots className={`${styles.cornerGridElement} ${showShadow ? styles.shadow : ''}`}>{panelName}</TimeSlots>
 );
 
-const NewRowStartCell = ({ title, range, units, conceptUuid, shadow = false }) => {
+const NewRowStartCell = ({ title, range, units, conceptUuid, shadow = false, isString = false }) => {
   const { patientUuid } = usePatient();
+
+  if (isString) {
+    <div
+      className={styles.rowStartCell}
+      style={{
+        boxShadow: shadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
+      }}
+    >
+      <span className={styles.trendlineLink}>{title}</span>
+      <span className={styles.rangeUnits}>
+        {range} {units}
+      </span>
+    </div>;
+  }
 
   return (
     <div
@@ -91,7 +105,8 @@ const DataRows: React.FC<DataRowsProps> = ({ timeColumns, rowData, sortedTimes, 
     <Grid dataColumns={timeColumns.length} padding style={{ gridColumn: 'span 2' }}>
       {rowData.map((row, index) => {
         const obs = row.entries;
-        const { units = '', range = '' } = row;
+        const { units = '', range = '', obs: values } = row;
+        const isString = isNaN(parseFloat(values?.[0]?.value));
         return (
           <React.Fragment key={index}>
             <NewRowStartCell
@@ -101,6 +116,7 @@ const DataRows: React.FC<DataRowsProps> = ({ timeColumns, rowData, sortedTimes, 
                 title: row.display,
                 shadow: showShadow,
                 conceptUuid: row.conceptUuid,
+                isString,
               }}
             />
             <GridItems {...{ sortedTimes, obs, zebra: !!(index % 2) }} />

--- a/packages/esm-patient-test-results-app/src/grouped-timeline/grouped-timeline.tsx
+++ b/packages/esm-patient-test-results-app/src/grouped-timeline/grouped-timeline.tsx
@@ -10,7 +10,6 @@ import type {
   TimelineCellProps,
   DataRowsProps,
 } from './grouped-timeline-types';
-import { dashboardMeta } from '../dashboard.meta';
 import FilterContext from '../filter/filter-context';
 import styles from './grouped-timeline.styles.scss';
 
@@ -31,20 +30,6 @@ const PanelNameCorner: React.FC<PanelNameCornerProps> = ({ showShadow, panelName
 const NewRowStartCell = ({ title, range, units, conceptUuid, shadow = false, isString = false }) => {
   const { patientUuid } = usePatient();
 
-  if (isString) {
-    <div
-      className={styles.rowStartCell}
-      style={{
-        boxShadow: shadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
-      }}
-    >
-      <span className={styles.trendlineLink}>{title}</span>
-      <span className={styles.rangeUnits}>
-        {range} {units}
-      </span>
-    </div>;
-  }
-
   return (
     <div
       className={styles.rowStartCell}
@@ -52,12 +37,16 @@ const NewRowStartCell = ({ title, range, units, conceptUuid, shadow = false, isS
         boxShadow: shadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
       }}
     >
-      <ConfigurableLink
-        to={`${testResultsBasePath(`/patient/${patientUuid}/chart`)}/trendline/${conceptUuid}`}
-        className={styles.trendlineLink}
-      >
-        {title}
-      </ConfigurableLink>
+      {!isString ? (
+        <ConfigurableLink
+          to={`${testResultsBasePath(`/patient/${patientUuid}/chart`)}/trendline/${conceptUuid}`}
+          className={styles.trendlineLink}
+        >
+          {title}
+        </ConfigurableLink>
+      ) : (
+        <span className={styles.trendlineLink}>{title}</span>
+      )}
       <span className={styles.rangeUnits}>
         {range} {units}
       </span>

--- a/packages/esm-patient-test-results-app/src/loadPatientTestData/helpers.ts
+++ b/packages/esm-patient-test-results-app/src/loadPatientTestData/helpers.ts
@@ -152,28 +152,32 @@ export function exist(...args: any[]): boolean {
 
 export const assessValue =
   (meta: ObsMetaInfo) =>
-  (value: number): OBSERVATION_INTERPRETATION => {
-    if (exist(meta.hiAbsolute) && value > meta.hiAbsolute) {
+  (value: string): OBSERVATION_INTERPRETATION => {
+    if (isNaN(parseFloat(value))) {
+      return 'NORMAL';
+    }
+    const numericValue = parseFloat(value);
+    if (exist(meta.hiAbsolute) && numericValue > meta.hiAbsolute) {
       return 'OFF_SCALE_HIGH';
     }
 
-    if (exist(meta.hiCritical) && value > meta.hiCritical) {
+    if (exist(meta.hiCritical) && numericValue > meta.hiCritical) {
       return 'CRITICALLY_HIGH';
     }
 
-    if (exist(meta.hiNormal) && value > meta.hiNormal) {
+    if (exist(meta.hiNormal) && numericValue > meta.hiNormal) {
       return 'HIGH';
     }
 
-    if (exist(meta.lowAbsolute) && value < meta.lowAbsolute) {
+    if (exist(meta.lowAbsolute) && numericValue < meta.lowAbsolute) {
       return 'OFF_SCALE_LOW';
     }
 
-    if (exist(meta.lowCritical) && value < meta.lowCritical) {
+    if (exist(meta.lowCritical) && numericValue < meta.lowCritical) {
       return 'CRITICALLY_LOW';
     }
 
-    if (exist(meta.lowNormal) && value < meta.lowNormal) {
+    if (exist(meta.lowNormal) && numericValue < meta.lowNormal) {
       return 'LOW';
     }
 

--- a/packages/esm-patient-test-results-app/src/panel-timeline/helpers.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-timeline/helpers.tsx
@@ -117,21 +117,6 @@ export const TimelineCell: React.FC<{
 };
 
 export const RowStartCell = ({ title, range, units, shadow = false, testUuid, isString = false }) => {
-  if (isString) {
-    return (
-      <div
-        className={styles['row-start-cell']}
-        style={{
-          boxShadow: shadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
-        }}
-      >
-        <span className={styles['trendline-link']}>{title}</span>
-        <span className={styles['range-units']}>
-          {range} {units}
-        </span>
-      </div>
-    );
-  }
   return (
     <div
       className={styles['row-start-cell']}

--- a/packages/esm-patient-test-results-app/src/panel-timeline/helpers.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-timeline/helpers.tsx
@@ -140,9 +140,13 @@ export const RowStartCell = ({ title, range, units, shadow = false, testUuid, is
       }}
     >
       <span className={styles['trendline-link']}>
-        <ConfigurableLink to={`${testResultsBasePath(`/patient/${patientUuid}/chart`)}/trendline/${testUuid}`}>
-          {title}
-        </ConfigurableLink>
+        {!isString ? (
+          <ConfigurableLink to={`${testResultsBasePath(`/patient/${patientUuid}/chart`)}/trendline/${testUuid}`}>
+            {title}
+          </ConfigurableLink>
+        ) : (
+          title
+        )}
       </span>
       <span className={styles['range-units']}>
         {range} {units}

--- a/packages/esm-patient-test-results-app/src/panel-timeline/helpers.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-timeline/helpers.tsx
@@ -116,23 +116,40 @@ export const TimelineCell: React.FC<{
   );
 };
 
-export const RowStartCell = ({ title, range, units, shadow = false, testUuid }) => (
-  <div
-    className={styles['row-start-cell']}
-    style={{
-      boxShadow: shadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
-    }}
-  >
-    <span className={styles['trendline-link']}>
-      <ConfigurableLink to={`${testResultsBasePath(`/patient/${patientUuid}/chart`)}/trendline/${testUuid}`}>
-        {title}
-      </ConfigurableLink>
-    </span>
-    <span className={styles['range-units']}>
-      {range} {units}
-    </span>
-  </div>
-);
+export const RowStartCell = ({ title, range, units, shadow = false, testUuid, isString = false }) => {
+  if (isString) {
+    return (
+      <div
+        className={styles['row-start-cell']}
+        style={{
+          boxShadow: shadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
+        }}
+      >
+        <span className={styles['trendline-link']}>{title}</span>
+        <span className={styles['range-units']}>
+          {range} {units}
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div
+      className={styles['row-start-cell']}
+      style={{
+        boxShadow: shadow ? '8px 0 20px 0 rgba(0,0,0,0.15)' : undefined,
+      }}
+    >
+      <span className={styles['trendline-link']}>
+        <ConfigurableLink to={`${testResultsBasePath(`/patient/${patientUuid}/chart`)}/trendline/${testUuid}`}>
+          {title}
+        </ConfigurableLink>
+      </span>
+      <span className={styles['range-units']}>
+        {range} {units}
+      </span>
+    </div>
+  );
+};
 
 export const TimeSlots: React.FC<{
   children?: React.ReactNode;

--- a/packages/esm-patient-test-results-app/src/panel-timeline/timeline.component.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-timeline/timeline.component.tsx
@@ -86,6 +86,7 @@ const DataRows: React.FC<DataRowsProps> = ({ timeColumns, rowData, sortedTimes, 
               title,
               shadow: showShadow,
               testUuid,
+              isString: isNaN(parseFloat(obs?.[0]?.value)),
             }}
           />
           <GridItems {...{ sortedTimes, obs, zebra: !!(rowCount % 2) }} />

--- a/packages/esm-patient-test-results-app/src/panel-timeline/timeline.scss
+++ b/packages/esm-patient-test-results-app/src/panel-timeline/timeline.scss
@@ -117,7 +117,6 @@
 
 .trendline-link {
   @include type.type-style('body-compact-01');
-  color: $interactive-01;
   cursor: pointer;
 }
 

--- a/packages/esm-patient-test-results-app/src/panel-view/index.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-view/index.tsx
@@ -4,12 +4,14 @@ import usePanelData from './usePanelData';
 import { Column, DataTableSkeleton, Button } from '@carbon/react';
 import { Search as SearchIcon } from '@carbon/react/icons';
 import styles from './panel-view.scss';
-import { useLayoutType } from '@openmrs/esm-framework';
+import { navigate, useLayoutType } from '@openmrs/esm-framework';
 import PanelTimelineComponent from '../panel-timeline';
 import { ObsRecord } from './types';
 import { useTranslation } from 'react-i18next';
 import { EmptyState } from '@openmrs/esm-patient-common-lib';
 import Trendline from '../trendline/trendline.component';
+import Overlay from '../tablet-overlay/tablet-overlay.component';
+import { testResultsBasePath } from '../helpers';
 
 interface PanelViewProps {
   expanded: boolean;
@@ -34,31 +36,71 @@ const PanelView: React.FC<PanelViewProps> = ({ expanded, testUuid, basePath, typ
     }
   }, [panels, activePanel, layout]);
 
+  const navigateBackFromTrendlineView = useCallback(() => {
+    navigate({
+      to: testResultsBasePath(`/patient/${patientUuid}/chart`),
+    });
+  }, [patientUuid]);
+
+  if (isTablet) {
+    return (
+      <>
+        <div>
+          <PanelViewHeader isTablet={isTablet} />
+          {!isLoading ? (
+            panels.length > 0 ? (
+              panels.map((panel) => (
+                <LabSetPanel
+                  panel={panel}
+                  observations={[panel, ...panel.relatedObs]}
+                  setActivePanel={setActivePanel}
+                  activePanel={activePanel}
+                />
+              ))
+            ) : (
+              <EmptyState displayText={t('panels', 'panels')} headerTitle={t('noPanelsFound', 'No panels found')} />
+            )
+          ) : (
+            <DataTableSkeleton columns={3} />
+          )}
+        </div>
+        {activePanel ? (
+          <Overlay close={() => setActivePanel(null)} headerText={activePanel?.name}>
+            <PanelTimelineComponent groupedObservations={groupedObservations} activePanel={activePanel} />
+          </Overlay>
+        ) : null}
+        {trendlineView ? (
+          <Overlay close={navigateBackFromTrendlineView} headerText={activePanel?.name}>
+            <Trendline patientUuid={patientUuid} conceptUuid={testUuid} basePath={basePath} />
+          </Overlay>
+        ) : null}
+      </>
+    );
+  }
+
   return (
     <>
-      {!isTablet && (
-        <Column sm={16} lg={fullWidthPanels ? 12 : 5}>
-          <>
-            <PanelViewHeader isTablet={isTablet} />
-            {!isLoading ? (
-              panels.length > 0 ? (
-                panels.map((panel) => (
-                  <LabSetPanel
-                    panel={panel}
-                    observations={[panel, ...panel.relatedObs]}
-                    setActivePanel={setActivePanel}
-                    activePanel={activePanel}
-                  />
-                ))
-              ) : (
-                <EmptyState displayText={t('panels', 'panels')} headerTitle={t('noPanelsFound', 'No panels found')} />
-              )
+      <Column sm={16} lg={fullWidthPanels ? 12 : 5}>
+        <>
+          <PanelViewHeader isTablet={isTablet} />
+          {!isLoading ? (
+            panels.length > 0 ? (
+              panels.map((panel) => (
+                <LabSetPanel
+                  panel={panel}
+                  observations={[panel, ...panel.relatedObs]}
+                  setActivePanel={setActivePanel}
+                  activePanel={activePanel}
+                />
+              ))
             ) : (
-              <DataTableSkeleton columns={3} />
-            )}
-          </>
-        </Column>
-      )}
+              <EmptyState displayText={t('panels', 'panels')} headerTitle={t('noPanelsFound', 'No panels found')} />
+            )
+          ) : (
+            <DataTableSkeleton columns={3} />
+          )}
+        </>
+      </Column>
       <Column
         sm={16}
         lg={fullWidthPanels ? 0 : 7}

--- a/packages/esm-patient-test-results-app/src/panel-view/index.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-view/index.tsx
@@ -80,7 +80,7 @@ const PanelView: React.FC<PanelViewProps> = ({ expanded, testUuid, basePath, typ
 
   return (
     <>
-      <Column sm={16} lg={fullWidthPanels ? 12 : 5}>
+      <div className={styles.leftSection}>
         <>
           <PanelViewHeader isTablet={isTablet} />
           {!isLoading ? (
@@ -100,25 +100,23 @@ const PanelView: React.FC<PanelViewProps> = ({ expanded, testUuid, basePath, typ
             <DataTableSkeleton columns={3} />
           )}
         </>
-      </Column>
-      <Column
-        sm={16}
-        lg={fullWidthPanels ? 0 : 7}
-        className={isTablet ? styles.headerMarginTablet : styles.headerMargin}
-      >
-        {isLoading ? (
-          <DataTableSkeleton columns={3} />
-        ) : trendlineView ? (
-          <Trendline patientUuid={patientUuid} conceptUuid={testUuid} basePath={basePath} showBackToTimelineButton />
-        ) : activePanel ? (
-          <PanelTimelineComponent groupedObservations={groupedObservations} activePanel={activePanel} />
-        ) : (
-          <EmptyState
-            headerTitle={t('noPanelSelected', 'No panel selected')}
-            displayText={t('observations', 'Observations')}
-          />
-        )}
-      </Column>
+      </div>
+      <div className={`${styles.headerMargin} ${styles.rightSection}`}>
+        <div className={styles.stickySection}>
+          {isLoading ? (
+            <DataTableSkeleton columns={3} />
+          ) : trendlineView ? (
+            <Trendline patientUuid={patientUuid} conceptUuid={testUuid} basePath={basePath} showBackToTimelineButton />
+          ) : activePanel ? (
+            <PanelTimelineComponent groupedObservations={groupedObservations} activePanel={activePanel} />
+          ) : (
+            <EmptyState
+              headerTitle={t('noPanelSelected', 'No panel selected')}
+              displayText={t('observations', 'Observations')}
+            />
+          )}
+        </div>
+      </div>
     </>
   );
 };

--- a/packages/esm-patient-test-results-app/src/panel-view/panel-view.scss
+++ b/packages/esm-patient-test-results-app/src/panel-view/panel-view.scss
@@ -2,6 +2,7 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @import '~@openmrs/esm-styleguide/src/vars';
+@import '../results-viewer/results-viewer.styles.scss';
 
 .panelViewHeader {
   display: flex;
@@ -18,9 +19,9 @@
   @include type.type-style('heading-compact-02');
 }
 
-.headerMargin, .headerMarginTablet {
+.stickySection {
+  top: 9rem;
   position: sticky;
-  top: 3rem;
 }
 
 .headerMargin {

--- a/packages/esm-patient-test-results-app/src/panel-view/panel.component.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-view/panel.component.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { RowData } from '../filter/filter-types';
 import styles from './result-panel.scss';
 import {
   DataTable,
@@ -15,7 +14,7 @@ import {
 } from '@carbon/react';
 import { getClass } from './helper';
 import { ObsRecord } from './types';
-import { formatDate, isDesktop, useLayoutType, usePatient } from '@openmrs/esm-framework';
+import { formatDate, isDesktop, useLayoutType } from '@openmrs/esm-framework';
 
 interface LabSetPanelProps {
   panel: ObsRecord;
@@ -82,7 +81,7 @@ const LabSetPanel: React.FC<LabSetPanelProps> = ({ panel, observations, activePa
             id: test.id,
             testName: test.name,
             value: {
-              content: <span>{`${test.value} ${test.meta?.units}`}</span>,
+              content: <span>{`${test.value} ${test.meta?.units ?? ''}`}</span>,
             },
             interpretation: test.interpretation,
           })),

--- a/packages/esm-patient-test-results-app/src/panel-view/usePanelData.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-view/usePanelData.tsx
@@ -183,7 +183,7 @@ export default function usePanelData() {
 
   return {
     panels,
-    isLoading: isLoadingObservations || isLoadingConcepts,
+    isLoading: isLoadingObservations,
     groupedObservations,
     conceptData,
   };

--- a/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.styles.scss
+++ b/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.styles.scss
@@ -11,6 +11,12 @@
   background-color: $ui-01;
 }
 
+.resultsHeaderTablet {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .resultsHeader {
   padding: 0.5rem 0;
   z-index: 10;
@@ -74,5 +80,19 @@
     display: flex;
     justify-content: flex-end;
     align-items: center;
+  }
+}
+
+.floatingTreeButton {
+  position: fixed;
+  bottom: 5rem;
+  right: spacing.$spacing-05;
+  padding: spacing.$spacing-03;
+  border-radius: 50%;
+  z-index: 99;
+  background-color: $brand-01;
+
+  svg {
+    fill: $ui-01 !important;
   }
 }

--- a/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.styles.scss
+++ b/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.styles.scss
@@ -11,6 +11,11 @@
   background-color: $ui-01;
 }
 
+.flex {
+  display: flex;
+  flex: 1;
+}
+
 .resultsHeaderTablet {
   display: flex;
   justify-content: space-between;
@@ -23,15 +28,33 @@
   background-color: $openmrs-background-grey;
   position: sticky;
   top: 3rem;
+  display: flex;
+}
+
+.leftHeaderSection {
+  display: flex;
+  align-items: center;
 }
 
 .viewOptsContentSwitcherContainer {
   margin-left: auto;
 }
 
-.leftHeader {
+.leftSection {
+  width: 45%;
+  margin-right: spacing.$spacing-05;
+}
+
+.rightSection, .rightSectionHeader {
+  width: 55%;
+}
+
+.rightSectionHeader {
   display: flex;
-  align-items: center;
+} 
+
+.rightSection :global(.cds--skeleton) {
+  width: 100%;
 }
 
 .leftHeaderActions {
@@ -39,7 +62,8 @@
   min-width: 2.5rem;
 }
 
-.leftHeaderActions > :global(.cds--content-switcher) {
+.leftHeaderActions > :global(.cds--content-switcher), 
+.viewOptsContentSwitcherContainer :global(.cds--content-switcher) {
   display: grid;
   grid-template-columns: 1fr 1fr;
   width: max-content;

--- a/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.styles.scss
+++ b/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.styles.scss
@@ -87,10 +87,13 @@
   position: fixed;
   bottom: 5rem;
   right: spacing.$spacing-05;
-  padding: spacing.$spacing-03;
-  border-radius: 50%;
   z-index: 99;
-  background-color: $brand-01;
+
+  button {
+    background-color: $brand-01 !important;
+    padding: spacing.$spacing-05;
+    border-radius: 50%;
+  }
 
   svg {
     fill: $ui-01 !important;

--- a/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.tsx
+++ b/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AccordionSkeleton, Button, Column, ContentSwitcher, DataTableSkeleton, Grid, Switch } from '@carbon/react';
 import { TreeViewAlt } from '@carbon/react/icons';
@@ -53,66 +53,39 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
   const { t } = useTranslation();
   const tablet = useLayoutType() === 'tablet';
   const [view, setView] = useState<viewOpts>('split');
-  const [leftContent, setLeftContent] = useState<panelOpts>('tree');
   const [showTreeOverlay, setShowTreeOverlay] = useState<boolean>(false);
-  const { resetTree, timelineData, totalResultsCount } = useContext(FilterContext);
+  const [selectedSection, setSelectedSection] = useState<panelOpts>('tree');
+  const { totalResultsCount } = useContext(FilterContext);
   const expanded = view === 'full';
   const { type, testUuid } = useParams();
+  const trendlineView = testUuid && type === 'trendline';
 
-  return (
-    <>
-      <Grid className={styles.resultsContainer}>
-        <Column className={styles.resultsHeader} sm={12} lg={!tablet ? 5 : 12}>
+  const navigateBackFromTrendlineView = useCallback(() => {
+    navigate({
+      to: testResultsBasePath(`/patient/${patientUuid}/chart`),
+    });
+  }, [patientUuid]);
+
+  if (tablet) {
+    return (
+      <div className={styles.resultsContainer}>
+        <div className={styles.resultsHeader}>
           <div className={styles.leftHeader}>
             <h4 style={{ flexGrow: 1 }}>{`${t('results', 'Results')} ${
               totalResultsCount ? `(${totalResultsCount})` : ''
             }`}</h4>
             <div className={styles.leftHeaderActions}>
-              {tablet && (
-                <Button
-                  size={tablet ? 'md' : 'sm'}
-                  kind="ghost"
-                  renderIcon={(props) => <TreeViewAlt {...props} size={16} />}
-                  onClick={() => setShowTreeOverlay(true)}
-                  style={{
-                    marginRight: '1rem',
-                  }}
-                >
-                  {t('showTreeButtonText', 'Show tree')}
-                </Button>
-              )}
-              {!expanded && (
-                <ContentSwitcher
-                  size={tablet ? 'lg' : 'md'}
-                  selectedIndex={['panel', 'tree'].indexOf(leftContent)}
-                  onChange={(e) => setLeftContent(e.name as panelOpts)}
-                >
-                  <Switch name="panel" text={t('panel', 'Panel')} />
-                  <Switch name="tree" text={t('tree', 'Tree')} />
-                </ContentSwitcher>
-              )}
-            </div>
-          </div>
-        </Column>
-        {!tablet && (
-          <Column className={styles.resultsHeader} sm={12} lg={7}>
-            <div
-              className={styles.viewOptsContentSwitcherContainer}
-              style={{ display: 'flex', justifyContent: 'flex-end' }}
-            >
               <ContentSwitcher
-                size={tablet ? 'lg' : 'md'}
-                style={{ maxWidth: '10rem' }}
-                onChange={(e) => setView(e.name as viewOpts)}
-                selectedIndex={expanded ? 1 : 0}
+                selectedIndex={['panel', 'tree'].indexOf(selectedSection)}
+                onChange={(e) => setSelectedSection(e.name as panelOpts)}
               >
-                <Switch name="split" text={t('split', 'Split')} disabled={loading} />
-                <Switch name="full" text={t('full', 'Full')} disabled={loading} />
+                <Switch name="panel" text={t('panel', 'Panel')} />
+                <Switch name="tree" text={t('tree', 'Tree')} />
               </ContentSwitcher>
             </div>
-          </Column>
-        )}
-        {leftContent === 'tree' ? (
+          </div>
+        </div>
+        {selectedSection === 'tree' ? (
           <TreeViewWrapper
             patientUuid={patientUuid}
             basePath={basePath}
@@ -120,7 +93,7 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
             expanded={expanded}
             testUuid={testUuid}
           />
-        ) : (
+        ) : selectedSection === 'panel' ? (
           <PanelView
             expanded={expanded}
             patientUuid={patientUuid}
@@ -128,39 +101,69 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
             type={type}
             testUuid={testUuid}
           />
+        ) : null}
+        {trendlineView && (
+          <TabletOverlay
+            headerText={t('trendline', 'Trendline')}
+            close={navigateBackFromTrendlineView}
+            buttonsGroup={<></>}
+          >
+            <Trendline patientUuid={patientUuid} conceptUuid={testUuid} basePath={basePath} />
+          </TabletOverlay>
         )}
-      </Grid>
+      </div>
+    );
+  }
 
-      {tablet && showTreeOverlay && (
-        <TabletOverlay
-          headerText={t('tree', 'Tree')}
-          close={() => setShowTreeOverlay(false)}
-          buttonsGroup={
-            <>
-              <Button kind="secondary" size="lg" onClick={resetTree} disabled={loading}>
-                {t('resetTreeText', 'Reset tree')}
-              </Button>
-              <Button kind="primary" size="lg" onClick={() => setShowTreeOverlay(false)} disabled={loading}>
-                {`${t('view', 'View')} ${
-                  !loading && timelineData?.loaded ? timelineData?.data?.rowData?.length : ''
-                } ${t('resultsText', 'results')}`}
-              </Button>
-            </>
-          }
+  return (
+    <Grid className={styles.resultsContainer}>
+      <Column className={styles.resultsHeader} sm={12} lg={!tablet ? 5 : 12}>
+        <div className={styles.leftHeader}>
+          <h4 style={{ flexGrow: 1 }}>{`${t('results', 'Results')} ${
+            totalResultsCount ? `(${totalResultsCount})` : ''
+          }`}</h4>
+          <div className={styles.leftHeaderActions}>
+            {!expanded && (
+              <ContentSwitcher
+                size={tablet ? 'lg' : 'md'}
+                selectedIndex={['panel', 'tree'].indexOf(selectedSection)}
+                onChange={(e) => setSelectedSection(e.name as panelOpts)}
+              >
+                <Switch name="panel" text={t('panel', 'Panel')} />
+                <Switch name="tree" text={t('tree', 'Tree')} />
+              </ContentSwitcher>
+            )}
+          </div>
+        </div>
+      </Column>
+      <Column className={styles.resultsHeader} sm={12} lg={!tablet ? 7 : 0}>
+        <div
+          className={styles.viewOptsContentSwitcherContainer}
+          style={{ display: 'flex', justifyContent: 'flex-end' }}
         >
-          {!loading ? <FilterSet hideFilterSetHeader /> : <AccordionSkeleton open count={4} align="start" />}
-        </TabletOverlay>
-      )}
-      {tablet && testUuid && type === 'trendline' && (
-        <TabletOverlay
-          headerText={t('trendline', 'Trendline')}
-          close={() => navigate({ to: testResultsBasePath(basePath) })}
-          buttonsGroup={<></>}
-        >
-          <Trendline patientUuid={patientUuid} conceptUuid={testUuid} basePath={basePath} />
-        </TabletOverlay>
-      )}
-    </>
+          <ContentSwitcher
+            size={tablet ? 'lg' : 'md'}
+            style={{ maxWidth: '10rem' }}
+            onChange={(e) => setView(e.name as viewOpts)}
+            selectedIndex={expanded ? 1 : 0}
+          >
+            <Switch name="split" text={t('split', 'Split')} disabled={loading} />
+            <Switch name="full" text={t('full', 'Full')} disabled={loading} />
+          </ContentSwitcher>
+        </div>
+      </Column>
+      {selectedSection === 'tree' ? (
+        <TreeViewWrapper
+          patientUuid={patientUuid}
+          basePath={basePath}
+          type={type}
+          expanded={expanded}
+          testUuid={testUuid}
+        />
+      ) : selectedSection === 'panel' ? (
+        <PanelView expanded={expanded} patientUuid={patientUuid} basePath={basePath} type={type} testUuid={testUuid} />
+      ) : null}
+    </Grid>
   );
 };
 

--- a/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.tsx
+++ b/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.tsx
@@ -1,12 +1,11 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AccordionSkeleton, Button, Column, ContentSwitcher, DataTableSkeleton, Grid, Switch } from '@carbon/react';
-import { TreeViewAlt } from '@carbon/react/icons';
+import { ContentSwitcher, Switch } from '@carbon/react';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
-import { isDesktop, navigate, useConfig, useLayoutType } from '@openmrs/esm-framework';
+import { navigate, useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { testResultsBasePath } from '../helpers';
-import FilterSet, { FilterContext, FilterProvider } from '../filter';
-import GroupedTimeline, { useGetManyObstreeData } from '../grouped-timeline';
+import { FilterContext, FilterProvider } from '../filter';
+import { useGetManyObstreeData } from '../grouped-timeline';
 import TabletOverlay from '../tablet-overlay';
 import Trendline from '../trendline/trendline.component';
 import styles from './results-viewer.styles.scss';
@@ -70,19 +69,17 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
     return (
       <div className={styles.resultsContainer}>
         <div className={styles.resultsHeader}>
-          <div className={styles.leftHeader}>
-            <h4 style={{ flexGrow: 1 }}>{`${t('results', 'Results')} ${
-              totalResultsCount ? `(${totalResultsCount})` : ''
-            }`}</h4>
-            <div className={styles.leftHeaderActions}>
-              <ContentSwitcher
-                selectedIndex={['panel', 'tree'].indexOf(selectedSection)}
-                onChange={(e) => setSelectedSection(e.name as panelOpts)}
-              >
-                <Switch name="panel" text={t('panel', 'Panel')} />
-                <Switch name="tree" text={t('tree', 'Tree')} />
-              </ContentSwitcher>
-            </div>
+          <h4 style={{ flexGrow: 1 }}>{`${t('results', 'Results')} ${
+            totalResultsCount ? `(${totalResultsCount})` : ''
+          }`}</h4>
+          <div className={styles.leftHeaderActions}>
+            <ContentSwitcher
+              selectedIndex={['panel', 'tree'].indexOf(selectedSection)}
+              onChange={(e) => setSelectedSection(e.name as panelOpts)}
+            >
+              <Switch name="panel" text={t('panel', 'Panel')} />
+              <Switch name="tree" text={t('tree', 'Tree')} />
+            </ContentSwitcher>
           </div>
         </div>
         {selectedSection === 'tree' ? (
@@ -116,9 +113,9 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
   }
 
   return (
-    <Grid className={styles.resultsContainer}>
-      <Column className={styles.resultsHeader} sm={12} lg={!tablet ? 5 : 12}>
-        <div className={styles.leftHeader}>
+    <div className={styles.resultsContainer}>
+      <div className={styles.resultsHeader}>
+        <div className={`${styles.leftSection} ${styles.leftHeaderSection}`}>
           <h4 style={{ flexGrow: 1 }}>{`${t('results', 'Results')} ${
             totalResultsCount ? `(${totalResultsCount})` : ''
           }`}</h4>
@@ -135,35 +132,41 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
             )}
           </div>
         </div>
-      </Column>
-      <Column className={styles.resultsHeader} sm={12} lg={!tablet ? 7 : 0}>
-        <div
-          className={styles.viewOptsContentSwitcherContainer}
-          style={{ display: 'flex', justifyContent: 'flex-end' }}
-        >
-          <ContentSwitcher
-            size={tablet ? 'lg' : 'md'}
-            style={{ maxWidth: '10rem' }}
-            onChange={(e) => setView(e.name as viewOpts)}
-            selectedIndex={expanded ? 1 : 0}
-          >
-            <Switch name="split" text={t('split', 'Split')} disabled={loading} />
-            <Switch name="full" text={t('full', 'Full')} disabled={loading} />
-          </ContentSwitcher>
+        <div className={styles.rightSectionHeader}>
+          <div className={styles.viewOptsContentSwitcherContainer}>
+            <ContentSwitcher
+              size={tablet ? 'lg' : 'md'}
+              style={{ maxWidth: '10rem' }}
+              onChange={(e) => setView(e.name as viewOpts)}
+              selectedIndex={expanded ? 1 : 0}
+            >
+              <Switch name="split" text={t('split', 'Split')} disabled={loading} />
+              <Switch name="full" text={t('full', 'Full')} disabled={loading} />
+            </ContentSwitcher>
+          </div>
         </div>
-      </Column>
-      {selectedSection === 'tree' ? (
-        <TreeViewWrapper
-          patientUuid={patientUuid}
-          basePath={basePath}
-          type={type}
-          expanded={expanded}
-          testUuid={testUuid}
-        />
-      ) : selectedSection === 'panel' ? (
-        <PanelView expanded={expanded} patientUuid={patientUuid} basePath={basePath} type={type} testUuid={testUuid} />
-      ) : null}
-    </Grid>
+      </div>
+
+      <div className={styles.flex}>
+        {selectedSection === 'tree' ? (
+          <TreeViewWrapper
+            patientUuid={patientUuid}
+            basePath={basePath}
+            type={type}
+            expanded={expanded}
+            testUuid={testUuid}
+          />
+        ) : selectedSection === 'panel' ? (
+          <PanelView
+            expanded={expanded}
+            patientUuid={patientUuid}
+            basePath={basePath}
+            type={type}
+            testUuid={testUuid}
+          />
+        ) : null}
+      </div>
+    </div>
   );
 };
 

--- a/packages/esm-patient-test-results-app/src/tablet-overlay/tablet-overlay.scss
+++ b/packages/esm-patient-test-results-app/src/tablet-overlay/tablet-overlay.scss
@@ -43,6 +43,9 @@
   grid-template-columns: 1fr 1fr;
 }
 
-.buttonsGroup button {
-  max-width: unset;
+.buttonsGroup {
+  button{
+    max-width: unset;
+    width: 100%;
+  }
 }

--- a/packages/esm-patient-test-results-app/src/tree-view/tree-view.component.tsx
+++ b/packages/esm-patient-test-results-app/src/tree-view/tree-view.component.tsx
@@ -30,7 +30,12 @@ const TreeView: React.FC<TreeViewProps> = ({ patientUuid, basePath, testUuid, lo
       <>
         <div>{!loading ? <GroupedTimeline /> : <DataTableSkeleton />}</div>
         <div className={styles.floatingTreeButton}>
-          <Button kind="ghost" renderIcon={TreeViewAlt} hasIconOnly onClick={() => setShowTreeOverlay(true)} />
+          <Button
+            renderIcon={TreeViewAlt}
+            hasIconOnly
+            onClick={() => setShowTreeOverlay(true)}
+            iconDescription={t('showTree', 'Show tree')}
+          />
         </div>
         {showTreeOverlay && (
           <TabletOverlay

--- a/packages/esm-patient-test-results-app/src/tree-view/tree-view.component.tsx
+++ b/packages/esm-patient-test-results-app/src/tree-view/tree-view.component.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
-import { AccordionSkeleton, Column, DataTableSkeleton, Grid } from '@carbon/react';
+import React, { useContext, useState } from 'react';
+import { AccordionSkeleton, Column, DataTableSkeleton, Button } from '@carbon/react';
+import { TreeViewAlt } from '@carbon/react/icons';
 import { useLayoutType } from '@openmrs/esm-framework';
-import FilterSet from '../filter';
+import FilterSet, { FilterContext } from '../filter';
 import GroupedTimeline from '../grouped-timeline';
 import Trendline from '../trendline/trendline.component';
 import styles from '../results-viewer/results-viewer.styles.scss';
+import { useTranslation } from 'react-i18next';
+import TabletOverlay from '../tablet-overlay';
 
 interface TreeViewProps {
   patientUuid: string;
@@ -17,6 +20,42 @@ interface TreeViewProps {
 
 const TreeView: React.FC<TreeViewProps> = ({ patientUuid, basePath, testUuid, loading, expanded, type }) => {
   const tablet = useLayoutType() === 'tablet';
+  const [showTreeOverlay, setShowTreeOverlay] = useState(false);
+  const { t } = useTranslation();
+
+  const { timelineData, resetTree } = useContext(FilterContext);
+
+  if (tablet) {
+    return (
+      <>
+        <div>{!loading ? <GroupedTimeline /> : <DataTableSkeleton />}</div>
+        <div className={styles.floatingTreeButton}>
+          <Button kind="ghost" renderIcon={TreeViewAlt} hasIconOnly onClick={() => setShowTreeOverlay(true)} />
+        </div>
+        {showTreeOverlay && (
+          <TabletOverlay
+            headerText={t('tree', 'Tree')}
+            close={() => setShowTreeOverlay(false)}
+            buttonsGroup={
+              <>
+                <Button kind="secondary" size="xl" onClick={resetTree} disabled={loading}>
+                  {t('resetTreeText', 'Reset tree')}
+                </Button>
+                <Button kind="primary" size="xl" onClick={() => setShowTreeOverlay(false)} disabled={loading}>
+                  {`${t('view', 'View')} ${
+                    !loading && timelineData?.loaded ? timelineData?.data?.rowData?.length : ''
+                  } ${t('resultsText', 'results')}`}
+                </Button>
+              </>
+            }
+          >
+            {!loading ? <FilterSet hideFilterSetHeader /> : <AccordionSkeleton open count={4} align="start" />}
+          </TabletOverlay>
+        )}
+      </>
+    );
+  }
+
   return (
     <>
       {!tablet && (

--- a/packages/esm-patient-test-results-app/src/tree-view/tree-view.component.tsx
+++ b/packages/esm-patient-test-results-app/src/tree-view/tree-view.component.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { AccordionSkeleton, Column, DataTableSkeleton, Button } from '@carbon/react';
+import { AccordionSkeleton, DataTableSkeleton, Button } from '@carbon/react';
 import { TreeViewAlt } from '@carbon/react/icons';
 import { useLayoutType } from '@openmrs/esm-framework';
 import FilterSet, { FilterContext } from '../filter';
@@ -64,11 +64,11 @@ const TreeView: React.FC<TreeViewProps> = ({ patientUuid, basePath, testUuid, lo
   return (
     <>
       {!tablet && (
-        <Column sm={16} lg={tablet || expanded ? 0 : 5} className={`${styles.columnPanel} ${styles.treeColumn}`}>
+        <div className={styles.leftSection}>
           {!loading ? <FilterSet /> : <AccordionSkeleton open count={4} align="start" />}
-        </Column>
+        </div>
       )}
-      <Column sm={16} lg={tablet || expanded ? 12 : 7} className={`${styles.columnPanel}`}>
+      <div className={`${styles.rightSection}`}>
         {!tablet && testUuid && type === 'trendline' ? (
           <Trendline patientUuid={patientUuid} conceptUuid={testUuid} basePath={basePath} showBackToTimelineButton />
         ) : !loading ? (
@@ -76,7 +76,7 @@ const TreeView: React.FC<TreeViewProps> = ({ patientUuid, basePath, testUuid, lo
         ) : (
           <DataTableSkeleton />
         )}
-      </Column>
+      </div>
     </>
   );
 };

--- a/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
+++ b/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
@@ -132,7 +132,7 @@ const Trendline: React.FC<TrendlineProps> = ({
 
     data.push({
       date: new Date(Date.parse(obs.obsDatetime)),
-      value: obs.value,
+      value: parseFloat(obs.value),
       group: chartTitle,
       ...range,
     });
@@ -142,7 +142,7 @@ const Trendline: React.FC<TrendlineProps> = ({
       date: formatDate(parseDate(obs.obsDatetime)),
       time: formatTime(parseDate(obs.obsDatetime)),
       value: {
-        value: obs.value,
+        value: parseFloat(obs.value),
         interpretation: obs.interpretation,
       },
     });

--- a/packages/esm-patient-test-results-app/translations/en.json
+++ b/packages/esm-patient-test-results-app/translations/en.json
@@ -13,6 +13,7 @@
   "resultsText": "results",
   "returnToTimeline": "Return to timeline",
   "seeAllResults": "See all results",
+  "showTree": "Show tree",
   "testName": "Test name",
   "testResults": "test results",
   "timeline": "Timeline",

--- a/packages/esm-patient-test-results-app/translations/en.json
+++ b/packages/esm-patient-test-results-app/translations/en.json
@@ -8,13 +8,16 @@
   "recentResults": "Recent Results",
   "recentTestResults": "recent test results",
   "referenceRange": "Reference range",
+  "resetTreeText": "Reset tree",
   "resulted": "Resulted",
+  "resultsText": "results",
   "returnToTimeline": "Return to timeline",
   "seeAllResults": "See all results",
   "testName": "Test name",
   "testResults": "test results",
   "timeline": "Timeline",
   "timeOfTest": "Time of Test",
+  "tree": "Tree",
   "trend": "Trend",
   "trendlineRangeSelector1Day": "1 day",
   "trendlineRangeSelector1Month": "1 month",
@@ -23,5 +26,6 @@
   "trendlineRangeSelector5Years": "5 years",
   "trendlineRangeSelectorAll": "All",
   "trendlineRangeSelectorMonths": "6 months",
-  "value": "Value"
+  "value": "Value",
+  "view": "View"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR introduces the following UI fixes for the test results viewer in small desktop and tablet views.

1. Fixing the UI for tablet view
2. Fixing the UI when screen size transitions from small desktop to tablet view
3. Hiding Trendline view for data which is not numeric
4. Sticking the panel's timeline at top on scrolling

## Screenshots

https://user-images.githubusercontent.com/51502471/205620443-952517eb-866c-403d-9a28-4a506f722267.mov

## Related Issue
<!-- https://issues.openmrs.org/browse/O3-1634

## Other
<!-- Anything not covered above -->
