### PR TITLE
(feat) O3-1942: Forms in workspace should be filtered by user privileges

### DIFF
--- a/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
@@ -10,6 +10,15 @@ import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
 const mockedOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockedUseConfig = useConfig as jest.Mock;
 
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+
+  return {
+    ...originalModule,
+    userHasAccess: jest.fn().mockImplementation(() => true),
+  };
+});
+
 it('renders an empty state if there are no forms persisted on the server', async () => {
   mockedOpenmrsFetch.mockReturnValue({
     data: { results: [] },

--- a/packages/esm-patient-forms-app/src/forms/forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.tsx
@@ -4,8 +4,7 @@ import dayjs from 'dayjs';
 import 'dayjs/plugin/isToday';
 import { ContentSwitcher, Switch, DataTableSkeleton, InlineLoading } from '@carbon/react';
 import { CardHeader, ErrorState, PatientProgram, useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
-import { useConfig, useLayoutType, useSession, userHasAccess } from '@openmrs/esm-framework';
-import { isValidOfflineFormEncounter } from '../offline-forms/offline-form-helpers';
+import { useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { useProgramConfig } from '../hooks/use-program-config';
 import { useForms } from '../hooks/use-forms';
 import { ConfigObject } from '../config-schema';
@@ -34,14 +33,7 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
   const isTablet = layout === 'tablet';
   const isDesktop = layout === 'small-desktop' || layout === 'large-desktop';
   const [formsCategory, setFormsCategory] = useState<FormsCategory>(showRecommendedFormsTab ? 'Recommended' : 'All');
-  const { isValidating, data, error } = useForms(patientUuid, undefined, undefined, isOffline);
-  const session = useSession();
-  let formsToDisplay = isOffline
-    ? data?.filter((formInfo) => isValidOfflineFormEncounter(formInfo.form, htmlFormEntryForms))
-    : data;
-  formsToDisplay = formsToDisplay?.filter((formInfo) =>
-    userHasAccess(formInfo?.form?.encounterType?.editPrivilege?.display, session?.user),
-  );
+  const { isValidating, data: formsToDisplay, error } = useForms(patientUuid, undefined, undefined, isOffline);
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
   const { programConfigs } = useProgramConfig(patientUuid, showRecommendedFormsTab);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
 - Each encounter type has associated user privileges (viewPrivilege and editPrivilege. Previously, we used these to filter 
    forms in the [forms component](https://github.com/openmrs/openmrs-esm-patient-chart/blob/40a0b56f6bf6905061a24a93225e6353c0a9d874/packages/esm-patient-forms-app/src/forms/forms.component.tsx#L40); 
   Lifted this logic to be handled directly from the **useForms** hook with the offline awareness logic
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1942

## Other
<!-- Anything not covered above -->
