### PR TITLE
O3-1594: Closing patient chart always returns to home page (part)

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -126,13 +126,12 @@ const VisitHeader: React.FC = () => {
 
   const noActiveVisit = !isLoading && visitNotLoaded;
 
-  const originPage = localStorage.getItem('fromPage');
-
   const onClosePatientChart = useCallback(() => {
-    originPage ? navigate({ to: `${window.spaBase}/${originPage}` }) : navigate({ to: `${window.spaBase}/home` });
+    const originPage = window.localStorage.getItem('patient-chart-origin-page');
+    originPage ? navigate({ to: `${window.spaBase}${originPage}` }) : navigate({ to: `${window.spaBase}/home` });
     setShowVisitHeader((prevState) => !prevState);
     localStorage.removeItem('fromPage');
-  }, [originPage]);
+  }, [navigate]);
 
   const render = useCallback(() => {
     if (!showVisitHeader) {

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -131,7 +131,7 @@ const VisitHeader: React.FC = () => {
     originPage ? navigate({ to: `${window.spaBase}${originPage}` }) : navigate({ to: `${window.spaBase}/home` });
     setShowVisitHeader((prevState) => !prevState);
     localStorage.removeItem('fromPage');
-  }, [navigate]);
+  }, []);
 
   const render = useCallback(() => {
     if (!showVisitHeader) {


### PR DESCRIPTION
P.S. This ticket was assigned to @SharleenAwinja and she has done the work. I did help with distributing the work into different repositories, and hence this ticket is assigned to @SharleenAwinja and hence she is the rightful owner.

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR adds the event listener to record the origin page for the patient-chart, so whenever we exit from the patient chart, we should be directed back to the origin page from where we jumped into the patient chart.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-1594

## Other
Dependent on https://github.com/openmrs/openmrs-esm-core/pull/579
