### PR TITLE
(fix) Fixed the workspace's width for various window sizes

### DIFF
--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
@@ -43,11 +43,11 @@
 
 .fullWidth {
   // Subtract side rail width
-  width: calc(100% - 50px);
+  width: calc(100% - 3rem);
 }
 
 .dynamicWidth {
-  width: calc(50% - 9.6rem);
+  width: calc(50% - 9.625rem);
 }
 
 /* Desktop */
@@ -75,6 +75,13 @@
       border-style: solid;
       border-width: 0 1px 0 0;
     }
+  }
+}
+
+/* Small desktop */
+:global(.omrs-breakpoint-lt-large-desktop){
+  .dynamicWidth {
+    width: calc(50% - 1.625rem);
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the workspace's width for small desktop and minor pixel overlappings.

## Previously

### Small Desktop
![image](https://user-images.githubusercontent.com/51502471/212135144-6811783b-ad44-4495-ae71-d8c51fdcfecc.png)

### Large Desktop (observe the minor overlap of workspace's header over order basket widget)
![image](https://user-images.githubusercontent.com/51502471/212135269-8c10da10-bddc-4539-8d1f-07c3cc121dc4.png)

### Large Desktop (observe the gap between workspace header and order basket widget)
![image](https://user-images.githubusercontent.com/51502471/212135510-a74bdbb0-f288-41c0-89af-6c3ab23f5455.png)


## Fixes

### Small Desktop
![image](https://user-images.githubusercontent.com/51502471/212135665-79714802-d52f-4f58-8651-774f709aea79.png)

### Large Desktop (observe the minor overlap of workspace's header over order basket widget)
![image](https://user-images.githubusercontent.com/51502471/212135725-c743994c-ae54-4733-bb88-51e2bc81e8f7.png)

### Large Desktop (observe the gap between workspace header and order basket widget)
![image](https://user-images.githubusercontent.com/51502471/212135778-143657a5-72bd-47f3-906f-f82859aa23c6.png)


## Related Issue
None

## Other
<!-- Anything not covered above -->
