### PR TITLE
(fix) Form entry loading regression in fast data entry app

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -91,7 +91,7 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
         ({ form, concepts }) => {
           this.form = form;
           if (concepts) {
-            this.labelMap = concepts?.reduce((acc, current) => {
+            this.labelMap = concepts.reduce((acc, current) => {
               if (Boolean(current)) {
                 acc[current.identifier] = current.display;
               }

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -90,7 +90,7 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
       .subscribe(
         ({ form, concepts }) => {
           this.form = form;
-          if (concepts.length) {
+          if (concepts) {
             this.labelMap = concepts?.reduce((acc, current) => {
               if (Boolean(current)) {
                 acc[current.identifier] = current.display;

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -90,13 +90,15 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
       .subscribe(
         ({ form, concepts }) => {
           this.form = form;
-          this.labelMap = concepts.reduce((acc, current) => {
-            if (Boolean(current)) {
-              acc[current.identifier] = current.display;
-            }
+          if (concepts.length) {
+            this.labelMap = concepts?.reduce((acc, current) => {
+              if (Boolean(current)) {
+                acc[current.identifier] = current.display;
+              }
 
-            return acc;
-          }, {});
+              return acc;
+            }, {});
+          }
           this.changeState('ready');
         },
         (err) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes a regression in the [fast-data-entry app](https://github.com/openmrs/openmrs-esm-fast-data-entry-app) where the form engine would fail to load a form at all if concepts are missing.


> Screenshots (console error from running fast-data-entry-app)

<img width="668" alt="Screenshot 2022-12-16 at 21 11 24" src="https://user-images.githubusercontent.com/8509731/208162067-cec92269-91b1-462e-bedd-a4ce5d6b70d0.png">

