### PR TITLE
Allow editing a past encounter without having an active visit

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -18,6 +18,8 @@ interface DiagnosisItem {
 interface VisitSummaryProps {
   encounters: Array<Encounter | OpenmrsResource>;
   patientUuid: string;
+  visitUuid: string;
+  visitTypeUuid: string;
 }
 
 export interface MappedEncounter {
@@ -27,10 +29,11 @@ export interface MappedEncounter {
   form: OpenmrsResource;
   obs: Array<Observation>;
   provider: string;
-  visitUuid?: string;
+  visitUuid: string;
+  visitTypeUuid: string;
 }
 
-const VisitSummary: React.FC<VisitSummaryProps> = ({ encounters, patientUuid }) => {
+const VisitSummary: React.FC<VisitSummaryProps> = ({ encounters, patientUuid, visitUuid, visitTypeUuid }) => {
   const config = useConfig();
   const { t } = useTranslation();
   const layout = useLayoutType();
@@ -146,7 +149,7 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ encounters, patientUuid }) 
             <MedicationSummary medications={medications} />
           </TabPanel>
           <TabPanel>
-            <VisitsTable visits={mapEncounters(encounters)} showAllEncounters={false} />
+            <VisitsTable visits={mapEncounters(encounters, visitUuid, visitTypeUuid)} showAllEncounters={false} />
           </TabPanel>
         </TabPanels>
       </Tabs>
@@ -156,13 +159,15 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ encounters, patientUuid }) 
 
 export default VisitSummary;
 
-export function mapEncounters(encounters) {
+export function mapEncounters(encounters, visitUuid, visitTypeUuid) {
   return encounters?.map((encounter) => ({
     id: encounter?.uuid,
     datetime: encounter?.encounterDatetime,
     encounterType: encounter?.encounterType?.display,
     form: encounter?.form,
     obs: encounter?.obs,
+    visitUuid: visitUuid,
+    visitTypeUuid: visitTypeUuid,
     provider:
       encounter?.encounterProviders?.length > 0 ? encounter.encounterProviders[0].provider?.person?.display : '--',
   }));

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -87,8 +87,14 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
     tableHeaders.sort((a, b) => (a.id > b.id ? 1 : -1));
   }
 
-  const launchWorkspace = (formUuid: string, visitUuid?: string, encounterUuid?: string, formName?: string) => {
-    formEntrySub.next({ formUuid, visitUuid, encounterUuid });
+  const launchWorkspace = (
+    formUuid: string,
+    visitUuid?: string,
+    encounterUuid?: string,
+    formName?: string,
+    visitTypeUuid?: string,
+  ) => {
+    formEntrySub.next({ formUuid, visitUuid, encounterUuid, visitTypeUuid });
     launchPatientWorkspace('patient-form-entry-workspace', { workspaceTitle: formName });
   };
 
@@ -188,6 +194,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
                                     visits[i].visitUuid,
                                     visits[i].id,
                                     visits[i].form.display,
+                                    visits[i].visitTypeUuid,
                                   )
                                 }
                               >
@@ -224,7 +231,15 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
                           <EncounterObservations observations={visits[i].obs} />
                           <Button
                             kind="ghost"
-                            onClick={() => launchWorkspace(visits[i].form.uuid, visits[i].visitUuid, visits[i].id)}
+                            onClick={() =>
+                              launchWorkspace(
+                                visits[i].form.uuid,
+                                visits[i].visitUuid,
+                                visits[i].id,
+                                visits[i].form.display,
+                                visits[i].visitTypeUuid,
+                              )
+                            }
                             renderIcon={(props) => <Edit size={16} {...props} />}
                             style={{ marginLeft: '-1rem', marginTop: '0.5rem' }}
                           >

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -74,7 +74,12 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
                       ) : null}
                     </div>
                   </div>
-                  <VisitSummary encounters={visit.encounters} patientUuid={patientUuid} />
+                  <VisitSummary
+                    encounters={visit.encounters}
+                    patientUuid={patientUuid}
+                    visitUuid={visit.uuid}
+                    visitTypeUuid={visit.visitType.uuid}
+                  />
                 </div>
               ))
             ) : (
@@ -116,7 +121,8 @@ export function mapEncounters(visit) {
     obs: encounter?.obs,
     provider:
       encounter?.encounterProviders?.length > 0 ? encounter.encounterProviders[0].provider?.person?.display : '--',
-    visitUuid: visit?.visitType.uuid,
+    visitUuid: visit?.uuid,
     visitType: visit?.visitType?.name,
+    visitTypeUuid: visit?.visitType.uuid,
   }));
 }

--- a/packages/esm-patient-common-lib/src/form-entry/form-entry.ts
+++ b/packages/esm-patient-common-lib/src/form-entry/form-entry.ts
@@ -5,6 +5,7 @@ export interface FormEntryProps {
   encounterUuid?: string;
   visitUuid?: string;
   formUuid: string;
+  visitTypeUuid?: string;
 }
 
 export const formEntrySub = new BehaviorSubject<FormEntryProps | null>(null);

--- a/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
@@ -17,8 +17,8 @@ const FormEntry: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWorkspac
     () => ({
       view: 'form',
       formUuid: selectedForm?.formUuid ?? null,
-      visitUuid: currentVisit.uuid ?? null,
-      visitTypeUuid: currentVisit.visitType?.uuid ?? null,
+      visitUuid: selectedForm?.visitUuid ?? currentVisit?.uuid ?? null,
+      visitTypeUuid: selectedForm?.visitTypeUuid ?? currentVisit?.visitType?.uuid ?? null,
       patientUuid: patientUuid ?? null,
       patient,
       encounterUuid: selectedForm?.encounterUuid ?? null,
@@ -34,7 +34,7 @@ const FormEntry: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWorkspac
 
   return (
     <div>
-      {selectedForm && patientUuid && patient && currentVisit && (
+      {selectedForm && patientUuid && patient && (
         <ExtensionSlot extensionSlotName="form-widget-slot" state={state} />
       )}
     </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Made changes to allow editing an encounter from a past visit. Trying to edit a past encounter without a past visit was raising an error. Visit type UUID wasn't being passed to form engine and passed visit UUID to which the encounter belong was wrong.

## Screenshots
![image](https://user-images.githubusercontent.com/68599335/207657023-e9c77932-bab3-43c4-aa15-3c8605f4648b.png)