### PR TITLE
(fix) O3-1947: Auto-expand the visit note textarea as the user types

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -61,6 +61,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, patie
   const [searchSecondaryResults, setSearchSecondaryResults] = useState<null | Array<Concept>>(null);
   const [combinedDiagnoses, setCombinedDiagnoses] = useState<Array<Diagnosis>>([]);
   const [visitDateTime, setVisitDateTime] = useState(new Date());
+  const [rows, setRows] = useState<number>();
 
   const { mutateVisitNotes } = useVisitNotes(patientUuid);
   const locationUuid = session?.sessionLocation?.uuid;
@@ -440,9 +441,15 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, patie
             <TextArea
               id="additionalNote"
               light={isTablet}
+              rows={rows}
               labelText={t('clinicalNoteLabel', 'Write your notes')}
               placeholder={t('clinicalNotePlaceholder', 'Write any notes here')}
-              onChange={(event) => setClinicalNote(event.currentTarget.value)}
+              onChange={(event) => {
+                setClinicalNote(event.currentTarget.value);
+                const textareaLineHeight = 24; // This is the default line height for Carbon's TextArea component
+                const newRows = Math.ceil(event.target.scrollHeight / textareaLineHeight);
+                setRows(newRows);
+              }}
             />
           </Column>
         </Row>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
  - A user should be able to view all the inputs while typing, just to keep track of whatever their doing as @gracepotma suggested in the issue below 

## Screencasts
<!-- Required if you are making UI changes. -->
### Before
[Screencast from 2023-03-10 18-49-18.webm](https://user-images.githubusercontent.com/104269786/224361322-04df9960-a5eb-42fc-89f4-2e8a284b4586.webm)

### After
[Screencast from 2023-03-10 18-39-16.webm](https://user-images.githubusercontent.com/104269786/224361410-2aebb5e7-adc7-4fb7-b8e8-4fadd0a52d65.webm)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1947

## Other
<!-- Anything not covered above -->
 - In the screencasts, ignore the **green round icon in the text area**. It's for the **Grammarly extension**.
