### PR TITLE
(feat) Support search on all pages in forms list

### DIFF
--- a/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
@@ -21,7 +21,7 @@ import {
 } from '@carbon/react';
 import { Edit } from '@carbon/react/icons';
 import { EmptyDataIllustration, PatientChartPagination, useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
-import { formatDatetime, useConfig, usePagination } from '@openmrs/esm-framework';
+import { formatDatetime, useConfig, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { ConfigObject } from '../config-schema';
 import { CompletedFormInfo } from '../types';
 import { launchFormEntryOrHtmlForms } from '../form-entry-interop';
@@ -50,6 +50,7 @@ interface FilterProps {
 const FormView: React.FC<FormViewProps> = ({ category, forms, patientUuid, patient, pageSize, pageUrl, urlLabel }) => {
   const { t } = useTranslation();
   const config = useConfig() as ConfigObject;
+  const isTablet = useLayoutType() === 'tablet';
   const htmlFormEntryForms = config.htmlFormEntryForms;
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
   const [searchTerm, setSearchTerm] = useState('');
@@ -73,11 +74,11 @@ const FormView: React.FC<FormViewProps> = ({ category, forms, patientUuid, patie
 
   const tableHeaders: Array<DataTableHeader> = useMemo(
     () => [
+      { key: 'formName', header: t('formName', 'Form name (A-Z)') },
       {
         key: 'lastCompleted',
         header: t('lastCompleted', 'Last completed'),
       },
-      { key: 'formName', header: t('formName', 'Form name (A-Z)') },
     ],
     [t],
   );
@@ -126,7 +127,8 @@ const FormView: React.FC<FormViewProps> = ({ category, forms, patientUuid, patie
                       expanded
                       light
                       onChange={(event) => handleSearch(event.target.value)}
-                      placeholder={t('searchThisList', 'Search this list')}
+                      placeholder={t('searchForAForm', 'Search for a form')}
+                      size={isTablet ? 'md' : 'sm'}
                     />
                   </TableToolbarContent>
                 </TableToolbar>
@@ -150,25 +152,27 @@ const FormView: React.FC<FormViewProps> = ({ category, forms, patientUuid, patie
                     {rows.map((row, index) => {
                       return (
                         <TableRow key={row.id}>
-                          <TableCell>{row.cells[0].value ?? t('never', 'Never')}</TableCell>
+                          <TableCell>
+                            <label
+                              onClick={() =>
+                                launchFormEntryOrHtmlForms(
+                                  currentVisit,
+                                  row.id,
+                                  patient,
+                                  htmlFormEntryForms,
+                                  '',
+                                  results[index].form.display ?? results[index].form.name,
+                                )
+                              }
+                              role="presentation"
+                              className={styles.formName}
+                            >
+                              {row.cells[0].value}
+                            </label>
+                          </TableCell>
                           <TableCell>
                             <div className={styles.tableCell}>
-                              <label
-                                onClick={() =>
-                                  launchFormEntryOrHtmlForms(
-                                    currentVisit,
-                                    row.id,
-                                    patient,
-                                    htmlFormEntryForms,
-                                    '',
-                                    results[index].form.display ?? results[index].form.name,
-                                  )
-                                }
-                                role="presentation"
-                                className={styles.formName}
-                              >
-                                {row.cells[1].value}
-                              </label>
+                              {row.cells[1].value ?? t('never', 'Never')}
                               {row.cells[0].value && (
                                 <Edit
                                   size={20}

--- a/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
@@ -208,7 +208,7 @@ const FormView: React.FC<FormViewProps> = ({ category, forms, patientUuid, patie
           </DataTable>
           <PatientChartPagination
             pageNumber={currentPage}
-            totalItems={forms?.length}
+            totalItems={filteredForms?.length}
             currentItems={results.length}
             pageSize={pageSize}
             onPageNumberChange={({ page }) => goTo(page)}

--- a/packages/esm-patient-forms-app/src/forms/forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.tsx
@@ -106,9 +106,9 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
             onChange={(event) => setFormsCategory(event.name as any)}
             selectedIndex={formsCategory}
           >
+            <Switch name={'All'} text={t('all', 'All')} />
             <Switch name={'Recommended'} text={t('recommended', 'Recommended')} />
             <Switch name={'Completed'} text={t('completed', 'Completed')} />
-            <Switch name={'All'} text={t('all', 'All')} />
           </ContentSwitcher>
         </div>
       </CardHeader>
@@ -124,9 +124,10 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
             urlLabel={urlLabel}
           />
         )}
-        {formsCategory === 'All' && (
+        {formsCategory === 'Recommended' && (
           <FormView
-            forms={formsToDisplay}
+            category={'Recommended'}
+            forms={recommendedForms}
             patientUuid={patientUuid}
             patient={patient}
             pageSize={pageSize}
@@ -134,10 +135,9 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
             urlLabel={urlLabel}
           />
         )}
-        {formsCategory === 'Recommended' && (
+        {formsCategory === 'All' && (
           <FormView
-            category={'Recommended'}
-            forms={recommendedForms}
+            forms={formsToDisplay}
             patientUuid={patientUuid}
             patient={patient}
             pageSize={pageSize}

--- a/packages/esm-patient-forms-app/translations/en.json
+++ b/packages/esm-patient-forms-app/translations/en.json
@@ -23,6 +23,7 @@
   "offlinePatientsTableSearchPlaceholder": "Search this list",
   "offlineToggle": "Offline toggle",
   "recommended": "Recommended",
+  "searchForAForm": "Search for a form",
   "searchThisList": "Search this list",
   "seeAll": "See all"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This pull request implements a way to search in the datatable that allows searching across all pages. Previously, the search only worked for the current page.

The following changes were made:

- Added a search input field to the datatable.
- Implemented a function that filters the table data based on the search input.
- Updated the table component to pass the filtered data to the table body.
- Added a memoized state to hold the filtered data, to avoid unnecessary re-renders.
- Added a useEffect hook to update the memoized state when the search input or the table data change.


## Screenshots
Before:
![search_before](https://user-images.githubusercontent.com/94977371/220666607-f92e6edd-4081-44e3-b360-63bb51f428b2.gif)


After:
![search_after](https://user-images.githubusercontent.com/94977371/220666649-06668048-06ab-4079-aa4e-1a299c23d1e6.gif)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

- Manually tested the search functionality by entering search terms and verifying that the table updates with the matching results.
- Tested the functionality of the search across multiple pages by entering search terms and verifying that the results included matches from all pages.
- Tested the performance of the search by searching through a large dataset to ensure that the search results are returned quickly.

