### PR TITLE
feat: Add ability to auto-populate start visit form with default values

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/hooks/useServiceQueue.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useServiceQueue.tsx
@@ -33,13 +33,14 @@ interface FHIRResponse {
 export function useServices(location: string) {
   const config = useConfig() as ChartConfig;
   const apiUrl = `/ws/rest/v1/queue?location=${location}`;
-  const { data } = useSWRImmutable<{ data: { results: Array<QueueServiceInfo> } }, Error>(
+  const { data, isLoading } = useSWRImmutable<{ data: { results: Array<QueueServiceInfo> } }, Error>(
     config.showServiceQueueFields && location ? apiUrl : null,
     openmrsFetch,
   );
 
   return {
     services: data ? data?.data.results : [],
+    isLoadingServices: isLoading,
   };
 }
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.component.tsx
@@ -4,13 +4,13 @@ import debounce from 'lodash-es/debounce';
 import isEmpty from 'lodash-es/isEmpty';
 import { Layer, RadioButtonGroup, RadioButton, Search, StructuredListSkeleton } from '@carbon/react';
 import { EmptyState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
-import { useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { useLayoutType, usePagination, VisitType } from '@openmrs/esm-framework';
 import styles from './visit-type-overview.scss';
 
 interface BaseVisitTypeProps {
   onChange: (event) => void;
   patientUuid: string;
-  visitTypes;
+  visitTypes: Array<VisitType>;
 }
 
 const BaseVisitType: React.FC<BaseVisitTypeProps> = ({ onChange, visitTypes }) => {
@@ -54,11 +54,11 @@ const BaseVisitType: React.FC<BaseVisitTypeProps> = ({ onChange, visitTypes }) =
 
           <RadioButtonGroup
             className={styles.radioButtonGroup}
-            defaultSelected="default-selected"
+            defaultSelected={results?.length === 1 && results[0].uuid}
             orientation="vertical"
             onChange={onChange}
             name="radio-button-group"
-            valueSelected="default-selected"
+            valueSelected={results?.length === 1 && results[0].uuid}
           >
             {results.map(({ uuid, display, name }) => (
               <RadioButton key={uuid} className={styles.radioButton} id={name} labelText={display} value={uuid} />

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -83,20 +83,27 @@ const StartVisitForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWor
   const [priority, setPriority] = useState('');
   const { priorities } = usePriorities();
   const { statuses } = useStatuses();
-  const [selectedService, setSelectedService] = useState('');
-  const [selectedStatus, setSelectedStatus] = useState('');
+  const [selectedStatus, setSelectedStatus] = useState(config.defaultStatusConceptUuid);
   const [errorFetchingResources, setErrorFetchingResources] = useState<{
     blockSavingForm: boolean;
   }>(null);
-  const [selectedQueueLocation, setSelectedQueueLocation] = useState('');
-  const { services } = useServices(selectedQueueLocation);
+  const [selectedQueueLocation, setSelectedQueueLocation] = useState(sessionUser?.sessionLocation?.uuid);
+  const { services, isLoadingServices } = useServices(selectedQueueLocation);
+  const [selectedService, setSelectedService] = useState('');
   const { queueLocations } = useQueueLocations();
+
+  useEffect(() => {
+    if (!isLoading) {
+      setSelectedService(services.length > 0 ? services[0].uuid : '');
+    }
+  }, [isLoading, isLoadingServices, services]);
 
   useEffect(() => {
     if (locations && sessionUser?.sessionLocation?.uuid) {
       setSelectedLocation(sessionUser?.sessionLocation?.uuid);
+      setVisitType(allVisitTypes?.length === 1 ? allVisitTypes[0].uuid : null);
     }
-  }, [locations, sessionUser]);
+  }, [allVisitTypes, locations, sessionUser]);
 
   const handleSubmit = useCallback(
     (event) => {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Auto populate the start-visit form to reduce number of clicks user has to make to start or checkin a patient

## To Do
We need to remove code on adding patients to queues to service queues module

## Screenshots

![auto-populate](https://user-images.githubusercontent.com/28008754/218565409-d8041413-e9ab-44bd-9048-3227dba95e10.gif)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

