### PR TITLE
03-1627: Attachements upload modal should be able to close

### DIFF
--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader.component.tsx
@@ -107,7 +107,7 @@ const CameraMediaUploaderModal: React.FC<CameraMediaUploaderModalProps> = ({
 const CameraMediaUploadTabs = () => {
   const { t } = useTranslation();
   const [view, setView] = useState('upload');
-  const { cameraOnly } = useContext(CameraMediaUploaderContext);
+  const { cameraOnly, closeModal } = useContext(CameraMediaUploaderContext);
   const mediaStream = useRef<MediaStream | undefined>();
 
   const stopCameraStream = useCallback(() => {
@@ -126,7 +126,7 @@ const CameraMediaUploadTabs = () => {
 
   return (
     <div className={styles.cameraSection}>
-      <ModalHeader>{t('addAttachment', 'Add Attachment')}</ModalHeader>
+      <ModalHeader closeModal={closeModal} title={t('addAttachment', 'Add Attachment')} />
       <ModalBody className={styles.modalBody}>
         <Tabs className={styles.tabs}>
           <TabList aria-label="Attachments-upload-section">

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
@@ -12,7 +12,8 @@ export interface FileReviewContainerProps {
 }
 
 const FileReviewContainer: React.FC<FileReviewContainerProps> = ({ onCompletion }) => {
-  const { filesToUpload, clearData, setFilesToUpload, collectDescription } = useContext(CameraMediaUploaderContext);
+  const { filesToUpload, clearData, setFilesToUpload, closeModal, collectDescription } =
+    useContext(CameraMediaUploaderContext);
   const { t } = useTranslation();
   const [currentFile, setCurrentFile] = useState(1);
 
@@ -36,7 +37,7 @@ const FileReviewContainer: React.FC<FileReviewContainerProps> = ({ onCompletion 
 
   return (
     <div className={styles.filePreviewContainer}>
-      <ModalHeader className={styles.productiveHeading03}>
+      <ModalHeader closeModal={closeModal} className={styles.productiveHeading03}>
         {t('addAttachment', 'Add Attachment')}{' '}
         {filesToUpload.length > 1 && `(${currentFile} of ${filesToUpload.length})`}
       </ModalHeader>

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/uploading-status.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/uploading-status.component.tsx
@@ -60,7 +60,7 @@ const UploadingStatusComponent: React.FC<UploadingStatusComponentProps> = () => 
 
   return (
     <div className={styles.cameraSection}>
-      <ModalHeader className={styles.productiveHeading03}>{t('addAttachment', 'Add Attachment')}</ModalHeader>
+      <ModalHeader closeModal={closeModal} className={styles.productiveHeading03} title={t('addAttachment', 'Add Attachment')} />
       <ModalBody>
         <p className="cds--label-description">
           {t(


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The close button on the attachment modal isn't working 
## Screenshots
<!-- Required if you are making UI changes. -->
[attachment.webm](https://user-images.githubusercontent.com/38831673/206453331-7e9c2570-fade-494b-9b89-c2e5f0bb6906.webm)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-1627

## Other
<!-- Anything not covered above -->
