### PR TITLE
(feat) Vitals header UI enhancements

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.component.tsx
@@ -11,11 +11,12 @@ interface VitalsHeaderItemProps {
 }
 
 const VitalsHeaderItem: React.FC<VitalsHeaderItemProps> = ({ interpretation, value, unitName, unitSymbol }) => {
+  const flaggedCritical = interpretation && interpretation.includes('critically');
   const flaggedAbnormal = interpretation && interpretation !== 'normal';
 
   return (
     <div className={styles.container}>
-      <div className={`${flaggedAbnormal ? styles['abnormal-value'] : ''}`}>
+      <div className={`${flaggedCritical && styles['critical-value']} ${flaggedAbnormal && styles['abnormal-value']}`}>
         <div className={styles['label-container']}>
           <label className={styles.label}>{unitName}</label>
           {flaggedAbnormal ? (

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-flow: row wrap;
   flex-direction: column;
-  margin: 0.5rem;
+  margin: 0.5rem 0rem;
   min-inline-size: max-content;
   width: 100%;
 }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
@@ -4,16 +4,16 @@
 
 .container {
   display: flex;
-  flex-wrap: wrap;
+  flex-flow: row wrap;
   flex-direction: column;
-  padding: 0.25rem 0.5rem;
   margin: 0.5rem;
-  width: 100%;
   min-inline-size: max-content;
+  width: 100%;
 }
 
 .abnormal-value {
-  border: 2px solid $danger;
+  border: 1px solid $ui-05;
+  background-color: white;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -21,9 +21,15 @@
   padding: 0rem 0.25rem;
 }
 
+.critical-value {
+  @extend .abnormal-value;
+  border: 2px solid $danger;
+}
+
 .label-container {
   align-items: center;
   display: flex;
+  justify-content: space-between;
 }
 
 .value-container {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
@@ -174,8 +174,14 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
       </span>
 
       <div className={styles.container}>
-        <Button className={styles['button-text']} onClick={launchVitalsAndBiometricsForm} kind="ghost" size="sm">
+        <Button
+          className={`${styles['record-vitals']} ${styles['arrow-up-icon']}`}
+          onClick={launchVitalsAndBiometricsForm}
+          kind="ghost"
+          size="sm"
+        >
           {t('recordVitals', 'Record vitals')}
+          <ArrowRight size={16} className={styles['arrow-up-button']} title={'ArrowRight'} />
         </Button>
       </div>
     </div>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import dayjs from 'dayjs';
 import isToday from 'dayjs/plugin/isToday';
 import { useTranslation } from 'react-i18next';
-import { Button, InlineLoading } from '@carbon/react';
-import { ArrowRight, WarningFilled } from '@carbon/react/icons';
+import { Button, InlineLoading, Tag } from '@carbon/react';
+import { ArrowRight, Time } from '@carbon/react/icons';
 import { ConfigurableLink, formatDate, parseDate, useConfig } from '@openmrs/esm-framework';
 import {
   formEntrySub,
@@ -12,13 +12,7 @@ import {
   useVitalsConceptMetadata,
 } from '@openmrs/esm-patient-common-lib';
 import { ConfigObject } from '../../config-schema';
-import {
-  assessValue,
-  getReferenceRangesForConcept,
-  hasAbnormalValues,
-  interpretBloodPressure,
-  useVitals,
-} from '../vitals.resource';
+import { assessValue, getReferenceRangesForConcept, interpretBloodPressure, useVitals } from '../vitals.resource';
 import VitalsHeaderItem from './vitals-header-item.component';
 import styles from './vitals-header.scss';
 import { launchVitalsForm } from '../vitals-utils';
@@ -60,28 +54,26 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
   }
 
   if (!isLoading && latestVitals && Object.keys(latestVitals).length && conceptMetadata?.length) {
-    const isNotRecordedToday = !dayjs(latestVitals?.date).isToday();
+    const vitalsTakenToday = Boolean(dayjs(latestVitals?.date).isToday());
 
     return (
-      <div
-        className={`${
-          Object.keys(latestVitals).length && hasAbnormalValues(latestVitals) && isNotRecordedToday
-            ? styles['warning-background']
-            : styles['default-background']
-        }`}
-      >
+      <div className={styles['background']}>
         <div className={styles['vitals-header']} role="button" tabIndex={0} onClick={toggleDetailsPanel}>
           <span className={styles.container}>
-            {hasAbnormalValues(latestVitals) && isNotRecordedToday ? (
-              <WarningFilled
-                size={20}
-                title={'WarningFilled'}
-                aria-label="Warning"
-                className={styles['warning-icon']}
-              />
-            ) : null}
             <span className={styles.heading}>{t('vitalsAndBiometrics', 'Vitals and biometrics')}</span>
-            <span className={styles['body-text']}>{formatDate(parseDate(latestVitals?.date))}</span>
+            <span className={styles['body-text']}>
+              {formatDate(parseDate(latestVitals?.date), { day: true, time: true })}
+            </span>
+            {!vitalsTakenToday ? (
+              <div className={styles.tag}>
+                <Tag type="red">
+                  <span className={styles.overdueIndicator}>
+                    <Time />
+                    Overdue
+                  </span>
+                </Tag>
+              </div>
+            ) : null}
             <ConfigurableLink
               className={styles.link}
               to={`\${openmrsSpaBase}/patient/${patientUuid}/chart/Vitals & Biometrics`}
@@ -89,9 +81,11 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
               {t('vitalsHistory', 'Vitals history')}
             </ConfigurableLink>
           </span>
-          <div className={styles.backgroundDataFetchingIndicator}>
-            <span>{isValidating ? <InlineLoading /> : null}</span>
-          </div>
+          {isLoading ? (
+            <div className={styles.backgroundDataFetchingIndicator}>
+              <span>{isValidating ? <InlineLoading /> : null}</span>
+            </div>
+          ) : null}
           <div className={styles['button-container']}>
             <Button
               className={`${styles['record-vitals']} ${styles['arrow-up-icon']}`}
@@ -104,80 +98,68 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
             </Button>
           </div>
         </div>
-        <div
-          className={
-            hasAbnormalValues(latestVitals) && isNotRecordedToday
-              ? `${styles['warning-border']}`
-              : `${styles['default-border']}`
-          }
-        >
-          <div className={styles['container-row']}>
-            <div className={styles.row}>
-              <VitalsHeaderItem
-                unitName={t('temperatureAbbreviated', 'Temp')}
-                unitSymbol={(latestVitals?.temperature && conceptUnits.get(config.concepts.temperatureUuid)) ?? ''}
-                value={latestVitals?.temperature ?? '--'}
-              />
-              <VitalsHeaderItem
-                interpretation={interpretBloodPressure(
-                  latestVitals?.systolic,
-                  latestVitals?.diastolic,
-                  config?.concepts,
-                  conceptMetadata,
-                )}
-                unitName={t('bp', 'BP')}
-                unitSymbol={
-                  (latestVitals?.systolic && conceptUnits.get(config.concepts.systolicBloodPressureUuid)) ?? ''
-                }
-                value={`${latestVitals?.systolic ?? '--'} / ${latestVitals?.diastolic ?? '--'}`}
-              />
-              <VitalsHeaderItem
-                interpretation={assessValue(
-                  latestVitals?.pulse,
-                  getReferenceRangesForConcept(config.concepts.pulseUuid, conceptMetadata),
-                )}
-                unitName={t('heartRate', 'Heart rate')}
-                unitSymbol={(latestVitals?.pulse && conceptUnits.get(config.concepts.pulseUuid)) ?? ''}
-                value={latestVitals?.pulse ?? '--'}
-              />
-              <VitalsHeaderItem
-                interpretation={assessValue(
-                  latestVitals?.spo2,
-                  getReferenceRangesForConcept(config.concepts.oxygenSaturationUuid, conceptMetadata),
-                )}
-                unitName={t('spo2', 'SpO2')}
-                unitSymbol={(latestVitals?.spo2 && conceptUnits.get(config.concepts.oxygenSaturationUuid)) ?? ''}
-                value={latestVitals?.spo2 ?? '--'}
-              />
-            </div>
-            <div className={styles.row}>
-              <VitalsHeaderItem
-                interpretation={assessValue(
-                  latestVitals?.respiratoryRate,
-                  getReferenceRangesForConcept(config.concepts.respiratoryRateUuid, conceptMetadata),
-                )}
-                unitName={t('respiratoryRate', 'R. Rate')}
-                unitSymbol={
-                  (latestVitals?.respiratoryRate && conceptUnits.get(config.concepts.respiratoryRateUuid)) ?? ''
-                }
-                value={latestVitals?.respiratoryRate ?? '--'}
-              />
-              <VitalsHeaderItem
-                unitName={t('height', 'Height')}
-                unitSymbol={(latestVitals?.height && conceptUnits.get(config.concepts.heightUuid)) ?? ''}
-                value={latestVitals?.height ?? '--'}
-              />
-              <VitalsHeaderItem
-                unitName={t('bmi', 'BMI')}
-                unitSymbol={latestVitals?.bmi && config.biometrics['bmiUnit']}
-                value={latestVitals?.bmi ?? '--'}
-              />
-              <VitalsHeaderItem
-                unitName={t('weight', 'Weight')}
-                unitSymbol={(latestVitals?.weight && conceptUnits.get(config.concepts.weightUuid)) ?? ''}
-                value={latestVitals?.weight ?? '--'}
-              />
-            </div>
+        <div className={styles['default-border']}>
+          <div className={styles.row}>
+            <VitalsHeaderItem
+              unitName={t('temperatureAbbreviated', 'Temp')}
+              unitSymbol={(latestVitals?.temperature && conceptUnits.get(config.concepts.temperatureUuid)) ?? ''}
+              value={latestVitals?.temperature ?? '--'}
+            />
+            <VitalsHeaderItem
+              interpretation={interpretBloodPressure(
+                latestVitals?.systolic,
+                latestVitals?.diastolic,
+                config?.concepts,
+                conceptMetadata,
+              )}
+              unitName={t('bp', 'BP')}
+              unitSymbol={(latestVitals?.systolic && conceptUnits.get(config.concepts.systolicBloodPressureUuid)) ?? ''}
+              value={`${latestVitals?.systolic ?? '--'} / ${latestVitals?.diastolic ?? '--'}`}
+            />
+            <VitalsHeaderItem
+              interpretation={assessValue(
+                latestVitals?.pulse,
+                getReferenceRangesForConcept(config.concepts.pulseUuid, conceptMetadata),
+              )}
+              unitName={t('heartRate', 'Heart rate')}
+              unitSymbol={(latestVitals?.pulse && conceptUnits.get(config.concepts.pulseUuid)) ?? ''}
+              value={latestVitals?.pulse ?? '--'}
+            />
+            <VitalsHeaderItem
+              interpretation={assessValue(
+                latestVitals?.respiratoryRate,
+                getReferenceRangesForConcept(config.concepts.respiratoryRateUuid, conceptMetadata),
+              )}
+              unitName={t('respiratoryRate', 'R. rate')}
+              unitSymbol={
+                (latestVitals?.respiratoryRate && conceptUnits.get(config.concepts.respiratoryRateUuid)) ?? ''
+              }
+              value={latestVitals?.respiratoryRate ?? '--'}
+            />
+            <VitalsHeaderItem
+              interpretation={assessValue(
+                latestVitals?.spo2,
+                getReferenceRangesForConcept(config.concepts.oxygenSaturationUuid, conceptMetadata),
+              )}
+              unitName={t('spo2', 'SpO2')}
+              unitSymbol={(latestVitals?.spo2 && conceptUnits.get(config.concepts.oxygenSaturationUuid)) ?? ''}
+              value={latestVitals?.spo2 ?? '--'}
+            />
+            <VitalsHeaderItem
+              unitName={t('weight', 'Weight')}
+              unitSymbol={(latestVitals?.weight && conceptUnits.get(config.concepts.weightUuid)) ?? ''}
+              value={latestVitals?.weight ?? '--'}
+            />
+            <VitalsHeaderItem
+              unitName={t('height', 'Height')}
+              unitSymbol={(latestVitals?.height && conceptUnits.get(config.concepts.heightUuid)) ?? ''}
+              value={latestVitals?.height ?? '--'}
+            />
+            <VitalsHeaderItem
+              unitName={t('bmi', 'BMI')}
+              unitSymbol={latestVitals?.bmi && config.biometrics['bmiUnit']}
+              value={latestVitals?.bmi ?? '--'}
+            />
           </div>
         </div>
       </div>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
@@ -7,7 +7,7 @@
   justify-content: space-between;
   align-items: center;
   height: spacing.$spacing-09;
-  padding: spacing.$spacing-05;
+  margin-left: spacing.$spacing-05;
   outline: none;
   pointer-events: visibleFill;
 }
@@ -17,25 +17,32 @@
   align-items: baseline;
 }
 
-.warning-background {
-  background-color: $warning-background;
-  border-left: 3px solid $inverse-support-03;
-}
-
-.default-background {
+.background {
   background-color: $openmrs-background-grey;
-}
-
-.align-center {
-  display: flex;
-  align-items: center;
 }
 
 .row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  flex-grow: 1;
+  margin: 0rem 1rem;
+  max-width: 100vw;
+}
+
+.default-border {
+  width: 100%;
+  border-bottom: 1px solid $ui-03;
+}
+
+:global(.omrs-breakpoint-lt-desktop) {
+  .row {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .default-border {
+    padding-bottom: 0.75rem;
+  }
 }
 
 .loading {
@@ -45,29 +52,22 @@
   min-height: spacing.$spacing-09;
 }
 
-.default-border {
-  border-bottom: 1px solid $ui-03;
-}
-
-.warning-border {
-  border-bottom: 1px solid $color-yellow-50;
-}
-
 .container-row {
   display: flex;
   flex-wrap: wrap;
 }
 
-.warning-icon {
-  display: flex;
-  align-self: center;
-  fill: $inverse-support-03;
-  margin-right: spacing.$spacing-05;
+.tag {
+  margin: 0 0.5rem;
 }
 
-.warning-icon [data-icon-path="inner-path"] {
-  fill: black;
-  opacity: 1;
+.overdueIndicator {
+  display: flex;
+  align-items: center;
+
+  svg {
+    margin-right: 0.25rem;
+  }
 }
 
 .button-container {
@@ -104,7 +104,6 @@
 
 .link {
   @extend .body-text;
-  margin-left: 0.5rem;
   text-decoration-line: none;
   color: $interactive-01;
 }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
@@ -21,6 +21,12 @@
   background-color: $openmrs-background-grey;
 }
 
+.row-container {
+  width: 100%;
+  border-bottom: 1px solid $ui-03;
+  padding-bottom: 0.75rem;
+}
+
 .row {
   display: flex;
   justify-content: space-between;
@@ -29,19 +35,11 @@
   max-width: 100vw;
 }
 
-.default-border {
-  width: 100%;
-  border-bottom: 1px solid $ui-03;
-}
 
 :global(.omrs-breakpoint-lt-desktop) {
   .row {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
-  .default-border {
-    padding-bottom: 0.75rem;
   }
 }
 
@@ -103,6 +101,7 @@
 }
 
 .link {
+  margin: 0 0.5rem;
   @extend .body-text;
   text-decoration-line: none;
   color: $interactive-01;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
@@ -73,10 +73,10 @@ describe('VitalsHeader: ', () => {
 
     await waitForLoadingToFinish();
 
-    expect(screen.getByText(/Vitals and biometrics/i)).toBeInTheDocument();
+    expect(screen.getByText(/vitals and biometrics/i)).toBeInTheDocument();
     expect(screen.getByText(/19-May-2021/i)).toBeInTheDocument();
+    expect(screen.getByText(/vitals history/i)).toBeInTheDocument();
     expect(screen.getByText(/Record vitals/i)).toBeInTheDocument();
-    expect(screen.getByRole('img', { name: /warning/i })).toBeInTheDocument();
 
     expect(getByTextWithMarkup(/Temp\s*37\s*DEG C/i)).toBeInTheDocument();
     expect(getByTextWithMarkup(/BP\s*121 \/ 89\s*mmHg/i)).toBeInTheDocument();
@@ -87,7 +87,7 @@ describe('VitalsHeader: ', () => {
     expect(getByTextWithMarkup(/BMI\s*-\s*/i)).toBeInTheDocument();
     expect(getByTextWithMarkup(/Weight\s*-\s*/i)).toBeInTheDocument();
 
-    expect(screen.getByRole('img', { name: /warning/i })).toBeInTheDocument();
+    expect(screen.getByText(/overdue/i)).toBeInTheDocument();
     expect(screen.getAllByTitle(/abnormal value/i).length).toEqual(2);
   });
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -52,21 +52,21 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
   const tableHeaders = [
     { key: 'date', header: 'Date and time', isSortable: true },
     {
+      key: 'temperature',
+      header: withUnit('Temp', conceptUnits.get(config.concepts.temperatureUuid) ?? ''),
+    },
+    {
       key: 'bloodPressure',
       header: withUnit('BP', conceptUnits.get(config.concepts.systolicBloodPressureUuid) ?? ''),
     },
+    { key: 'pulse', header: withUnit('Pulse', conceptUnits.get(config.concepts.pulseUuid) ?? '') },
     {
       key: 'respiratoryRate',
       header: withUnit('R. Rate', conceptUnits.get(config.concepts.respiratoryRateUuid) ?? ''),
     },
-    { key: 'pulse', header: withUnit('Pulse', conceptUnits.get(config.concepts.pulseUuid) ?? '') },
     {
       key: 'spo2',
       header: withUnit('SPO2', conceptUnits.get(config.concepts.oxygenSaturationUuid) ?? ''),
-    },
-    {
-      key: 'temperature',
-      header: withUnit('Temp', conceptUnits.get(config.concepts.temperatureUuid) ?? ''),
     },
   ];
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

Enhancements to the vitals header UI that get in line with the available designs.

## Designs

- [Zeplin](https://zpl.io/aBPkgOO)
- [Design docs](https://zeroheight.com/23a080e38/p/61756c-vitals-header)

## Screenshots

> Desktop
<img width="1406" alt="Screenshot 2023-03-17 at 9 33 54 PM" src="https://user-images.githubusercontent.com/8509731/225990509-54e4d66e-03a3-45be-9618-c6c703a552b8.png">

> Tablet
<img width="850" alt="Screenshot 2023-03-17 at 9 34 12 PM" src="https://user-images.githubusercontent.com/8509731/225990554-a159e981-0161-4045-bf7c-3bf6bc6f9da8.png">

> Abnormal values now tally with the vitals widget

<img width="1040" alt="Screenshot 2023-03-17 at 9 49 07 PM" src="https://user-images.githubusercontent.com/8509731/225992694-fc777f53-cc7c-4415-88e7-566daa0b592a.png">

<img width="850" alt="Screenshot 2023-03-17 at 9 34 28 PM" src="https://user-images.githubusercontent.com/8509731/225990611-d039f083-8b8e-4649-903e-c6e572fa52ff.png">

