### PR TITLE
Fix "Basket icon stays selected when entering a form"

### DIFF
--- a/packages/esm-patient-medications-app/src/medications-summary/order-basket-action-button.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/order-basket-action-button.component.tsx
@@ -15,7 +15,7 @@ const OrderBasketActionButton: React.FC = () => {
   const { items } = useStore(orderBasketStore);
   const { patientUuid } = usePatient();
 
-  const isActive = workspaces.find(({ name }) => name.includes('order-basket'));
+  const isActive = workspaces[0]?.name === 'order-basket-workspace';
 
   const patientOrderItems = getOrderItems(items, patientUuid);
 

--- a/packages/esm-patient-medications-app/src/medications-summary/order-basket-action-button.test.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/order-basket-action-button.test.tsx
@@ -33,7 +33,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
     ...originalModule,
     launchPatientWorkspace: jest.fn(),
     useWorkspaces: jest.fn(() => {
-      return { workspaces: [{ name: 'order-basket' }] };
+      return { workspaces: [{ name: 'order-basket-workspace' }] };
     }),
     useVisitOrOfflineVisit: jest.fn(() => ({
       currentVisit: {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
At the moment this ticket is dependent on [this](https://github.com/openmrs/openmrs-esm-patient-chart/pull/814) pr. which is expected to launch the forms upon clicking the form icon. so fo the sake of testing, I tested with the notes. when a user opens the OrderBasket and leaves it open and then clilcks on the notes icon, the notes page becomes the active page and hence the notes icon becomes active. If the user did begin typing / entering an Order but hasn't saved it, the functionality of is also on a different ticket.

## Screenshots
[Screencast from 27-01-23 18:56:16.webm](https://user-images.githubusercontent.com/29108523/215133259-482f7d7b-b91b-4ccc-9743-242e7db26c27.webm)


## Related Issue
[<!-- Paste the link to the Jira ticket here if one exists. -->](https://issues.openmrs.org/browse/O3-1775)
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
