### PR TITLE
(fix) 03-1848: The condition name field should not be editable when editing conditions

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -230,6 +230,7 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
             placeholder={t('searchConditions', 'Search conditions')}
             onChange={handleSearchTermChange}
             onClear={() => setSelectedCondition(null)}
+            disabled={context === 'editing'}
             value={(() => {
               if (conditionToLookup) {
                 return conditionToLookup;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Disable the condition field on editing

## Screenshots
- 
<img width="1440" alt="Screenshot 2023-02-07 at 00 19 30" src="https://user-images.githubusercontent.com/30952856/217091281-d0a1f5a8-c712-42cb-b6a0-557972f9dbac.png">


## Related Issue
- https://issues.openmrs.org/browse/O3-1848

