### PR TITLE
(fix) O3-1492: Remove dangerous global selectors from stylesheets

### DIFF
--- a/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.scss
+++ b/packages/esm-patient-banner-app/src/banner-tags/active-visit-tag.scss
@@ -10,10 +10,6 @@
   margin-bottom: 0.5rem; 
 }
 
-:global(.cds--tooltip--definition .cds--tooltip__trigger){
-  border-bottom: none;
-}
-
 .definitionToolTip {
   & > button{
     border-bottom: none;

--- a/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
+++ b/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
@@ -45,6 +45,7 @@ const TrendlineHeader = ({ patientUuid, title, referenceRange, isValidating, sho
       </div>
       <div className={styles.content}>
         <span className={styles.title}>{title}</span>
+        {/* FIXME: Incorrectly spelt classname. Amend to reference the correct className. */}
         <span className={styles.referenceange}>{referenceRange}</span>
       </div>
       <div>{isValidating && <InlineLoading className={styles.inlineLoader} />}</div>
@@ -222,7 +223,7 @@ const Trendline: React.FC<TrendlineProps> = ({
   }
 
   return (
-    <>
+    <div className={styles.container}>
       {!hideTrendlineHeader && (
         <TrendlineHeader
           showBackToTimelineButton={showBackToTimelineButton}
@@ -237,7 +238,7 @@ const Trendline: React.FC<TrendlineProps> = ({
         <LineChart data={data} options={chartOptions} />
       </TrendLineBackground>
       <DrawTable {...{ tableData, tableHeaderData }} />
-    </>
+    </div>
   );
 };
 

--- a/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
+++ b/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
@@ -45,8 +45,7 @@ const TrendlineHeader = ({ patientUuid, title, referenceRange, isValidating, sho
       </div>
       <div className={styles.content}>
         <span className={styles.title}>{title}</span>
-        {/* FIXME: Incorrectly spelt classname. Amend to reference the correct className. */}
-        <span className={styles.referenceange}>{referenceRange}</span>
+        <span className={styles['reference-range']}>{referenceRange}</span>
       </div>
       <div>{isValidating && <InlineLoading className={styles.inlineLoader} />}</div>
     </div>

--- a/packages/esm-patient-test-results-app/src/trendline/trendline.scss
+++ b/packages/esm-patient-test-results-app/src/trendline/trendline.scss
@@ -3,6 +3,13 @@
 @import "~@carbon/charts/styles.css";
 @import '~@openmrs/esm-styleguide/src/vars';
 
+.container {
+  :global(.cds--cc--area path.area) {
+    stroke: none;
+    fill: #a7f0ba;
+  }  
+}
+
 .ui-shell-header-modal-bar-default {
   height: 3rem;
   object-fit: contain;
@@ -31,10 +38,6 @@
  //  color: $text-05; // WIP
 }
 
-:global(.cds--cc--area path.area) {
-  stroke: none;
-  fill: #a7f0ba;
-}
 
 .header {
   display: grid;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes some global style rules or at least scopes them within a class so they're self-contained to the components they affect and don't pollute the global scope. 

## Related Issue

https://issues.openmrs.org/browse/O3-1492