### PR TITLE
(fix) Fix incorrect dates on the vitals and biometrics widgets

### DIFF
--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics.resource.ts
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics.resource.ts
@@ -21,7 +21,7 @@ export interface PatientBiometrics {
 
 type MappedBiometrics = {
   code: string;
-  issued: Date;
+  recordedDate: Date;
   value: number;
 };
 
@@ -53,7 +53,7 @@ export function useBiometrics(patientUuid: string, concepts: Record<string, stri
 
   const mapBiometricsProperties = (resource: FHIRResource['resource']): MappedBiometrics => ({
     code: resource?.code?.coding?.[0]?.code,
-    issued: resource?.issued,
+    recordedDate: resource?.effectiveDateTime,
     value: resource?.valueQuantity?.value,
   });
 
@@ -61,16 +61,16 @@ export function useBiometrics(patientUuid: string, concepts: Record<string, stri
   const biometricsResponse = data?.data?.entry?.map((entry) => entry.resource ?? []).map(mapBiometricsProperties);
 
   biometricsResponse?.map((biometrics) => {
-    const issuedDate = new Date(new Date(biometrics.issued)).toISOString();
+    const recordedDate = new Date(new Date(biometrics.recordedDate)).toISOString();
 
-    if (biometricsHashTable.has(issuedDate)) {
-      biometricsHashTable.set(issuedDate, {
-        ...biometricsHashTable.get(issuedDate),
+    if (biometricsHashTable.has(recordedDate)) {
+      biometricsHashTable.set(recordedDate, {
+        ...biometricsHashTable.get(recordedDate),
         [getBiometricValueKey(biometrics.code)]: biometrics.value,
       });
     } else {
       biometrics.value &&
-        biometricsHashTable.set(issuedDate, {
+        biometricsHashTable.set(recordedDate, {
           [getBiometricValueKey(biometrics.code)]: biometrics.value,
         });
     }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
@@ -15,7 +15,7 @@ export type ObservationInterpretation = 'critically_low' | 'critically_high' | '
 type MappedVitals = {
   code: string;
   interpretation: string;
-  issued: Date;
+  recordedDate: Date;
   value: number;
 };
 
@@ -98,7 +98,7 @@ export function useVitals(patientUuid: string, includeBiometrics: boolean = fals
       resource?.valueQuantity?.value,
       getReferenceRangesForConcept(resource?.code?.coding?.[0]?.code, conceptMetadata),
     ),
-    issued: resource?.issued,
+    recordedDate: resource?.effectiveDateTime,
     value: resource?.valueQuantity?.value,
   });
 
@@ -106,17 +106,17 @@ export function useVitals(patientUuid: string, includeBiometrics: boolean = fals
   const vitalsResponse = data?.data?.entry?.map((entry) => entry.resource ?? []).map(mapVitalsProperties);
 
   vitalsResponse?.map((vitalSign) => {
-    const issuedDate = new Date(new Date(vitalSign.issued)).toISOString();
+    const recordedDate = new Date(new Date(vitalSign.recordedDate)).toISOString();
 
-    if (vitalsHashTable.has(issuedDate) && vitalsHashTable.get(issuedDate)) {
-      vitalsHashTable.set(issuedDate, {
-        ...vitalsHashTable.get(issuedDate),
+    if (vitalsHashTable.has(recordedDate) && vitalsHashTable.get(recordedDate)) {
+      vitalsHashTable.set(recordedDate, {
+        ...vitalsHashTable.get(recordedDate),
         [getVitalSignKey(vitalSign.code)]: vitalSign.value,
         [getVitalSignKey(vitalSign.code) + 'Interpretation']: vitalSign.interpretation,
       });
     } else {
       vitalSign.value &&
-        vitalsHashTable.set(issuedDate, {
+        vitalsHashTable.set(recordedDate, {
           [getVitalSignKey(vitalSign.code)]: vitalSign.value,
           [getVitalSignKey(vitalSign.code) + 'Interpretation']: vitalSign.interpretation,
         });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes an issue where incorrect dates show up in the `Date and Time` columns of the vitals and biometrics widgets. This is because the resources fetching that data were referencing the  `issued` property of the Observations instead of their `effectiveDateTime`.


## Screenshots

> Before

<img width="1050" alt="Screenshot 2023-01-25 at 10 52 27" src="https://user-images.githubusercontent.com/8509731/214509826-82425a09-62e4-4e54-82ad-25c3cfcc3d38.png">

> After

<img width="1050" alt="Screenshot 2023-01-25 at 10 52 08" src="https://user-images.githubusercontent.com/8509731/214509847-4a58716b-56af-4e33-ae5c-7be87c9129ed.png">
