### PR TITLE
(fix) O3-1928: Set maximal width on vitals header item container

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
@@ -9,6 +9,7 @@
   padding: 0.25rem 0.5rem;
   margin: 0.5rem;
   width: 100%;
+  min-inline-size: max-content;
 }
 
 .abnormal-value {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary

Fixes the appearance of items in the vitals header when horizontal space is constrained by setting a `max-inline-size` property with a `max-content` value on the `container` div.

##  Before

https://user-images.githubusercontent.com/59338693/221400057-0b28dbcd-b469-4e5b-aa92-7d64b7a6d51e.mp4


## After

https://user-images.githubusercontent.com/59338693/221400090-11a9751e-1bf3-4f75-b021-a8480ef118fe.mp4


## Related Issue
https://issues.openmrs.org/browse/O3-1928
