### PR TITLE
03-1627: Delete attachments component close button should be functional

### DIFF
--- a/packages/esm-patient-attachments-app/src/attachments/delete-attachment-confirmation-modal.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/delete-attachment-confirmation-modal.component.tsx
@@ -19,7 +19,7 @@ const DeleteAttachmentConfirmation: React.FC<DeleteAttachmentConfirmationProps> 
 
   return (
     <>
-      <ModalHeader className={styles.productiveHeading03}>
+      <ModalHeader closeModal={close} className={styles.productiveHeading03}>
         {t('delete', 'Delete')} {attachment.bytesContentFamily.toLowerCase()} ?
       </ModalHeader>
       <ModalBody>

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
@@ -12,8 +12,7 @@ export interface FileReviewContainerProps {
 }
 
 const FileReviewContainer: React.FC<FileReviewContainerProps> = ({ onCompletion }) => {
-  const { filesToUpload, clearData, setFilesToUpload, closeModal, collectDescription } =
-    useContext(CameraMediaUploaderContext);
+  const { filesToUpload, clearData, setFilesToUpload, closeModal, collectDescription } = useContext(CameraMediaUploaderContext);
   const { t } = useTranslation();
   const [currentFile, setCurrentFile] = useState(1);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The close button on the delete attachment confirmation modal isn't working

## Screenshots
<!-- Required if you are making UI changes. -->
[deletemodal.webm](https://user-images.githubusercontent.com/38831673/206922439-1f6b7fe5-1a59-460a-bcf8-e071b4fe61c2.webm)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1627

## Other
<!-- Anything not covered above -->
