### PR TITLE
(refactor) Refactor start visit form

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/hooks/useRecommendedVisitTypes.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useRecommendedVisitTypes.tsx
@@ -18,12 +18,10 @@ export const useRecommendedVisitTypes = (
   locationUuid: string,
 ) => {
   const { visitTypeResourceUrl, showRecommendedVisitTypeTab } = useConfig() as ChartConfig;
+  const url = `${visitTypeResourceUrl}${patientUuid}/program/${programUuid}/enrollment/${enrollmentUuid}?intendedLocationUuid=${locationUuid}`;
+
   const { data, error, isLoading } = useSWR<{ data: EnrollmentVisitType }>(
-    showRecommendedVisitTypeTab &&
-      patientUuid &&
-      enrollmentUuid &&
-      programUuid &&
-      `${visitTypeResourceUrl}${patientUuid}/program/${programUuid}/enrollment/${enrollmentUuid}?intendedLocationUuid=${locationUuid}`,
+    showRecommendedVisitTypeTab && patientUuid && enrollmentUuid && programUuid ? url : null,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.component.tsx
@@ -26,7 +26,7 @@ const BaseVisitType: React.FC<BaseVisitTypeProps> = ({ onChange, visitTypes }) =
     }
   }, [searchTerm, visitTypes]);
 
-  const handleSearch = React.useMemo(() => debounce((searchTerm) => setSearchTerm(searchTerm), 300), []);
+  const handleSearch = useMemo(() => debounce((searchTerm) => setSearchTerm(searchTerm), 300), []);
 
   const { results, currentPage, goTo } = usePagination(searchResults, 5);
 
@@ -54,11 +54,11 @@ const BaseVisitType: React.FC<BaseVisitTypeProps> = ({ onChange, visitTypes }) =
 
           <RadioButtonGroup
             className={styles.radioButtonGroup}
-            defaultSelected={results?.length === 1 && results[0].uuid}
+            defaultSelected={results?.length === 1 ? results[0].uuid : ''}
             orientation="vertical"
             onChange={onChange}
             name="radio-button-group"
-            valueSelected={results?.length === 1 && results[0].uuid}
+            valueSelected={results?.length === 1 ? results[0].uuid : ''}
           >
             {results.map(({ uuid, display, name }) => (
               <RadioButton key={uuid} className={styles.radioButton} id={name} labelText={display} value={uuid} />

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -42,6 +42,18 @@ jest.mock('@openmrs/esm-framework', () => {
   };
 });
 
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
+
+  return {
+    ...originalModule,
+    useActivePatientEnrollment: jest.fn().mockReturnValue({
+      activePatientEnrollment: [],
+      isLoading: false,
+    }),
+  };
+});
+
 describe('Visit Form', () => {
   it('renders the Start Visit form with all the relevant fields and values', () => {
     renderVisitForm();
@@ -50,8 +62,6 @@ describe('Visit Form', () => {
     expect(screen.getByRole('textbox', { name: /Time/i })).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: /Time/i })).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: /Select a location/i })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: /Recommended/i })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: /All/i })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: /Outpatient Visit/ })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: /HIV Return Visit/ })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /AM/i })).toBeInTheDocument();

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -105,6 +105,7 @@
   "seeAll": "See all",
   "selectAnOption": "Select an option",
   "selectLocation": "Select a location",
+  "selectOption": "Select an option",
   "selectProgramType": "Select program type",
   "selectQueueLocation": "Select a queue location",
   "selectService": "Select a service",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR refactors the start visit form as follows:

- Replaces a couple of unnecessary `useEffect`s and instead computes their associated state updates during rendering.
- Replaces some repetitive code with a `ResponsiveWrapper` component that wraps its children in a `Layer` component when viewing the UI in the tablet viewport.
- Refactors the `Visit Type` selection logic so that the `ContentSwitcher` gets shown only when the Recommended Visit type feature gets enabled via config. Clicking on the `Recommended` tab of the ContentSwitcher reveals a never-ending loading screen. This feature depends on an implementation-specific external API to work, and it makes sense to disable it by default via configuration.

## Video

https://user-images.githubusercontent.com/8509731/222425399-88ee898a-4e00-4056-8aec-6f324413b535.mp4

