### PR TITLE
(fix) Remove redundant styling for search fields

### DIFF
--- a/packages/esm-patient-forms-app/src/forms/form-view.scss
+++ b/packages/esm-patient-forms-app/src/forms/form-view.scss
@@ -120,10 +120,3 @@
   color: $color-gray-70;
   margin: 0.5rem 0;
 }
-
-.searchInput {
-  input:focus {
-    outline: none;
-    border: spacing.$spacing-01 solid var(--omrs-color-brand-orange);
-  }
-}

--- a/packages/esm-patient-forms-app/src/forms/forms-list.scss
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.scss
@@ -34,10 +34,6 @@
     padding: 0 4rem !important;
   }
 
-  input:focus {
-    outline: 1px solid colors.$orange-40;
-  }
-
   :global(.cds--search-close:focus) {
     outline: none;
     outline-offset: 0;

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search/order-basket-search.scss
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search/order-basket-search.scss
@@ -15,7 +15,3 @@
   box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.3);
   z-index: 1;
 }
-
-.searchPopupContainer :global(.cds--search-input:focus) {
-  outline: 2px solid #ff832b;
-}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Custom styling for search fields on focus is no longer required following https://github.com/openmrs/openmrs-esm-core/pull/607. This PR removes existing custom styling.