### PR TITLE
(refactor) Use the bound mutate API instead of global mutate

### DIFF
--- a/__mocks__/appointments.mock.ts
+++ b/__mocks__/appointments.mock.ts
@@ -381,7 +381,7 @@ export const mockUseAppointmentServiceData = [
     name: 'Outpatient',
     description: null,
     speciality: {},
-    startTime: '',
+    startDateTime: new Date().toISOString(),
     endTime: '',
     maxAppointmentsLimit: null,
     durationMins: null,

--- a/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
+++ b/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
@@ -24,11 +24,14 @@ type UseAllergies = {
   isError: Error | null;
   isLoading: boolean;
   isValidating: boolean;
+  mutate: () => void;
 };
 
 export function useAllergies(patientUuid: string): UseAllergies {
-  const { data, error, isLoading, isValidating } = useSWR<{ data: FHIRAllergyResponse }, Error>(
-    `${fhirBaseUrl}/AllergyIntolerance?patient=${patientUuid}`,
+  const allergiesUrl = `${fhirBaseUrl}/AllergyIntolerance?patient=${patientUuid}`;
+
+  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: FHIRAllergyResponse }, Error>(
+    patientUuid ? allergiesUrl : null,
     openmrsFetch,
   );
 
@@ -45,6 +48,7 @@ export function useAllergies(patientUuid: string): UseAllergies {
     isError: error,
     isLoading,
     isValidating,
+    mutate,
   };
 }
 

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-form.test.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-form.test.tsx
@@ -42,7 +42,7 @@ jest.mock('./appointments.resource', () => {
 
 describe('AppointmentForm', () => {
   it('renders the appointments form showing all the relevant fields and values', async () => {
-    mockOpenmrsFetch.mockReturnValueOnce(mockUseAppointmentServiceData);
+    mockOpenmrsFetch.mockReturnValue(mockUseAppointmentServiceData);
 
     renderAppointmentsForm();
 
@@ -71,7 +71,7 @@ describe('AppointmentForm', () => {
   it('closes the form and the workspace when the cancel button is clicked', async () => {
     const user = userEvent.setup();
 
-    mockOpenmrsFetch.mockReturnValueOnce(mockAppointmentsData);
+    mockOpenmrsFetch.mockReturnValueOnce(mockUseAppointmentServiceData);
 
     renderAppointmentsForm();
 
@@ -86,8 +86,8 @@ describe('AppointmentForm', () => {
   it('renders a success toast notification upon successfully scheduling an appointment', async () => {
     const user = userEvent.setup();
 
-    mockOpenmrsFetch.mockReturnValueOnce({ data: mockUseAppointmentServiceData });
-    mockCreateAppointment.mockResolvedValueOnce({ status: 200, statusText: 'Ok' });
+    mockOpenmrsFetch.mockReturnValue({ data: mockUseAppointmentServiceData });
+    mockCreateAppointment.mockResolvedValue({ status: 200, statusText: 'Ok' });
 
     renderAppointmentsForm();
 

--- a/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments.resource.tsx
@@ -5,7 +5,7 @@ import { AppointmentPayload, AppointmentService, AppointmentsFetchResponse } fro
 import isToday from 'dayjs/plugin/isToday';
 dayjs.extend(isToday);
 
-export const appointmentsSearchUrl = `/ws/rest/v1/appointments/search`;
+const appointmentsSearchUrl = `/ws/rest/v1/appointments/search`;
 
 export function useAppointments(patientUuid: string, startDate: string, abortController: AbortController) {
   /*
@@ -25,7 +25,7 @@ export function useAppointments(patientUuid: string, startDate: string, abortCon
       },
     });
 
-  const { data, error, isLoading, isValidating } = useSWR<AppointmentsFetchResponse, Error>(
+  const { data, error, isLoading, isValidating, mutate } = useSWR<AppointmentsFetchResponse, Error>(
     appointmentsSearchUrl,
     fetcher,
   );
@@ -51,6 +51,7 @@ export function useAppointments(patientUuid: string, startDate: string, abortCon
     isError: error,
     isLoading,
     isValidating,
+    mutate,
   };
 }
 

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
@@ -50,13 +50,14 @@ const AttachmentsOverview: React.FC<{ patientUuid: string }> = ({ patientUuid })
     (attachment: Attachment) => {
       deleteAttachmentPermanently(attachment.id, new AbortController())
         .then(() => {
+          mutate();
+          setAttachmentToPreview(null);
+
           showToast({
             title: t('fileDeleted', 'File deleted'),
             description: `${attachment.title} ${t('successfullyDeleted', 'successfully deleted')}`,
             kind: 'success',
           });
-          setAttachmentToPreview(null);
-          mutate();
         })
         .catch((error) => {
           showToast({

--- a/packages/esm-patient-chart-app/src/visit/hooks/useRecommendedVisitTypes.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useRecommendedVisitTypes.tsx
@@ -28,7 +28,6 @@ export const useRecommendedVisitTypes = (
   );
 
   const recommendedVisitTypes = useMemo(() => data?.data?.visitTypes?.allowed.map(mapToVisitType) ?? [], [data]);
-
   return { recommendedVisitTypes, error, isLoading };
 };
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -156,6 +156,8 @@ const StartVisitForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWor
                   .subscribe(
                     (response) => {
                       if (response.status === 201) {
+                        mutate();
+
                         showToast({
                           kind: 'success',
                           title: t('visitStarted', 'Visit started'),
@@ -165,7 +167,6 @@ const StartVisitForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWor
                             `${hours} : ${minutes}`,
                           ),
                         });
-                        mutate();
                       }
                     },
                     (error) => {
@@ -178,8 +179,9 @@ const StartVisitForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWor
                     },
                   );
               }
-              closeWorkspace();
               mutate();
+              closeWorkspace();
+
               showToast({
                 critical: true,
                 kind: 'success',

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.component.tsx
@@ -26,13 +26,14 @@ const CancelVisitDialog: React.FC<CancelVisitDialogProps> = ({ patientUuid, clos
     }).then(
       () => {
         mutate();
+        closeModal();
+        setSubmitting(false);
+
         showToast({
           title: t('cancelVisit', 'Cancel visit'),
           kind: 'success',
           description: t('visitCanceled', 'Canceled active visit successfully'),
         });
-        closeModal();
-        setSubmitting(false);
       },
       (error) => {
         showNotification({

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -6,7 +6,6 @@
   "address": "Address",
   "all": "All",
   "allEncounters": "All encounters",
-  "allVisits": "All visits",
   "cancel": "Cancel",
   "cancelActiveVisit": "Cancel active visit",
   "cancelVisit": "Cancel Visit",

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
@@ -42,6 +42,9 @@ jest.mock('@openmrs/esm-framework', () => {
 
 jest.mock('./conditions.resource', () => ({
   createPatientCondition: jest.fn(),
+  useConditions: jest.fn().mockImplementation(() => ({
+    mutate: jest.fn(),
+  })),
   useConditionsSearch: jest.fn().mockImplementation(() => ({
     conditions: [],
     error: null,

--- a/packages/esm-patient-conditions-app/src/conditions/conditions.resource.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions.resource.tsx
@@ -26,7 +26,8 @@ export type CodedCondition = {
 
 export function useConditions(patientUuid: string) {
   const conditionsUrl = `${fhirBaseUrl}/Condition?patient=${patientUuid}&_count=100`;
-  const { data, error, isLoading, isValidating } = useSWR<{ data: FHIRConditionResponse }, Error>(
+
+  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: FHIRConditionResponse }, Error>(
     patientUuid ? conditionsUrl : null,
     openmrsFetch,
   );
@@ -44,6 +45,7 @@ export function useConditions(patientUuid: string) {
     isError: error,
     isLoading,
     isValidating,
+    mutate,
   };
 }
 

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -10,8 +10,8 @@ import { useMemo } from 'react';
  * @param patientUuid The UUID of the patient whose orders should be fetched.
  * @param status The status/the kind of orders to be fetched.
  */
-export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any', careSettingUuid: string) {
-  const { drugOrderTypeUUID } = useConfig() as ConfigObject;
+export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any') {
+  const { careSettingUuid, drugOrderTypeUUID } = useConfig() as ConfigObject;
   const customRepresentation =
     'custom:(uuid,dosingType,orderNumber,accessionNumber,' +
     'patient:ref,action,careSetting:ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,' +
@@ -19,9 +19,10 @@ export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any', 
     'commentToFulfiller,drug:(uuid,display,strength,dosageForm:(display,uuid),concept),dose,doseUnits:ref,' +
     'frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,numRefills,dosingInstructions,' +
     'duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)';
+  const ordersUrl = `/ws/rest/v1/order?patient=${patientUuid}&careSetting=${careSettingUuid}&status=${status}&orderType=${drugOrderTypeUUID}&v=${customRepresentation}`;
 
-  const { data, error, isLoading, isValidating } = useSWR<FetchResponse<PatientMedicationFetchResponse>, Error>(
-    `/ws/rest/v1/order?patient=${patientUuid}&careSetting=${careSettingUuid}&status=${status}&orderType=${drugOrderTypeUUID}&v=${customRepresentation}`,
+  const { data, error, isLoading, isValidating, mutate } = useSWR<FetchResponse<PatientMedicationFetchResponse>, Error>(
+    patientUuid ? ordersUrl : null,
     openmrsFetch,
   );
 
@@ -40,6 +41,7 @@ export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any', 
     error: error,
     isLoading,
     isValidating,
+    mutateOrders: mutate,
   };
 }
 

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -22,14 +22,14 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
     error: activeOrdersError,
     isLoading: isLoadingActiveOrders,
     isValidating: isValidatingActiveOrders,
-  } = usePatientOrders(patientUuid, 'ACTIVE', config.careSettingUuid);
+  } = usePatientOrders(patientUuid, 'ACTIVE');
 
   const {
     data: pastOrders,
     error: pastOrdersError,
     isLoading: isLoadingPastOrders,
     isValidating: isValidatingPastOrders,
-  } = usePatientOrders(patientUuid, 'any', config.careSettingUuid);
+  } = usePatientOrders(patientUuid, 'any');
 
   return (
     <>

--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
@@ -21,12 +21,7 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, show
   const displayText = t('activeMedicationsDisplayText', 'Active medications');
   const headerTitle = t('activeMedicationsHeaderTitle', 'active medications');
 
-  const {
-    data: activePatientOrders,
-    error,
-    isLoading,
-    isValidating,
-  } = usePatientOrders(patientUuid, 'ACTIVE', config.careSettingUuid);
+  const { data: activePatientOrders, error, isLoading, isValidating } = usePatientOrders(patientUuid, 'ACTIVE');
 
   const { launchOrderBasket } = useLaunchOrderBasket(patientUuid);
 

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -31,8 +31,6 @@ import {
 } from '@openmrs/esm-framework';
 import {
   fetchConceptDiagnosisByName,
-  useLocationUuid,
-  useProviderUuid,
   savePatientDiagnosis,
   saveVisitNote,
   useVisitNotes,
@@ -65,8 +63,8 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, patie
   const [visitDateTime, setVisitDateTime] = useState(new Date());
 
   const { mutateVisitNotes } = useVisitNotes(patientUuid);
-  const { locationUuid } = useLocationUuid(session?.sessionLocation?.uuid);
-  const { providerUuid } = useProviderUuid(session?.currentProvider?.uuid);
+  const locationUuid = session?.sessionLocation?.uuid;
+  const providerUuid = session?.currentProvider?.uuid;
 
   const handlePrimarySearchChange = (event) => {
     setIsPrimarySearching(true);

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -1,14 +1,9 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import { of } from 'rxjs/internal/observable/of';
-import { createErrorHandler, showNotification, showToast, useConfig, useSession } from '@openmrs/esm-framework';
-import {
-  fetchConceptDiagnosisByName,
-  fetchLocationByUuid,
-  fetchProviderByUuid,
-  saveVisitNote,
-} from './visit-notes.resource';
+import { showNotification, useConfig, useSession } from '@openmrs/esm-framework';
+import { fetchConceptDiagnosisByName, useLocationUuid, useProviderUuid, saveVisitNote } from './visit-notes.resource';
 import { ConfigMock } from '../../../../__mocks__/chart-widgets-config.mock';
 import { mockPatient } from '../../../../__mocks__/patient.mock';
 import {
@@ -26,10 +21,9 @@ const testProps = {
   promptBeforeClosing: jest.fn(),
 };
 
-const mockCreateErrorHandler = createErrorHandler as jest.Mock;
 const mockFetchDiagnosisByName = fetchConceptDiagnosisByName as jest.Mock;
-const mockFetchLocationByUuid = fetchLocationByUuid as jest.Mock;
-const mockFetchProviderByUuid = fetchProviderByUuid as jest.Mock;
+const mockUseLocationUuid = useLocationUuid as jest.Mock;
+const mockUseProviderUuid = useProviderUuid as jest.Mock;
 const mockSaveVisitNote = saveVisitNote as jest.Mock;
 const mockShowNotification = showNotification as jest.Mock;
 const mockUseConfig = useConfig as jest.Mock;
@@ -52,9 +46,16 @@ jest.mock('@openmrs/esm-framework', () => {
 
 jest.mock('./visit-notes.resource', () => ({
   fetchConceptDiagnosisByName: jest.fn(),
-  fetchLocationByUuid: jest.fn(),
-  fetchProviderByUuid: jest.fn(),
+  useLocationUuid: jest.fn().mockImplementation(() => ({
+    data: mockFetchLocationByUuidResponse.data.uuid,
+  })),
+  useProviderUuid: jest.fn().mockImplementation(() => ({
+    data: mockFetchProviderByUuidResponse.data.uuid,
+  })),
   saveVisitNote: jest.fn(),
+  useVisitNotes: jest.fn().mockImplementation(() => ({
+    mutateVisitNotes: jest.fn(),
+  })),
 }));
 
 test('renders the visit notes form with all the relevant fields and values', () => {
@@ -122,12 +123,12 @@ test('renders a success toast notification upon successfully recording a visit n
     encounterProviders: expect.arrayContaining([
       {
         encounterRole: ConfigMock.visitNoteConfig.clinicianEncounterRole,
-        provider: null,
+        provider: undefined,
       },
     ]),
     encounterType: ConfigMock.visitNoteConfig.encounterTypeUuid,
     form: ConfigMock.visitNoteConfig.formConceptUuid,
-    location: null,
+    location: undefined,
     obs: expect.arrayContaining([
       {
         concept: { display: '', uuid: '162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
@@ -201,8 +202,8 @@ test('renders an error notification if there was a problem recording a condition
 });
 
 function renderVisitNotesForm() {
-  mockFetchLocationByUuid.mockResolvedValue(mockFetchLocationByUuidResponse);
-  mockFetchProviderByUuid.mockResolvedValue(mockFetchProviderByUuidResponse);
+  mockUseLocationUuid.mockResolvedValue(mockFetchLocationByUuidResponse);
+  mockUseProviderUuid.mockResolvedValue(mockFetchProviderByUuidResponse);
   mockUseConfig.mockReturnValue(ConfigMock);
   mockUseSession.mockReturnValue(mockSessionDataResponse);
   render(<VisitNotesForm {...testProps} />);

--- a/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
@@ -5,8 +5,6 @@ import {
   EncountersFetchResponse,
   RESTPatientNote,
   PatientNote,
-  Location,
-  Provider,
   VisitNotePayload,
   DiagnosisPayload,
   Concept,
@@ -62,28 +60,6 @@ export function useVisitNotes(patientUuid: string): UseVisitNotes {
     isLoading,
     isValidating,
     mutateVisitNotes: mutate,
-  };
-}
-
-export function useLocationUuid(locationUuid: string) {
-  const locationUrl = `/ws/rest/v1/location/${locationUuid}`;
-  const { data, error, isLoading } = useSWR<{ data: Location }, Error>(locationUuid ? locationUrl : null, openmrsFetch);
-
-  return {
-    locationUuid: data?.data?.uuid,
-    errorFetchingLocation: error,
-    isLoadingLocation: isLoading,
-  };
-}
-
-export function useProviderUuid(providerUuid: string) {
-  const providerUrl = `/ws/rest/v1/provider/${providerUuid}`;
-  const { data, error, isLoading } = useSWR<{ data: Provider }, Error>(providerUuid ? providerUrl : null, openmrsFetch);
-
-  return {
-    providerUuid: data?.data?.uuid,
-    errorFetchingProvider: error,
-    isLoadingProvider: isLoading,
   };
 }
 

--- a/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
@@ -1,6 +1,5 @@
 import React, { SyntheticEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSWRConfig } from 'swr';
 import dayjs from 'dayjs';
 import filter from 'lodash-es/filter';
 import includes from 'lodash-es/includes';
@@ -46,10 +45,8 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ closeWorkspace, patientUuid
   const isTablet = useLayoutType() === 'tablet';
   const session = useSession();
   const availableLocations = useLocations();
-  const { mutate } = useSWRConfig();
-
   const { data: availablePrograms } = useAvailablePrograms();
-  const { data: enrollments } = useEnrollments(patientUuid);
+  const { data: enrollments, mutateEnrollments } = useEnrollments(patientUuid);
 
   const currentEnrollment = programEnrollmentId && enrollments.filter((e) => e.uuid == programEnrollmentId)[0];
   const currentProgram = currentEnrollment
@@ -95,6 +92,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ closeWorkspace, patientUuid
         ? updateProgramEnrollment(currentEnrollment.uuid, payload, abortController).subscribe(
             (response) => {
               if (response.status === 200) {
+                mutateEnrollments();
                 closeWorkspace();
 
                 showToast({
@@ -106,8 +104,6 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ closeWorkspace, patientUuid
                   ),
                   title: t('enrollmentUpdated', 'Program enrollment updated'),
                 });
-
-                mutate(`/ws/rest/v1/programenrollment?patient=${patientUuid}&v=${customRepresentation}`);
               }
             },
             (err) => {
@@ -124,6 +120,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ closeWorkspace, patientUuid
         : createProgramEnrollment(payload, abortController).subscribe(
             (response) => {
               if (response.status === 201) {
+                mutateEnrollments();
                 closeWorkspace();
 
                 showToast({
@@ -132,8 +129,6 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ closeWorkspace, patientUuid
                   description: t('enrollmentNowVisible', 'It is now visible in the Programs table'),
                   title: t('enrollmentSaved', 'Program enrollment saved'),
                 });
-
-                mutate(`/ws/rest/v1/programenrollment?patient=${patientUuid}&v=${customRepresentation}`);
               }
             },
             (err) => {
@@ -152,15 +147,15 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({ closeWorkspace, patientUuid
       };
     },
     [
-      closeWorkspace,
-      completionDate,
-      enrollmentDate,
-      mutate,
-      patientUuid,
       selectedProgram,
-      t,
+      patientUuid,
+      enrollmentDate,
+      completionDate,
       userLocation,
       currentEnrollment,
+      mutateEnrollments,
+      closeWorkspace,
+      t,
     ],
   );
   const programSelect = (

--- a/packages/esm-patient-programs-app/src/programs/programs.resource.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs.resource.tsx
@@ -1,4 +1,4 @@
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 import { map as rxjsMap } from 'rxjs/operators';
 import { openmrsFetch, openmrsObservableFetch, useConfig } from '@openmrs/esm-framework';
 import { ConfigurableProgram, PatientProgram, Program, ProgramsFetchResponse } from '../types';
@@ -11,8 +11,9 @@ import { ConfigObject } from '../config-schema';
 export const customRepresentation = `custom:(uuid,display,program,dateEnrolled,dateCompleted,location:(uuid,display))`;
 
 export function useEnrollments(patientUuid: string) {
-  const { data, error, isLoading, isValidating } = useSWR<{ data: ProgramsFetchResponse }, Error>(
-    `/ws/rest/v1/programenrollment?patient=${patientUuid}&v=${customRepresentation}`,
+  const enrollmentsUrl = `/ws/rest/v1/programenrollment?patient=${patientUuid}&v=${customRepresentation}`;
+  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: ProgramsFetchResponse }, Error>(
+    patientUuid ? enrollmentsUrl : null,
     openmrsFetch,
   );
 
@@ -29,6 +30,7 @@ export function useEnrollments(patientUuid: string) {
     isLoading,
     isValidating,
     activeEnrollments,
+    mutateEnrollments: mutate,
   };
 }
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.test.tsx
@@ -44,6 +44,9 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
 
 jest.mock('../vitals.resource', () => ({
   savePatientVitals: jest.fn(),
+  useVitals: jest.fn().mockImplementation(() => ({
+    mutate: jest.fn,
+  })),
 }));
 
 describe('VitalsBiometricsForm: ', () => {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
@@ -67,7 +67,10 @@ export function useVitals(patientUuid: string, includeBiometrics: boolean = fals
     `&_count=${pageSize}
         `;
 
-  const { data, error, isLoading, isValidating } = useSWR<{ data: VitalsFetchResponse }, Error>(apiUrl, openmrsFetch);
+  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: VitalsFetchResponse }, Error>(
+    apiUrl,
+    openmrsFetch,
+  );
 
   const getVitalSignKey = (conceptUuid: string): string => {
     switch (conceptUuid) {
@@ -143,6 +146,7 @@ export function useVitals(patientUuid: string, includeBiometrics: boolean = fals
     isError: error,
     isLoading,
     isValidating,
+    mutate,
   };
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary

SWR offers two approaches for using the `mutate` API to mutate data: 

- The global mutate API which can mutate any key, 
- And the bound mutate API only mutates the data of its corresponding SWR hook.

This PR refactors usages of `mutate` to use the bound mutate API so that developers don't have to pass `keys` to SWR hooks.
