### PR TITLE
(bug fix): Free text dosage drug ordering not working as expected.[03-1744 and 03-1746]

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -98,7 +98,7 @@ const MedicationsDetailsTable = connect<
               <p className={styles.bodyLong01}>
                 <span className={styles.label01}>{t('dose', 'Dose').toUpperCase()}</span>{' '}
                 <span className={styles.dosage}>
-                  {medication.dose} {medication.doseUnits.display.toLowerCase()}
+                  {medication.dose} {medication.doseUnits?.display.toLowerCase()}
                 </span>{' '}
                 &mdash; {medication.route?.display.toLowerCase()} &mdash; {medication.frequency?.display.toLowerCase()}{' '}
                 &mdash;{' '}
@@ -281,16 +281,16 @@ function OrderBasketItemActions({
         drug: medication.drug,
         dosage: medication.dose,
         unit: {
-          value: medication.doseUnits.display,
-          valueCoded: medication.doseUnits.uuid,
+          value: medication.doseUnits?.display,
+          valueCoded: medication.doseUnits?.uuid,
         },
         frequency: {
-          valueCoded: medication.frequency.uuid,
+          valueCoded: medication.frequency?.uuid,
           value: medication.frequency.display,
         },
         route: {
-          valueCoded: medication.route.uuid,
-          value: medication.route.display,
+          valueCoded: medication.route?.uuid,
+          value: medication.route?.display,
         },
         commonMedicationName: medication.drug.name,
         isFreeTextDosage: medication.dosingType === 'org.openmrs.FreeTextDosingInstructions',
@@ -328,18 +328,18 @@ function OrderBasketItemActions({
         drug: medication.drug,
         dosage: medication.dose,
         unit: {
-          value: medication.doseUnits.display,
-          valueCoded: medication.doseUnits.uuid,
+          value: medication.doseUnits?.display,
+          valueCoded: medication.doseUnits?.uuid,
         },
         frequency: {
-          valueCoded: medication.frequency.uuid,
-          value: medication.frequency.display,
+          valueCoded: medication.frequency?.uuid,
+          value: medication.frequency?.display,
         },
         route: {
-          valueCoded: medication.route.uuid,
-          value: medication.route.display,
+          valueCoded: medication.route?.uuid,
+          value: medication.route?.display,
         },
-        commonMedicationName: medication.drug.name,
+        commonMedicationName: medication.drug?.name,
         isFreeTextDosage: medication.dosingType === 'org.openmrs.FreeTextDosingInstructions',
         freeTextDosage:
           medication.dosingType === 'org.openmrs.FreeTextDosingInstructions' ? medication.dosingInstructions : '',
@@ -355,9 +355,9 @@ function OrderBasketItemActions({
         pillsDispensed: medication.quantity,
         numRefills: medication.numRefills,
         indication: medication.orderReasonNonCoded,
-        orderer: medication.orderer.uuid,
-        careSetting: medication.careSetting.uuid,
-        quantityUnits: medication.quantityUnits.uuid,
+        orderer: medication.orderer?.uuid,
+        careSetting: medication.careSetting?.uuid,
+        quantityUnits: medication.quantityUnits?.uuid,
       },
     ]);
     openOrderBasket();
@@ -374,18 +374,18 @@ function OrderBasketItemActions({
         drug: medication.drug,
         dosage: medication.dose,
         unit: {
-          value: medication.doseUnits.display,
-          valueCoded: medication.doseUnits.uuid,
+          value: medication.doseUnits?.display,
+          valueCoded: medication.doseUnits?.uuid,
         },
         frequency: {
-          valueCoded: medication.frequency.uuid,
-          value: medication.frequency.display,
+          valueCoded: medication.frequency?.uuid,
+          value: medication.frequency?.display,
         },
         route: {
-          valueCoded: medication.route.uuid,
-          value: medication.route.display,
+          valueCoded: medication.route?.uuid,
+          value: medication.route?.display,
         },
-        commonMedicationName: medication.drug.name,
+        commonMedicationName: medication.drug?.name,
         isFreeTextDosage: medication.dosingType === 'org.openmrs.FreeTextDosingInstructions',
         freeTextDosage:
           medication.dosingType === 'org.openmrs.FreeTextDosingInstructions' ? medication.dosingInstructions : '',
@@ -401,9 +401,9 @@ function OrderBasketItemActions({
         pillsDispensed: medication.quantity,
         numRefills: medication.numRefills,
         indication: medication.orderReasonNonCoded,
-        orderer: medication.orderer.uuid,
-        careSetting: medication.careSetting.uuid,
-        quantityUnits: medication.quantityUnits.uuid,
+        orderer: medication.orderer?.uuid,
+        careSetting: medication.careSetting?.uuid,
+        quantityUnits: medication.quantityUnits?.uuid,
       },
     ]);
     openOrderBasket();

--- a/packages/esm-patient-medications-app/src/order-basket/drug-ordering.ts
+++ b/packages/esm-patient-medications-app/src/order-basket/drug-ordering.ts
@@ -43,16 +43,16 @@ function medicationOrderToApiDto(
         encounter: encounterUuid,
         drug: order.drug.uuid,
         dose: order.dosage,
-        doseUnits: order.unit.valueCoded,
-        route: order.route.valueCoded,
-        frequency: order.frequency.valueCoded,
+        doseUnits: order.unit?.valueCoded,
+        route: order.route?.valueCoded,
+        frequency: order.frequency?.valueCoded,
         asNeeded: order.asNeeded,
         asNeededCondition: order.asNeededCondition,
         numRefills: order.numRefills,
         quantity: order.pillsDispensed,
         quantityUnits: order.quantityUnits,
         duration: order.duration,
-        durationUnits: order.durationUnit.uuid,
+        durationUnits: order.durationUnit?.uuid,
         dosingType: order.isFreeTextDosage
           ? 'org.openmrs.FreeTextDosingInstructions'
           : 'org.openmrs.SimpleDosingInstructions',
@@ -72,16 +72,16 @@ function medicationOrderToApiDto(
         encounter: encounterUuid,
         drug: order.drug.uuid,
         dose: order.dosage,
-        doseUnits: order.unit.valueCoded,
-        route: order.route.valueCoded,
-        frequency: order.frequency.valueCoded,
+        doseUnits: order.unit?.valueCoded,
+        route: order.route?.valueCoded,
+        frequency: order.frequency?.valueCoded,
         asNeeded: order.asNeeded,
         asNeededCondition: order.asNeededCondition,
         numRefills: order.numRefills,
         quantity: order.pillsDispensed,
         quantityUnits: order.quantityUnits,
         duration: order.duration,
-        durationUnits: order.durationUnit.uuid,
+        durationUnits: order.durationUnit?.uuid,
         dosingType: order.isFreeTextDosage
           ? 'org.openmrs.FreeTextDosingInstructions'
           : 'org.openmrs.SimpleDosingInstructions',
@@ -110,8 +110,8 @@ function medicationOrderToApiDto(
 }
 
 function calculateEndDate(orderBasketItem: OrderBasketItem) {
-  const dayJsDuration = orderBasketItem.durationUnit.display
-    .substring(0, orderBasketItem.durationUnit.display.lastIndexOf('s'))
+  const dayJsDuration = orderBasketItem.durationUnit?.display
+    .substring(0, orderBasketItem.durationUnit?.display.lastIndexOf('s'))
     .toLowerCase();
 
   return (

--- a/packages/esm-patient-medications-app/src/order-basket/medication-order-form.scss
+++ b/packages/esm-patient-medications-app/src/order-basket/medication-order-form.scss
@@ -91,7 +91,7 @@
       order: 1;
       margin-right: 0.5rem;
       margin-left: 0rem !important;
-    }  
+    }
 
     span {
       order: 2;
@@ -143,6 +143,7 @@
 .gridRow {
   @extend .row;
   padding: 0px;
+  margin-bottom: 0.5rem;
 
   :global(.cds--number) {
     display: inline-block;

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-item.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-item.component.tsx
@@ -48,10 +48,10 @@ export default function OrderBasketItemTile({ orderBasketItem, onItemClick, onRe
         <span className={styles.label01}>
           <span className={styles.doseCaption}>{t('dose', 'Dose').toUpperCase()}</span>{' '}
           <span className={styles.dosageLabel}>
-            {orderBasketItem.dosage} {orderBasketItem.unit.value}
+            {orderBasketItem.dosage} {orderBasketItem.unit?.value}
           </span>{' '}
           <span className={styles.dosageInfo}>
-            &mdash; {orderBasketItem.route.value} &mdash; {orderBasketItem.frequency.value} &mdash;{' '}
+            &mdash; {orderBasketItem.route?.value} &mdash; {orderBasketItem.frequency?.value} &mdash;{' '}
             {t('refills', 'Refills').toUpperCase()} {orderBasketItem.numRefills}{' '}
             {t('quantity', 'Quantity').toUpperCase()} {orderBasketItem.pillsDispensed}{' '}
           </span>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
- The Error was resulting from `null dosage and unit` so to access `unit.value` would throw an error, so adding a ternary check fixes it.
- Also fix the bug on signing free text dosages.
- Also fixed the bottom spacing in the medications form

## Screenshots
Missing margin
<img width="561" alt="Screenshot 2023-01-12 at 13 14 48" src="https://user-images.githubusercontent.com/30952856/212040022-e3d7a7e8-23aa-4001-95f0-76d4f8075e9f.png">

Fixed margin
<img width="618" alt="Screenshot 2023-01-12 at 13 10 11" src="https://user-images.githubusercontent.com/30952856/212039478-910d8e4f-1019-4db2-8f3c-a5907231e8c9.png">

Free text save and sign order fix

https://user-images.githubusercontent.com/30952856/212040075-5a2c4e57-1b65-4d40-b924-9068150974c8.mov


## Related Issue
- https://issues.openmrs.org/browse/O3-1744
- https://issues.openmrs.org/browse/O3-1746

## Other
<!-- Anything not covered above -->
