### PR TITLE
Ensure the patient instructions are visible on the order card

### DIFF
--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-item.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-item.component.tsx
@@ -56,7 +56,8 @@ export default function OrderBasketItemTile({ orderBasketItem, onItemClick, onRe
             &mdash; {orderBasketItem.route?.value} &mdash; {orderBasketItem.frequency?.value} &mdash;{' '}
             {t('refills', 'Refills').toUpperCase()} {orderBasketItem.numRefills}{' '}
             {t('quantity', 'Quantity').toUpperCase()}{' '}
-            {`${orderBasketItem.pillsDispensed} ${orderBasketItem.quantityUnits?.value.toLowerCase()}`}
+            {`${orderBasketItem.pillsDispensed} ${orderBasketItem.quantityUnits?.value.toLowerCase()}`} &mdash; {' '}
+            {`${orderBasketItem.patientInstructions}`}
           </span>
         </span>
         <br />

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-item.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-item.component.tsx
@@ -56,8 +56,8 @@ export default function OrderBasketItemTile({ orderBasketItem, onItemClick, onRe
             &mdash; {orderBasketItem.route?.value} &mdash; {orderBasketItem.frequency?.value} &mdash;{' '}
             {t('refills', 'Refills').toUpperCase()} {orderBasketItem.numRefills}{' '}
             {t('quantity', 'Quantity').toUpperCase()}{' '}
-            {`${orderBasketItem.pillsDispensed} ${orderBasketItem.quantityUnits?.value.toLowerCase()}`} &mdash; {' '}
-            {`${orderBasketItem.patientInstructions}`}
+            {`${orderBasketItem.pillsDispensed} ${orderBasketItem.quantityUnits?.value.toLowerCase()}`}
+            {orderBasketItem.patientInstructions && <>&mdash; {orderBasketItem.patientInstructions}</>}
           </span>
         </span>
         <br />


### PR DESCRIPTION
## Requirements

 - [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
 - [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
 - [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
It was/is possible to fill in patient instructions in the drug order form however the patient instructions were not visible on the order card.

The designs can be found at https://zeroheight.com/23a080e38/p/030b9a-order-basket-item

## Screenshots
<!-- Required if you are making UI changes. -->
[Screencast from 15-02-23 12:50:12.webm](https://user-images.githubusercontent.com/47120265/218993603-f0f7efef-e595-497c-a0d7-2e82db1f93f0.webm)




## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-1845
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
