### PR TITLE
(feat) O3-1810: Remove Recent Results widget from Pt Summary

### DIFF
--- a/packages/esm-patient-test-results-app/src/index.ts
+++ b/packages/esm-patient-test-results-app/src/index.ts
@@ -37,17 +37,18 @@ function setupOpenMRS() {
 
   return {
     extensions: [
-      {
-        name: 'test-results-summary-widget',
-        slot: 'patient-chart-summary-dashboard-slot',
-        order: 2,
-        load: getAsyncLifecycle(() => import('./overview/recent-overview.component'), options),
-        meta: {
-          columnSpan: 4,
-        },
-        online: true,
-        offline: true,
-      },
+      // Removed this extension with reference to O3-1810
+      // {
+      //   name: 'test-results-summary-widget',
+      //   slot: 'patient-chart-summary-dashboard-slot',
+      //   order: 2,
+      //   load: getAsyncLifecycle(() => import('./overview/recent-overview.component'), options),
+      //   meta: {
+      //     columnSpan: 4,
+      //   },
+      //   online: true,
+      //   offline: true,
+      // },
       {
         name: 'test-results-summary-dashboard',
         slot: 'patient-chart-dashboard-slot',

--- a/packages/esm-patient-test-results-app/src/index.ts
+++ b/packages/esm-patient-test-results-app/src/index.ts
@@ -37,18 +37,6 @@ function setupOpenMRS() {
 
   return {
     extensions: [
-      // Removed this extension with reference to O3-1810
-      // {
-      //   name: 'test-results-summary-widget',
-      //   slot: 'patient-chart-summary-dashboard-slot',
-      //   order: 2,
-      //   load: getAsyncLifecycle(() => import('./overview/recent-overview.component'), options),
-      //   meta: {
-      //     columnSpan: 4,
-      //   },
-      //   online: true,
-      //   offline: true,
-      // },
       {
         name: 'test-results-summary-dashboard',
         slot: 'patient-chart-dashboard-slot',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [] My work includes tests or is validated by existing tests.

## Summary

This PR removes the Recent Results widget from the Patient Summary as per our discussion on the Design Call on 23rd Jan 2023.

## Related issue

https://issues.openmrs.org/browse/O3-1810
