### PR TITLE
O3-1328: (fix) Configure default view for the obs-by-encounter widget

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/config-schema.ts
+++ b/packages/esm-generic-patient-widgets-app/src/config-schema.ts
@@ -64,7 +64,7 @@ export const configSchema = {
   showGraphByDefault: {
     _type: Type.Boolean,
     _description: 'Displayed graph by default',
-    _default: true,
+    _default: false,
   },
   encounterTypes: {
     _type: Type.Array,

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
@@ -60,7 +60,11 @@ const ObsSwitchable: React.FC<ObsSwitchableProps> = ({ patientUuid }) => {
                   </div>
                 ) : null}
               </CardHeader>
-              {chartView ? <ObsGraph patientUuid={patientUuid} /> : <ObsTable patientUuid={patientUuid} />}
+              {chartView && hasNumberType ? (
+                <ObsGraph patientUuid={patientUuid} />
+              ) : (
+                <ObsTable patientUuid={patientUuid} />
+              )}
             </div>
           );
         }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
There was a problem with the patients' widgets configuration, by default _**showGraphByDefault**_ was true.
This brought the problem when no configuration was provided and there was no numeric data, the graph view was displayed (unwanted) with no possibility to change to the table display.

So there were applied two changes:

> First in the configuration (changed the default to _**false**_ ).

> Secondly, a redundant verification, making sure that we only access the graph view if there is numeric values (**_hasNumberType_**)

## Related Issue
[Should be possible to configure obs-by-encounter widget to default to the graph view](https://issues.openmrs.org/browse/O3-1328?jql=project%20%3D%20O3%20AND%20status%20%3D%20%22In%20Progress%22%20AND%20assignee%20in%20(angomes)%20ORDER%20BY%20created%20DESC)
