### PR TITLE
(fix) Port over styling for identifiers in the patient banner

### DIFF
--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -24,7 +24,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
   hideActionsOverflow,
 }) => {
   const { t } = useTranslation();
-  const overFlowMenuRef = React.useRef(null);
+  const overflowMenuRef = React.useRef(null);
 
   const patientActionsSlotState = React.useMemo(
     () => ({ patientUuid, onClick, onTransition }),
@@ -48,7 +48,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
 
   const handleNavigateToPatientChart = (event: MouseEvent) => {
     if (onClick) {
-      !(overFlowMenuRef?.current && overFlowMenuRef?.current.contains(event.target)) && onClick(patientUuid);
+      !(overflowMenuRef?.current && overflowMenuRef?.current.contains(event.target)) && onClick(patientUuid);
     }
   };
   const [showDropdown, setShowDropdown] = React.useState(false);
@@ -56,6 +56,21 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
     event.stopPropagation();
     setShowDropdown((value) => !value);
   }, []);
+
+  const getGender = (gender: string): string => {
+    switch (gender) {
+      case 'male':
+        return t('male', 'Male');
+      case 'female':
+        return t('female', 'Female');
+      case 'other':
+        return t('other', 'Other');
+      case 'unknown':
+        return t('unknown', 'Unknown');
+      default:
+        return gender;
+    }
+  };
 
   const { excludePatientIdentifierCodeTypes } = useConfig();
   const identifiers = patient?.identifier.filter(
@@ -82,7 +97,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
               />
             </div>
             {!hideActionsOverflow && (
-              <div ref={overFlowMenuRef}>
+              <div ref={overflowMenuRef}>
                 <CustomOverflowMenuComponent
                   menuTitle={
                     <>
@@ -104,7 +119,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
             )}
           </div>
           <div className={styles.demographics}>
-            <span>{capitalize(patient?.gender)}</span> &middot; <span>{age(patient?.birthDate)}</span> &middot;{' '}
+            <span>{getGender(patient.gender)}</span> &middot; <span>{age(patient.birthDate)}</span> &middot;{' '}
             <span>{formatDate(parseDate(patient?.birthDate), { mode: 'wide', time: false })}</span>
           </div>
           <div className={styles.row}>
@@ -112,11 +127,10 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
               {identifiers.length
                 ? identifiers.map(({ value, type }) => (
                     <span className={styles.identifierTag}>
-                      <Tag key={value} type="gray" title={type.text}>
+                      <Tag key={value} className={styles.tag} type="gray" title={type.text}>
                         {type.text}
                       </Tag>
                       {value}
-                      &#183;
                     </span>
                   ))
                 : ''}

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.scss
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.scss
@@ -1,4 +1,3 @@
-@use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @import '~@openmrs/esm-styleguide/src/vars';
 
@@ -68,7 +67,8 @@
 .identifierTag {
   display: flex;
   align-items: center;
-  padding: spacing.$spacing-01;
+  margin-right: 0.75rem;
+
 }
 
 .tag {

--- a/packages/esm-patient-banner-app/translations/en.json
+++ b/packages/esm-patient-banner-app/translations/en.json
@@ -4,9 +4,13 @@
   "address": "Address",
   "contactDetails": "Contact Details",
   "deceased": "Deceased",
+  "female": "Female",
   "loading": "Loading...",
+  "male": "Male",
+  "other": "Other",
   "relationships": "Relationships",
   "showAllDetails": "Show all details",
   "showLess": "Show less",
-  "started": "Started"
+  "started": "Started",
+  "unknown": "Unknown"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Ports over some useful styling for identifiers in the patient banner that should've been part of https://github.com/openmrs/openmrs-esm-patient-chart/pull/1033.

## Screenshots

> Before (note the extraneous margin around the identifier tag and the middot after the identifier value)

<img width="568" alt="Screenshot 2023-03-15 at 4 45 38 PM" src="https://user-images.githubusercontent.com/8509731/225330431-e05bce91-6c1c-4d12-ac9e-ecc6e5f895e5.png">

> After

<img width="549" alt="Screenshot 2023-03-15 at 4 43 28 PM" src="https://user-images.githubusercontent.com/8509731/225330467-37e3975c-fff0-4e60-8225-02ce97489a47.png">

