### PR TITLE
(fix): Properly pass the patient object datasource to the CVD calc

### DIFF
--- a/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
@@ -109,7 +109,8 @@ export class FormCreationService {
     this.dataSources.registerDataSource('personAttribute', dataSources.location);
     this.dataSources.registerDataSource('conceptAnswers', dataSources.conceptAnswers);
     this.dataSources.registerDataSource('patient', { visitTypeUuid }, true);
-    this.dataSources.registerDataSource('patient', dataSources, true);
+    const patientObj = this.formDataSourceService.getPatientObject(patient);
+    this.dataSources.registerDataSource('patient', patientObj, true);
     this.dataSources.registerDataSource('rawPrevEnc', createFormParams.previousEncounter, false);
     const rawPrevObs = await dataSources.recentObs(patient.id);
     this.dataSources.registerDataSource('rawPrevObs', rawPrevObs, false);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Pass the correct patient object to the data source so as to provide the correct `sex` and `age` values to the `CVD calculation`

## Screenshots
- Fix


https://user-images.githubusercontent.com/30952856/212120831-eb501683-4711-4e75-b19c-c0e281f4078c.mov



## Related Issue
- Related to https://issues.openmrs.org/browse/KH-28

## Other
- Now the historical values issues should also be fixed
