### PR TITLE
(feat) obs-by-encounter-widget can support Date concepts

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/config-schema.ts
+++ b/packages/esm-generic-patient-widgets-app/src/config-schema.ts
@@ -74,6 +74,11 @@ export const configSchema = {
     },
     _default: [],
   },
+  dateFormat: {
+    _type: Type.String,
+    _description: 'Date formating string',
+    _default: 'DD/MM/YYY',
+  },
 };
 
 export interface ConfigObject {
@@ -91,4 +96,5 @@ export interface ConfigObject {
   };
   showGraphByDefault: boolean;
   encounterTypes: Array<string>;
+  dateFormat: string;
 }

--- a/packages/esm-generic-patient-widgets-app/src/config-schema.ts
+++ b/packages/esm-generic-patient-widgets-app/src/config-schema.ts
@@ -76,8 +76,8 @@ export const configSchema = {
   },
   dateFormat: {
     _type: Type.String,
-    _description: 'Date formating string',
-    _default: 'DD/MM/YYY',
+    _description: 'Type of display for data',
+    _default: 'dateTime',
   },
 };
 
@@ -96,5 +96,5 @@ export interface ConfigObject {
   };
   showGraphByDefault: boolean;
   encounterTypes: Array<string>;
-  dateFormat: string;
+  dateFormat: 'date' | 'time' | 'dateTime';
 }

--- a/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
@@ -13,6 +13,7 @@ import { usePagination, useConfig, formatDatetime } from '@openmrs/esm-framework
 import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import { useObs } from '../resources/useObs';
 import styles from './obs-table.scss';
+import dayjs from 'dayjs';
 
 interface ObsTableProps {
   patientUuid: string;
@@ -21,7 +22,6 @@ interface ObsTableProps {
 const ObsTable: React.FC<ObsTableProps> = ({ patientUuid }) => {
   const config = useConfig();
   const { data: obss, error, isLoading, isValidating } = useObs(patientUuid);
-
   const uniqueDates = [...new Set(obss.map((o) => o.issued))].sort();
   const obssByDate = uniqueDates.map((date) => obss.filter((o) => o.issued === date));
 
@@ -66,12 +66,16 @@ const ObsTable: React.FC<ObsTableProps> = ({ patientUuid }) => {
             case 'Coded':
               rowData[obs.conceptUuid] = obs.valueCodeableConcept?.coding[0]?.display;
               break;
+
+            case 'DateTime':
+              rowData[obs.conceptUuid] = dayjs(new Date(obs.valueDateTime)).format(config.dateFormat);
+              break;
           }
         }
 
         return rowData;
       }),
-    [config.data, obssByDate],
+    [config.data, config.dateFormat, obssByDate],
   );
 
   const { results, goTo, currentPage } = usePagination(tableRows, config.table.pageSize);

--- a/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
@@ -9,11 +9,10 @@ import {
   TableHeader,
   TableRow,
 } from '@carbon/react';
-import { usePagination, useConfig, formatDatetime } from '@openmrs/esm-framework';
+import { usePagination, useConfig, formatDatetime, formatDate, formatTime } from '@openmrs/esm-framework';
 import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import { useObs } from '../resources/useObs';
 import styles from './obs-table.scss';
-import dayjs from 'dayjs';
 
 interface ObsTableProps {
   patientUuid: string;
@@ -68,14 +67,24 @@ const ObsTable: React.FC<ObsTableProps> = ({ patientUuid }) => {
               break;
 
             case 'DateTime':
-              rowData[obs.conceptUuid] = dayjs(new Date(obs.valueDateTime)).format(config.dateFormat);
+              if (config?.dateFormat === 'dateTime') {
+                rowData[obs.conceptUuid] = formatDatetime(new Date(obs.valueDateTime), { mode: 'standard' });
+              } else if (config?.dateFormat === 'time') {
+                rowData[obs.conceptUuid] = formatTime(new Date(obs.valueDateTime));
+              } else if (config?.dateFormat === 'date') {
+                rowData[obs.conceptUuid] = formatDate(new Date(obs.valueDateTime), { mode: 'standard' });
+              } else {
+                //maintain the default behavior
+                rowData[obs.conceptUuid] = formatDatetime(new Date(obs.valueDateTime), { mode: 'standard' });
+              }
+
               break;
           }
         }
 
         return rowData;
       }),
-    [config.data, config.dateFormat, obssByDate],
+    [config, obssByDate],
   );
 
   const { results, goTo, currentPage } = usePagination(tableRows, config.table.pageSize);

--- a/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
+++ b/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
@@ -78,6 +78,7 @@ export interface UseObsResult {
 type ObsResult = FHIRResource['resource'] & {
   conceptUuid: string;
   dataType?: string;
+  valueDateTime?: string;
 };
 
 function isUuid(input: string) {

--- a/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
+++ b/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
@@ -28,6 +28,10 @@ export function useObs(patientUuid: string): UseObsResult {
         conceptUuid: entry.resource.code.coding.filter((c) => isUuid(c.code))[0]?.code,
       };
 
+      if (entry.resource.hasOwnProperty('valueDateTime')) {
+        observation.dataType = 'DateTime';
+      }
+
       if (entry.resource.hasOwnProperty('valueString')) {
         observation.dataType = 'Text';
       }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
Currently the **_obs-by-encounter-widget_** only support concepts where the answer value is **_Coded, Number_** or **_Text_**.

This PR is to improve the **_obs-by-encounter-widget_** to support **_Date concepts_**.

## Screenshots
<img width="842" alt="image" src="https://user-images.githubusercontent.com/106243905/210828992-f61f3585-1213-4218-b92a-da71f7db448d.png">


## Related Issue
For this PR to be completely integrated with no problems these changes on openmrs-esm-core need to be merged:
[(feat) Added property to FHIR resource so it can support DateTime values #588](https://github.com/openmrs/openmrs-esm-core/pull/588)
