### PR TITLE
O3-1617: location_id is not saved in encounter while saving a form 

### DIFF
--- a/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.ts
@@ -150,6 +150,11 @@ export class FormSubmissionService {
     }
 
     const encounterPayload = this.encounterAdapter.generateFormPayload(form) as unknown as EncounterCreate;
+
+    //Assign location to encounter payload if no location field is present on the form
+    if (!encounterPayload.hasOwnProperty('location') && form.dataSourcesContainer.dataSources?.userLocation?.uuid)
+      encounterPayload.location = form.dataSourcesContainer.dataSources.userLocation.uuid;
+
     return isEmpty(encounterPayload) ? undefined : encounterPayload;
   }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
In this development we are implementing, when saving a form that doesn't have a field to select a location, the use of the location of the current session.

## Related Issue
[This PR 880 was closed because of some git errors, so this is the continuation of that development](https://github.com/openmrs/openmrs-esm-patient-chart/pull/880)


[O3-1617](https://issues.openmrs.org/browse/O3-1617)
