### PR TITLE
(feat) Fix visits table pagination

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -64,11 +64,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
     return visits;
   }, [filter, visits]);
 
-  const {
-    results: paginatedVisits,
-    goTo,
-    currentPage,
-  } = usePagination(filteredRows ? filteredRows : visits ?? [], visitCount);
+  const { results: paginatedVisits, goTo, currentPage } = usePagination(filteredRows ?? [], visitCount);
 
   const tableHeaders = [
     {
@@ -282,7 +278,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
               onPageNumberChange={({ page }) => goTo(page)}
               pageNumber={currentPage}
               pageSize={visitCount}
-              totalItems={filteredRows ? filteredRows.length : visits.length}
+              totalItems={filteredRows.length}
             />
           ) : null}
         </>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes the pagination in the visits table widget. More specifically, it amends the pagination logic such that the pagination controls display the correct page numbers and sizes when a filter gets applied. Also refactors the code to use better variable names and gets rid of an unnecessary `useEffect`.

## Videos

https://user-images.githubusercontent.com/8509731/212882883-e491ae96-58a7-482e-b630-3229d5274d82.mp4
