### PR TITLE
(feat) change formUuid property type to support arbitrary strings

### DIFF
--- a/packages/esm-patient-forms-app/src/config-schema.ts
+++ b/packages/esm-patient-forms-app/src/config-schema.ts
@@ -5,7 +5,7 @@ export const configSchema = {
     _type: Type.Array,
     _elements: {
       formUuid: {
-        _type: Type.UUID,
+        _type: Type.String,
         _description: 'The UUID of the form',
       },
       formName: {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently this configuration allows to open OpenMRS2 forms in the OpenMRS3 interface
Before, in OpenMRS2 the uuids created had no restriction on their format, which could generate invalid uuids. That's what happened. Currently we have dozens of old forms with invalid uuids.

Changing these uuids will be a very complicated job, as we have several features/developments on top of them, not only in the context of OpenMRS, and changing them could lead to irreparable errors in the future.

As this is a configuration made by the administrator, I propose to change the type of the `formUuid` property to string. This change should not impact any distribution currently running and avoids hundreds/thousands of errors that are being triggered, impacting performance.

I remind you that this type to be changed is not in the list of forms, but in the configuration of OpenMRS2 forms that are opened from the O3 interface.

Thanks.


## Screenshots
<!-- Required if you are making UI changes. -->
![Pasted Graphic](https://user-images.githubusercontent.com/94977371/219711600-f49a0660-7fae-42fe-8973-1760b575430e.png)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
