### PR TITLE
(feat) O3-1649: Show vital signs without needing to expand the vitals header

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.component.tsx
@@ -14,20 +14,25 @@ const VitalsHeaderItem: React.FC<VitalsHeaderItemProps> = ({ interpretation, val
   const flaggedAbnormal = interpretation && interpretation !== 'normal';
 
   return (
-    <div className={`${styles.container} ${flaggedAbnormal ? styles['abnormal-value'] : ''}`}>
-      <div className={styles['label-container']}>
-        <label className={styles.label}>{unitName}</label>
-        {flaggedAbnormal ? <CircleSolid size={16} title="abnormal value" className={styles['danger-icon']} /> : null}
-      </div>
-      <div className={styles['value-container']}>
-        <label className={styles['pad-right']}>
-          <span className={styles.value}>{value || '-'} </span>
-          <span className={styles.units}>{value && unitSymbol}</span>
-        </label>
-        {interpretation === 'high' ? <span className={styles.high}></span> : null}
-        {interpretation === 'critically_high' ? <span className={styles['critically-high']}></span> : null}
-        {interpretation === 'low' ? <span className={styles.low}></span> : null}
-        {interpretation === 'critically_low' ? <span className={styles['critically-low']}></span> : null}
+    <div className={`${styles.container}`}>
+      <div className={`${flaggedAbnormal ? styles['abnormal-value'] : ''}`}>
+        <div className={styles['label-container']}>
+          <label className={styles.label}>{unitName}</label>
+          {flaggedAbnormal ? (
+            <div title="abnormal value">
+              {interpretation === 'high' ? <span className={styles.high}></span> : null}
+              {interpretation === 'critically_high' ? <span className={styles['critically-high']}></span> : null}
+              {interpretation === 'low' ? <span className={styles.low}></span> : null}
+              {interpretation === 'critically_low' ? <span className={styles['critically-low']}></span> : null}
+            </div>
+          ) : null}
+        </div>
+        <div className={styles['value-container']}>
+          <label className={styles['pad-right']}>
+            <span className={styles.value}>{value || '-'} </span>
+            <span className={styles.units}>{value && unitSymbol}</span>
+          </label>
+        </div>
       </div>
     </div>
   );

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.component.tsx
@@ -14,7 +14,7 @@ const VitalsHeaderItem: React.FC<VitalsHeaderItemProps> = ({ interpretation, val
   const flaggedAbnormal = interpretation && interpretation !== 'normal';
 
   return (
-    <div className={`${styles.container}`}>
+    <div className={styles.container}>
       <div className={`${flaggedAbnormal ? styles['abnormal-value'] : ''}`}>
         <div className={styles['label-container']}>
           <label className={styles.label}>{unitName}</label>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
@@ -12,7 +12,12 @@
 }
 
 .abnormal-value {
-  background-color: rgba(0, 0, 0, 0.1);
+  border: 2px solid $danger;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: fit-content;
+  padding: 0 0.25rem 0 0.25rem;
 }
 
 .label-container {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
@@ -17,7 +17,7 @@
   flex-direction: column;
   justify-content: center;
   width: fit-content;
-  padding: 0 0.25rem 0 0.25rem;
+  padding: 0rem 0.25rem;
 }
 
 .label-container {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
@@ -7,7 +7,7 @@
   flex-wrap: wrap;
   flex-direction: column;
   padding: 0.25rem 0.5rem;
-  margin: 0.5rem 1rem;
+  margin: 0.5rem;
   width: 100%;
 }
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
@@ -89,14 +89,14 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
             <span>{isValidating ? <InlineLoading /> : null}</span>
           </div>
           <div className={styles['button-container']}>
-            <Button className={styles['record-vitals']} kind="ghost" size="sm" onClick={launchVitalsAndBiometricsForm}>
+            <Button
+              className={`${styles['record-vitals']} ${styles['arrow-up-icon']}`}
+              kind="ghost"
+              size="sm"
+              onClick={launchVitalsAndBiometricsForm}
+            >
               {t('recordVitals', 'Record vitals')}
-              <ArrowRight
-                size={16}
-                className={styles['arrow-up-button']}
-                style={{ fill: '#0f62fe' }}
-                title={'ArrowRight'}
-              />
+              <ArrowRight size={16} className={styles['arrow-up-button']} title={'ArrowRight'} />
             </Button>
           </div>
         </div>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 import isToday from 'dayjs/plugin/isToday';
 import { useTranslation } from 'react-i18next';
 import { Button, InlineLoading } from '@carbon/react';
-import { ChevronDown, ChevronUp, WarningFilled } from '@carbon/react/icons';
+import { ArrowRight, WarningFilled } from '@carbon/react/icons';
 import { formatDate, parseDate, useConfig } from '@openmrs/esm-framework';
 import {
   formEntrySub,
@@ -91,38 +91,23 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
           <div className={styles['button-container']}>
             <Button className={styles['record-vitals']} kind="ghost" size="sm" onClick={launchVitalsAndBiometricsForm}>
               {t('recordVitals', 'Record vitals')}
+              <ArrowRight
+                size={16}
+                className={styles['arrow-up-button']}
+                style={{ fill: '#0f62fe' }}
+                title={'ArrowRight'}
+              />
             </Button>
-            {showDetailsPanel ? (
-              <ChevronUp
-                size={16}
-                className={styles['collapse-button']}
-                title={'ChevronUp'}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  toggleDetailsPanel();
-                }}
-              />
-            ) : (
-              <ChevronDown
-                size={16}
-                className={styles['expand-button']}
-                title={'ChevronDown'}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  toggleDetailsPanel();
-                }}
-              />
-            )}
           </div>
         </div>
-        {showDetailsPanel ? (
-          <div
-            className={
-              hasAbnormalValues(latestVitals) && isNotRecordedToday
-                ? `${styles['warning-border']}`
-                : `${styles['default-border']}`
-            }
-          >
+        <div
+          className={
+            hasAbnormalValues(latestVitals) && isNotRecordedToday
+              ? `${styles['warning-border']}`
+              : `${styles['default-border']}`
+          }
+        >
+          <div className={styles['container-row']}>
             <div className={styles.row}>
               <VitalsHeaderItem
                 unitName={t('temperatureAbbreviated', 'Temp')}
@@ -190,7 +175,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
               />
             </div>
           </div>
-        ) : null}
+        </div>
       </div>
     );
   }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
@@ -4,7 +4,7 @@ import isToday from 'dayjs/plugin/isToday';
 import { useTranslation } from 'react-i18next';
 import { Button, InlineLoading } from '@carbon/react';
 import { ArrowRight, WarningFilled } from '@carbon/react/icons';
-import { formatDate, parseDate, useConfig } from '@openmrs/esm-framework';
+import { ConfigurableLink, formatDate, parseDate, useConfig } from '@openmrs/esm-framework';
 import {
   formEntrySub,
   launchPatientWorkspace,
@@ -81,9 +81,13 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
               />
             ) : null}
             <span className={styles.heading}>{t('vitalsAndBiometrics', 'Vitals and biometrics')}</span>
-            <span className={styles['body-text']}>
-              {t('lastRecorded', 'Last recorded')}: {formatDate(parseDate(latestVitals?.date), { mode: 'wide' })}
-            </span>
+            <span className={styles['body-text']}>{formatDate(parseDate(latestVitals?.date))}</span>
+            <ConfigurableLink
+              className={styles.link}
+              to={`\${openmrsSpaBase}/patient/${patientUuid}/chart/Vitals & Biometrics`}
+            >
+              {t('vitalsHistory', 'Vitals history')}
+            </ConfigurableLink>
           </span>
           <div className={styles.backgroundDataFetchingIndicator}>
             <span>{isValidating ? <InlineLoading /> : null}</span>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
@@ -35,7 +35,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: 0.25rem 0.5rem;
   flex-grow: 1;
 }
 
@@ -55,7 +54,6 @@
 }
 
 .container-row {
-  border-bottom: 1px solid $grey-2;
   display: flex;
   flex-wrap: wrap;
 }
@@ -100,6 +98,13 @@
 }
 
 .body-text {
-  @include type.type-style('body-compact-01');
+  @include type.type-style('label-01');
   color: $text-02;
+}
+
+.link {
+  @extend .body-text;
+  margin-left: 0.5rem;
+  text-decoration-line: none;
+  color: $interactive-01;
 }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
@@ -36,6 +36,7 @@
   justify-content: space-between;
   align-items: center;
   margin: 0.25rem 0.5rem;
+  flex-grow: 1;
 }
 
 .loading {
@@ -51,6 +52,12 @@
 
 .warning-border {
   border-bottom: 1px solid $color-yellow-50;
+}
+
+.container-row {
+  border-bottom: 1px solid $grey-2;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .warning-icon {
@@ -70,8 +77,7 @@
   align-items: center;
 }
 
-.collapse-button, .expand-button {
-  color: $color-blue-60-2;
+.arrow-up-button {
   display: flex;
   align-items: baseline;
   justify-content: center;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
@@ -85,6 +85,10 @@
   margin-left: 0.5rem;
 }
 
+.arrow-up-icon:not([disabled]) svg {
+  fill: $color-blue-60-2;
+}
+
 .heading {
   @include type.type-style("heading-compact-02");
   margin-right: spacing.$spacing-03;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
@@ -74,8 +74,7 @@ describe('VitalsHeader: ', () => {
     await waitForLoadingToFinish();
 
     expect(screen.getByText(/Vitals and biometrics/i)).toBeInTheDocument();
-    expect(screen.getByText(/Last recorded/i)).toBeInTheDocument();
-    expect(screen.getByText(/19 — May — 2021/i)).toBeInTheDocument();
+    expect(screen.getByText(/19-May-2021/i)).toBeInTheDocument();
     expect(screen.getByText(/Record vitals/i)).toBeInTheDocument();
     expect(screen.getByRole('img', { name: /warning/i })).toBeInTheDocument();
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
@@ -79,10 +79,6 @@ describe('VitalsHeader: ', () => {
     expect(screen.getByText(/Record vitals/i)).toBeInTheDocument();
     expect(screen.getByRole('img', { name: /warning/i })).toBeInTheDocument();
 
-    const expandButton = screen.getByTitle(/ChevronDown/);
-
-    await waitFor(() => user.click(expandButton));
-
     expect(getByTextWithMarkup(/Temp\s*37\s*DEG C/i)).toBeInTheDocument();
     expect(getByTextWithMarkup(/BP\s*121 \/ 89\s*mmHg/i)).toBeInTheDocument();
     expect(getByTextWithMarkup(/Heart rate\s*76\s*beats\/min/i)).toBeInTheDocument();
@@ -94,13 +90,6 @@ describe('VitalsHeader: ', () => {
 
     expect(screen.getByRole('img', { name: /warning/i })).toBeInTheDocument();
     expect(screen.getAllByTitle(/abnormal value/i).length).toEqual(2);
-
-    const collapseButton = screen.getByTitle(/ChevronUp/);
-
-    await waitFor(() => user.click(collapseButton));
-
-    expect(screen.queryByText(/Temp/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/BP/i)).not.toBeInTheDocument();
   });
 
   it('launches the vitals form when the `record vitals` button gets clicked', async () => {
@@ -129,9 +118,6 @@ describe('VitalsHeader: ', () => {
 
     renderVitalsHeader();
     await waitForLoadingToFinish();
-    const expandButton = screen.getByTitle(/ChevronDown/);
-
-    await waitFor(() => user.click(expandButton));
 
     expect(screen.queryByTitle(/abnormal value/i)).not.toBeInTheDocument();
   });
@@ -148,9 +134,6 @@ describe('VitalsHeader: ', () => {
     renderVitalsHeader();
 
     await waitForLoadingToFinish();
-    const expandButton = screen.getByTitle(/ChevronDown/);
-
-    await waitFor(() => user.click(expandButton));
 
     expect(screen.queryByTitle(/abnormal value/i)).toBeInTheDocument();
   });

--- a/packages/esm-patient-vitals-app/translations/en.json
+++ b/packages/esm-patient-vitals-app/translations/en.json
@@ -12,7 +12,6 @@
   "goToSummary": "Go to Summary",
   "heartRate": "Heart rate",
   "height": "Height",
-  "lastRecorded": "Last recorded",
   "loading": "Loading",
   "muac": "MUAC",
   "noDataRecorded": "No data has been recorded for this patient",
@@ -37,6 +36,7 @@
   "vitalsAndBiometricsNowAvailable": "They are now visible on the Vitals and Biometrics page",
   "vitalsAndBiometricsRecorded": "Vitals and Biometrics saved",
   "vitalsAndBiometricsSaveError": "Error saving vitals and biometrics",
+  "vitalsHistory": "Vitals history",
   "vitalSignDisplayed": "Vital Sign Displayed",
   "vitalSigns": "Vital signs",
   "weight": "Weight"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The vitals header design has been improved so that it is no longer collapsable. This ensures the most recent vitals for the patient are always visible.

Full design documentation for the vitals header [can be found here](https://zeroheight.com/23a080e38/p/61756c-vitals-header) 

Current & updated Vital Signs designs: https://zpl.io/aBPkgOO

cc @hadijahkyampeire @denniskigen @vasharma05 

## Screenshots
<!-- Required if you are making UI changes. -->

https://user-images.githubusercontent.com/58003327/219154235-45289df2-5f5d-4bd1-bbaf-1f322c8346ca.mov

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
