### PR TITLE
Change on getCurrentUser to return the user data and sessionLocation

### DIFF
--- a/packages/esm-form-entry-app/src/app/openmrs-api/openmrs-esm-api.service.ts
+++ b/packages/esm-form-entry-app/src/app/openmrs-api/openmrs-esm-api.service.ts
@@ -8,7 +8,11 @@ export class OpenmrsEsmApiService {
   constructor() {}
 
   public getCurrentUser(): Observable<LoggedInUser> {
-    return getCurrentUser().pipe(map((session: Session) => session.user));
+    return getCurrentUser().pipe(
+      map((session: Session) => {
+        return { ...session.user, sessionLocation: session.sessionLocation };
+      }),
+    );
   }
 
   public openmrsFetch(url): Observable<any> {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
When we called the getCurrentUser function the property sessionLocation was always null.
This caused, when we tried to save a form, to be stored with no location.

