### PR TITLE
(fix) Order basket fixes

### DIFF
--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -108,12 +108,10 @@ export function useCurrentOrderBasketEncounter(patientUuid: string) {
   useEffect(() => {
     const abortController = new AbortController();
     if (!data?.data?.results?.length) {
-      createEmptyEncounter(patientUuid, sessionObject, config, abortController).then((res) => {
-        mutate();
-      });
+      createEmptyEncounter(patientUuid, sessionObject, config, abortController)
+        .then(() => mutate())
+        .catch((error) => console.error('Error creating empty encounter', error));
     }
-
-    return () => abortController.abort();
   }, [data, mutate, config, patientUuid, sessionObject]);
 
   const results = useMemo(

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -140,7 +140,7 @@ const MedicationsDetailsTable = connect<
         content: (
           <div className={styles.startDateColumn}>
             <span>{formatDate(new Date(medication.dateActivated))}</span>
-            <InfoTooltip orderer={medication.orderer?.person?.display ?? '--'} />
+            <InfoTooltip orderer={medication.orderer?.person?.display ?? '--'} t={t} />
           </div>
         ),
       },
@@ -227,13 +227,14 @@ const MedicationsDetailsTable = connect<
   },
 );
 
-function InfoTooltip({ orderer }) {
+function InfoTooltip({ orderer, t }) {
   return (
     <IconButton
       className={styles.tooltip}
       align="top-left"
       direction="top"
       label={orderer}
+      iconDescription={t('orderer', 'Orderer')}
       renderIcon={(props) => <User size={16} {...props} />}
       kind="ghost"
       size="sm"

--- a/packages/esm-patient-medications-app/src/order-basket/drug-search.ts
+++ b/packages/esm-patient-medications-app/src/order-basket/drug-search.ts
@@ -4,26 +4,10 @@ import { OrderBasketItem } from '../types/order-basket-item';
 import { Drug } from '../types/order';
 import { DrugOrderTemplate, OrderTemplate } from '../api/drug-order-template';
 
-// Note:
-// There's currently no backend API available for the data in `common-medication.json`.
-// This means that there's also no external API where we can search for that data.
-// This results in us having to simulate a search on the frontend.
-// The way this works is that we search all drugs matching the search term(s) in the backend and enrich that drug data
-// with the data found in `common-medication.json`. These exploded results are then again filtered with the search term(s).
-//
-// For example, imagine that we search for "Aspirin 81mg".
-// We call the drug endpoint with both "Aspirin" and "81mg" and receive a single drug (Aspirin) for the first term.
-// `common-medication.json` now defines a lot of additional data for Aspirin (e.g. 81mg, 243mg, ...).
-// -> We explode this info into multiple Aspirin results. But since the user also entered "81mg" as a search term, we
-// also slim the final list of search results down again.
-//
-// This method certainly isn't perfect, but again, since the common medication data is only available to us, it's kind of
-// the best thing we can do here.
 interface DaysDurationUnit {
   uuid: string;
   display: string;
 }
-
 export async function searchMedications(
   searchTerm: string,
   encounterUuid: string,
@@ -32,27 +16,30 @@ export async function searchMedications(
 ) {
   const allSearchTerms = searchTerm.match(/\S+/g);
   const drugs = await searchDrugsInBackend(allSearchTerms, abortController);
-  const drugToOrderTemplates = (await Promise.all(
+  const drugToOrderTemplates: Array<{ drug: Drug; templates: Array<DrugOrderTemplate> }> = await Promise.all(
     drugs.map(async (drug) => {
-      let response: any = null;
+      let response = null;
       try {
         response = await getOrderTemplatesByDrug(drug.uuid);
       } catch (error) {
         // most likely there is no `Order Template` backend support
         response = { data: { results: [] } }; // empty response
       }
-      const orderTemplates = response.data.results.map((ot) => {
+
+      const orderTemplates: Array<DrugOrderTemplate> = response.data.results.map((orderTemplate) => {
         try {
-          ot.template = JSON.parse(ot.template);
-          return ot;
+          orderTemplate.template = JSON.parse(orderTemplate.template);
+          return orderTemplate;
         } catch (error) {
           console.error(error);
           return null;
         }
-      }) as Array<DrugOrderTemplate>;
+      });
+
       return { drug: drug, templates: orderTemplates.filter((x) => !!x) };
     }),
-  )) as any as Array<{ drug: Drug; templates: Array<DrugOrderTemplate> }>;
+  );
+
   const explodedSearchResults = drugToOrderTemplates.flatMap(({ drug, templates }) => [
     ...explodeResultWithOrderTemplates(drug, templates, encounterUuid, daysDurationUnit),
   ]);
@@ -136,19 +123,19 @@ function* explodeResultWithOrderTemplates(
   }
 }
 
-function filterExplodedResultsBySearchTerm(allSearchTerms: Array<string>, results: any) {
+function filterExplodedResultsBySearchTerm(allSearchTerms: Array<string>, results) {
   return results.filter((result) =>
     allSearchTerms.every(
       (searchTerm) =>
-        includesIgnoreCase(result.drug.name, searchTerm) ||
-        includesIgnoreCase(result.dosageUnit.name, searchTerm) ||
-        includesIgnoreCase(result.dosage.dosage, searchTerm) ||
-        includesIgnoreCase(result.frequency.name, searchTerm) ||
-        includesIgnoreCase(result.route.name, searchTerm),
+        includesIgnoreCase(result?.drug?.name, searchTerm) ||
+        includesIgnoreCase(result?.dosageUnit?.name, searchTerm) ||
+        includesIgnoreCase(result?.dosage?.dosage, searchTerm) ||
+        includesIgnoreCase(result?.frequency?.name, searchTerm) ||
+        includesIgnoreCase(result?.route?.name, searchTerm),
     ),
   );
 }
 
-function includesIgnoreCase(a: string, b: string) {
-  return a.toLowerCase().includes(b.toLowerCase());
+function includesIgnoreCase(a: string, b: string): boolean {
+  return a?.toLowerCase()?.includes(b?.toLowerCase());
 }

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.component.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Pagination, ClickableTile, Tile, SkeletonText, SkeletonIcon } from '@carbon/react';
+import { Button, ClickableTile, Tile, SkeletonText, SkeletonIcon } from '@carbon/react';
 import { ShoppingCart } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
 import { createErrorHandler, useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { searchMedications } from './drug-search';
 import { OrderBasketItem } from '../types/order-basket-item';
-import { paginate } from '../utils/pagination';
 import { ConfigObject } from '../config-schema';
 import styles from './order-basket-search-results.scss';
 
@@ -26,9 +25,6 @@ export default function OrderBasketSearchResults({
   const isTablet = useLayoutType() === 'tablet';
   const [isLoading, setIsLoading] = useState(false);
   const [searchResults, setSearchResults] = useState<Array<OrderBasketItem>>([]);
-  const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(10);
-  const [currentSearchResultPage] = paginate(searchResults, page, pageSize);
   const config = useConfig() as ConfigObject;
 
   useEffect(() => {
@@ -39,6 +35,7 @@ export default function OrderBasketSearchResults({
         return;
       }
       setIsLoading(true);
+
       searchMedications(searchTerm, encounterUuid, abortController, config.daysDurationUnit).then((results) => {
         setIsLoading(false);
         setSearchResults(results);
@@ -56,12 +53,7 @@ export default function OrderBasketSearchResults({
 
   return (
     <>
-      {!!searchTerm && isLoading && (
-        <>
-          <DrugOrderSearchResultSkeleton />
-          <DrugOrderSearchResultSkeleton />
-        </>
-      )}
+      {!!searchTerm && isLoading && <Skeleton />}
       {!!searchTerm && !isLoading && (
         <div className={styles.container}>
           <div className={styles.orderBasketSearchResultsHeader}>
@@ -72,10 +64,10 @@ export default function OrderBasketSearchResults({
               })}
             </span>
             <Button kind="ghost" onClick={() => setSearchTerm('')} size={isTablet ? 'md' : 'sm'}>
-              {t('clearSearchResults', 'Clear Results')}
+              {t('clearSearchResults', 'Clear results')}
             </Button>
           </div>
-          {currentSearchResultPage.map((result, index) => (
+          {searchResults?.map((result, index) => (
             <ClickableTile
               role="listitem"
               key={index}
@@ -108,21 +100,7 @@ export default function OrderBasketSearchResults({
             </ClickableTile>
           ))}
           {searchResults.length > 0 && (
-            <>
-              <Pagination
-                page={page}
-                pageSize={pageSize}
-                pageSizes={[10, 20, 30, 40, 50]}
-                totalItems={searchResults.length}
-                onChange={({ page, pageSize }) => {
-                  setPage(page);
-                  setPageSize(pageSize);
-                }}
-              />
-              <hr
-                className={`${styles.divider} ${isTablet ? `${styles.tabletDivider}` : `${styles.desktopDivider}`}`}
-              />
-            </>
+            <hr className={`${styles.divider} ${isTablet ? `${styles.tabletDivider}` : `${styles.desktopDivider}`}`} />
           )}
         </div>
       )}
@@ -130,11 +108,15 @@ export default function OrderBasketSearchResults({
   );
 }
 
-const DrugOrderSearchResultSkeleton = () => {
+const Skeleton = () => {
   return (
-    <Tile>
-      <div className={styles.searchResultSkeletonWrapper}>
-        <SkeletonIcon style={{ height: '26px', margin: '0px 15px 10px', width: '23px' }} />
+    <Tile className={styles.searchResultSkeletonWrapper}>
+      <div>
+        <SkeletonIcon className={styles.skeletonIcon} />
+        <SkeletonText lineCount={4} />
+      </div>
+      <div>
+        <SkeletonIcon className={styles.skeletonIcon} />
         <SkeletonText lineCount={4} />
       </div>
     </Tile>

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.scss
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search-results.scss
@@ -66,6 +66,24 @@
 }
 
 .searchResultSkeletonWrapper {
-  @extend .searchResultTile;
-  border-bottom: 1px solid $ui-03;
+  display: flex;
+  flex-direction: column;
+
+  > div {
+    padding-bottom: 0.5rem;
+    display: flex;
+  
+    &:first-of-type {
+      border-bottom: 1px solid $ui-03;
+    }
+
+    &:last-of-type {
+      margin-top: 1rem;
+    }
+  }
+}
+
+.skeletonIcon {
+  margin: 0 1rem 0.5rem;
+  width: 1.5rem;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR provides several fixes to the Order Basket. These include:

- Fixing an issue where the search wouldn't complete for certain search terms due to silent error object property access errors in the `filterExplodedResultsBySearchTerm` function.
- Fixing a premature request cancellation in the `useCurrentOrderBasketEncounter` hook when creating an empty encounter (by removing the `abortController.abort` invocation).
- Removing the Pagination component from the order basket search results. It's been removed from latest Zeplin designs.
- Adding some missing type annotations.
- Removing a potentially misleading comment from the `drug-search` resource that referred to an old approach for fetching medications.
- Adding a missing `iconDescription` property to the `InfoTooltip` component.
