### PR TITLE
(fix) Set `Active` as the default conditions table filter

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
@@ -42,7 +42,7 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patient }) => {
   const pageUrl = `\${openmrsSpaBase}/patient/${patient.id}/chart/Conditions`;
 
   const { data: conditions, isError, isLoading, isValidating } = useConditions(patient.id);
-  const [filter, setFilter] = useState('');
+  const [filter, setFilter] = useState<'All' | 'Active' | 'Inactive'>('Active');
   const launchConditionsForm = useCallback(
     () => launchPatientWorkspace('conditions-form-workspace', { workspaceTitle: 'Record a Condition' }),
     [],

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
@@ -102,7 +102,7 @@ describe('ConditionsOverview: ', () => {
     });
 
     expect(screen.getAllByRole('row').length).toEqual(6);
-    expect(screen.getByText(/1–5 of 8 items/i)).toBeInTheDocument();
+    expect(screen.getByText(/1–5 of 7 items/i)).toBeInTheDocument();
 
     const nextPageButton = screen.getByRole('button', { name: /next page/i });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR sets the default value of the conditions widget status filter to `Active`. This ensures that the widget will show only conditions whose clinical status is set to `Active` by default.
