### PR TITLE
(fix) Medication search results should show Drug's display value instead of Drug's concept's display value

### DIFF
--- a/__mocks__/medication.mock.ts
+++ b/__mocks__/medication.mock.ts
@@ -5,7 +5,8 @@ export const mockDrugSearchResults = {
     results: [
       {
         uuid: '18f43c99-2329-426e-97b5-c3356e6afe54',
-        name: 'aspirin',
+        name: 'Aspirin',
+        display: 'Aspirin',
         strength: '81mg',
         dosageForm: {
           display: 'Tablet',
@@ -280,7 +281,8 @@ export const mockMedicationOrderSearchResults = [
     action: 'NEW',
     drug: {
       uuid: '18f43c99-2329-426e-97b5-c3356e6afe54',
-      name: 'aspirin',
+      name: 'Aspirin',
+      display: 'Aspirin',
       strength: '81mg',
       dosageForm: {
         display: 'Tablet',
@@ -364,7 +366,8 @@ export const mockMedicationOrderSearchResults = [
     action: 'NEW',
     drug: {
       uuid: '18f43c99-2329-426e-97b5-c3356e6afe54',
-      name: 'Aspirin 125mg',
+      name: 'Aspirin',
+      display: 'Aspirin',
       strength: '125mg',
       dosageForm: {
         display: 'Tablet',
@@ -478,7 +481,8 @@ export const mockMedicationOrderSearchResults = [
     action: 'NEW',
     drug: {
       uuid: '18f43c99-2329-426e-97b5-c3356e6afe54',
-      name: 'Aspirin 243mg',
+      name: 'Aspirin',
+      display: 'Aspirin',
       strength: '243mg',
       dosageForm: {
         display: 'Tablet',
@@ -682,7 +686,7 @@ export const mockDrugOrders = {
         commentToFulfiller: null,
         drug: {
           uuid: '18f43c99-2329-426e-97b5-c3356e6afe54',
-          name: 'aspirin',
+          name: 'Aspirin',
           strength: '81mg',
           dosageForm: {
             display: 'Tablet',

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -54,7 +54,7 @@ export function getPatientEncounterId(patientUuid: string, abortController: Abor
 
 export function getDrugByName(drugName: string, abortController?: AbortController) {
   return openmrsFetch(
-    `/ws/rest/v1/drug?q=${drugName}&v=custom:(uuid,name,strength,dosageForm:(display,uuid),concept)`,
+    `/ws/rest/v1/drug?q=${drugName}&v=custom:(uuid,display,name,strength,dosageForm:(display,uuid),concept)`,
     {
       signal: abortController?.signal,
     },

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
@@ -85,7 +85,7 @@ export default function OrderBasketSearchResults({
               <div className={styles.searchResultTile}>
                 <div className={styles.searchResultTileContent}>
                   <p>
-                    <strong>{result.drug?.concept?.display}</strong> &mdash; {result?.drug?.strength} &mdash;{' '}
+                    <strong>{result.drug?.display}</strong> &mdash; {result?.drug?.strength} &mdash;{' '}
                     {result?.drug?.dosageForm?.display}
                     {result.template && (
                       <>

--- a/packages/esm-patient-medications-app/src/types/order.ts
+++ b/packages/esm-patient-medications-app/src/types/order.ts
@@ -61,6 +61,7 @@ export interface Drug {
   strength: string;
   concept: OpenmrsResource;
   dosageForm: OpenmrsResource;
+  display: string;
 }
 
 export interface OrderPost {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the showcase of drug's display in the drug search component, instead of drug's concept's display.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
