### PR TITLE
(feat) O3-1681: Tiles should have a max width

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.scss
@@ -18,7 +18,8 @@ $actionPanelExpandedOffset: $actionNavOffset+$actionPanelOffset;
   grid-column: 1;
   align-self: start;
   height: 90%;
-  width: calc(100% - 15.625rem);
+  width: 100%;
+  max-width: 60rem;
   margin: 0 auto;
   padding-bottom: spacing.$spacing-10;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This is a continuation for https://github.com/openmrs/openmrs-esm-patient-chart/pull/981
The max-width of the tiles on the patient chart is fixed to `60rem` aligned-center. 
The width of the tiles will be confined to `60rem` for small & large-desktops.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-1681

## Other
<!-- Anything not covered above -->
