### PR TITLE
(feat) O3-1942: Lift form privileges to useForms hook

### DIFF
--- a/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
@@ -57,6 +57,8 @@ it('renders a list of forms fetched from the server', async () => {
   expect(searchbox).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /clear search input/i })).toBeInTheDocument();
   expect(screen.getByRole('table')).toBeInTheDocument();
+  expect(screen.getByRole('cell', { name: /Laboratory Tests/i })).toBeInTheDocument();
+  expect(screen.queryByText('PiusRocks')).toBe(null);
 
   const expectedColumnHeaders = [/form name \(A-Z\)/, /last completed/];
 

--- a/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
@@ -9,6 +9,15 @@ import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
 
 const mockedOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockedUseConfig = useConfig as jest.Mock;
+const mockedUserHasAccess = jest.fn();
+
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+  return {
+    ...originalModule,
+    userHasAccess: () => mockedUserHasAccess,
+  };
+});
 
 it('renders an empty state if there are no forms persisted on the server', async () => {
   mockedOpenmrsFetch.mockReturnValue({
@@ -35,6 +44,10 @@ it('renders a list of forms fetched from the server', async () => {
     showHtmlFormEntryForms: true,
     showConfigurableForms: false,
   }));
+
+  mockedUserHasAccess.mockImplementation((privilege) => {
+    return privilege === 'edit' ? false : true;
+  });
 
   renderFormsList();
 
@@ -89,7 +102,7 @@ const forms = [
       uuid: '0e8230ce-bd1d-43f5-a863-cf44344fa4b0',
       name: 'Adult Visit',
       viewPrivilege: null,
-      editPrivilege: null,
+      editPrivilege: 'edit',
     },
     version: '1.0.2',
     published: false,
@@ -111,7 +124,7 @@ const forms = [
       uuid: 'dd528487-82a5-4082-9c72-ed246bd49591',
       name: 'Consultation',
       viewPrivilege: null,
-      editPrivilege: null,
+      editPrivilege: 'edit',
     },
     version: '1',
     published: false,
@@ -133,7 +146,7 @@ const forms = [
       uuid: 'dd528487-82a5-4082-9c72-ed246bd49591',
       name: 'Consultation',
       viewPrivilege: null,
-      editPrivilege: null,
+      editPrivilege: 'edit',
     },
     version: '2',
     published: true,

--- a/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
@@ -58,7 +58,7 @@ it('renders a list of forms fetched from the server', async () => {
   expect(screen.getByRole('button', { name: /clear search input/i })).toBeInTheDocument();
   expect(screen.getByRole('table')).toBeInTheDocument();
   expect(screen.getByRole('cell', { name: /Laboratory Tests/i })).toBeInTheDocument();
-  expect(screen.queryByText('PiusRocks')).toBe(null);
+  expect(screen.queryByText('PiusRocks')).toBeNull();
 
   const expectedColumnHeaders = [/form name \(A-Z\)/, /last completed/];
 

--- a/packages/esm-patient-forms-app/src/forms/forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.tsx
@@ -4,8 +4,7 @@ import dayjs from 'dayjs';
 import 'dayjs/plugin/isToday';
 import { ContentSwitcher, Switch, DataTableSkeleton, InlineLoading } from '@carbon/react';
 import { CardHeader, ErrorState, PatientProgram, useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
-import { useConfig, useLayoutType, useSession, userHasAccess } from '@openmrs/esm-framework';
-import { isValidOfflineFormEncounter } from '../offline-forms/offline-form-helpers';
+import { useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { useProgramConfig } from '../hooks/use-program-config';
 import { useForms } from '../hooks/use-forms';
 import { ConfigObject } from '../config-schema';
@@ -28,20 +27,18 @@ interface FormsProps {
 
 const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, urlLabel, isOffline }) => {
   const { t } = useTranslation();
-  const { htmlFormEntryForms, showRecommendedFormsTab, showConfigurableForms } = useConfig() as ConfigObject;
+  const { showRecommendedFormsTab, showConfigurableForms } = useConfig() as ConfigObject;
   const headerTitle = t('forms', 'Forms');
   const layout = useLayoutType();
   const isTablet = layout === 'tablet';
   const isDesktop = layout === 'small-desktop' || layout === 'large-desktop';
   const [formsCategory, setFormsCategory] = useState<FormsCategory>(showRecommendedFormsTab ? 'Recommended' : 'All');
-  const { isValidating, data, error, mutateForms } = useForms(patientUuid, undefined, undefined, isOffline);
-  const session = useSession();
-  let formsToDisplay = isOffline
-    ? data?.filter((formInfo) => isValidOfflineFormEncounter(formInfo.form, htmlFormEntryForms))
-    : data;
-  formsToDisplay = formsToDisplay?.filter((formInfo) =>
-    userHasAccess(formInfo?.form?.encounterType?.editPrivilege?.display, session?.user),
-  );
+  const {
+    isValidating,
+    data: formsToDisplay,
+    error,
+    mutateForms,
+  } = useForms(patientUuid, undefined, undefined, isOffline);
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
   const { programConfigs } = useProgramConfig(patientUuid, showRecommendedFormsTab);
 

--- a/packages/esm-patient-forms-app/src/hooks/use-forms.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-forms.ts
@@ -1,9 +1,16 @@
 import dayjs from 'dayjs';
 import useSWR from 'swr';
-import { getDynamicOfflineDataEntries, openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import {
+  getDynamicOfflineDataEntries,
+  openmrsFetch,
+  useConfig,
+  userHasAccess,
+  useSession,
+} from '@openmrs/esm-framework';
 import { ListResponse, Form, EncounterWithFormRef, CompletedFormInfo } from '../types';
 import { customEncounterRepresentation, formEncounterUrl, formEncounterUrlPoc } from '../constants';
 import { ConfigObject } from '../config-schema';
+import { isValidOfflineFormEncounter } from '../offline-forms/offline-form-helpers';
 
 export function useFormEncounters(cachedOfflineFormsOnly = false, patientUuid: string = '') {
   const { showConfigurableForms, customFormsUrl, showHtmlFormEntryForms } = useConfig() as ConfigObject;
@@ -39,10 +46,12 @@ export function useEncountersWithFormRef(
 }
 
 export function useForms(patientUuid: string, startDate?: Date, endDate?: Date, cachedOfflineFormsOnly = false) {
+  const { htmlFormEntryForms } = useConfig() as ConfigObject;
   const allFormsRes = useFormEncounters(cachedOfflineFormsOnly, patientUuid);
   const encountersRes = useEncountersWithFormRef(patientUuid, startDate, endDate);
   const pastEncounters = encountersRes.data?.data?.results ?? [];
   const data = allFormsRes.data ? mapToFormCompletedInfo(allFormsRes.data, pastEncounters) : undefined;
+  const session = useSession();
 
   const mutateForms = () => {
     allFormsRes.mutate();
@@ -55,9 +64,15 @@ export function useForms(patientUuid: string, startDate?: Date, endDate?: Date, 
   // If this ever becomes a problem for online mode (i.e. if an error should be rendered there when past encounters
   // for determining filled out forms can't be loaded) this should ideally be conditionally controlled via a flag
   // such that the current offline behavior doesn't change.
+  let formsToDisplay = cachedOfflineFormsOnly
+    ? data?.filter((formInfo) => isValidOfflineFormEncounter(formInfo.form, htmlFormEntryForms))
+    : data;
+  formsToDisplay = formsToDisplay?.filter((formInfo) =>
+    userHasAccess(formInfo?.form?.encounterType?.editPrivilege?.display, session?.user),
+  );
 
   return {
-    data,
+    data: formsToDisplay,
     error: allFormsRes.error,
     isValidating: allFormsRes.isValidating || encountersRes.isValidating,
     allForms: allFormsRes.data,

--- a/packages/esm-patient-forms-app/src/hooks/use-forms.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-forms.ts
@@ -67,9 +67,12 @@ export function useForms(patientUuid: string, startDate?: Date, endDate?: Date, 
   let formsToDisplay = cachedOfflineFormsOnly
     ? data?.filter((formInfo) => isValidOfflineFormEncounter(formInfo.form, htmlFormEntryForms))
     : data;
-  formsToDisplay = formsToDisplay?.filter((formInfo) =>
-    userHasAccess(formInfo?.form?.encounterType?.editPrivilege?.display, session?.user),
-  );
+
+  if (session?.user) {
+    formsToDisplay = formsToDisplay?.filter((formInfo) =>
+      userHasAccess(formInfo?.form?.encounterType?.editPrivilege?.display, session?.user),
+    );
+  }
 
   return {
     data: formsToDisplay,

--- a/packages/esm-patient-forms-app/src/hooks/use-forms.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-forms.ts
@@ -70,7 +70,7 @@ export function useForms(patientUuid: string, startDate?: Date, endDate?: Date, 
 
   if (session?.user) {
     formsToDisplay = formsToDisplay?.filter((formInfo) =>
-      userHasAccess(formInfo?.form?.encounterType?.editPrivilege?.display, session?.user),
+      userHasAccess(formInfo?.form?.encounterType?.editPrivilege?.display, session.user),
     );
   }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
 - Each encounter type has associated user privileges (viewPrivilege and editPrivilege. Previously, we used these to filter 
    forms in the [forms component](https://github.com/openmrs/openmrs-esm-patient-chart/blob/40a0b56f6bf6905061a24a93225e6353c0a9d874/packages/esm-patient-forms-app/src/forms/forms.component.tsx#L40); 
   Lifted this logic to be handled directly from the **useForms** hook with the offline awareness logic
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1942

## Other
<!-- Anything not covered above -->
