### PR TITLE
(fix) Remove global left nav menu style overrides

### DIFF
--- a/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import last from 'lodash-es/last';
 import { ConfigurableLink } from '@openmrs/esm-framework';
-import styles from './dashboardextension.scss';
 
 export interface DashboardExtensionProps {
   title: string;
@@ -13,14 +12,9 @@ export const DashboardExtension = ({ title, basePath }: DashboardExtensionProps)
   const location = useLocation();
   const navLink = useMemo(() => decodeURIComponent(last(location.pathname.split('/'))), [location.pathname]);
 
-  const activeClassName = title === navLink ? 'active-left-nav-link' : 'non-active';
-
   return (
-    <div key={title} className={activeClassName}>
-      <ConfigurableLink
-        to={`${basePath}/${encodeURIComponent(title)}`}
-        className={'cds--side-nav__link ' + styles.link}
-      >
+    <div key={title} className={title === navLink && 'active-left-nav-link'}>
+      <ConfigurableLink to={`${basePath}/${encodeURIComponent(title)}`} className={'cds--side-nav__link'}>
         {title}
       </ConfigurableLink>
     </div>

--- a/packages/esm-patient-common-lib/src/dashboards/dashboardextension.scss
+++ b/packages/esm-patient-common-lib/src/dashboards/dashboardextension.scss
@@ -1,6 +1,0 @@
-@import "~@openmrs/esm-styleguide/src/vars";
-
-:global(.active-left-nav-link) .link:nth-child(1) {
-  color: $ui-05;
-  padding: 1.2rem 0 1.2rem 1.2rem;
-}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Removes some style overrides that affect the appearance of the [left panel](https://zeroheight.com/23a080e38/p/796c6a-left-panel). The source of truth for styling the left panel ought to be the Left Nav menu component [stylesheet](https://github.com/openmrs/openmrs-esm-core/blob/43a4cbe41f05df9e828d4a30c9d94b88f46a18ff/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss#L1).