### PR TITLE
feat:(form-entry-app) Use conceptreferences endpoint (O3-1658)

### DIFF
--- a/packages/esm-form-entry-app/package.json
+++ b/packages/esm-form-entry-app/package.json
@@ -9,12 +9,12 @@
   "scripts": {
     "start": "openmrs develop",
     "serve": "ng serve --port 4200 --live-reload true",
-    "debug": "npm run serve",
+    "debug": "yarn run serve",
     "build": "ng build --configuration production",
     "lint": "eslint src --ext ts --fix --max-warnings=0"
   },
   "openmrs:develop": {
-    "command": "npm run serve",
+    "command": "yarn run serve",
     "url": "http://localhost:4200/openmrs-esm-form-entry-app.js"
   },
   "browserslist": [

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -92,7 +92,7 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
           this.form = form;
           this.labelMap = concepts.reduce((acc, current) => {
             if (Boolean(current)) {
-              acc[current.uuid] = current.display;
+              acc[current.identifier] = current.display;
             }
 
             return acc;

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -79,18 +79,22 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
         take(1),
         map((createFormParams) => from(this.formCreationService.initAndCreateForm(createFormParams))),
         concatAll(),
-        mergeMap((form) => {
+        mergeMap(async (form) => {
           const unlabeledConcepts = FormSchemaService.getUnlabeledConceptIdentifiersFromSchema(form.schema);
-          return this.conceptService
-            .searchBulkConceptsByUUID(unlabeledConcepts, this.language)
-            .pipe(map((concepts) => ({ form, concepts })));
+          return {
+            form,
+            concepts: await this.conceptService.searchConceptsByIdentifiers(unlabeledConcepts).toPromise(),
+          };
         }),
       )
       .subscribe(
         ({ form, concepts }) => {
           this.form = form;
           this.labelMap = concepts.reduce((acc, current) => {
-            acc[current.uuid] = current.display;
+            if (Boolean(current)) {
+              acc[current.uuid] = current.display;
+            }
+
             return acc;
           }, {});
           this.changeState('ready');

--- a/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts
@@ -187,6 +187,10 @@ export class FormSchemaService {
           results.add(question.concept);
         }
 
+        if (!question.label && typeof question.questionOptions?.concept === 'string') {
+          results.add(question.questionOptions.concept);
+        }
+
         for (const answer of question.questionOptions?.answers ?? []) {
           if (!answer.label && typeof answer.concept === 'string') {
             results.add(answer.concept);

--- a/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts
@@ -183,16 +183,12 @@ export class FormSchemaService {
     const results = new Set<string>();
     const walkQuestions = (questions: Array<Questions>) => {
       for (const question of questions) {
-        if (typeof question.concept === 'string') {
+        if (!question.label && typeof question.concept === 'string') {
           results.add(question.concept);
         }
 
-        if (typeof question.questionOptions?.concept === 'string') {
-          results.add(question.questionOptions.concept);
-        }
-
         for (const answer of question.questionOptions?.answers ?? []) {
-          if (typeof answer.concept === 'string') {
+          if (!answer.label && typeof answer.concept === 'string') {
             results.add(answer.concept);
           }
         }

--- a/packages/esm-form-entry-app/src/app/offline/caching.ts
+++ b/packages/esm-form-entry-app/src/app/offline/caching.ts
@@ -89,10 +89,9 @@ async function getCacheableFormUrls(formUuid: string) {
     [],
   ) as FormSchema;
 
-  const conceptLang = (window as any).i18next?.language?.substring(0, 2).toLowerCase() || 'en';
   const requiredConceptIdentifiers = FormSchemaService.getUnlabeledConceptIdentifiersFromSchema(formSchema);
-  const conceptUrls = ConceptService.getRelativeConceptLabelUrls(requiredConceptIdentifiers, conceptLang).map(
-    (relativeUrl) => `/ws/rest/v1/concept${relativeUrl}`,
+  const conceptUrls = ConceptService.getConceptReferenceUrls(requiredConceptIdentifiers).map(
+    (relativeUrl) => `/ws/rest/v1/${relativeUrl}`,
   );
 
   return [

--- a/packages/esm-form-entry-app/src/app/services/concept.service.ts
+++ b/packages/esm-form-entry-app/src/app/services/concept.service.ts
@@ -1,10 +1,13 @@
-import { forkJoin, Observable } from 'rxjs';
+import { of } from 'rxjs';
+import { concatAll, map } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { WindowRef } from '../window-ref';
-import { ListResult } from '../types';
-import { map } from 'rxjs/operators';
+
+interface ConceptReferencesResult {
+  [key: string]: ConceptMetadata;
+}
 
 interface ConceptMetadata {
   uuid: string;
@@ -19,50 +22,39 @@ export class ConceptService {
 
   constructor(private http: HttpClient, private windowRef: WindowRef) {}
 
-  public getUrl(): string {
-    return this.windowRef.openmrsRestBase + 'concept';
-  }
-
-  public searchConceptByUUID(conceptUUID: string, lang: string): Observable<any> {
-    return this.http.get(this.getUrl() + `/${conceptUUID}?v=full&lang=${lang}`, {
-      headers: this.headers,
-    });
-  }
-
-  public searchBulkConceptsByUUID(conceptUuids: Array<string>, lang: string): Observable<Array<ConceptMetadata>> {
-    const observablesArray = [];
-    const relativeConceptLabelUrls = ConceptService.getRelativeConceptLabelUrls(conceptUuids, lang);
-
-    for (const relativeConceptLabelUrl of relativeConceptLabelUrls) {
-      observablesArray.push(
+  public searchConceptsByIdentifiers(conceptIdentifiers: Array<string>) {
+    return of(...ConceptService.getConceptReferenceUrls(conceptIdentifiers)).pipe(
+      map((referenceUrl) =>
         this.http
-          .get<ListResult<ConceptMetadata>>(this.windowRef.openmrsRestBase + relativeConceptLabelUrl, {
+          .get<ConceptReferencesResult>(this.windowRef.openmrsRestBase + referenceUrl + '?v=custom:(uuid,display)', {
             headers: this.headers,
           })
           .pipe(
-            map((r) => {
-              return r.results;
-            }),
-          ),
-      );
-    }
+            map((result) =>
+              Object.entries(result).reduce((acc, reference) => {
+                acc.push({
+                  uuid: reference[0],
+                  display: reference[1].display,
+                });
 
-    return forkJoin(observablesArray).pipe(
-      map((response) => {
-        return response.flat() as Array<ConceptMetadata>;
-      }),
+                return acc;
+              }, [] as ConceptMetadata[]),
+            ),
+          ),
+      ),
+      concatAll(),
     );
   }
 
   /**
-   * Partitions the given concept UUIDs into relative URLs pointing to the concept
+   * Partitions the given concept identifiers into relative URLs pointing to the concept
    * bulk fetching endpoint.
-   * @param conceptUuids The concept UUIDs to be partitioned into bulk fetching URLs.
+   * @param conceptIdentifiers The concept identifiers to be chunked
    */
-  public static getRelativeConceptLabelUrls(conceptUuids: Array<string>, lang: string) {
+  public static getConceptReferenceUrls(conceptIdentifiers: Array<string>) {
     const chunkSize = 100;
-    return [...new Set(conceptUuids)]
+    return [...new Set(conceptIdentifiers)]
       .reduceRight((acc, _, __, array) => [...acc, array.splice(0, chunkSize)], [])
-      .map((uuidPartition) => `concept?references=${uuidPartition.join(',')}`);
+      .map((partition) => `conceptreferences?references=${partition.join(',')}`);
   }
 }

--- a/packages/esm-form-entry-app/src/app/services/concept.service.ts
+++ b/packages/esm-form-entry-app/src/app/services/concept.service.ts
@@ -10,7 +10,7 @@ interface ConceptReferencesResult {
 }
 
 interface ConceptMetadata {
-  uuid: string;
+  identifier: string;
   display: string;
 }
 
@@ -26,19 +26,19 @@ export class ConceptService {
     return of(...ConceptService.getConceptReferenceUrls(conceptIdentifiers)).pipe(
       map((referenceUrl) =>
         this.http
-          .get<ConceptReferencesResult>(this.windowRef.openmrsRestBase + referenceUrl + '?v=custom:(uuid,display)', {
+          .get<ConceptReferencesResult>(this.windowRef.openmrsRestBase + referenceUrl, {
             headers: this.headers,
           })
           .pipe(
             map((result) =>
               Object.entries(result).reduce((acc, reference) => {
                 acc.push({
-                  uuid: reference[0],
+                  identifier: reference[0],
                   display: reference[1].display,
                 });
 
                 return acc;
-              }, [] as ConceptMetadata[]),
+              }, [] as Array<ConceptMetadata>),
             ),
           ),
       ),
@@ -55,6 +55,6 @@ export class ConceptService {
     const chunkSize = 100;
     return [...new Set(conceptIdentifiers)]
       .reduceRight((acc, _, __, array) => [...acc, array.splice(0, chunkSize)], [])
-      .map((partition) => `conceptreferences?references=${partition.join(',')}`);
+      .map((partition) => `conceptreferences?references=${partition.join(',')}&v=custom:(uuid,display)`);
   }
 }

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
@@ -12,7 +12,8 @@ export interface FileReviewContainerProps {
 }
 
 const FileReviewContainer: React.FC<FileReviewContainerProps> = ({ onCompletion }) => {
-  const { filesToUpload, clearData, setFilesToUpload, closeModal, collectDescription } = useContext(CameraMediaUploaderContext);
+  const { filesToUpload, clearData, setFilesToUpload, closeModal, collectDescription } =
+    useContext(CameraMediaUploaderContext);
   const { t } = useTranslation();
   const [currentFile, setCurrentFile] = useState(1);
 

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/uploading-status.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/uploading-status.component.tsx
@@ -60,7 +60,11 @@ const UploadingStatusComponent: React.FC<UploadingStatusComponentProps> = () => 
 
   return (
     <div className={styles.cameraSection}>
-      <ModalHeader closeModal={closeModal} className={styles.productiveHeading03} title={t('addAttachment', 'Add Attachment')} />
+      <ModalHeader
+        closeModal={closeModal}
+        className={styles.productiveHeading03}
+        title={t('addAttachment', 'Add Attachment')}
+      />
       <ModalBody>
         <p className="cds--label-description">
           {t(


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Uses the new conceptreferences endpoint (from [REST-894](https://github.com/openmrs/openmrs-module-webservices.rest/commit/2227f456686b8acf5005cad952bb5e0a8cae9f74)) instead of using the `concept?references=`. This allows fewer calls to the backend that are more directed and should allow us to "properly" use ConceptMaps to refer to concepts in forms.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1658

## Other
<!-- Anything not covered above -->
