### PR TITLE
(fix)Showing the drug strength and drug dosage form in drug search results should be optional

### DIFF
--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
@@ -85,8 +85,9 @@ export default function OrderBasketSearchResults({
               <div className={styles.searchResultTile}>
                 <div className={styles.searchResultTileContent}>
                   <p>
-                    <strong>{result.drug?.display}</strong> &mdash; {result?.drug?.strength} &mdash;{' '}
-                    {result?.drug?.dosageForm?.display}
+                    <strong>{result.drug?.display}</strong>{' '}
+                    {result?.drug?.strength && <>&mdash; {result?.drug?.strength}</>}{' '}
+                    {result?.drug?.dosageForm?.display && <>&mdash; {result?.drug?.dosageForm?.display}</>}
                     {result.template && (
                       <>
                         <span className={styles.label01}>{result.frequency?.value}</span> &mdash;{' '}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR adds a condition to show the drug strength and drug dosage form only if they are available.

## Screenshots
This PR will resolve the issue in the image below, by not rendering the - in the first place if the drug strength is not present or the second - if the drug dosage isn't.
![image](https://user-images.githubusercontent.com/51502471/208882283-a046aefc-6d8a-4838-968a-bf77feb69121.png)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
