### PR TITLE
(fix) 03-1971: Forms should sort alphabetically.

### DIFF
--- a/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
@@ -79,7 +79,7 @@ const FormView: React.FC<FormViewProps> = ({
   const handleSearch = React.useMemo(() => debounce((searchTerm) => setSearchTerm(searchTerm), 300), []);
 
   const { results, goTo, currentPage } = usePagination(
-    filteredForms?.sort((a, b) => (b.lastCompleted?.getTime() ?? 0) - (a.lastCompleted?.getTime() ?? 0)),
+    filteredForms?.sort((a, b) => (a.form?.display > b.form?.display ? 1 : -1)),
     pageSize,
   );
 

--- a/packages/esm-patient-forms-app/src/hooks/use-forms.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-forms.ts
@@ -72,7 +72,7 @@ function mapToFormCompletedInfo(
   return allForms.map((form) => {
     const associatedEncounters = encounters
       .filter((encounter) => encounter.form?.uuid === form?.uuid)
-      .sort((a, b) => new Date(b.encounterDatetime).getTime() - new Date(a.encounterDatetime).getTime());
+      .sort((a, b) => (a.form?.display > b.form?.display ? 1 : -1));
     const lastCompleted =
       associatedEncounters.length > 0 ? new Date(associatedEncounters?.[0].encounterDatetime) : undefined;
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This PR changes the default sort of forms from using `lastCompleted` to `Alphabetical` order

## Screenshots
- Before
<img width="963" alt="Screenshot 2023-03-19 at 01 27 57" src="https://user-images.githubusercontent.com/30952856/226145307-d9d1c610-79a2-40c6-a2a7-a16d8690bbec.png">

- After fixing
<img width="967" alt="Screenshot 2023-03-19 at 01 47 53" src="https://user-images.githubusercontent.com/30952856/226145312-d552db22-9fa1-4ca8-b90c-2aa2d26d5135.png">


## Related Issue
- https://issues.openmrs.org/browse/O3-1971

