### PR TITLE
(feat) O3-1681: Tiles should have a max width

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.scss
@@ -18,7 +18,7 @@ $actionPanelExpandedOffset: $actionNavOffset+$actionPanelOffset;
   grid-column: 1;
   align-self: start;
   height: 90%;
-  width: 45.6125rem;
+  width: calc(100% - 15.625rem);
   margin: 0 auto;
   padding-bottom: spacing.$spacing-10;
 }

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.scss
@@ -18,6 +18,8 @@ $actionPanelExpandedOffset: $actionNavOffset+$actionPanelOffset;
   grid-column: 1;
   align-self: start;
   height: 90%;
+  width: 45.6125rem;
+  margin: 0 auto;
   padding-bottom: spacing.$spacing-10;
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Tiles had a full width which violates the design https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d59c8c2ad2f809f62880ec 
cc @gracepotma @hadijahkyampeire @denniskigen 

## Screenshots
<!-- Required if you are making UI changes. -->

https://user-images.githubusercontent.com/58003327/216000428-e747b0ee-545d-4c39-9c8b-4c2eb631b21c.mov

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1681

## Other
<!-- Anything not covered above -->
