### PR TITLE
O3-1648 Tweak appearance of the Recent Results widget tooltip

### DIFF
--- a/packages/esm-patient-test-results-app/src/overview/common-overview.component.tsx
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.component.tsx
@@ -147,7 +147,7 @@ const Separator = ({ ...props }) => <div {...props} className={styles.separator}
 const InfoTooltip = ({ effectiveDateTime, issuedDateTime }) => {
   const { t } = useTranslation();
   return (
-    <Toggletip align="bottom">
+    <Toggletip align="bottom" className={styles.tooltipContainer}>
       <ToggletipButton label="Additional information">
         <Information />
       </ToggletipButton>

--- a/packages/esm-patient-test-results-app/src/overview/common-overview.scss
+++ b/packages/esm-patient-test-results-app/src/overview/common-overview.scss
@@ -35,6 +35,11 @@
 
 .meta {
   display: flex;
+  align-items: center;
+}
+
+.tooltipContainer {
+  margin: 0 0.5rem;
 }
 
 .tooltip {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Recent Results tooltip adjustment. Defined the correct margins and item alignment

## Screenshots
<img width="944" alt="image" src="https://user-images.githubusercontent.com/26409082/208515235-5a1607fd-78f7-4a69-b3f5-f457cc856549.png">

## Related Issue
https://issues.openmrs.org/browse/O3-1648
