### PR TITLE
feat: Add ability to navigate back from patient-chart to previous url

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
@@ -58,6 +58,7 @@ const ChartReview: React.FC<ChartReviewProps> = ({ patientUuid, patient, view })
         to={makePath(defaultDashboard, {
           patientUuid,
         })}
+        replace
       />
     );
   } else {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes an issue where if the user is on patient-chart landing page and clicks the back button the user isn't navigated back to the url they came from. e.g if i navigated to patient-chart from service queues clicking the back button should not take me back to service queues instead of the home page. 

## Screenshots

![Kapture 2023-02-22 at 13 17 57](https://user-images.githubusercontent.com/28008754/220591462-df67b76f-08e7-4162-838e-d560b1c70d89.gif)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
