### PR TITLE
(fix) 03-1917: Forms icon in the side rails loses the active class.

### DIFF
--- a/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
+++ b/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
@@ -13,7 +13,9 @@ const ClinicalFormActionButton: React.FC = () => {
   const { workspaces } = useWorkspaces();
   const { launchFormsWorkspace } = useLaunchFormsWorkspace();
 
-  const isActiveWorkspace = workspaces?.[0]?.name?.match(/clinical-forms-workspace/i);
+  const isActiveWorkspace =
+    workspaces?.[0]?.name?.match(/clinical-forms-workspace/i) ||
+    workspaces?.[0]?.name?.match(/patient-form-entry-workspace/i);
 
   if (layout === 'tablet') {
     return (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
- This PR fixes the bug where we were losing the active styles on the form icon when we click a specific form. This was because we were only checking for the `clinical-forms-workspace` and the form itself had another name `patient-form-entry-workspace` so I added that as a check to add the active class to the forms icons.

## Screenshots

https://user-images.githubusercontent.com/30952856/221686837-2e1c0e57-158c-4227-9b2f-345a529fd38f.mov


## Related Issue
- https://issues.openmrs.org/browse/O3-1917

