### PR TITLE
(refactor) Derive isLoading state directly from SWR hooks

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
+++ b/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
@@ -11,6 +11,7 @@ export function useObs(patientUuid: string): UseObsResult {
   const {
     data: result,
     error,
+    isLoading,
     isValidating,
   } = useSWR<{ data: ObsFetchResponse }, Error>(
     `${fhirBaseUrl}/Observation?subject:Patient=${patientUuid}&code=` +
@@ -46,7 +47,7 @@ export function useObs(patientUuid: string): UseObsResult {
   return {
     data: observations,
     error: error,
-    isLoading: !result && !error,
+    isLoading,
     isValidating,
   };
 }

--- a/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
+++ b/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
@@ -27,7 +27,7 @@ type UseAllergies = {
 };
 
 export function useAllergies(patientUuid: string): UseAllergies {
-  const { data, error, isValidating } = useSWR<{ data: FHIRAllergyResponse }, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: FHIRAllergyResponse }, Error>(
     `${fhirBaseUrl}/AllergyIntolerance?patient=${patientUuid}`,
     openmrsFetch,
   );
@@ -43,7 +43,7 @@ export function useAllergies(patientUuid: string): UseAllergies {
   return {
     allergies: data ? formattedAllergies : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }

--- a/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
@@ -25,7 +25,10 @@ export function useAppointments(patientUuid: string, startDate: string, abortCon
       },
     });
 
-  const { data, error, isValidating } = useSWR<AppointmentsFetchResponse, Error>(appointmentsSearchUrl, fetcher);
+  const { data, error, isLoading, isValidating } = useSWR<AppointmentsFetchResponse, Error>(
+    appointmentsSearchUrl,
+    fetcher,
+  );
 
   const appointments = data?.data?.length
     ? data.data.sort((a, b) => (b.startDateTime > a.startDateTime ? 1 : -1))
@@ -46,13 +49,13 @@ export function useAppointments(patientUuid: string, startDate: string, abortCon
   return {
     data: data ? { pastAppointments, upcomingAppointments, todaysAppointments } : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }
 
 export function useAppointmentService() {
-  const { data, error } = useSWR<{ data: Array<AppointmentService> }, Error>(
+  const { data, error, isLoading } = useSWR<{ data: Array<AppointmentService> }, Error>(
     `/ws/rest/v1/appointmentService/all/full`,
     openmrsFetch,
   );
@@ -60,7 +63,7 @@ export function useAppointmentService() {
   return {
     data: data ? data.data : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
   };
 }
 

--- a/packages/esm-patient-attachments-app/src/attachments.resource.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments.resource.tsx
@@ -12,20 +12,19 @@ export function getAttachmentByUuid(attachmentUuid: string, abortController: Abo
 }
 
 export function useAttachments(patientUuid: string, includeEncounterless: boolean) {
-  const { data, error, mutate, isValidating } = useSWR<FetchResponse<{ results: Array<AttachmentResponse> }>>(
-    `${attachmentUrl}?patient=${patientUuid}&includeEncounterless=${includeEncounterless}`,
-    openmrsFetch,
-  );
+  const { data, error, mutate, isLoading, isValidating } = useSWR<
+    FetchResponse<{ results: Array<AttachmentResponse> }>
+  >(`${attachmentUrl}?patient=${patientUuid}&includeEncounterless=${includeEncounterless}`, openmrsFetch);
 
   const results = useMemo(
     () => ({
-      isLoading: !data && !error,
+      isLoading,
       data: data?.data.results ?? [],
       error,
       mutate,
       isValidating,
     }),
-    [isValidating, data, error, mutate],
+    [data, error, isLoading, isValidating, mutate],
   );
 
   return results;

--- a/packages/esm-patient-banner-app/src/contact-details/relationships.resource.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/relationships.resource.tsx
@@ -8,7 +8,7 @@ const customRepresentation =
   'relationshipType:(uuid,display,description,aIsToB,bIsToA))';
 
 export function useRelationships(patientUuid: string) {
-  const { data, error, isValidating } = useSWR<{ data: RelationshipsResponse }, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: RelationshipsResponse }, Error>(
     `/ws/rest/v1/relationship?v=${customRepresentation}&person=${patientUuid}`,
     openmrsFetch,
   );
@@ -20,7 +20,7 @@ export function useRelationships(patientUuid: string) {
   return {
     data: data ? formattedRelationships : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }

--- a/packages/esm-patient-banner-app/src/hooks/usePatientAttributes.tsx
+++ b/packages/esm-patient-banner-app/src/hooks/usePatientAttributes.tsx
@@ -15,13 +15,13 @@ const customRepresentation =
  * @returns Object containing `patient-attributes`, `isLoading` loading status, `error`
  */
 export const usePatientAttributes = (patientUuid: string) => {
-  const { data, error } = useSWRImmutable<{ data: Patient }>(
+  const { data, error, isLoading } = useSWRImmutable<{ data: Patient }>(
     `/ws/rest/v1/patient/${patientUuid}?v=${customRepresentation}`,
     openmrsFetch,
   );
 
   return {
-    isLoading: !data && !error,
+    isLoading,
     attributes: data?.data?.person?.attributes ?? [],
     person: data?.data?.person ?? null,
     error: error,
@@ -47,7 +47,7 @@ export const usePatientContactAttributes = (patientUuid: string) => {
 };
 
 export function useOmrsRestPatient(patientUuid: string) {
-  const { data, error, isValidating, mutate } = useSWR<{ data: PersonFetchResponse }, Error>(
+  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: PersonFetchResponse }, Error>(
     `/ws/rest/v1/patient/${patientUuid}`,
     openmrsFetch,
   );
@@ -55,11 +55,11 @@ export function useOmrsRestPatient(patientUuid: string) {
     return {
       person: data?.data?.person ?? null,
       personError: error,
-      isPersonLoading: !data && !error,
+      isPersonLoading: isLoading,
       isPersonError: error,
       isPersonValidating: isValidating,
       mutate,
     };
-  }, [data, error, isValidating, mutate]);
+  }, [data, error, isLoading, isValidating, mutate]);
   return result;
 }

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics.resource.ts
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics.resource.ts
@@ -35,7 +35,10 @@ export function useBiometrics(patientUuid: string, concepts: Record<string, stri
     `&_count=${pageSize}
   `;
 
-  const { data, error, isValidating } = useSWR<{ data: BiometricsFetchResponse }, Error>(apiUrl, openmrsFetch);
+  const { data, error, isLoading, isValidating } = useSWR<{ data: BiometricsFetchResponse }, Error>(
+    apiUrl,
+    openmrsFetch,
+  );
 
   const getBiometricValueKey = (conceptUuid: string): string => {
     switch (conceptUuid) {
@@ -87,7 +90,7 @@ export function useBiometrics(patientUuid: string, concepts: Record<string, stri
   return {
     biometrics: formattedBiometrics,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }

--- a/packages/esm-patient-chart-app/src/banner/contact-details/relationships.resource.tsx
+++ b/packages/esm-patient-chart-app/src/banner/contact-details/relationships.resource.tsx
@@ -8,7 +8,7 @@ const customRepresentation =
   'relationshipType:(uuid,display,description,aIsToB,bIsToA))';
 
 export function useRelationships(patientUuid: string) {
-  const { data, error, isValidating } = useSWR<{ data: RelationshipsResponse }, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: RelationshipsResponse }, Error>(
     `/ws/rest/v1/relationship?v=${customRepresentation}&person=${patientUuid}`,
     openmrsFetch,
   );
@@ -20,7 +20,7 @@ export function useRelationships(patientUuid: string) {
   return {
     data: data ? formattedRelationships : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }

--- a/packages/esm-patient-chart-app/src/banner/hooks/usePatientAttributes.tsx
+++ b/packages/esm-patient-chart-app/src/banner/hooks/usePatientAttributes.tsx
@@ -12,13 +12,13 @@ const customRepresentation =
  * @returns Object containing `patient-attributes`, `isLoading` loading status, `error`
  */
 export const usePatientAttributes = (patientUuid: string) => {
-  const { data, error } = useSWRImmutable<{ data: Patient }>(
+  const { data, error, isLoading } = useSWRImmutable<{ data: Patient }>(
     `/ws/rest/v1/patient/${patientUuid}?v=${customRepresentation}`,
     openmrsFetch,
   );
 
   return {
-    isLoading: !data && !error,
+    isLoading,
     attributes: data?.data?.person?.attributes ?? [],
     error: error,
   };

--- a/packages/esm-patient-chart-app/src/deceased/deceased.resource.ts
+++ b/packages/esm-patient-chart-app/src/deceased/deceased.resource.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
-
+import useSWR from 'swr';
 import { openmrsFetch, usePatient } from '@openmrs/esm-framework';
-import useSWR, { SWRConfig } from 'swr';
 
 interface CauseOfDeathFetchResponse {
   uuid: string;
@@ -97,7 +96,7 @@ export function markPatientAlive(personUuid: string, abortController: AbortContr
 }
 
 export function useConceptAnswers(conceptUuid: string) {
-  const { data, error, isValidating } = useSWR<{ data: ConceptAnswersResponse }, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: ConceptAnswersResponse }, Error>(
     `/ws/rest/v1/concept/${conceptUuid}`,
     (url) => (conceptUuid ? openmrsFetch(url) : undefined),
     {
@@ -109,14 +108,14 @@ export function useConceptAnswers(conceptUuid: string) {
 
   return {
     conceptAnswers: data?.data?.answers ?? ([] as ConceptAnswer[]),
-    isConceptLoading: !data && !error,
+    isConceptLoading: isLoading,
     conceptError: error,
     isConceptAnswerValidating: isValidating,
   };
 }
 
 export function useCauseOfDeathConcept() {
-  const { data, error, isValidating } = useSWR<{ data: CauseOfDeathFetchResponse }>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: CauseOfDeathFetchResponse }>(
     `/ws/rest/v1/systemsetting/concept.causeOfDeath`,
     openmrsFetch,
     {
@@ -128,9 +127,9 @@ export function useCauseOfDeathConcept() {
   const result = useMemo(() => {
     return {
       value: data?.data?.value ?? undefined,
-      isCauseOfDeathLoading: !data && !error,
+      isCauseOfDeathLoading: isLoading,
       isCauseOfDeathValidating: isValidating,
     };
-  }, [data, error, isValidating]);
+  }, [data, isLoading, isValidating]);
   return result;
 }

--- a/packages/esm-patient-chart-app/src/visit/hooks/useRecommendedVisitTypes.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useRecommendedVisitTypes.tsx
@@ -1,7 +1,7 @@
+import { useMemo } from 'react';
 import useSWR from 'swr';
 import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
 import { ChartConfig } from '../../config-schema';
-import { useMemo } from 'react';
 
 interface EnrollmentVisitType {
   dataDependencies: Array<string>;
@@ -18,7 +18,7 @@ export const useRecommendedVisitTypes = (
   locationUuid: string,
 ) => {
   const { visitTypeResourceUrl, showRecommendedVisitTypeTab } = useConfig() as ChartConfig;
-  const { data, error } = useSWR<{ data: EnrollmentVisitType }>(
+  const { data, error, isLoading } = useSWR<{ data: EnrollmentVisitType }>(
     showRecommendedVisitTypeTab &&
       patientUuid &&
       enrollmentUuid &&
@@ -28,7 +28,8 @@ export const useRecommendedVisitTypes = (
   );
 
   const recommendedVisitTypes = useMemo(() => data?.data?.visitTypes?.allowed.map(mapToVisitType) ?? [], [data]);
-  return { recommendedVisitTypes, error, isLoading: !data && !error };
+
+  return { recommendedVisitTypes, error, isLoading };
 };
 
 const mapToVisitType = (visitType) => {

--- a/packages/esm-patient-chart-app/src/visit/hooks/useServiceQueue.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useServiceQueue.tsx
@@ -39,11 +39,14 @@ export function useStatuses() {
   const statusConceptSetUuid = config.statusConceptSetUuid;
 
   const apiUrl = `/ws/rest/v1/concept/${statusConceptSetUuid}`;
-  const { data, error } = useSWRImmutable<FetchResponse>(config.showServiceQueueFields ? apiUrl : null, openmrsFetch);
+  const { data, error, isLoading } = useSWRImmutable<FetchResponse>(
+    config.showServiceQueueFields ? apiUrl : null,
+    openmrsFetch,
+  );
 
   return {
     statuses: data ? data?.data?.setMembers : [],
-    isLoading: !data && !error,
+    isLoading,
   };
 }
 

--- a/packages/esm-patient-chart-app/src/visit/hooks/useVisitAttributeType.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useVisitAttributeType.tsx
@@ -35,7 +35,7 @@ const visitAttributeTypeCustomRepresentation =
   'custom:(uuid,display,name,description,datatypeClassname,datatypeConfig)';
 
 export function useVisitAttributeType(uuid) {
-  const { data, error } = useSWRImmutable<FetchResponse<VisitAttributeType>, Error>(
+  const { data, error, isLoading } = useSWRImmutable<FetchResponse<VisitAttributeType>, Error>(
     `/ws/rest/v1/visitattributetype/${uuid}?v=${visitAttributeTypeCustomRepresentation}`,
     openmrsFetch,
   );
@@ -52,17 +52,17 @@ export function useVisitAttributeType(uuid) {
 
   const results = useMemo(() => {
     return {
-      isLoading: !data && !error,
+      isLoading,
       error: error,
       data: data?.data,
     };
-  }, [data, error]);
+  }, [data, error, isLoading]);
 
   return results;
 }
 
 export function useConceptAnswersForVisitAttributeType(conceptUuid) {
-  const { data, error } = useSWRImmutable<FetchResponse<Concept>, Error>(
+  const { data, error, isLoading } = useSWRImmutable<FetchResponse<Concept>, Error>(
     conceptUuid ? `/ws/rest/v1/concept/${conceptUuid}` : null,
     openmrsFetch,
   );
@@ -79,12 +79,12 @@ export function useConceptAnswersForVisitAttributeType(conceptUuid) {
 
   const results = useMemo(() => {
     return {
-      isLoading: !data && !error,
+      isLoading,
       error: error,
       data: data?.data,
       answers: data?.data?.answers,
     };
-  }, [data, error]);
+  }, [data, error, isLoading]);
 
   return results;
 }

--- a/packages/esm-patient-chart-app/src/visit/queue-entry/queue.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/queue-entry/queue.resource.tsx
@@ -70,7 +70,7 @@ interface UseVisitQueueEntries {
 
 export function useVisitQueueEntries(): UseVisitQueueEntries {
   const apiUrl = `/ws/rest/v1/visit-queue-entry?v=full`;
-  const { data, error, isValidating } = useSWR<{ data: { results: Array<VisitQueueEntry> } }, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<VisitQueueEntry> } }, Error>(
     apiUrl,
     openmrsFetch,
   );
@@ -97,7 +97,7 @@ export function useVisitQueueEntries(): UseVisitQueueEntries {
 
   return {
     visitQueueEntries: mappedVisitQueueEntries ? mappedVisitQueueEntries : null,
-    isLoading: !data && !error,
+    isLoading,
     isError: error,
     isValidating,
   };

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -11,7 +11,7 @@ export function useVisits(patientUuid: string) {
     'encounterProviders:(uuid,display,encounterRole:(uuid,display),' +
     'provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient';
 
-  const { data, error, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
     `/ws/rest/v1/visit?patient=${patientUuid}&v=${customRepresentation}`,
     openmrsFetch,
   );
@@ -19,7 +19,7 @@ export function useVisits(patientUuid: string) {
   return {
     visits: data ? data?.data?.results : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }
@@ -41,7 +41,7 @@ export function useEncounters(patientUuid: string) {
       .map(([key, value]) => `${key}=${value}`)
       .join('&');
 
-  const { data, error, isValidating } = useSWR<{ data: { results: Array<Record<string, unknown>> } }, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<Record<string, unknown>> } }, Error>(
     fullRequest,
     openmrsFetch,
   );
@@ -49,7 +49,7 @@ export function useEncounters(patientUuid: string) {
   return {
     encounters: data ? data?.data?.results : null,
     error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }
@@ -63,7 +63,7 @@ export function usePastVisits(patientUuid: string) {
     'visitType:(uuid,name,display),attributes:(uuid,display,value),location:(uuid,name,display),startDatetime,' +
     'stopDatetime)';
 
-  const { data, error, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
     `/ws/rest/v1/visit?patient=${patientUuid}&v=${customRepresentation}`,
     openmrsFetch,
   );
@@ -71,7 +71,7 @@ export function usePastVisits(patientUuid: string) {
   return {
     data: data ? data.data.results : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }

--- a/packages/esm-patient-common-lib/src/programs/usePatientProgramEnrollment.tsx
+++ b/packages/esm-patient-common-lib/src/programs/usePatientProgramEnrollment.tsx
@@ -6,7 +6,7 @@ import uniqBy from 'lodash-es/uniqBy';
 const customRepresentation = `custom:(uuid,display,program,dateEnrolled,dateCompleted,location:(uuid,display))`;
 
 export const useActivePatientEnrollment = (patientUuid: string) => {
-  const { data, error } = useSWR<{ data: { results: Array<PatientProgram> } }>(
+  const { data, error, isLoading } = useSWR<{ data: { results: Array<PatientProgram> } }>(
     `/ws/rest/v1/programenrollment?patient=${patientUuid}&v=${customRepresentation}`,
     openmrsFetch,
   );
@@ -22,6 +22,6 @@ export const useActivePatientEnrollment = (patientUuid: string) => {
   return {
     activePatientEnrollment: uniqBy(activePatientEnrollment, (program) => program?.program?.uuid),
     error,
-    isLoading: !data && !error,
+    isLoading,
   };
 };

--- a/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
+++ b/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
@@ -7,7 +7,10 @@ export function useVitalsConceptMetadata() {
 
   const apiUrl = `/ws/rest/v1/concept/?q=VITALS SIGNS&v=${customRepresentation}`;
 
-  const { data, error } = useSWRImmutable<{ data: VitalsConceptMetadataResponse }, Error>(apiUrl, openmrsFetch);
+  const { data, error, isLoading } = useSWRImmutable<{ data: VitalsConceptMetadataResponse }, Error>(
+    apiUrl,
+    openmrsFetch,
+  );
 
   const conceptMetadata = data?.data?.results[0]?.setMembers;
 
@@ -17,7 +20,7 @@ export function useVitalsConceptMetadata() {
   return {
     data: conceptUnits,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     conceptMetadata,
   };
 }

--- a/packages/esm-patient-conditions-app/src/conditions/conditions.resource.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions.resource.tsx
@@ -25,7 +25,7 @@ export type CodedCondition = {
 };
 
 export function useConditions(patientUuid: string) {
-  const { data, error, isValidating } = useSWR<{ data: FHIRConditionResponse }, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: FHIRConditionResponse }, Error>(
     `${fhirBaseUrl}/Condition?patient=${patientUuid}&_count=100`,
     openmrsFetch,
   );
@@ -41,7 +41,7 @@ export function useConditions(patientUuid: string) {
   return {
     data: data ? formattedConditions : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }
@@ -50,17 +50,17 @@ export function useConditionsSearch(conditionToLookup: string) {
   const config = useConfig();
   const conditionConceptClassUuid = config?.conditionConceptClassUuid;
 
-  const CONDITIONS_SEARCH_URL = `/ws/rest/v1/conceptsearch?conceptClasses=${conditionConceptClassUuid}&q=${conditionToLookup}`;
+  const conditionsSearchUrl = `/ws/rest/v1/conceptsearch?conceptClasses=${conditionConceptClassUuid}&q=${conditionToLookup}`;
 
-  const { data, error } = useSWR<{ data: { results: Array<CodedCondition> } }, Error>(
-    conditionToLookup ? CONDITIONS_SEARCH_URL : null,
+  const { data, error, isLoading } = useSWR<{ data: { results: Array<CodedCondition> } }, Error>(
+    conditionToLookup ? conditionsSearchUrl : null,
     openmrsFetch,
   );
 
   return {
     conditions: data?.data?.results ?? [],
     error: error,
-    isSearchingConditions: !data && !error,
+    isSearchingConditions: isLoading,
   };
 }
 

--- a/packages/esm-patient-forms-app/src/hooks/use-program-config.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-program-config.ts
@@ -14,7 +14,7 @@ interface ProgramConfig {
 }
 
 export const useProgramConfig = (patientUuid: string, loadProgramConfig: boolean = false) => {
-  const { data, error } = useSWR<{ data: ProgramConfig }>(
+  const { data, error, isLoading } = useSWR<{ data: ProgramConfig }>(
     loadProgramConfig && `/etl-latest/etl/patient-program-config?patientUuid=${patientUuid}`,
     openmrsFetch,
   );

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations.resource.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations.resource.tsx
@@ -51,7 +51,7 @@ export function useImmunizationsConceptSet() {
   const conceptSetMappingUrl = `/ws/rest/v1/concept?source=${source}&code=${code}&v=full`;
   const conceptSetUuidUrl = `/ws/rest/v1/concept/${conceptSetSearchTerm}?v=full`;
 
-  const { data, error } = useSWR<{ data: { results: Array<OpenmrsConcept> } }, Error>(
+  const { data, error, isLoading } = useSWR<{ data: { results: Array<OpenmrsConcept> } }, Error>(
     isConceptMapping(conceptSetSearchTerm) ? conceptSetMappingUrl : conceptSetUuidUrl,
     openmrsFetch,
   );
@@ -59,21 +59,24 @@ export function useImmunizationsConceptSet() {
   return {
     data: data ? data.data.results[0] : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
   };
 }
 
 export function useImmunizations(patientUuid: string) {
   const immunizationsUrl = `${fhirBaseUrl}/Immunization?patient=${patientUuid}`;
 
-  const { data, error, isValidating } = useSWR<{ data: FHIRImmunizationBundle }, Error>(immunizationsUrl, openmrsFetch);
+  const { data, error, isLoading, isValidating } = useSWR<{ data: FHIRImmunizationBundle }, Error>(
+    immunizationsUrl,
+    openmrsFetch,
+  );
 
   const existingImmunizations = data ? mapFromFHIRImmunizationBundle(data.data) : null;
 
   return {
     data: data ? existingImmunizations : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -20,7 +20,7 @@ export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any', 
     'frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,numRefills,dosingInstructions,' +
     'duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)';
 
-  const { data, error, isValidating } = useSWR<FetchResponse<PatientMedicationFetchResponse>, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<FetchResponse<PatientMedicationFetchResponse>, Error>(
     `/ws/rest/v1/order?patient=${patientUuid}&careSetting=${careSettingUuid}&status=${status}&orderType=${drugOrderTypeUUID}&v=${customRepresentation}`,
     openmrsFetch,
   );
@@ -38,7 +38,7 @@ export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any', 
   return {
     data: data ? drugOrders : null,
     error: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }

--- a/packages/esm-patient-medications-app/src/api/order-config.ts
+++ b/packages/esm-patient-medications-app/src/api/order-config.ts
@@ -1,14 +1,7 @@
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
-import {
-  CommonMedicationValueCoded,
-  DosingUnit,
-  DurationUnit,
-  MedicationFrequency,
-  MedicationRoute,
-  QuantityUnit,
-} from './drug-order-template';
+import { DosingUnit, DurationUnit, MedicationFrequency, MedicationRoute, QuantityUnit } from './drug-order-template';
 
 export interface CommonConfigProps {
   uuid: string;
@@ -34,7 +27,7 @@ export function useOrderConfig(): {
     orderFrequencies: Array<MedicationFrequency>;
   };
 } {
-  const { data, error, isValidating } = useSWRImmutable<{ data: OrderConfig }, Error>(
+  const { data, error, isLoading, isValidating } = useSWRImmutable<{ data: OrderConfig }, Error>(
     `/ws/rest/v1/orderentryconfig`,
     openmrsFetch,
   );
@@ -63,10 +56,10 @@ export function useOrderConfig(): {
           value: display,
         })),
       },
-      isLoading: !data && !error,
+      isLoading,
       error,
     }),
-    [data, error],
+    [data, error, isLoading],
   );
 
   return results;

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search/drug-search.resource.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search/drug-search.resource.tsx
@@ -10,7 +10,7 @@ export function useDrugSearch(query): {
   drugs: Array<Drug>;
   error: Error;
 } {
-  const { data, error } = useSWRImmutable<FetchResponse<{ results: Array<Drug> }>, Error>(
+  const { data, error, isLoading } = useSWRImmutable<FetchResponse<{ results: Array<Drug> }>, Error>(
     query
       ? `/ws/rest/v1/drug?q=${query}&v=custom:(uuid,display,name,strength,dosageForm:(display,uuid),concept:(display,uuid))`
       : null,
@@ -19,11 +19,11 @@ export function useDrugSearch(query): {
 
   const results = useMemo(
     () => ({
-      isLoading: !data && !error,
+      isLoading,
       drugs: data?.data?.results,
       error,
     }),
-    [data, error],
+    [data, error, isLoading],
   );
 
   return results;
@@ -34,7 +34,7 @@ export function useDrugTemplate(drugUuid: string): {
   templates: Array<DrugOrderTemplate>;
   error: Error;
 } {
-  const { data, error } = useSWRImmutable<
+  const { data, error, isLoading } = useSWRImmutable<
     FetchResponse<{
       results: Array<{
         uuid: string;
@@ -48,14 +48,14 @@ export function useDrugTemplate(drugUuid: string): {
 
   const results = useMemo(
     () => ({
-      isLoading: !data && !error,
+      isLoading,
       templates: data?.data?.results?.map((drug) => ({
         ...drug,
         template: JSON.parse(drug.template) as OrderTemplate,
       })),
       error: error,
     }),
-    [data, error],
+    [data, error, isLoading],
   );
   return results;
 }

--- a/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
@@ -32,7 +32,7 @@ export function useVisitNotes(patientUuid: string): UseVisitNotes {
     'diagnoses';
 
   const encountersApiUrl = `/ws/rest/v1/encounter?patient=${patientUuid}&obs=${visitDiagnosesConceptUuid}&v=${customRepresentation}`;
-  const { data, error, isValidating } = useSWR<{ data: EncountersFetchResponse }, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: EncountersFetchResponse }, Error>(
     encountersApiUrl,
     openmrsFetch,
   );
@@ -58,7 +58,7 @@ export function useVisitNotes(patientUuid: string): UseVisitNotes {
   return {
     visitNotes: data ? formattedVisitNotes : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }

--- a/packages/esm-patient-programs-app/src/programs/programs.resource.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs.resource.tsx
@@ -11,7 +11,7 @@ import { ConfigObject } from '../config-schema';
 export const customRepresentation = `custom:(uuid,display,program,dateEnrolled,dateCompleted,location:(uuid,display))`;
 
 export function useEnrollments(patientUuid: string) {
-  const { data, error, isValidating } = useSWR<{ data: ProgramsFetchResponse }, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<{ data: ProgramsFetchResponse }, Error>(
     `/ws/rest/v1/programenrollment?patient=${patientUuid}&v=${customRepresentation}`,
     openmrsFetch,
   );
@@ -26,14 +26,14 @@ export function useEnrollments(patientUuid: string) {
   return {
     data: data ? uniqBy(formattedEnrollments, (program) => program?.program?.uuid) : null,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
     activeEnrollments,
   };
 }
 
 export function useAvailablePrograms(enrollments?: Array<PatientProgram>) {
-  const { data, error } = useSWR<{ data: { results: Array<Program> } }, Error>(
+  const { data, error, isLoading } = useSWR<{ data: { results: Array<Program> } }, Error>(
     `/ws/rest/v1/program?v=custom:(uuid,display,allWorkflows,concept:(uuid,display))`,
     openmrsFetch,
   );
@@ -48,7 +48,7 @@ export function useAvailablePrograms(enrollments?: Array<PatientProgram>) {
   return {
     data: availablePrograms,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     eligiblePrograms,
   };
 }
@@ -91,14 +91,14 @@ export function updateProgramEnrollment(programEnrollmentUuid: string, payload, 
 
 export const useConfigurableProgram = (patientUuid: string) => {
   const { customUrl } = useConfig() as ConfigObject;
-  const { data, error } = useSWR<{ data: Array<ConfigurableProgram> }>(
+  const { data, error, isLoading } = useSWR<{ data: Array<ConfigurableProgram> }>(
     customUrl ? `${customUrl}${patientUuid}` : null,
     openmrsFetch,
   );
   const configurablePrograms = data?.data ?? [];
   return {
     configurablePrograms,
-    isLoading: !data && !error,
+    isLoading,
     error: error,
   };
 };

--- a/packages/esm-patient-test-results-app/src/grouped-timeline/useObstreeData.ts
+++ b/packages/esm-patient-test-results-app/src/grouped-timeline/useObstreeData.ts
@@ -55,7 +55,7 @@ const useGetManyObstreeData = (uuidArray) => {
       return `/ws/rest/v1/obstree?patient=${patientUuid}&concept=${uuidArray[index]}`;
     } else return null;
   };
-  const { data, error } = useSWRInfinite(getObstreeUrl, openmrsFetch, { initialSize: uuidArray.length });
+  const { data, error, isLoading } = useSWRInfinite(getObstreeUrl, openmrsFetch, { initialSize: uuidArray.length });
 
   const result = useMemo(() => {
     return (

--- a/packages/esm-patient-test-results-app/src/panel-view/usePanelData.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-view/usePanelData.tsx
@@ -25,14 +25,13 @@ export function useObservations() {
     },
     [patientUuid],
   );
-  const { data, error, size, setSize } = useSWRInfinite<FetchResponse<FhirResponse<FHIRObservationResource>>, Error>(
-    getUrl,
-    openmrsFetch,
-    {
-      revalidateIfStale: false,
-      revalidateOnFocus: false,
-    },
-  );
+  const { data, error, size, setSize, isLoading } = useSWRInfinite<
+    FetchResponse<FhirResponse<FHIRObservationResource>>,
+    Error
+  >(getUrl, openmrsFetch, {
+    revalidateIfStale: false,
+    revalidateOnFocus: false,
+  });
 
   useEffect(() => {
     // Infinitely fetching all the data
@@ -49,10 +48,10 @@ export function useObservations() {
       : null;
     return {
       observations,
-      isLoading: !data && !error,
+      isLoading,
       conceptUuids: observations ? [...new Set(observations.map((obs) => getConceptUuid(obs)))] : null,
     };
-  }, [data, error]);
+  }, [data, isLoading]);
 
   return results;
 }
@@ -67,7 +66,7 @@ function useConcepts(conceptUuids: Array<string>) {
     },
     [conceptUuids],
   );
-  const { data, error } = useSWRInfinite<FetchResponse<Concept>>(getUrl, openmrsFetch, {
+  const { data, error, isLoading } = useSWRInfinite<FetchResponse<Concept>>(getUrl, openmrsFetch, {
     initialSize: conceptUuids?.length ?? 1,
     revalidateIfStale: false,
     revalidateOnFocus: false,
@@ -81,9 +80,9 @@ function useConcepts(conceptUuids: Array<string>) {
         ? concepts.filter((c) => c.conceptClass.display === 'Test' || c.conceptClass.display === 'LabSet')
         : null,
       // If there are no observations, hence no concept UUIDS, then it should return isLoading as false
-      isLoading: conceptUuids?.length === 0 ? false : !data && !error,
+      isLoading: conceptUuids?.length === 0 ? false : isLoading,
     };
-  }, [data, error, conceptUuids]);
+  }, [data, conceptUuids, isLoading]);
 
   return results;
 }

--- a/packages/esm-patient-test-results-app/src/trendline/trendline-resource.tsx
+++ b/packages/esm-patient-test-results-app/src/trendline/trendline-resource.tsx
@@ -35,7 +35,7 @@ export function useObstreeData(
   trendlineData: TreeNode;
   isValidating: boolean;
 } {
-  const { data, error, isValidating } = useSWR<FetchResponse<TreeNode>, Error>(
+  const { data, error, isLoading, isValidating } = useSWR<FetchResponse<TreeNode>, Error>(
     `/ws/rest/v1/obstree?patient=${patientUuid}&concept=${conceptUuid}`,
     openmrsFetch,
   );
@@ -49,7 +49,7 @@ export function useObstreeData(
 
   const returnValue = useMemo(
     () => ({
-      isLoading: !data && !error,
+      isLoading,
       trendlineData:
         computeTrendlineData(data?.data)?.[0] ??
         ({
@@ -62,7 +62,7 @@ export function useObstreeData(
         } as TreeNode),
       isValidating,
     }),
-    [data, error, isValidating],
+    [data?.data, isLoading, isValidating],
   );
 
   return returnValue;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
@@ -67,7 +67,7 @@ export function useVitals(patientUuid: string, includeBiometrics: boolean = fals
     `&_count=${pageSize}
         `;
 
-  const { data, error, isValidating } = useSWR<{ data: VitalsFetchResponse }, Error>(apiUrl, openmrsFetch);
+  const { data, error, isLoading, isValidating } = useSWR<{ data: VitalsFetchResponse }, Error>(apiUrl, openmrsFetch);
 
   const getVitalSignKey = (conceptUuid: string): string => {
     switch (conceptUuid) {
@@ -141,7 +141,7 @@ export function useVitals(patientUuid: string, includeBiometrics: boolean = fals
   return {
     vitals: formattedVitals,
     isError: error,
-    isLoading: !data && !error,
+    isLoading,
     isValidating,
   };
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
 
`isLoading` is a [new state](https://swr.vercel.app/blog/swr-v2#isloading) returned by `useSWR` and its derivatives (useSWRInfinite and useSWRImmutable) that indicates that **the request is still ongoing, and there is no data loaded yet**. Previously we had to check if both `data` and `error` from `useSWR` were undefined to determine if it was the initial loading state. 

This PR refactors all usages of `useSWR` and its derivatives (useSWRInfinite and useSWRImmutable) so that the `isLoading` state gets immediately derived.  
