### PR TITLE
(fix) 03-1945: Do not launch the forms dashboard when there is an open form.

### DIFF
--- a/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
+++ b/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useLayoutType } from '@openmrs/esm-framework';
 import { useWorkspaces, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import useLaunchFormsWorkspace from './forms/use-launch-forms-workspace';
+import { clinicalFormsWorkspace, formEntryWorkspace } from './constants';
 import styles from './clinical-form-action-button.scss';
 
 const ClinicalFormActionButton: React.FC = () => {
@@ -13,12 +14,25 @@ const ClinicalFormActionButton: React.FC = () => {
   const { workspaces } = useWorkspaces();
   const { launchFormsWorkspace } = useLaunchFormsWorkspace();
 
-  const isActiveWorkspace =
-    workspaces?.[0]?.name?.match(/clinical-forms-workspace/i) ||
-    workspaces?.[0]?.name?.match(/patient-form-entry-workspace/i);
+  const workspaceIndex = workspaces.findIndex(
+    (workspace) => workspace.name === clinicalFormsWorkspace || workspace.name === formEntryWorkspace,
+  );
+  const isActiveWorkspace = workspaceIndex === 0;
 
-  const recentlyOpenedForm = workspaces.filter((w) => w.name === 'patient-form-entry-workspace')[0];
-  const isFormOpen = workspaces.filter((w) => w.name === 'patient-form-entry-workspace')?.length >= 1;
+  const formEntryWorkspaces = workspaces.filter((w) => w.name === formEntryWorkspace);
+  const recentlyOpenedForm = formEntryWorkspaces[0];
+
+  const isClinicalFormOpen = formEntryWorkspaces?.length >= 1;
+
+  const launchWorkspace = () => {
+    if (isClinicalFormOpen) {
+      launchPatientWorkspace('patient-form-entry-workspace', {
+        workspaceTitle: recentlyOpenedForm?.additionalProps?.['workspaceTitle'],
+      });
+    } else {
+      launchFormsWorkspace();
+    }
+  };
 
   if (layout === 'tablet') {
     return (
@@ -26,14 +40,7 @@ const ClinicalFormActionButton: React.FC = () => {
         kind="ghost"
         className={`${styles.container} ${isActiveWorkspace ? styles.active : ''}`}
         tabIndex={0}
-        onClick={
-          isFormOpen
-            ? () =>
-                launchPatientWorkspace('patient-form-entry-workspace', {
-                  workspaceTitle: recentlyOpenedForm?.additionalProps?.['workspaceTitle'],
-                })
-            : launchFormsWorkspace
-        }
+        onClick={launchWorkspace}
       >
         <Document size={16} />
         <span>{t('clinicalForm', 'Clinical form')}</span>
@@ -48,14 +55,7 @@ const ClinicalFormActionButton: React.FC = () => {
       renderIcon={(props) => <Document size={20} {...props} />}
       hasIconOnly
       iconDescription={t('form', 'Form')}
-      onClick={
-        isFormOpen
-          ? () =>
-              launchPatientWorkspace('patient-form-entry-workspace', {
-                workspaceTitle: recentlyOpenedForm?.additionalProps?.['workspaceTitle'],
-              })
-          : launchFormsWorkspace
-      }
+      onClick={launchWorkspace}
       enterDelayMs={1000}
       tooltipAlignment="center"
       tooltipPosition="left"

--- a/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
+++ b/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
@@ -3,7 +3,7 @@ import { Button } from '@carbon/react';
 import { Document } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
 import { useLayoutType } from '@openmrs/esm-framework';
-import { useWorkspaces } from '@openmrs/esm-patient-common-lib';
+import { useWorkspaces, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import useLaunchFormsWorkspace from './forms/use-launch-forms-workspace';
 import styles from './clinical-form-action-button.scss';
 
@@ -17,6 +17,7 @@ const ClinicalFormActionButton: React.FC = () => {
     workspaces?.[0]?.name?.match(/clinical-forms-workspace/i) ||
     workspaces?.[0]?.name?.match(/patient-form-entry-workspace/i);
 
+  const recentlyOpenedForm = workspaces.filter((w) => w.name === 'patient-form-entry-workspace')[0];
   const isFormOpen = workspaces.filter((w) => w.name === 'patient-form-entry-workspace')?.length >= 1;
 
   if (layout === 'tablet') {
@@ -25,8 +26,14 @@ const ClinicalFormActionButton: React.FC = () => {
         kind="ghost"
         className={`${styles.container} ${isActiveWorkspace ? styles.active : ''}`}
         tabIndex={0}
-        disabled={isFormOpen}
-        onClick={launchFormsWorkspace}
+        onClick={
+          isFormOpen
+            ? () =>
+                launchPatientWorkspace('patient-form-entry-workspace', {
+                  workspaceTitle: recentlyOpenedForm?.additionalProps?.['workspaceTitle'],
+                })
+            : launchFormsWorkspace
+        }
       >
         <Document size={16} />
         <span>{t('clinicalForm', 'Clinical form')}</span>
@@ -41,11 +48,17 @@ const ClinicalFormActionButton: React.FC = () => {
       renderIcon={(props) => <Document size={20} {...props} />}
       hasIconOnly
       iconDescription={t('form', 'Form')}
-      onClick={launchFormsWorkspace}
+      onClick={
+        isFormOpen
+          ? () =>
+              launchPatientWorkspace('patient-form-entry-workspace', {
+                workspaceTitle: recentlyOpenedForm?.additionalProps?.['workspaceTitle'],
+              })
+          : launchFormsWorkspace
+      }
       enterDelayMs={1000}
       tooltipAlignment="center"
       tooltipPosition="left"
-      disabled={isFormOpen}
       size="sm"
     />
   );

--- a/packages/esm-patient-forms-app/src/constants.ts
+++ b/packages/esm-patient-forms-app/src/constants.ts
@@ -4,3 +4,6 @@ export const customEncounterRepresentation = `custom:(uuid,encounterDatetime,enc
 
 export const formEncounterUrl = `/ws/rest/v1/form?v=custom:${customFormRepresentation}`;
 export const formEncounterUrlPoc = `/ws/rest/v1/form?v=custom:${customFormRepresentation}&q=poc`;
+
+export const clinicalFormsWorkspace = 'clinical-forms-workspace';
+export const formEntryWorkspace = 'patient-form-entry-workspace';


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The most recent PR for disabling the form was causing a bug, when the forms workspace would be hidden, there was no way to get back to the forms, so this PR instead of disabling the form icon, it again calls the function that launches that most recent form, it kind of prevents the form icon from launching all forms as it is its default behaviour.

## Video

https://loom.com/share/0a0f6c68c74840b68164cf4aa43883a9


## Related Issue
https://issues.openmrs.org/browse/O3-1945

