### PR TITLE
(fix) Attempt to fix weird overflow menu UI

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -132,7 +132,6 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
 
   return (
     <DataTable
-      data-floating-menu-container
       filterRows={handleFilter}
       headers={tableHeaders}
       rows={tableRows}
@@ -188,7 +187,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
                 </TableRow>
               </TableHead>
               <TableBody>
-                {rows.map((row, i) => (
+                {rows.map((row, index) => (
                   <React.Fragment key={row.id}>
                     <TableExpandRow {...getRowProps({ row })}>
                       {row.cells.map((cell) => (
@@ -196,19 +195,24 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
                       ))}
                       {showAllEncounters ? (
                         <TableCell className="cds--table-column-menu">
-                          <Layer>
-                            <OverflowMenu ariaLabel="Actions menu" size="sm" flipped>
+                          <Layer className={styles.layer}>
+                            <OverflowMenu
+                              data-floating-menu-container
+                              ariaLabel="Encounter table actions menu"
+                              size="sm"
+                              flipped
+                            >
                               <OverflowMenuItem
                                 className={styles.menuItem}
                                 id="#editEncounter"
                                 itemText={t('editThisEncounter', 'Edit this encounter')}
                                 onClick={() =>
                                   launchWorkspace(
-                                    visits[i].form.uuid,
-                                    visits[i].visitUuid,
-                                    visits[i].id,
-                                    visits[i].form.display,
-                                    visits[i].visitTypeUuid,
+                                    visits[index].form.uuid,
+                                    visits[index].visitUuid,
+                                    visits[index].id,
+                                    visits[index].form.display,
+                                    visits[index].visitTypeUuid,
                                   )
                                 }
                               >
@@ -242,16 +246,16 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits }) =>
                         colSpan={headers.length + 2}
                       >
                         <>
-                          <EncounterObservations observations={visits[i].obs} />
+                          <EncounterObservations observations={visits[index].obs} />
                           <Button
                             kind="ghost"
                             onClick={() =>
                               launchWorkspace(
-                                visits[i].form.uuid,
-                                visits[i].visitUuid,
-                                visits[i].id,
-                                visits[i].form.display,
-                                visits[i].visitTypeUuid,
+                                visits[index].form.uuid,
+                                visits[index].visitUuid,
+                                visits[index].id,
+                                visits[index].form.display,
+                                visits[index].visitTypeUuid,
                               )
                             }
                             renderIcon={(props) => <Edit size={16} {...props} />}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.scss
@@ -116,3 +116,7 @@
     min-height: 2.5rem;
   }
 }
+
+.layer {
+  height: 100%;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR is an absolute shot in the dark at fixing an issue where overflow menus in the visits table get rendered with a green background. Nothing in this PR directly addresses that issue, and the weird thing is that neither @hadijahkyampeire nor I could replicate it locally. Per the browser inspector tool, the offending `background-color` property appears to come from the `cds--btn-primary` class in the overflow menu wrapper. This is weird because this implementation matches the conditions widget overflow menu implementation almost to the letter, yet that issue doesn't occur in the conditions widget.

## Screenshots

> Devtools inspector

<img width="787" alt="Screenshot 2023-03-01 at 00 07 49" src="https://user-images.githubusercontent.com/8509731/221980011-78e488e7-a6d3-465d-a4db-6b41b9695333.png">

> Issue on dev3 (note the green background color on the overflow menu buttons)

<img width="1175" alt="Screenshot 2023-03-01 at 00 14 24" src="https://user-images.githubusercontent.com/8509731/221981592-1248794f-b4c2-4483-9bec-6304ef29161e.png">

> Same UI when run locally
 
<img width="886" alt="Screenshot 2023-03-01 at 00 22 23" src="https://user-images.githubusercontent.com/8509731/221983224-0852bc5f-746c-4ae1-b5c0-93207654216e.png">
