### PR TITLE
03-1761: Pt Chart tab: Default to "Upcoming Appointments"

### DIFF
--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
@@ -14,8 +14,8 @@ interface AppointmentsBaseProps {
 }
 
 enum AppointmentTypes {
-  TODAY = 0,
-  UPCOMING = 1,
+  UPCOMING = 0,
+  TODAY = 1,
   PAST = 2,
 }
 
@@ -49,8 +49,8 @@ const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
           ) : null}
           <div className={styles.contentSwitcherWrapper}>
             <ContentSwitcher size="md" onChange={({ index }) => setContentSwitcherValue(index)}>
-              <Switch name={'today'} text={t('today', 'Today')} />
               <Switch name={'upcoming'} text={t('upcoming', 'Upcoming')} />
+              <Switch name={'today'} text={t('today', 'Today')} />
               <Switch name={'past'} text={t('past', 'Past')} />
             </ContentSwitcher>
             <div className={styles.divider}></div>
@@ -65,6 +65,21 @@ const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
           </div>
         </CardHeader>
         {(() => {
+          if (contentSwitcherValue === AppointmentTypes.UPCOMING) {
+            if (appointmentsData.upcomingAppointments?.length) {
+              return <AppointmentsTable patientAppointments={appointmentsData?.upcomingAppointments} />;
+            }
+            return (
+              <Layer>
+                <Tile className={styles.tile}>
+                  <EmptyDataIllustration />
+                  <p className={styles.content}>
+                    {t('noUpcomingAppointments', 'There are no upcoming appointments to display for this patient')}
+                  </p>
+                </Tile>
+              </Layer>
+            );
+          }
           if (contentSwitcherValue === AppointmentTypes.TODAY) {
             if (appointmentsData.todaysAppointments?.length) {
               return <AppointmentsTable patientAppointments={appointmentsData?.todaysAppointments} />;
@@ -83,21 +98,7 @@ const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
               </Layer>
             );
           }
-          if (contentSwitcherValue === AppointmentTypes.UPCOMING) {
-            if (appointmentsData.upcomingAppointments?.length) {
-              return <AppointmentsTable patientAppointments={appointmentsData?.upcomingAppointments} />;
-            }
-            return (
-              <Layer>
-                <Tile className={styles.tile}>
-                  <EmptyDataIllustration />
-                  <p className={styles.content}>
-                    {t('noUpcomingAppointments', 'There are no upcoming appointments to display for this patient')}
-                  </p>
-                </Tile>
-              </Layer>
-            );
-          }
+
           if (contentSwitcherValue === AppointmentTypes.PAST) {
             if (appointmentsData.pastAppointments?.length) {
               return <AppointmentsTable patientAppointments={appointmentsData?.pastAppointments} />;

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.test.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.test.tsx
@@ -88,9 +88,7 @@ describe('AppointmensOverview', () => {
     expect(screen.getByRole('tablist')).toContainElement(upcomingAppointmentsTab);
     expect(screen.getByRole('tablist')).toContainElement(pastAppointmentsTab);
     expect(screen.getByTitle(/Empty data illustration/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/There are no appointments scheduled for today to display for this patient/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/There are no upcoming appointments to display for this patient/i)).toBeInTheDocument();
 
     await waitFor(() => user.click(pastAppointmentsTab));
     expect(screen.getByRole('table')).toBeInTheDocument();

--- a/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
@@ -32,15 +32,15 @@ export function useAppointments(patientUuid: string, startDate: string, abortCon
     : null;
 
   const pastAppointments = appointments?.filter(({ startDateTime }) =>
-    dayjs(new Date(startDateTime).toLocaleDateString()).isBefore(new Date().setHours(0, 0, 0, 0)),
+    dayjs(new Date(startDateTime).toISOString()).isBefore(new Date().setHours(0, 0, 0, 0)),
   );
 
   const upcomingAppointments = appointments?.filter(({ startDateTime }) =>
-    dayjs(new Date(startDateTime).toLocaleDateString()).isAfter(new Date()),
+    dayjs(new Date(startDateTime).toISOString()).isAfter(new Date()),
   );
 
   const todaysAppointments = appointments?.filter(({ startDateTime }) =>
-    dayjs(new Date(startDateTime).toLocaleDateString()).isToday(),
+    dayjs(new Date(startDateTime).toISOString()).isToday(),
   );
 
   return {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
- Made the `Upcoming appointments` the default view.
- Fix the date filtering which was causing appointments not to show.

## Screenshots
<img width="1440" alt="Screenshot 2023-01-16 at 14 39 31" src="https://user-images.githubusercontent.com/30952856/212674192-261065ff-240f-4e2d-946b-6fbed51c9325.png">


## Related Issue
- https://issues.openmrs.org/browse/O3-1761


