### PR TITLE
(feat) O3-1896: Number input steppers in vitals and biometrics form shouldn't exceed ranges

### DIFF
--- a/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
+++ b/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
@@ -19,13 +19,16 @@ export function useVitalsConceptMetadata() {
     : new Map<string, string>([]);
 
   const conceptRanges = conceptMetadata?.length
-    ? new Map<string, { lowAbsolute: number | string | null; highAbsolute: number | string | null }>(
+    ? new Map<string, { lowAbsolute: number | null; highAbsolute: number | null }>(
         conceptMetadata.map((concept) => [
           concept.uuid,
-          { lowAbsolute: concept.lowAbsolute, highAbsolute: concept.hiAbsolute },
+          {
+            lowAbsolute: concept.lowAbsolute ?? null,
+            highAbsolute: concept.hiAbsolute ?? null,
+          },
         ]),
       )
-    : new Map<string, { lowAbsolute: number | string | null; highAbsolute: number | string | null }>([]);
+    : new Map<string, { lowAbsolute: number | null; highAbsolute: number | null }>([]);
 
   return {
     data: conceptUnits,
@@ -43,12 +46,12 @@ export const withUnit = (label: string, unit: string | null | undefined) => {
 export interface ConceptMetadata {
   uuid: string;
   display: string;
-  hiNormal: number | string | null;
-  hiAbsolute: number | string | null;
-  hiCritical: number | string | null;
-  lowNormal: number | string | null;
-  lowAbsolute: number | string | null;
-  lowCritical: number | string | null;
+  hiNormal: number | null;
+  hiAbsolute: number | null;
+  hiCritical: number | null;
+  lowNormal: number | null;
+  lowAbsolute: number | null;
+  lowCritical: number | null;
   units: string | null;
 }
 

--- a/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
+++ b/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
@@ -17,11 +17,22 @@ export function useVitalsConceptMetadata() {
   const conceptUnits = conceptMetadata?.length
     ? new Map<string, string>(conceptMetadata.map((concept) => [concept.uuid, concept.units]))
     : new Map<string, string>([]);
+
+  const conceptRanges = conceptMetadata?.length
+    ? new Map<string, { lowAbsolute: number | string | null; highAbsolute: number | string | null }>(
+        conceptMetadata.map((concept) => [
+          concept.uuid,
+          { lowAbsolute: concept.lowAbsolute, highAbsolute: concept.hiAbsolute },
+        ]),
+      )
+    : new Map<string, { lowAbsolute: number | string | null; highAbsolute: number | string | null }>([]);
+
   return {
     data: conceptUnits,
     isError: error,
     isLoading,
     conceptMetadata,
+    conceptRanges,
   };
 }
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -53,15 +53,15 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
   };
 
   const concepts = {
-    systolicBloodPressureRange: conceptRanges.get(config.concepts.systolicBloodPressureUuid),
+    midUpperArmCircumferenceRange: conceptRanges.get(config.concepts.midUpperArmCircumferenceUuid),
     diastolicBloodPressureRange: conceptRanges.get(config.concepts.diastolicBloodPressureUuid),
-    pulseRange: conceptRanges.get(config.concepts.pulseUuid),
+    systolicBloodPressureRange: conceptRanges.get(config.concepts.systolicBloodPressureUuid),
     oxygenSaturationRange: conceptRanges.get(config.concepts.oxygenSaturationUuid),
     respiratoryRateRange: conceptRanges.get(config.concepts.respiratoryRateUuid),
+    temperatureRange: conceptRanges.get(config.concepts.temperatureUuid),
     weightRange: conceptRanges.get(config.concepts.weightUuid),
     heightRange: conceptRanges.get(config.concepts.heightUuid),
-    temperatureRange: conceptRanges.get(config.concepts.temperatureUuid),
-    midUpperArmCircumferenceRange: conceptRanges.get(config.concepts.midUpperArmCircumferenceUuid),
+    pulseRange: conceptRanges.get(config.concepts.pulseUuid),
   };
 
   const savePatientVitalsAndBiometrics = (event: SyntheticEvent) => {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -40,7 +40,7 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
   const { currentVisit } = useVisit(patientUuid);
   const { mutate } = useVitals(patientUuid);
   const config = useConfig() as ConfigObject;
-  const { data: conceptUnits, conceptMetadata } = useVitalsConceptMetadata();
+  const { data: conceptUnits, conceptMetadata, conceptRanges } = useVitalsConceptMetadata();
   const biometricsUnitsSymbols = config.biometrics;
   const [patientVitalAndBiometrics, setPatientVitalAndBiometrics] = useState<PatientVitalsAndBiometrics>();
   const [patientBMI, setPatientBMI] = useState<number>();
@@ -50,6 +50,18 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
   const isBMIInNormalRange = (value: number | undefined | string) => {
     if (value === undefined || value === '') return true;
     return value >= 18.5 && value <= 24.9;
+  };
+
+  const concepts = {
+    systolicBloodPressureRange: conceptRanges.get(config.concepts.systolicBloodPressureUuid),
+    diastolicBloodPressureRange: conceptRanges.get(config.concepts.diastolicBloodPressureUuid),
+    pulseRange: conceptRanges.get(config.concepts.pulseUuid),
+    oxygenSaturationRange: conceptRanges.get(config.concepts.oxygenSaturationUuid),
+    respiratoryRateRange: conceptRanges.get(config.concepts.respiratoryRateUuid),
+    weightRange: conceptRanges.get(config.concepts.weightUuid),
+    heightRange: conceptRanges.get(config.concepts.heightUuid),
+    temperatureRange: conceptRanges.get(config.concepts.temperatureUuid),
+    midUpperArmCircumferenceRange: conceptRanges.get(config.concepts.midUpperArmCircumferenceUuid),
   };
 
   const savePatientVitalsAndBiometrics = (event: SyntheticEvent) => {
@@ -162,6 +174,8 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
                     name: t('temperature', 'Temperature'),
                     type: 'number',
                     value: patientVitalAndBiometrics?.temperature || '',
+                    min: concepts.temperatureRange.lowAbsolute,
+                    max: concepts.temperatureRange.highAbsolute,
                   },
                 ]}
                 unitSymbol={conceptUnits.get(config.concepts.temperatureUuid) ?? ''}
@@ -192,11 +206,15 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
                     separator: '/',
                     type: 'number',
                     value: patientVitalAndBiometrics?.systolicBloodPressure || '',
+                    min: concepts.systolicBloodPressureRange.lowAbsolute,
+                    max: concepts.systolicBloodPressureRange.highAbsolute,
                   },
                   {
                     name: t('diastolic', 'diastolic'),
                     type: 'number',
                     value: patientVitalAndBiometrics?.diastolicBloodPressure || '',
+                    min: concepts.diastolicBloodPressureRange.lowAbsolute,
+                    max: concepts.diastolicBloodPressureRange.highAbsolute,
                   },
                 ]}
                 unitSymbol={conceptUnits.get(config.concepts.systolicBloodPressureUuid) ?? ''}
@@ -228,6 +246,8 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
                     name: t('pulse', 'Pulse'),
                     type: 'number',
                     value: patientVitalAndBiometrics?.pulse || '',
+                    min: concepts.pulseRange.lowAbsolute,
+                    max: concepts.pulseRange.highAbsolute,
                   },
                 ]}
                 unitSymbol={conceptUnits.get(config.concepts.pulseUuid) ?? ''}
@@ -252,6 +272,8 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
                     name: t('oxygenSaturation', 'Oxygen Saturation'),
                     type: 'number',
                     value: patientVitalAndBiometrics?.oxygenSaturation || '',
+                    min: concepts.oxygenSaturationRange.lowAbsolute,
+                    max: concepts.oxygenSaturationRange.highAbsolute,
                   },
                 ]}
                 unitSymbol={conceptUnits.get(config.concepts.oxygenSaturationUuid) ?? ''}
@@ -279,6 +301,8 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
                     name: t('respirationRate', 'Respiration Rate'),
                     type: 'number',
                     value: patientVitalAndBiometrics?.respiratoryRate || '',
+                    min: concepts.respiratoryRateRange.lowAbsolute,
+                    max: concepts.respiratoryRateRange.highAbsolute,
                   },
                 ]}
                 unitSymbol={conceptUnits.get(config.concepts.respiratoryRateUuid) ?? ''}
@@ -334,6 +358,8 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
                     name: t('weight', 'Weight'),
                     type: 'number',
                     value: patientVitalAndBiometrics?.weight || '',
+                    min: concepts.weightRange.lowAbsolute,
+                    max: concepts.weightRange.highAbsolute,
                   },
                 ]}
                 unitSymbol={conceptUnits.get(config.concepts.weightUuid) ?? ''}
@@ -358,6 +384,8 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
                     name: t('height', 'Height'),
                     type: 'number',
                     value: patientVitalAndBiometrics?.height || '',
+                    min: concepts.heightRange.lowAbsolute,
+                    max: concepts.heightRange.highAbsolute,
                   },
                 ]}
                 unitSymbol={conceptUnits.get(config.concepts.heightUuid) ?? ''}
@@ -394,6 +422,8 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
                     name: t('muac', 'MUAC'),
                     type: 'number',
                     value: patientVitalAndBiometrics?.midUpperArmCircumference || '',
+                    min: concepts.midUpperArmCircumferenceRange.lowAbsolute,
+                    max: concepts.midUpperArmCircumferenceRange.highAbsolute,
                   },
                 ]}
                 unitSymbol={conceptUnits.get(config.concepts.midUpperArmCircumferenceUuid) ?? ''}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.test.tsx
@@ -21,10 +21,10 @@ const mockConceptUnits = new Map<string, string>(
   mockVitalsSignsConcept.data.results[0].setMembers.map((concept) => [concept.uuid, concept.units]),
 );
 
-const mockConceptRanges = new Map<string, { lowAbsolute: number; highAbsolute: number }>(
+const mockConceptRanges = new Map<string, { lowAbsolute: number | null; highAbsolute: number | null }>(
   mockVitalsSignsConcept.data.results[0].setMembers.map((concept) => [
     concept.uuid,
-    { lowAbsolute: concept.lowAbsolute, highAbsolute: concept.hiAbsolute },
+    { lowAbsolute: concept.lowAbsolute ?? null, highAbsolute: concept.hiAbsolute ?? null },
   ]),
 );
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.test.tsx
@@ -21,6 +21,13 @@ const mockConceptUnits = new Map<string, string>(
   mockVitalsSignsConcept.data.results[0].setMembers.map((concept) => [concept.uuid, concept.units]),
 );
 
+const mockConceptRanges = new Map<string, { lowAbsolute: number; highAbsolute: number }>(
+  mockVitalsSignsConcept.data.results[0].setMembers.map((concept) => [
+    concept.uuid,
+    { lowAbsolute: concept.lowAbsolute, highAbsolute: concept.hiAbsolute },
+  ]),
+);
+
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
 
@@ -38,6 +45,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
     useVitalsConceptMetadata: jest.fn().mockImplementation(() => ({
       data: mockConceptUnits,
       conceptMetadata: mockConceptMetadata,
+      conceptRanges: mockConceptRanges,
     })),
   };
 });

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -14,8 +14,8 @@ interface VitalsBiometricInputProps {
     value: number | string;
     className?: string;
     invalid?: boolean;
-    min?: string | number;
-    max?: string | number;
+    min?: number | null;
+    max?: number | null;
   }>;
   unitSymbol?: string;
   textFieldWidth?: string;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -14,6 +14,8 @@ interface VitalsBiometricInputProps {
     value: number | string;
     className?: string;
     invalid?: boolean;
+    min?: string | number;
+    max?: string | number;
   }>;
   unitSymbol?: string;
   textFieldWidth?: string;
@@ -61,7 +63,8 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
                   id={val.name}
                   invalid={invalid}
                   type={val.type}
-                  min={0}
+                  min={val.min}
+                  max={val.max}
                   name={val.name}
                   onChange={(e) => check(e.target.value)}
                   onInput={onInputChange}


### PR DESCRIPTION
… and biometrics form

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- As Ian suggested, if a user is using the numeric dials, they should start at the absolute minimum and go only as far as the absolute maximum
- Updated unit test to handle the change 

## Screenshots
<!-- Required if you are making UI changes. -->
[Screencast from 2023-02-23 19-02-19.webm](https://user-images.githubusercontent.com/104269786/221401249-270d7523-abd2-457e-94bf-1cb3fa442754.webm)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1896

## Other
<!-- Anything not covered above -->
