### PR TITLE
(feat) O3-1879: P.R.N. Instructions Text area should be disabled if `PRN as needed` is not selected

### DIFF
--- a/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
@@ -353,7 +353,27 @@ export default function MedicationOrderForm({ initialOrderBasketItem, onSign, on
                 </Column>
                 <Column lg={16} md={4} sm={4}>
                   <Grid className={styles.gridRow}>
-                    <Column lg={12} md={8} sm={4} className={styles.prnTextArea}>
+                    <Column lg={6} md={8} sm={4}>
+                      <InputWrapper>
+                        <FormGroup legendText={t('prn', 'P.R.N.')}>
+                          <Checkbox
+                            id="prn"
+                            labelText={t('takeAsNeeded', 'Take as needed')}
+                            size="lg"
+                            checked={orderBasketItem.asNeeded}
+                            onChange={(e) =>
+                              setOrderBasketItem({
+                                ...orderBasketItem,
+                                asNeeded: e.target.checked,
+                                asNeededCondition: e.target.checked ? orderBasketItem?.asNeededCondition : '',
+                              })
+                            }
+                          />
+                        </FormGroup>
+                      </InputWrapper>
+                    </Column>
+
+                    <Column lg={10} md={8} sm={4}>
                       <InputWrapper>
                         <TextArea
                           labelText={t('prnReason', 'P.R.N. reason')}
@@ -367,26 +387,8 @@ export default function MedicationOrderForm({ initialOrderBasketItem, onSign, on
                               asNeededCondition: e.target.value,
                             })
                           }
+                          disabled={!orderBasketItem?.asNeeded}
                         />
-                      </InputWrapper>
-                    </Column>
-
-                    <Column lg={4} md={8} sm={4} className={styles.prnCheckbox}>
-                      <InputWrapper>
-                        <FormGroup legendText={t('prn', 'P.R.N.')}>
-                          <Checkbox
-                            id="prn"
-                            labelText={t('takeAsNeeded', 'Take as needed')}
-                            size="lg"
-                            checked={orderBasketItem.asNeeded}
-                            onChange={(e) =>
-                              setOrderBasketItem({
-                                ...orderBasketItem,
-                                asNeeded: e.target.checked,
-                              })
-                            }
-                          />
-                        </FormGroup>
                       </InputWrapper>
                     </Column>
                   </Grid>

--- a/packages/esm-patient-medications-app/src/order-basket/medication-order-form.scss
+++ b/packages/esm-patient-medications-app/src/order-basket/medication-order-form.scss
@@ -214,11 +214,4 @@
     background-color: $ui-02;
   }
 
-  .prnTextArea {
-    grid-row: 2;
-  }
-
-  .prnCheckbox {
-    grid-row: 1;
-  }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR introduces an enhancement to only record `P.R.N. reason` only when `Take as needed` checkbox is checked.

## Screenshots

https://user-images.githubusercontent.com/51502471/221497611-f9ee5ece-7972-44eb-945f-59a7b91cc23e.mov


## Related Issue
https://issues.openmrs.org/browse/O3-1879

## Other
<!-- Anything not covered above -->
