### PR TITLE
(feat) Extend the patient object to support `other` and `unknown` genders

### DIFF
--- a/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
@@ -315,7 +315,7 @@ export class FormDataSourceService {
         case 'unknown':
           return 'U';
         default:
-          return 'M';
+          return 'U';
       }
     };
     model['birthdate'] = new Date(patient?.birthDate);

--- a/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
@@ -303,7 +303,21 @@ export class FormDataSourceService {
 
   public getPatientObject(patient): object {
     const model: object = {};
-    model['sex'] = patient?.gender === 'male' ? 'M' : 'F';
+    const gender = patient?.gender;
+    model['sex'] = (gender) => {
+      switch (gender) {
+        case 'male':
+          return 'M';
+        case 'female':
+          return 'F';
+        case 'other':
+          return 'O';
+        case 'unknown':
+          return 'U';
+        default:
+          return 'M';
+      }
+    };
     model['birthdate'] = new Date(patient?.birthDate);
     model['age'] = this.calculateAge(patient?.birthDate);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

I'm working on displaying Pictograms on Ampath forms based on the gender of the patient. Currently, I'm able to render options for male and female patients based on `model['sex'] = 'M' or 'F'`. 

I have now slightly modified the model object so that now it also stores `O` for `Other` and `U` for `Unknown` genders. 

[Issue](https://tfs.ext.icrc.org/ICRCCollection/Pearlii/_sprints/backlog/ThoughtWorks/Pearlii/Application/EMR/ThoughtWorks/2023/2023%20Sprint%205?workitem=349498)