### PR TITLE
(fix) Remove bottom border from workspace header

### DIFF
--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
@@ -6,7 +6,6 @@
 .header {
   background-color: $ui-03;
   top: 3rem;
-  border-bottom: 1px solid $text-03;
   z-index: 1000;
 
   a {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Removes a bottom border from the workspace header. This fixes an issue where the Close button appeared to overlap the header in tablet mode.

## Screenshots

<img width="774" alt="Screenshot 2023-01-27 at 22 41 50" src="https://user-images.githubusercontent.com/8509731/215421962-f56d288c-8ccd-4b07-abf9-40144b627317.png">

<img width="774" alt="Screenshot 2023-01-27 at 22 42 23" src="https://user-images.githubusercontent.com/8509731/215422004-8e6bdbb8-603b-4ec3-99d4-4fe00a4a1177.png">
