### PR TITLE
(fix) Show effective date on obs table component instead of issued date

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
@@ -38,7 +38,7 @@ const ObsGraph: React.FC<ObsGraphProps> = ({ patientUuid }) => {
       .filter((obs) => obs.conceptUuid === selectedConcept.uuid && obs.dataType === 'Number')
       .map((obs) => ({
         group: selectedConcept.label,
-        key: formatDate(new Date(obs.issued), { year: false, time: false }),
+        key: formatDate(new Date(obs.effectiveDateTime), { year: false, time: false }),
         value: obs.valueQuantity.value,
       }));
 

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
@@ -102,8 +102,8 @@ describe('Switchable obs viewer ', () => {
     );
 
     const expectedTableRows = [
-      /2\d — Oct — 2021, \d{2}:\d{2}\s+AM -- 180/,
-      /1\d — Oct — 2021, \d{2}:\d{2}\s+AM 198 200/,
+      /1\d — Oct — 2021, \d{2}:\d{2}\s+PM -- 180/,
+      /1\d — Oct — 2021, \d{2}:\d{2}\s+PM 198 200/,
     ];
 
     expectedTableRows.map((row) =>

--- a/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
@@ -37,7 +37,7 @@ const ObsTable: React.FC<ObsTableProps> = ({ patientUuid }) => {
       obssByDate?.map((obss, index) => {
         const rowData = {
           id: `${index}`,
-          date: formatDatetime(new Date(obss[0].issued), { mode: 'wide' }),
+          date: formatDatetime(new Date(obss[0].effectiveDateTime), { mode: 'wide' }),
         };
 
         for (let obs of obss) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
Obs table was showing, in the date column, the obs issued date instead of the effective date. This meant that if, I created an encounter now with a past date, I would see, on the widget, the current date instead of the date explicitly selected for the encounter.

## Screenshots
![image](https://user-images.githubusercontent.com/68599335/216351083-ff6d6a44-befb-4f4e-a702-43e89b6a13c3.png)

