### PR TITLE
(fix) 03-1968: Panel and tree views should be full-width when the `full` button is clicked

### DIFF
--- a/packages/esm-patient-test-results-app/src/panel-view/index.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-view/index.tsx
@@ -102,37 +102,41 @@ const PanelView: React.FC<PanelViewProps> = ({ expanded, testUuid, basePath, typ
 
   return (
     <>
-      <div className={styles.leftSection}>
-        <>
-          <PanelViewHeader
-            isTablet={isTablet}
-            setSearchTerm={setSearchTerm}
-            searchTerm={searchTerm}
-            totalSearchResults={filteredPanels?.length ?? 0}
-          />
-          {!isLoading ? (
-            panels.length > 0 ? (
-              filteredPanels.length ? (
-                filteredPanels.map((panel) => (
-                  <LabSetPanel
-                    panel={panel}
-                    observations={[panel, ...panel.relatedObs]}
-                    setActivePanel={setActivePanel}
-                    activePanel={activePanel}
-                  />
-                ))
+      {!expanded ? (
+        <div className={styles.leftSection}>
+          <>
+            <PanelViewHeader
+              isTablet={isTablet}
+              setSearchTerm={setSearchTerm}
+              searchTerm={searchTerm}
+              totalSearchResults={filteredPanels?.length ?? 0}
+            />
+            {!isLoading ? (
+              panels.length > 0 ? (
+                filteredPanels.length ? (
+                  filteredPanels.map((panel) => (
+                    <LabSetPanel
+                      panel={panel}
+                      observations={[panel, ...panel.relatedObs]}
+                      setActivePanel={setActivePanel}
+                      activePanel={activePanel}
+                    />
+                  ))
+                ) : (
+                  <FilterEmptyState clearFilter={() => setSearchTerm('')} />
+                )
               ) : (
-                <FilterEmptyState clearFilter={() => setSearchTerm('')} />
+                <EmptyState displayText={t('panels', 'panels')} headerTitle={t('noPanelsFound', 'No panels found')} />
               )
             ) : (
-              <EmptyState displayText={t('panels', 'panels')} headerTitle={t('noPanelsFound', 'No panels found')} />
-            )
-          ) : (
-            <DataTableSkeleton columns={3} />
-          )}
-        </>
-      </div>
-      <div className={`${styles.headerMargin} ${styles.rightSection}`}>
+              <DataTableSkeleton columns={3} />
+            )}
+          </>
+        </div>
+      ) : null}
+      <div
+        className={`${styles.headerMargin} ${styles.rightSection}  ${expanded ? styles.fullView : styles.splitView}`}
+      >
         <div className={styles.stickySection}>
           {isLoading ? (
             <DataTableSkeleton columns={3} />

--- a/packages/esm-patient-test-results-app/src/panel-view/index.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-view/index.tsx
@@ -1,18 +1,18 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import LabSetPanel from './panel.component';
-import usePanelData from './usePanelData';
 import { DataTableSkeleton, Button, Search, Form } from '@carbon/react';
 import { Search as SearchIcon, Close } from '@carbon/react/icons';
-import styles from './panel-view.scss';
-import { navigate, useLayoutType } from '@openmrs/esm-framework';
-import PanelTimelineComponent from '../panel-timeline';
-import { ObsRecord } from './types';
 import { useTranslation } from 'react-i18next';
+import { navigate, useLayoutType } from '@openmrs/esm-framework';
 import { EmptyState } from '@openmrs/esm-patient-common-lib';
-import Trendline from '../trendline/trendline.component';
-import Overlay from '../tablet-overlay/tablet-overlay.component';
-import { testResultsBasePath } from '../helpers';
 import { FilterEmptyState } from '../ui-elements/resetFiltersEmptyState';
+import { ObsRecord } from './types';
+import { testResultsBasePath } from '../helpers';
+import LabSetPanel from './panel.component';
+import Overlay from '../tablet-overlay/tablet-overlay.component';
+import PanelTimelineComponent from '../panel-timeline';
+import Trendline from '../trendline/trendline.component';
+import usePanelData from './usePanelData';
+import styles from './panel-view.scss';
 
 interface PanelViewProps {
   expanded: boolean;
@@ -23,13 +23,13 @@ interface PanelViewProps {
 }
 
 const PanelView: React.FC<PanelViewProps> = ({ expanded, testUuid, basePath, type, patientUuid }) => {
+  const { t } = useTranslation();
   const layout = useLayoutType();
   const isTablet = layout === 'tablet';
-  const { panels, isLoading, groupedObservations } = usePanelData();
-  const [activePanel, setActivePanel] = useState<ObsRecord>(null);
-  const { t } = useTranslation();
   const trendlineView = testUuid && type === 'trendline';
+  const { panels, isLoading, groupedObservations } = usePanelData();
   const [searchTerm, setSearchTerm] = useState('');
+  const [activePanel, setActivePanel] = useState<ObsRecord>(null);
 
   const filteredPanels = useMemo(() => {
     if (!searchTerm) {
@@ -42,18 +42,18 @@ const PanelView: React.FC<PanelViewProps> = ({ expanded, testUuid, basePath, typ
     );
   }, [panels, searchTerm]);
 
+  const navigateBackFromTrendlineView = useCallback(() => {
+    navigate({
+      to: testResultsBasePath(`/patient/${patientUuid}/chart`),
+    });
+  }, [patientUuid]);
+
   useEffect(() => {
     // Selecting the active panel should not occur in small-desktop
     if (layout !== 'tablet' && filteredPanels) {
       setActivePanel(filteredPanels?.[0]);
     }
   }, [filteredPanels, layout]);
-
-  const navigateBackFromTrendlineView = useCallback(() => {
-    navigate({
-      to: testResultsBasePath(`/patient/${patientUuid}/chart`),
-    });
-  }, [patientUuid]);
 
   if (isTablet) {
     return (

--- a/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.styles.scss
+++ b/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.styles.scss
@@ -47,11 +47,15 @@
 
 .rightSection, .rightSectionHeader {
   width: 55%;
+
+  &.fullView {
+    width: 100%;
+  }
 }
 
 .rightSectionHeader {
   display: flex;
-} 
+}
 
 .rightSection :global(.cds--skeleton) {
   width: 100%;

--- a/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.tsx
+++ b/packages/esm-patient-test-results-app/src/results-viewer/results-viewer.tsx
@@ -120,16 +120,14 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
             totalResultsCount ? `(${totalResultsCount})` : ''
           }`}</h4>
           <div className={styles.leftHeaderActions}>
-            {!expanded && (
-              <ContentSwitcher
-                size={tablet ? 'lg' : 'md'}
-                selectedIndex={['panel', 'tree'].indexOf(selectedSection)}
-                onChange={(e) => setSelectedSection(e.name as panelOpts)}
-              >
-                <Switch name="panel" text={t('panel', 'Panel')} />
-                <Switch name="tree" text={t('tree', 'Tree')} />
-              </ContentSwitcher>
-            )}
+            <ContentSwitcher
+              size={tablet ? 'lg' : 'md'}
+              selectedIndex={['panel', 'tree'].indexOf(selectedSection)}
+              onChange={(e) => setSelectedSection(e.name as panelOpts)}
+            >
+              <Switch name="panel" text={t('panel', 'Panel')} />
+              <Switch name="tree" text={t('tree', 'Tree')} />
+            </ContentSwitcher>
           </div>
         </div>
         <div className={styles.rightSectionHeader}>

--- a/packages/esm-patient-test-results-app/src/tree-view/tree-view.component.tsx
+++ b/packages/esm-patient-test-results-app/src/tree-view/tree-view.component.tsx
@@ -63,12 +63,12 @@ const TreeView: React.FC<TreeViewProps> = ({ patientUuid, basePath, testUuid, lo
 
   return (
     <>
-      {!tablet && (
+      {!tablet && !expanded && (
         <div className={styles.leftSection}>
           {!loading ? <FilterSet /> : <AccordionSkeleton open count={4} align="start" />}
         </div>
       )}
-      <div className={`${styles.rightSection}`}>
+      <div className={`${styles.rightSection} ${expanded ? styles.fullView : styles.splitView}`}>
         {!tablet && testUuid && type === 'trendline' ? (
           <Trendline patientUuid={patientUuid} conceptUuid={testUuid} basePath={basePath} showBackToTimelineButton />
         ) : !loading ? (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR implements the full view of the test results in the tree and panel mode.

## Video
https://www.loom.com/share/5c316ce5de7a45028953ecf4f6b8abec

## Related Issue
https://issues.openmrs.org/browse/O3-1968

