### PR TITLE
(fix) 03-1932: Form Icon should be disabled if a specific form is open

### DIFF
--- a/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
+++ b/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
@@ -17,12 +17,15 @@ const ClinicalFormActionButton: React.FC = () => {
     workspaces?.[0]?.name?.match(/clinical-forms-workspace/i) ||
     workspaces?.[0]?.name?.match(/patient-form-entry-workspace/i);
 
+  const isFormOpen = workspaces.filter((w) => w.name === 'patient-form-entry-workspace')?.length >= 1;
+
   if (layout === 'tablet') {
     return (
       <Button
         kind="ghost"
         className={`${styles.container} ${isActiveWorkspace ? styles.active : ''}`}
         tabIndex={0}
+        disabled={isFormOpen}
         onClick={launchFormsWorkspace}
       >
         <Document size={16} />
@@ -42,6 +45,7 @@ const ClinicalFormActionButton: React.FC = () => {
       enterDelayMs={1000}
       tooltipAlignment="center"
       tooltipPosition="left"
+      disabled={isFormOpen}
       size="sm"
     />
   );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This PR adds the ability to disable the form icon in the side rail when a form is open so as to prevent switching forms without first discarding the open form.

## Screenshots

https://user-images.githubusercontent.com/30952856/222009469-4eb3e27f-fdef-485a-b6c9-c515122f360c.mov


## Related Issue
- https://issues.openmrs.org/browse/O3-1932

