### PR TITLE
(refactor) Refactor visit header

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -149,7 +149,7 @@ const VisitHeader: React.FC = () => {
   const visitNotLoaded = !isValidating && currentVisit === null;
   const toggleSideMenu = useCallback(() => setIsSideMenuExpanded((prevState) => !prevState), []);
 
-  const hasActiveVisit = !isLoading && visitNotLoaded;
+  const hasActiveVisit = !isLoading && !visitNotLoaded;
 
   const originPage = localStorage.getItem('fromPage');
 
@@ -191,7 +191,7 @@ const VisitHeader: React.FC = () => {
             <PatientInfo patient={patient} />
           </div>
           <HeaderGlobalBar>
-            {hasActiveVisit && (
+            {!hasActiveVisit && (
               <Button className={styles.startVisitButton} onClick={launchStartVisitForm} size="lg">
                 {startVisitLabel ? startVisitLabel : t('startVisit', 'Start a visit')}
               </Button>

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -1,14 +1,14 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
-  Tooltip,
   Header,
   HeaderContainer,
   HeaderGlobalAction,
   HeaderGlobalBar,
   HeaderMenuButton,
   Tag,
+  Tooltip,
 } from '@carbon/react';
 import { CloseFilled } from '@carbon/react/icons';
 import {
@@ -22,7 +22,7 @@ import {
   useConfig,
 } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { MappedQueuePriority, MappedVisitQueueEntry, useVisitQueueEntries } from '../visit/queue-entry/queue.resource';
+import { MappedQueuePriority, useVisitQueueEntries } from '../visit/queue-entry/queue.resource';
 import { EditQueueEntry } from '../visit/queue-entry/edit-queue-entry.component';
 import VisitHeaderSideMenu from './visit-header-side-menu.component';
 import styles from './visit-header.scss';
@@ -55,10 +55,31 @@ const PatientInfo: React.FC<PatientInfoProps> = ({ patient }) => {
   const info = `${parseInt(age(patient?.birthDate))}, ${getGender(patient?.gender)}`;
   const truncate = !isTablet && name.trim().length > 25;
   const { visitQueueEntries, isLoading } = useVisitQueueEntries();
-  const [currentService, setCurrentService] = useState('');
-  const [visitType, setVisitType] = useState('');
-  const [priority, setPriority] = useState<MappedQueuePriority>('');
-  const [queueEntry, setQueueEntry] = useState<MappedVisitQueueEntry>(null);
+
+  const queueEntry =
+    visitQueueEntries?.find(
+      (visitQueueEntry) =>
+        visitQueueEntry?.patientUuid == patientUuid && currentVisit?.uuid === visitQueueEntry.visitUuid,
+    ) ?? null;
+
+  const visitType = queueEntry?.visitType ?? '';
+  const priority = queueEntry?.priority ?? '';
+
+  const getServiceString = () => {
+    switch (queueEntry?.status?.toLowerCase()) {
+      case 'waiting':
+        return `Waiting for ${queueEntry.service}`;
+      case 'in service':
+        return `Attending ${queueEntry.service}`;
+      case 'finished service':
+        return `Finished ${queueEntry.service}`;
+      default:
+        return '';
+    }
+  };
+
+  const currentService = queueEntry ? getServiceString() : null;
+
   const { currentVisit } = useVisit(patientUuid);
 
   const getTagType = (priority: string) => {
@@ -71,23 +92,6 @@ const PatientInfo: React.FC<PatientInfoProps> = ({ patient }) => {
         return 'gray';
     }
   };
-
-  useEffect(() => {
-    visitQueueEntries?.forEach((element) => {
-      if (element?.patientUuid == patientUuid && currentVisit?.uuid === element.visitUuid) {
-        setVisitType(element.visitType);
-        setPriority(element.priority);
-        setQueueEntry(element);
-        if (element.status?.toLocaleLowerCase() === 'waiting') {
-          setCurrentService(`Waiting for ${element.service}`);
-        } else if (element.status?.toLocaleLowerCase() === 'in service') {
-          setCurrentService(`Attending ${element.service}`);
-        } else if (element.status?.toLocaleLowerCase() === 'finished service') {
-          setCurrentService(`Finished ${element.service}`);
-        }
-      }
-    });
-  }, [currentVisit?.uuid, patientUuid, visitQueueEntries]);
 
   const text = (
     <>
@@ -132,12 +136,12 @@ const PatientInfo: React.FC<PatientInfoProps> = ({ patient }) => {
 const VisitHeader: React.FC = () => {
   const { t } = useTranslation();
   const { patient } = usePatient();
+  const { startVisitLabel } = useConfig();
+  const { currentVisit, isValidating } = useVisit(patient?.id);
   const [showVisitHeader, setShowVisitHeader] = useState<boolean>(true);
   const [isSideMenuExpanded, setIsSideMenuExpanded] = useState(false);
   const navMenuItems = useAssignedExtensions('patient-chart-dashboard-slot').map((extension) => extension.id);
-  const { startVisitLabel } = useConfig();
 
-  const { currentVisit, isValidating } = useVisit(patient?.id);
   const launchStartVisitForm = React.useCallback(() => launchPatientWorkspace('start-visit-workspace-form'), []);
   const showHamburger = useLayoutType() !== 'large-desktop' && navMenuItems.length > 0;
 
@@ -145,7 +149,7 @@ const VisitHeader: React.FC = () => {
   const visitNotLoaded = !isValidating && currentVisit === null;
   const toggleSideMenu = useCallback(() => setIsSideMenuExpanded((prevState) => !prevState), []);
 
-  const noActiveVisit = !isLoading && visitNotLoaded;
+  const hasActiveVisit = !isLoading && visitNotLoaded;
 
   const originPage = localStorage.getItem('fromPage');
 
@@ -187,16 +191,10 @@ const VisitHeader: React.FC = () => {
             <PatientInfo patient={patient} />
           </div>
           <HeaderGlobalBar>
-            {noActiveVisit && (
-              <HeaderGlobalAction
-                className={styles.headerGlobalBarButton}
-                aria-label={startVisitLabel ?? t('startVisit', 'Start a visit')}
-                onClick={launchStartVisitForm}
-              >
-                <Button as="div" className={styles.startVisitButton}>
-                  {!startVisitLabel ? <>{t('startVisit', 'Start a visit')}</> : startVisitLabel}
-                </Button>
-              </HeaderGlobalAction>
+            {hasActiveVisit && (
+              <Button className={styles.startVisitButton} onClick={launchStartVisitForm} size="lg">
+                {startVisitLabel ? startVisitLabel : t('startVisit', 'Start a visit')}
+              </Button>
             )}
             <HeaderGlobalAction
               className={styles.headerGlobalBarCloseButton}
@@ -209,19 +207,19 @@ const VisitHeader: React.FC = () => {
           <VisitHeaderSideMenu isExpanded={isSideMenuExpanded} toggleSideMenu={toggleSideMenu} />
         </Header>
       );
-    } else {
-      return null;
     }
+
+    return null;
   }, [
-    showVisitHeader,
-    patient,
-    showHamburger,
+    hasActiveVisit,
     isSideMenuExpanded,
-    noActiveVisit,
-    t,
-    startVisitLabel,
     launchStartVisitForm,
     onClosePatientChart,
+    patient,
+    showHamburger,
+    showVisitHeader,
+    startVisitLabel,
+    t,
     toggleSideMenu,
   ]);
 

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.scss
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.scss
@@ -39,11 +39,14 @@
     text-align: center
   }
 
-  .patientName, .longPatientNameBtn {
+  .patientName {
     @include type.type-style('heading-compact-01');
-    margin-right: spacing.$spacing-05;
     color: $ui-02;
-    margin: spacing.$spacing-04 0;
+  }
+
+  .longPatientNameBtn {
+    @extend .patientName;
+    margin-right: spacing.$spacing-05;
     padding-right: 0.5rem;
   }
   
@@ -61,7 +64,7 @@
   .patientInfo {
     color: $color-gray-30;
     @include type.type-style('body-compact-01');
-    margin: 0 spacing.$spacing-05 0;
+    margin-left: spacing.$spacing-03;
   }
 }
 

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.scss
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.scss
@@ -8,10 +8,6 @@
   @include brand-02(background-color);
 }
  
-.headerGlobalBarButton {
-  @include brand-01(background-color);
-}
- 
 .headerGlobalBarCloseButton {
   @include brand-02(background-color);
 }
@@ -26,7 +22,7 @@
 }
  
 .startVisitButton {
-  width: 15rem;
+  @include brand-03(background-color);
 }
  
 .patientDetails {
@@ -42,6 +38,7 @@
   :global(.cds--popover--bottom .cds--popover-content) {
     text-align: center
   }
+
   .patientName, .longPatientNameBtn {
     @include type.type-style('heading-compact-01');
     margin-right: spacing.$spacing-05;
@@ -49,21 +46,25 @@
     margin: spacing.$spacing-04 0;
     padding-right: 0.5rem;
   }
+  
   .tooltipPatientName {
     @include type.type-style('productive-heading-01');
     color:$ui-02; 
   }
+  
   .longPatientNameBtn {
     background-color: transparent;
     border: none;
     outline: none;
   }
+  
   .patientInfo {
     color: $color-gray-30;
     @include type.type-style('body-compact-01');
     margin: 0 spacing.$spacing-05 0;
   }
 }
+
 .tooltipPatientInfo {
   @include type.type-style('body-short-01');
   color:$color-gray-30;

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -119,7 +119,7 @@
   "start": "Start",
   "startDate": "Start date",
   "startNewVisit": "Start new visit",
-  "startVisit": "Start visit",
+  "startVisit": "Start a visit",
   "startVisitError": "Error starting current visit",
   "status": "Status",
   "tests": "Tests",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Refactors the visit header component as follows:

- Amend the `Start a visit` button to a `Button` component instead of a `HeaderGlobalAction`. This change also fixes an issue where a partial black tooltip appears under the button when you hover over it.
- Remove an unnecessary useEffect hook and a bunch of state variables.
- Changes the colour of the `Start a visit` button to match the design https://zpl.io/2G3xNrJ.
- Fix some spacing issues in the patient details UI.

## Screenshots

<img width="911" alt="visit-header" src="https://user-images.githubusercontent.com/8509731/217777619-52f82e42-553f-43db-a7d8-f036ec2f09f1.png">

