### PR TITLE
(feat) Add batch expansion to the visit notes table

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/paginated-notes.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/paginated-notes.component.tsx
@@ -76,12 +76,20 @@ const PaginatedNotes: React.FC<PaginatedNotes> = ({ notes, pageSize, pageUrl, ur
   return (
     <>
       <DataTable rows={tableRows} sortRow={customSortRow} headers={tableHeaders} isSortable size="sm" useZebraStyles>
-        {({ rows, headers, getTableProps, getTableContainerProps, getHeaderProps, getRowProps }) => (
+        {({
+          rows,
+          headers,
+          getExpandHeaderProps,
+          getTableProps,
+          getTableContainerProps,
+          getHeaderProps,
+          getRowProps,
+        }) => (
           <TableContainer {...getTableContainerProps}>
             <Table {...getTableProps()}>
               <TableHead>
                 <TableRow>
-                  <TableExpandHeader />
+                  <TableExpandHeader enableToggle {...getExpandHeaderProps()} />
                   {headers.map((header, i) => (
                     <TableHeader
                       key={i}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Adds the ability to batch-expand rows from the visit notes widget table.

## Video

https://user-images.githubusercontent.com/8509731/217786108-7011c915-6134-4fb6-b63b-15da61b7d529.mp4
