### PR TITLE
(feat) Move `active-left-nav-link` class to the anchor element

### DIFF
--- a/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
@@ -13,8 +13,11 @@ export const DashboardExtension = ({ title, basePath }: DashboardExtensionProps)
   const navLink = useMemo(() => decodeURIComponent(last(location.pathname.split('/'))), [location.pathname]);
 
   return (
-    <div key={title} className={title === navLink && 'active-left-nav-link'}>
-      <ConfigurableLink to={`${basePath}/${encodeURIComponent(title)}`} className={'cds--side-nav__link'}>
+    <div key={title}>
+      <ConfigurableLink
+        to={`${basePath}/${encodeURIComponent(title)}`}
+        className={`cds--side-nav__link ${title === navLink && 'active-left-nav-link'}`}
+      >
         {title}
       </ConfigurableLink>
     </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Moves the `active-left-nav-link` class from the parent div to the nested anchor element so it's easier to target for styling [here](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss).

## Screenshots

<img width="332" alt="Screenshot 2023-03-16 at 10 25 22 PM" src="https://user-images.githubusercontent.com/8509731/225731707-a3f4a4fe-ce0c-4e24-9d78-8a71c7c3313f.png">

