### PR TITLE
O3-1670: Show strength and dosage form for order basket search results 

### DIFF
--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
@@ -77,7 +77,6 @@ export default function OrderBasketSearchResults({
           </div>
           {currentSearchResultPage.map((result, index) => (
             <ClickableTile
-              light={isTablet}
               role="listitem"
               key={index}
               className={isTablet ? `${styles.tabletSearchResultTile}` : `${styles.desktopSearchResultTile}`}
@@ -86,14 +85,11 @@ export default function OrderBasketSearchResults({
               <div className={styles.searchResultTile}>
                 <div className={styles.searchResultTileContent}>
                   <p>
-                    <span>
-                      <strong>{result.drug?.concept?.display}</strong> &mdash; {result?.drug?.strength} &mdash;{' '}
-                      {result?.drug?.dosageForm?.display}
-                    </span>
+                    {/* prettier-ignore */}
+                    <strong>{result.drug?.concept?.display}</strong> &mdash; {result?.drug?.strength} &mdash;{' '}
+                    {result?.drug?.dosageForm?.display}
                     {result.template && (
                       <>
-                        &mdash; {result.dosage?.value} {result.unit?.value} &mdash; {result.drug.dosageForm.display}
-                        <br />
                         <span className={styles.label01}>{result.frequency?.value}</span> &mdash;{' '}
                         <span className={styles.label01}>{result.route?.value}</span>
                       </>

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
@@ -85,7 +85,6 @@ export default function OrderBasketSearchResults({
               <div className={styles.searchResultTile}>
                 <div className={styles.searchResultTileContent}>
                   <p>
-                    {/* prettier-ignore */}
                     <strong>{result.drug?.concept?.display}</strong> &mdash; {result?.drug?.strength} &mdash;{' '}
                     {result?.drug?.dosageForm?.display}
                     {result.template && (

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Link, Pagination, ClickableTile, Tile, SkeletonText, SkeletonIcon } from '@carbon/react';
+import { Button, Pagination, ClickableTile, Tile, SkeletonText, SkeletonIcon } from '@carbon/react';
 import { ShoppingCart } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
 import { createErrorHandler, useConfig, useLayoutType } from '@openmrs/esm-framework';
@@ -71,7 +71,9 @@ export default function OrderBasketSearchResults({
                 searchTerm,
               })}
             </span>
-            <Link onClick={() => setSearchTerm('')}>{t('clearSearchResults', 'Clear Results')}</Link>
+            <Button kind="ghost" onClick={() => setSearchTerm('')} size={isTablet ? 'md' : 'sm'}>
+              {t('clearSearchResults', 'Clear Results')}
+            </Button>
           </div>
           {currentSearchResultPage.map((result, index) => (
             <ClickableTile
@@ -84,7 +86,10 @@ export default function OrderBasketSearchResults({
               <div className={styles.searchResultTile}>
                 <div className={styles.searchResultTileContent}>
                   <p>
-                    <strong>{result.template ? result.drug.concept.display : result.drug.name}</strong>{' '}
+                    <span>
+                      <strong>{result.drug?.concept?.display}</strong> &mdash; {result?.drug?.strength} &mdash;{' '}
+                      {result?.drug?.dosageForm?.display}
+                    </span>
                     {result.template && (
                       <>
                         &mdash; {result.dosage?.value} {result.unit?.value} &mdash; {result.drug.dosageForm.display}

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.scss
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.scss
@@ -3,7 +3,7 @@
 @import "../root";
 
 .container {
-  margin: 1rem 1rem 0.5rem;
+  margin: spacing.$spacing-03 1rem spacing.$spacing-03;
 }
 
 .desktopSearchResultTile {
@@ -11,7 +11,7 @@
   border-left: 4px solid var(--brand-03);
 
   &:not(:last-of-type) {
-    margin-bottom: 0.5rem;
+    margin-bottom: spacing.$spacing-03;
   }
 }
 
@@ -31,11 +31,11 @@
 }
 
 .desktopDivider {
-  margin: 3rem auto;
+  margin: spacing.$spacing-07 auto spacing.$spacing-05;
 }
 
 .tabletDivider {
-  margin: 2.5rem auto;
+  margin: spacing.$spacing-08 auto spacing.$spacing-06;
 }
 
 .searchResultsCount {
@@ -46,7 +46,8 @@
 .orderBasketSearchResultsHeader {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 0.875rem;
+  margin-bottom: spacing.$spacing-03;
+  align-items: center;
 }
 
 .searchResultTile {

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.test.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.test.tsx
@@ -45,7 +45,6 @@ describe('OrderBasketSearchResults', () => {
     // Anotates results with dosing info if an order-template was found.
     expect(getByTextWithMarkup(/Aspirin — 81mg — Tablet\s*Once daily — Oral/i)).toBeInTheDocument();
     // Only displays drug name for results without a matching order template
-    // expect(getByTextWithMarkup(/Aspirin\s*-\s*125mg\s*-\s*Tablet/i)).toBeInTheDocument();
     expect(getByTextWithMarkup(/Aspirin — 125mg — Tablet/i)).toBeInTheDocument();
     expect(getByTextWithMarkup(/Aspirin — 243mg — Tablet/i)).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: /Immediately add to basket/i }).length).toEqual(3);

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.test.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.test.tsx
@@ -45,8 +45,9 @@ describe('OrderBasketSearchResults', () => {
     // Anotates results with dosing info if an order-template was found.
     expect(getByTextWithMarkup(/Aspirin — 81mg — Tablet\s*Once daily — Oral/i)).toBeInTheDocument();
     // Only displays drug name for results without a matching order template
-    expect(getByTextWithMarkup(/Aspirin - 125mg - Tablet/i)).toBeInTheDocument();
-    expect(getByTextWithMarkup(/Aspirin - 243mg - Tablet/i)).toBeInTheDocument();
+    // expect(getByTextWithMarkup(/Aspirin\s*-\s*125mg\s*-\s*Tablet/i)).toBeInTheDocument();
+    expect(getByTextWithMarkup(/Aspirin — 125mg — Tablet/i)).toBeInTheDocument();
+    expect(getByTextWithMarkup(/Aspirin — 243mg — Tablet/i)).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: /Immediately add to basket/i }).length).toEqual(3);
 
     await waitFor(() => user.click(screen.getAllByRole('listitem')[0]));

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.test.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.test.tsx
@@ -43,10 +43,10 @@ describe('OrderBasketSearchResults', () => {
     await screen.findAllByRole('listitem');
     expect(screen.getAllByRole('listitem').length).toEqual(3);
     // Anotates results with dosing info if an order-template was found.
-    expect(getByTextWithMarkup(/Aspirin — 81 mg — Tablet\s*Once daily — Oral/i)).toBeInTheDocument();
+    expect(getByTextWithMarkup(/Aspirin — 81mg — Tablet\s*Once daily — Oral/i)).toBeInTheDocument();
     // Only displays drug name for results without a matching order template
-    expect(getByTextWithMarkup(/Aspirin 125mg/i)).toBeInTheDocument();
-    expect(getByTextWithMarkup(/Aspirin 243mg/i)).toBeInTheDocument();
+    expect(getByTextWithMarkup(/Aspirin - 125mg - Tablet/i)).toBeInTheDocument();
+    expect(getByTextWithMarkup(/Aspirin - 243mg - Tablet/i)).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: /Immediately add to basket/i }).length).toEqual(3);
 
     await waitFor(() => user.click(screen.getAllByRole('listitem')[0]));


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR adds the drug strength and dosage form to the drug results in the order basket.

## Screenshots
![image](https://user-images.githubusercontent.com/51502471/207542238-f067ff04-3b29-41f9-9c3c-483e3f69506e.png)

## Related Issue
https://issues.openmrs.org/browse/O3-1670

## Other
<!-- Anything not covered above -->
