### PR TITLE
(fix) Allow opening legacy html forms on visit list

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -149,7 +149,7 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ encounters, patientUuid, vi
             <MedicationSummary medications={medications} />
           </TabPanel>
           <TabPanel>
-            <VisitsTable visits={mapEncounters(encounters, visitUuid, visitTypeUuid)} showAllEncounters={false} />
+            <VisitsTable visits={mapEncounters(encounters, visitUuid, visitTypeUuid)} showAllEncounters={false} patientUuid={patientUuid} />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -149,7 +149,11 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ encounters, patientUuid, vi
             <MedicationSummary medications={medications} />
           </TabPanel>
           <TabPanel>
-            <VisitsTable visits={mapEncounters(encounters, visitUuid, visitTypeUuid)} showAllEncounters={false} patientUuid={patientUuid} />
+            <VisitsTable
+              visits={mapEncounters(encounters, visitUuid, visitTypeUuid)}
+              showAllEncounters={false}
+              patientUuid={patientUuid}
+            />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../../../../__mocks__/visits.mock';
 import { mockPatient } from '../../../../../../__mocks__/patient.mock';
 import VisitSummary from './visit-summary.component';
-import { getConfig } from "@openmrs/esm-framework";
+import { getConfig } from '@openmrs/esm-framework';
 
 const mockEncounter = visitOverviewDetailMockData.data.results[0].encounters.map((encounter) => encounter);
 const mockGetConfig = getConfig as jest.Mock;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
@@ -7,8 +7,10 @@ import {
 } from '../../../../../../__mocks__/visits.mock';
 import { mockPatient } from '../../../../../../__mocks__/patient.mock';
 import VisitSummary from './visit-summary.component';
+import { getConfig } from "@openmrs/esm-framework";
 
 const mockEncounter = visitOverviewDetailMockData.data.results[0].encounters.map((encounter) => encounter);
+const mockGetConfig = getConfig as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -30,6 +32,7 @@ jest.mock('@openmrs/esm-framework', () => {
 describe('VisitSummary', () => {
   it('should display empty state for notes, test and medication summary', async () => {
     const user = userEvent.setup();
+    mockGetConfig.mockReturnValue(Promise.resolve({ htmlFormEntryForms: [] }));
 
     renderVisitSummary();
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -24,19 +24,28 @@ import {
   Tile,
 } from '@carbon/react';
 import { Edit } from '@carbon/react/icons';
-import {formatDatetime, navigate, parseDate, useLayoutType, usePagination, Visit, getConfig, useConfig} from '@openmrs/esm-framework';
+import {
+  formatDatetime,
+  navigate,
+  parseDate,
+  useLayoutType,
+  usePagination,
+  Visit,
+  getConfig,
+  useConfig,
+} from '@openmrs/esm-framework';
 import {
   formEntrySub,
   launchPatientWorkspace,
   launchStartVisitPrompt,
-  PatientChartPagination
+  PatientChartPagination,
 } from '@openmrs/esm-patient-common-lib';
 import { MappedEncounter } from '../visit-summary.component';
 import EncounterObservations from '../../encounter-observations';
 import styles from './visits-table.scss';
-import type {HtmlFormEntryForm} from "@openmrs/esm-patient-forms-app/src/config-schema";
-import isEmpty from "lodash-es/isEmpty";
-import {launchFormEntry} from "@openmrs/esm-patient-forms-app/src/form-entry-interop";
+import type { HtmlFormEntryForm } from '@openmrs/esm-patient-forms-app/src/config-schema';
+import isEmpty from 'lodash-es/isEmpty';
+import { launchFormEntry } from '@openmrs/esm-patient-forms-app/src/form-entry-interop';
 
 interface VisitTableProps {
   visits: Array<MappedEncounter>;
@@ -52,7 +61,7 @@ type FilterProps = {
   getCellId: (row, key) => string;
 };
 
-const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, patientUuid}) => {
+const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, patientUuid }) => {
   const visitCount = 20;
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
@@ -164,15 +173,15 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
       useZebraStyles={visits?.length > 1 ? true : false}
     >
       {({
-          rows,
-          headers,
-          getHeaderProps,
-          getRowProps,
-          getExpandHeaderProps,
-          getTableProps,
-          getToolbarProps,
-          onInputChange,
-        }) => (
+        rows,
+        headers,
+        getHeaderProps,
+        getRowProps,
+        getExpandHeaderProps,
+        getTableProps,
+        getToolbarProps,
+        onInputChange,
+      }) => (
         <>
           <TableContainer className={styles.tableContainer}>
             <TableToolbar {...getToolbarProps()}>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -24,15 +24,24 @@ import {
   Tile,
 } from '@carbon/react';
 import { Edit } from '@carbon/react/icons';
-import { formatDatetime, parseDate, useLayoutType, usePagination } from '@openmrs/esm-framework';
-import { formEntrySub, launchPatientWorkspace, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
+import {formatDatetime, navigate, parseDate, useLayoutType, usePagination, Visit, getConfig, useConfig} from '@openmrs/esm-framework';
+import {
+  formEntrySub,
+  launchPatientWorkspace,
+  launchStartVisitPrompt,
+  PatientChartPagination
+} from '@openmrs/esm-patient-common-lib';
 import { MappedEncounter } from '../visit-summary.component';
 import EncounterObservations from '../../encounter-observations';
 import styles from './visits-table.scss';
+import {HtmlFormEntryForm} from "@openmrs/esm-patient-forms-app/src/config-schema";
+import isEmpty from "lodash-es/isEmpty";
+import {launchFormEntry} from "@openmrs/esm-patient-forms-app/src/form-entry-interop";
 
 interface VisitTableProps {
   visits: Array<MappedEncounter>;
   showAllEncounters?: boolean;
+  patientUuid: string;
 }
 
 type FilterProps = {
@@ -43,10 +52,18 @@ type FilterProps = {
   getCellId: (row, key) => string;
 };
 
-const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) => {
+const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, patientUuid}) => {
   const visitCount = 20;
   const { t } = useTranslation();
+  const config = useConfig();
   const isTablet = useLayoutType() === 'tablet';
+
+  const [htmlFormEntryFormsConfig, setHtmlFormEntryFormsConfig] = React.useState<null | Array<HtmlFormEntryForm>>(null);
+  React.useEffect(() => {
+    getConfig('@openmrs/esm-patient-forms-app').then((config) => {
+      setHtmlFormEntryFormsConfig(config.htmlFormEntryForms as HtmlFormEntryForm[]);
+    });
+  }, [config]);
 
   const encounterTypes = [...new Set(visits.map((encounter) => encounter.encounterType))].sort();
 
@@ -101,8 +118,15 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
     formName?: string,
     visitTypeUuid?: string,
   ) => {
-    formEntrySub.next({ formUuid, visitUuid, encounterUuid, visitTypeUuid });
-    launchPatientWorkspace('patient-form-entry-workspace', { workspaceTitle: formName });
+    const htmlForm = htmlFormEntryFormsConfig.find((form) => form.formUuid === formUuid);
+    if (isEmpty(htmlForm)) {
+      formEntrySub.next({ formUuid, visitUuid, encounterUuid, visitTypeUuid });
+      launchPatientWorkspace('patient-form-entry-workspace', { workspaceTitle: formName });
+    } else {
+      navigate({
+        to: `\${openmrsBase}/htmlformentryui/htmlform/${htmlForm.formUiPage}.page?patientId=${patientUuid}&visitId=${visitUuid}&encounterId=${encounterUuid}&returnUrl=${window.location.href}`,
+      });
+    }
   };
 
   const tableRows = useMemo(() => {
@@ -141,15 +165,15 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
       useZebraStyles={visits?.length > 1 ? true : false}
     >
       {({
-        rows,
-        headers,
-        getHeaderProps,
-        getRowProps,
-        getExpandHeaderProps,
-        getTableProps,
-        getToolbarProps,
-        onInputChange,
-      }) => (
+          rows,
+          headers,
+          getHeaderProps,
+          getRowProps,
+          getExpandHeaderProps,
+          getTableProps,
+          getToolbarProps,
+          onInputChange,
+        }) => (
         <>
           <TableContainer className={styles.tableContainer}>
             <TableToolbar {...getToolbarProps()}>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -34,7 +34,7 @@ import {
 import { MappedEncounter } from '../visit-summary.component';
 import EncounterObservations from '../../encounter-observations';
 import styles from './visits-table.scss';
-import {HtmlFormEntryForm} from "@openmrs/esm-patient-forms-app/src/config-schema";
+import type {HtmlFormEntryForm} from "@openmrs/esm-patient-forms-app/src/config-schema";
 import isEmpty from "lodash-es/isEmpty";
 import {launchFormEntry} from "@openmrs/esm-patient-forms-app/src/form-entry-interop";
 
@@ -55,15 +55,14 @@ type FilterProps = {
 const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, patientUuid}) => {
   const visitCount = 20;
   const { t } = useTranslation();
-  const config = useConfig();
   const isTablet = useLayoutType() === 'tablet';
 
-  const [htmlFormEntryFormsConfig, setHtmlFormEntryFormsConfig] = React.useState<null | Array<HtmlFormEntryForm>>(null);
-  React.useEffect(() => {
+  const [htmlFormEntryFormsConfig, setHtmlFormEntryFormsConfig] = useState<Array<HtmlFormEntryForm> | undefined>();
+  useEffect(() => {
     getConfig('@openmrs/esm-patient-forms-app').then((config) => {
       setHtmlFormEntryFormsConfig(config.htmlFormEntryForms as HtmlFormEntryForm[]);
     });
-  }, [config]);
+  });
 
   const encounterTypes = [...new Set(visits.map((encounter) => encounter.encounterType))].sort();
 
@@ -118,7 +117,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
     formName?: string,
     visitTypeUuid?: string,
   ) => {
-    const htmlForm = htmlFormEntryFormsConfig.find((form) => form.formUuid === formUuid);
+    const htmlForm = htmlFormEntryFormsConfig?.find((form) => form.formUuid === formUuid);
     if (isEmpty(htmlForm)) {
       formEntrySub.next({ formUuid, visitUuid, encounterUuid, visitTypeUuid });
       launchPatientWorkspace('patient-form-entry-workspace', { workspaceTitle: formName });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -124,7 +124,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
       launchPatientWorkspace('patient-form-entry-workspace', { workspaceTitle: formName });
     } else {
       navigate({
-        to: `\${openmrsBase}/htmlformentryui/htmlform/${htmlForm.formUiPage}.page?patientId=${patientUuid}&visitId=${visitUuid}&encounterId=${encounterUuid}&returnUrl=${window.location.href}`,
+        to: `\${openmrsBase}/htmlformentryui/htmlform/${htmlForm.formUiPage}.page?patientId=${patientUuid}&visitId=${visitUuid}&encounterId=${encounterUuid}&definitionUiResource=${htmlForm.formUiResource}&returnUrl=${window.location.href}`,
       });
     }
   };

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';
-import { usePagination } from '@openmrs/esm-framework';
+import { useConfig, usePagination } from '@openmrs/esm-framework';
 import { renderWithSwr } from '../../../../../../../tools/test-helpers';
 import { mockEncounters } from '../../../../../../../__mocks__/visits.mock';
 import VisitsTable from './visits-table.component';
@@ -14,6 +14,7 @@ const testProps = {
 };
 
 const mockedUsePagination = usePagination as jest.Mock;
+const mockUseConfig = useConfig as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';
-import { useConfig, usePagination } from '@openmrs/esm-framework';
+import { getConfig, useConfig, usePagination } from '@openmrs/esm-framework';
 import { renderWithSwr } from '../../../../../../../tools/test-helpers';
 import { mockEncounters } from '../../../../../../../__mocks__/visits.mock';
 import VisitsTable from './visits-table.component';
@@ -15,6 +15,7 @@ const testProps = {
 
 const mockedUsePagination = usePagination as jest.Mock;
 const mockUseConfig = useConfig as jest.Mock;
+const mockGetConfig = getConfig as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -33,6 +34,7 @@ describe('EncounterList', () => {
   it('renders an empty state when no encounters are available', () => {
     testProps.visits = [];
 
+    mockGetConfig.mockReturnValue(Promise.resolve({ htmlFormEntryForms: [] }));
     mockedUsePagination.mockImplementationOnce(() => ({
       currentPage: 1,
       goTo: () => {},

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -92,7 +92,7 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
             ) : isError ? (
               <ErrorState headerTitle={t('visits', 'visits')} error={isError} />
             ) : visits?.length ? (
-              <VisitsTable visits={visitsWithEncounters} showAllEncounters />
+              <VisitsTable visits={visitsWithEncounters} showAllEncounters patientUuid={patientUuid} />
             ) : (
               <EmptyState headerTitle={t('visits', 'visits')} displayText={t('Visits', 'Visits')} />
             )}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, getConfig } from '@openmrs/esm-framework';
 import { renderWithSwr, waitForLoadingToFinish } from '../../../../../tools/test-helpers';
 import { visitOverviewDetailMockData } from '../../../../../__mocks__/visits.mock';
 import { mockPatient } from '../../../../../__mocks__/patient.mock';
@@ -12,6 +12,7 @@ const testProps = {
 };
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
+const mockGetConfig = getConfig as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -28,6 +29,7 @@ jest.mock('@openmrs/esm-framework', () => {
 describe('VisitDetailOverview', () => {
   it('renders an empty state view if encounters data is unavailable', async () => {
     mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
+    mockGetConfig.mockReturnValue({ htmlFormEntryForms: [] });
 
     renderVisitDetailOverview();
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -29,7 +29,7 @@ jest.mock('@openmrs/esm-framework', () => {
 describe('VisitDetailOverview', () => {
   it('renders an empty state view if encounters data is unavailable', async () => {
     mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
-    mockGetConfig.mockReturnValue(Promise.resolve({ htmlFormEntryForms: [] }));
+    mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
 
     renderVisitDetailOverview();
 
@@ -65,7 +65,7 @@ describe('VisitDetailOverview', () => {
     const user = userEvent.setup();
 
     mockOpenmrsFetch.mockReturnValueOnce(visitOverviewDetailMockData);
-    mockGetConfig.mockReturnValue(Promise.resolve({ htmlFormEntryForms: [] }));
+    mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
 
     renderVisitDetailOverview();
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -29,7 +29,7 @@ jest.mock('@openmrs/esm-framework', () => {
 describe('VisitDetailOverview', () => {
   it('renders an empty state view if encounters data is unavailable', async () => {
     mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
-    mockGetConfig.mockReturnValue({ htmlFormEntryForms: [] });
+    mockGetConfig.mockReturnValue(Promise.resolve({ htmlFormEntryForms: [] }));
 
     renderVisitDetailOverview();
 
@@ -65,6 +65,7 @@ describe('VisitDetailOverview', () => {
     const user = userEvent.setup();
 
     mockOpenmrsFetch.mockReturnValueOnce(visitOverviewDetailMockData);
+    mockGetConfig.mockReturnValue(Promise.resolve({ htmlFormEntryForms: [] }));
 
     renderVisitDetailOverview();
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This fix will allow editing encounters recorded on HTMLFormEntry from the visits list. Prior to this fix, if the user tried to open a legacy form, an error would occur.
The configuration used to check whether a form is legacy html or not is the same already in place for the "Forms & Notes" list.

## Screenshots
![image](https://user-images.githubusercontent.com/68599335/221821565-bfc35e87-a3a4-4113-bb49-644cf11fc263.png)