### PR TITLE
(chore): Unable to view Notes and Type entered about Appointment.(03-1763 & 03-1782)

### DIFF
--- a/packages/esm-patient-appointments-app/src/appointments/appointments-form.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-form.component.tsx
@@ -71,7 +71,7 @@ const AppointmentsForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeW
       startDateTime: dayjs(startDatetime).format(),
       endDateTime: dayjs(endDatetime).format(),
       providerUuid: session?.currentProvider?.uuid,
-      providers: [{ uuid: session.currentProvider.uuid, comments: appointmentNote }],
+      providers: [{ uuid: session.currentProvider.uuid }],
       locationUuid: userLocation,
       patientUuid: patientUuid,
       comments: appointmentNote,

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-form.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-form.component.tsx
@@ -74,6 +74,7 @@ const AppointmentsForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeW
       providers: [{ uuid: session.currentProvider.uuid, comments: appointmentNote }],
       locationUuid: userLocation,
       patientUuid: patientUuid,
+      comments: appointmentNote,
     };
 
     const abortController = new AbortController();

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-form.test.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-form.test.tsx
@@ -118,9 +118,10 @@ describe('AppointmentForm', () => {
     expect(mockCreateAppointment).toHaveBeenCalledWith(
       expect.objectContaining({
         appointmentKind: 'Scheduled',
+        comments: '',
         serviceUuid: mockUseAppointmentServiceData[0].uuid,
         providerUuid: mockSessionDataResponse.data.currentProvider.uuid,
-        providers: [{ uuid: mockSessionDataResponse.data.currentProvider.uuid, comments: '' }],
+        providers: [{ uuid: mockSessionDataResponse.data.currentProvider.uuid }],
         locationUuid: mockLocationsDataResponse.data.results[1].uuid,
         patientUuid: mockPatient.id,
       }),

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-table.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-table.component.tsx
@@ -35,6 +35,7 @@ const AppointmentsTable: React.FC<AppointmentTableProps> = ({ patientAppointment
       { key: 'location', header: t('location', 'Location') },
       { key: 'service', header: t('service', 'Service') },
       { key: 'status', header: t('status', 'Status') },
+      { key: 'type', header: t('type', 'Type') },
       { key: 'notes', header: t('notes', 'Notes') },
     ],
     [t],
@@ -49,6 +50,7 @@ const AppointmentsTable: React.FC<AppointmentTableProps> = ({ patientAppointment
           location: appointment?.location?.name ?? '—',
           service: appointment.service.name,
           status: appointment.status,
+          type: appointment.appointmentKind ?? '—',
           notes: appointment.comments ?? '—',
         };
       }),

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-table.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-table.component.tsx
@@ -35,6 +35,7 @@ const AppointmentsTable: React.FC<AppointmentTableProps> = ({ patientAppointment
       { key: 'location', header: t('location', 'Location') },
       { key: 'service', header: t('service', 'Service') },
       { key: 'status', header: t('status', 'Status') },
+      { key: 'notes', header: t('notes', 'Notes') },
     ],
     [t],
   );
@@ -45,9 +46,10 @@ const AppointmentsTable: React.FC<AppointmentTableProps> = ({ patientAppointment
         return {
           id: appointment.uuid,
           date: formatDatetime(parseDate(appointment.startDateTime), { mode: 'wide' }),
-          location: appointment?.location?.name ?? '--',
+          location: appointment?.location?.name ?? '—',
           service: appointment.service.name,
           status: appointment.status,
+          notes: appointment.comments ?? '—',
         };
       }),
     [paginatedAppointments],

--- a/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
@@ -8,7 +8,7 @@ dayjs.extend(isToday);
 export const appointmentsSearchUrl = `/ws/rest/v1/appointments/search`;
 
 export function useAppointments(patientUuid: string, startDate: string, abortController: AbortController) {
-  /* 
+  /*
     SWR isn't meant to make POST requests for data fetching. This is a consequence of the API only exposing this resource via POST.
     This works but likely isn't recommended.
   */

--- a/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
@@ -8,7 +8,7 @@ dayjs.extend(isToday);
 export const appointmentsSearchUrl = `/ws/rest/v1/appointments/search`;
 
 export function useAppointments(patientUuid: string, startDate: string, abortController: AbortController) {
-  /*
+  /* 
     SWR isn't meant to make POST requests for data fetching. This is a consequence of the API only exposing this resource via POST.
     This works but likely isn't recommended.
   */

--- a/packages/esm-patient-appointments-app/src/types/index.ts
+++ b/packages/esm-patient-appointments-app/src/types/index.ts
@@ -50,7 +50,7 @@ export interface AppointmentPayload {
   startDateTime: string;
   endDateTime: string;
   appointmentKind: string;
-  providers: Array<{ uuid: string; comments: string; response?: string }>;
+  providers: Array<{ uuid: string; response?: string }>;
   locationUuid: string;
   comments: string;
 }

--- a/packages/esm-patient-appointments-app/src/types/index.ts
+++ b/packages/esm-patient-appointments-app/src/types/index.ts
@@ -52,4 +52,5 @@ export interface AppointmentPayload {
   appointmentKind: string;
   providers: Array<{ uuid: string; comments: string; response?: string }>;
   locationUuid: string;
+  comments: string;
 }

--- a/packages/esm-patient-appointments-app/translations/en.json
+++ b/packages/esm-patient-appointments-app/translations/en.json
@@ -18,6 +18,7 @@
   "noCurrentAppointments": "There are no appointments scheduled for today to display for this patient",
   "noPastAppointments": "There are no past appointments to display for this patient",
   "note": "Note",
+  "notes": "Notes",
   "noUpcomingAppointments": "There are no upcoming appointments to display for this patient",
   "past": "Past",
   "saveAndClose": "Save and close",

--- a/packages/esm-patient-appointments-app/translations/en.json
+++ b/packages/esm-patient-appointments-app/translations/en.json
@@ -29,5 +29,6 @@
   "status": "Status",
   "time": "Time",
   "today": "Today",
+  "type": "Type",
   "upcoming": "Upcoming"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
- Retrieve the appointment notes and display them in the table.
- Display the appointment type in the table.

## Screenshots
<img width="1126" alt="Screenshot 2023-01-19 at 16 53 08" src="https://user-images.githubusercontent.com/30952856/213460825-ca54a90c-93a0-40bd-9624-2d0510d8a335.png">

- Showing very long notes and Appointment Type
<img width="1118" alt="Screenshot 2023-01-20 at 00 40 54" src="https://user-images.githubusercontent.com/30952856/213569037-60a3232d-bf31-48f6-9394-0c9577ff000b.png">



## Related Issue
- [Display Appointment Notes](https://issues.openmrs.org/browse/O3-1763)
- [Display Appointment Type](https://issues.openmrs.org/browse/O3-1782)

