### PR TITLE
(feat) O3-1738: Show more than just ten items in conditions widget 

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -15,14 +15,8 @@ import {
   TableRow,
 } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
-import { formatDate, parseDate, usePagination } from '@openmrs/esm-framework';
-import {
-  CardHeader,
-  EmptyState,
-  ErrorState,
-  launchPatientWorkspace,
-  PatientChartPagination,
-} from '@openmrs/esm-patient-common-lib';
+import { formatDate, parseDate } from '@openmrs/esm-framework';
+import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { Condition, useConditions } from './conditions.resource';
 import styles from './conditions-detailed-summary.scss';
 
@@ -30,13 +24,7 @@ function ConditionsDetailedSummary({ patient }) {
   const { t } = useTranslation();
   const displayText = t('conditions', 'Conditions');
   const headerTitle = t('conditions', 'Conditions');
-
-  const conditionsCount = 10;
-  const urlLabel = t('seeAll', 'See all');
-  const pageUrl = `\${openmrsSpaBase}/patient/${patient.id}/chart/Conditions`;
-
   const { data: conditions, isError, isLoading, isValidating } = useConditions(patient.id);
-  const { results: paginatedConditions, goTo, currentPage } = usePagination(conditions ?? [], conditionsCount);
 
   const headers = React.useMemo(
     () => [
@@ -57,7 +45,7 @@ function ConditionsDetailedSummary({ patient }) {
   );
 
   const tableRows: Array<Condition> = React.useMemo(() => {
-    return paginatedConditions?.map((condition) => {
+    return conditions?.map((condition) => {
       return {
         ...condition,
         id: condition.id,
@@ -66,7 +54,7 @@ function ConditionsDetailedSummary({ patient }) {
         status: capitalize(condition.clinicalStatus),
       };
     });
-  }, [paginatedConditions]);
+  }, [conditions]);
 
   const launchConditionsForm = React.useCallback(() => launchPatientWorkspace('conditions-form-workspace'), []);
 
@@ -118,15 +106,6 @@ function ConditionsDetailedSummary({ patient }) {
             </TableContainer>
           )}
         </DataTable>
-        <PatientChartPagination
-          currentItems={paginatedConditions.length}
-          onPageNumberChange={({ page }) => goTo(page)}
-          pageNumber={currentPage}
-          pageSize={conditionsCount}
-          totalItems={conditions.length}
-          dashboardLinkUrl={pageUrl}
-          dashboardLinkLabel={urlLabel}
-        />
       </div>
     );
   }

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -15,8 +15,14 @@ import {
   TableRow,
 } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
-import { formatDate, parseDate } from '@openmrs/esm-framework';
-import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { formatDate, parseDate, usePagination } from '@openmrs/esm-framework';
+import {
+  CardHeader,
+  EmptyState,
+  ErrorState,
+  launchPatientWorkspace,
+  PatientChartPagination,
+} from '@openmrs/esm-patient-common-lib';
 import { Condition, useConditions } from './conditions.resource';
 import styles from './conditions-detailed-summary.scss';
 
@@ -24,7 +30,13 @@ function ConditionsDetailedSummary({ patient }) {
   const { t } = useTranslation();
   const displayText = t('conditions', 'Conditions');
   const headerTitle = t('conditions', 'Conditions');
+
+  const conditionsCount = 10;
+  const urlLabel = t('seeAll', 'See all');
+  const pageUrl = `\${openmrsSpaBase}/patient/${patient.id}/chart/Conditions`;
+
   const { data: conditions, isError, isLoading, isValidating } = useConditions(patient.id);
+  const { results: paginatedConditions, goTo, currentPage } = usePagination(conditions ?? [], conditionsCount);
 
   const headers = React.useMemo(
     () => [
@@ -45,7 +57,7 @@ function ConditionsDetailedSummary({ patient }) {
   );
 
   const tableRows: Array<Condition> = React.useMemo(() => {
-    return conditions?.map((condition) => {
+    return paginatedConditions?.map((condition) => {
       return {
         ...condition,
         id: condition.id,
@@ -54,7 +66,7 @@ function ConditionsDetailedSummary({ patient }) {
         status: capitalize(condition.clinicalStatus),
       };
     });
-  }, [conditions]);
+  }, [paginatedConditions]);
 
   const launchConditionsForm = React.useCallback(() => launchPatientWorkspace('conditions-form-workspace'), []);
 
@@ -106,6 +118,15 @@ function ConditionsDetailedSummary({ patient }) {
             </TableContainer>
           )}
         </DataTable>
+        <PatientChartPagination
+          currentItems={paginatedConditions.length}
+          onPageNumberChange={({ page }) => goTo(page)}
+          pageNumber={currentPage}
+          pageSize={conditionsCount}
+          totalItems={conditions.length}
+          dashboardLinkUrl={pageUrl}
+          dashboardLinkLabel={urlLabel}
+        />
       </div>
     );
   }

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
@@ -1,28 +1,14 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { attach, openmrsFetch, usePagination } from '@openmrs/esm-framework';
+import { openmrsFetch } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
-import { mockConditions, mockFhirConditionsResponse } from '../../../../__mocks__/conditions.mock';
+import { mockFhirConditionsResponse } from '../../../../__mocks__/conditions.mock';
 import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import ConditionsDetailedSummary from './conditions-detailed-summary.component';
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
-const mockUsePagination = usePagination as jest.Mock;
-
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    usePagination: jest.fn().mockImplementation(() => ({
-      currentPage: 1,
-      goTo: () => {},
-      results: [],
-    })),
-  };
-});
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
@@ -74,11 +60,6 @@ it('renders an error state view if there is a problem fetching conditions data',
 
 it("renders a detailed summary of the patient's conditions when present", async () => {
   mockOpenmrsFetch.mockReturnValueOnce({ data: mockFhirConditionsResponse });
-  mockUsePagination.mockImplementation(() => ({
-    currentPage: 1,
-    goTo: () => {},
-    results: mockConditions,
-  }));
   renderConditionsDetailedSummary();
 
   await waitForLoadingToFinish();

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
@@ -76,7 +76,7 @@ it("renders a detailed summary of the patient's conditions when present", async 
   expectedTableRows.forEach((row) => {
     expect(screen.getByRole('row', { name: new RegExp(row, 'i') })).toBeInTheDocument();
   });
-  expect(screen.getAllByRole('row').length).toEqual(6);
+  expect(screen.getAllByRole('row').length).toEqual(9);
 });
 
 it('clicking the Add button or Record Conditions link launches the conditions form', async () => {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions.resource.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions.resource.tsx
@@ -26,7 +26,7 @@ export type CodedCondition = {
 
 export function useConditions(patientUuid: string) {
   const { data, error, isValidating } = useSWR<{ data: FHIRConditionResponse }, Error>(
-    `${fhirBaseUrl}/Condition?patient=${patientUuid}`,
+    `${fhirBaseUrl}/Condition?patient=${patientUuid}&_count=500`,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-conditions-app/src/conditions/conditions.resource.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions.resource.tsx
@@ -26,7 +26,7 @@ export type CodedCondition = {
 
 export function useConditions(patientUuid: string) {
   const { data, error, isValidating } = useSWR<{ data: FHIRConditionResponse }, Error>(
-    `${fhirBaseUrl}/Condition?patient=${patientUuid}&_count=500`,
+    `${fhirBaseUrl}/Condition?patient=${patientUuid}&_count=100`,
     openmrsFetch,
   );
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
- Request for `500` results from the Backend so as to increase the returned conditions.

## Screenshots
<img width="1123" alt="Screenshot 2023-01-17 at 08 47 29" src="https://user-images.githubusercontent.com/30952856/212819660-77ceeee9-d207-4298-935e-055456fcab83.png">


## Video recording

https://user-images.githubusercontent.com/30952856/212733598-70829170-d912-4175-a401-6a0cd1099111.mov


## Related Issue
- https://issues.openmrs.org/browse/O3-1738

## Other
- Ignore the blue links, it looks like I have some cache on my local.
- I removed the pagination, so ignore the one in the video.
