### PR TITLE
(enhancement) require an active visit before filling vitals or biometrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,13 @@ typings/
 .env
 
 # next.js build output
+# nyc test coverage
+.nyc_output
+
+# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+# Bower dependency directory (https://b
 .next
 dist
 
@@ -76,3 +83,4 @@ dist
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+~

--- a/__mocks__/vitals.mock.ts
+++ b/__mocks__/vitals.mock.ts
@@ -2386,6 +2386,7 @@ export const mockVitalsConfig = {
   vitals: {
     encounterTypeUuid: '67a71486-1a54-468f-ac3e-7091a9a79584',
     formUuid: 'a000cb34-9ec1-4344-a1c8-f692232f6edd',
+    useFormEngine: false,
   },
 };
 

--- a/packages/esm-patient-biometrics-app/src/biometrics-utils.ts
+++ b/packages/esm-patient-biometrics-app/src/biometrics-utils.ts
@@ -1,0 +1,21 @@
+import { Visit } from '@openmrs/esm-framework';
+import { formEntrySub, launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
+import { ConfigObject } from './config-schema';
+import { patientVitalsBiometricsFormWorkspace } from './constants';
+
+export function launchFormEntry(formUuid: string, encounterUuid?: string, formName?: string) {
+  formEntrySub.next({ formUuid, encounterUuid });
+  launchPatientWorkspace('patient-form-entry-workspace', { workspaceTitle: formName });
+}
+
+export function launchVitalsAndBiometricsForm(currentVisit: Visit, config: ConfigObject) {
+  if (currentVisit && config.vitals.useFormEngine) {
+    launchFormEntry(config.vitals.formUuid, '', config.vitals.formName);
+  }
+  if (currentVisit) {
+    launchPatientWorkspace(patientVitalsBiometricsFormWorkspace);
+  }
+  if (!currentVisit) {
+    launchStartVisitPrompt();
+  }
+}

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
@@ -10,6 +10,7 @@ import {
   useVitalsConceptMetadata,
   launchPatientWorkspace,
   withUnit,
+  useVisitOrOfflineVisit,
 } from '@openmrs/esm-patient-common-lib';
 import { ConfigObject } from '../config-schema';
 import { patientVitalsBiometricsFormWorkspace } from '../constants';
@@ -17,6 +18,7 @@ import { useBiometrics } from './biometrics.resource';
 import BiometricsChart from './biometrics-chart.component';
 import PaginatedBiometrics from './paginated-biometrics.component';
 import styles from './biometrics-overview.scss';
+import { launchVitalsAndBiometricsForm } from '../biometrics-utils';
 
 interface BiometricsBaseProps {
   patientUuid: string;
@@ -42,10 +44,11 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
   const { bmiUnit } = config.biometrics;
   const { biometrics, isLoading, isError, isValidating } = useBiometrics(patientUuid, config.concepts);
   const { data: conceptUnits } = useVitalsConceptMetadata();
+  const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
 
   const launchBiometricsForm = React.useCallback(
-    () => launchPatientWorkspace(patientVitalsBiometricsFormWorkspace),
-    [],
+    () => launchVitalsAndBiometricsForm(currentVisit, config),
+    [config, currentVisit],
   );
 
   const tableHeaders = [

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.test.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.test.tsx
@@ -35,6 +35,8 @@ jest.mock('@openmrs/esm-framework', () => {
   return {
     ...originalModule,
     useConfig: jest.fn().mockImplementation(() => mockBiometricsConfig),
+    useVisitOrOfflineVisit: jest.fn(),
+    useConnectivity: jest.fn(),
     usePagination: jest.fn().mockImplementation(() => ({
       currentPage: 1,
       goTo: () => {},

--- a/packages/esm-patient-biometrics-app/src/config-schema.ts
+++ b/packages/esm-patient-biometrics-app/src/config-schema.ts
@@ -16,6 +16,26 @@ export const configSchema = {
       _default: '1343AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     },
   },
+  vitals: {
+    useFormEngine: {
+      _type: Type.Boolean,
+      _default: false,
+      _description:
+        'Whether to use an Ampath form as the vitals and biometrics form. If set to true, encounterUuid and formUuid must be set as well.',
+    },
+    encounterTypeUuid: {
+      _type: Type.UUID,
+      _default: '67a71486-1a54-468f-ac3e-7091a9a79584',
+    },
+    formUuid: {
+      _type: Type.UUID,
+      _default: '9f26aad4-244a-46ca-be49-1196df1a8c9a',
+    },
+    formName: {
+      _type: Type.String,
+      _default: 'Vitals',
+    },
+  },
   biometrics: biometricsConfigSchema,
 };
 
@@ -26,4 +46,10 @@ export interface ConfigObject {
     muacUuid: string;
   };
   biometrics: BiometricsConfigObject;
+  vitals: {
+    useFormEngine: boolean;
+    encounterTypeUuid: string;
+    formUuid: string;
+    formName: string;
+  };
 }

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -140,7 +140,6 @@ const VisitHeader: React.FC = () => {
   const { currentVisit, isValidating } = useVisit(patient?.id);
   const [showVisitHeader, setShowVisitHeader] = useState<boolean>(true);
   const [isSideMenuExpanded, setIsSideMenuExpanded] = useState(false);
-  const [isActiveVisit, setIsActiveVisit] = useState(false);
   const navMenuItems = useAssignedExtensions('patient-chart-dashboard-slot').map((extension) => extension.id);
   const { startVisitLabel, endVisitLabel } = useConfig();
 
@@ -245,7 +244,7 @@ const VisitHeader: React.FC = () => {
     toggleSideMenu,
     endVisitLabel,
     openModal,
-    currentVisit
+    currentVisit,
   ]);
 
   return <HeaderContainer render={render} />;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
@@ -5,9 +5,13 @@ import { useTranslation } from 'react-i18next';
 import { Button, InlineLoading } from '@carbon/react';
 import { ChevronDown, ChevronUp, WarningFilled } from '@carbon/react/icons';
 import { formatDate, parseDate, useConfig } from '@openmrs/esm-framework';
-import { formEntrySub, launchPatientWorkspace, useVitalsConceptMetadata } from '@openmrs/esm-patient-common-lib';
+import {
+  formEntrySub,
+  launchPatientWorkspace,
+  useVisitOrOfflineVisit,
+  useVitalsConceptMetadata,
+} from '@openmrs/esm-patient-common-lib';
 import { ConfigObject } from '../../config-schema';
-import { patientVitalsBiometricsFormWorkspace } from '../../constants';
 import {
   assessValue,
   getReferenceRangesForConcept,
@@ -17,6 +21,7 @@ import {
 } from '../vitals.resource';
 import VitalsHeaderItem from './vitals-header-item.component';
 import styles from './vitals-header.scss';
+import { launchVitalsForm } from '../vitals-utils';
 
 dayjs.extend(isToday);
 
@@ -38,17 +43,14 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
   const latestVitals = vitals?.[0];
   const [showDetailsPanel, setShowDetailsPanel] = useState(false);
   const toggleDetailsPanel = () => setShowDetailsPanel(!showDetailsPanel);
+  const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
 
   const launchVitalsAndBiometricsForm = React.useCallback(
     (e) => {
       e.stopPropagation();
-      if (config.vitals.useFormEngine) {
-        launchFormEntry(config.vitals.formUuid, '', config.vitals.formName);
-      } else {
-        launchPatientWorkspace(patientVitalsBiometricsFormWorkspace);
-      }
+      launchVitalsForm(currentVisit, config);
     },
-    [config.vitals],
+    [config, currentVisit],
   );
 
   if (isLoading) {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../../../__mocks__/vitals.mock';
 import VitalsHeader from './vitals-header.component';
 import { patientVitalsBiometricsFormWorkspace } from '../../constants';
+import { mockCurrentVisit } from '../../../../../__mocks__/visits.mock';
 
 const testProps = {
   patientUuid: mockPatient.id,
@@ -36,6 +37,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
       data: mockConceptUnits,
       conceptMetadata: mockConceptMetadata,
     })),
+    useVisitOrOfflineVisit: jest.fn().mockImplementation(() => ({ currentVisit: mockCurrentVisit })),
   };
 });
 
@@ -45,6 +47,7 @@ jest.mock('@openmrs/esm-framework', () => {
   return {
     ...originalModule,
     useConfig: jest.fn(() => mockVitalsConfig),
+    useConnectivity: jest.fn(),
   };
 });
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -8,6 +8,7 @@ import {
   ErrorState,
   formEntrySub,
   launchPatientWorkspace,
+  useVisitOrOfflineVisit,
   useVitalsConceptMetadata,
   withUnit,
 } from '@openmrs/esm-patient-common-lib';
@@ -18,6 +19,7 @@ import VitalsChart from './vitals-chart.component';
 import { ConfigObject } from '../config-schema';
 import { useVitals } from './vitals.resource';
 import styles from './vitals-overview.scss';
+import { launchVitalsForm } from './vitals-utils';
 
 interface VitalsOverviewProps {
   patientUuid: string;
@@ -38,17 +40,14 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
   const displayText = t('vitalSigns', 'Vital signs');
   const headerTitle = t('vitals', 'Vitals');
   const [chartView, setChartView] = React.useState<boolean>();
+  const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
 
   const { vitals, isError, isLoading, isValidating } = useVitals(patientUuid);
   const { data: conceptUnits } = useVitalsConceptMetadata();
 
   const launchVitalsBiometricsForm = React.useCallback(() => {
-    if (config.vitals.useFormEngine) {
-      launchFormEntry(config.vitals.formUuid, '', config.vitals.formName);
-    } else {
-      launchPatientWorkspace(patientVitalsBiometricsFormWorkspace);
-    }
-  }, [config.vitals]);
+    launchVitalsForm(currentVisit, config);
+  }, [config, currentVisit]);
 
   const tableHeaders = [
     { key: 'date', header: 'Date and time', isSortable: true },

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -47,6 +47,8 @@ jest.mock('@openmrs/esm-framework', () => {
   return {
     ...originalModule,
     useConfig: jest.fn(() => mockVitalsConfig),
+    useVisitOrOfflineVisit: jest.fn(),
+    useConnectivity: jest.fn(),
     usePagination: jest.fn().mockImplementation(() => ({
       currentPage: 1,
       goTo: () => {},

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-utils.ts
@@ -1,0 +1,17 @@
+import { Visit } from '@openmrs/esm-framework';
+import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
+import { ConfigObject } from '../config-schema';
+import { patientVitalsBiometricsFormWorkspace } from '../constants';
+import { launchFormEntry } from './vitals-overview.component';
+
+export function launchVitalsForm(currentVisit: Visit, config: ConfigObject) {
+  if (currentVisit && config.vitals.useFormEngine) {
+    launchFormEntry(config.vitals.formUuid, '', config.vitals.formName);
+  }
+  if (currentVisit) {
+    launchPatientWorkspace(patientVitalsBiometricsFormWorkspace);
+  }
+  if (!currentVisit) {
+    launchStartVisitPrompt();
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Add ability to require a visit is started before filling in Bio metrics and vital signs

## Screenshots

![requirevisit](https://user-images.githubusercontent.com/28008754/218736073-69dd2ccc-41b6-4383-8c1d-14c02feb0d8b.gif)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
