### PR TITLE
(test) Fix tests failing due to inconsistent whitespace

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
@@ -101,7 +101,10 @@ describe('Switchable obs viewer ', () => {
       expect(within(table).getByRole('columnheader', { name: new RegExp(header, 'i') })).toBeInTheDocument(),
     );
 
-    const expectedTableRows = [/2\d — Oct — 2021, \d\d:\d\d AM -- 180/, /1\d — Oct — 2021, \d\d:\d\d AM 198 200/];
+    const expectedTableRows = [
+      /2\d — Oct — 2021, \d{2}:\d{2}\s+AM -- 180/,
+      /1\d — Oct — 2021, \d{2}:\d{2}\s+AM 198 200/,
+    ];
 
     expectedTableRows.map((row) =>
       expect(within(table).getByRole('row', { name: new RegExp(row, 'i') })).toBeInTheDocument(),

--- a/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.test.tsx
@@ -8,14 +8,14 @@ describe('DeceasedPatientTag', () => {
   it('does not render Deceased tag for patients who are still alive', () => {
     const patient = { ...mockPatient, deceasedDateTime: null };
     render(<DeceasedPatientBannerTag patient={patient} patientUuid={mockDeceasedPatient.id} />);
-    expect(screen.queryByRole('tooltip', { name: / 04-Apr-1972, 12:00 AM/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tooltip', { name: / 04-Apr-1972, 12:00\s+AM/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Deceased/ })).not.toBeInTheDocument();
   });
 
   it('renders a deceased tag in the patient banner for patients who died', () => {
     render(<DeceasedPatientBannerTag patient={mockDeceasedPatient} patientUuid={mockDeceasedPatient.id} />);
 
-    expect(screen.getByRole('tooltip', { name: / 04-Apr-1972, 12:00 AM/i }));
+    expect(screen.getByRole('tooltip', { name: / 04-Apr-1972, 12:00\s+AM/i }));
     expect(screen.getByRole('button', { name: /Deceased/ })).toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -68,9 +68,9 @@ describe('EncounterList', () => {
     });
 
     const expectedTableRows = [
-      /18-Jan-2022, 04:25 PM Facility Visit Admission/,
-      /03-Aug-2021, 12:47 AM Facility Visit Visit Note User One/,
-      /05-Jul-2021, 10:07 AM Facility Visit Consultation Dennis The Doctor/,
+      /18-Jan-2022, 04:25\s+PM Facility Visit Admission/,
+      /03-Aug-2021, 12:47\s+AM Facility Visit Visit Note User One/,
+      /05-Jul-2021, 10:07\s+AM Facility Visit Consultation Dennis The Doctor/,
     ];
     expectedTableRows.forEach((row) => {
       expect(screen.getByRole('row', { name: new RegExp(row, 'i') })).toBeInTheDocument();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR provides a potential fix for an unusual regression I'm experiencing with tests on my local setup. More specifically, three tests that use `getByRole` matchers are failing. The failing expectations seem to be based on assertions that involving the [formatDateTime](https://github.com/openmrs/openmrs-esm-core/blob/95911641a40e15ccf9bb3a3a5298da7b14f4c002/packages/framework/esm-utils/src/omrs-dates.ts#L251) helper. The regression appears to be because Jest seems to expect a [non-breaking white space](https://www.compart.com/en/unicode/U+00A0) between the datetime value and the meridian indicators (AM / PM). 

This is strange because I'd expect a whitespace between the datetime value and the meridian indicator.

To address this, I've amended the assertions to use the `\s+` whitespace regex matcher in place of plain whitespace. This fix is compatible with setups experiencing this issue as well as those that are not.

<img width="1250" alt="Screenshot 2023-01-09 at 21 08 18" src="https://user-images.githubusercontent.com/8509731/211377338-f98faecb-552c-4e47-ae31-95cebb21c041.png">

