### PR TITLE
(fix) O3-1973: Separate active orders and past orders in the medications  summary table

### DIFF
--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -16,20 +16,25 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
   const { t } = useTranslation();
   const config = useConfig() as ConfigObject;
   const { launchOrderBasket } = useLaunchOrderBasket(patientUuid);
+  const currentDate = new Date();
 
   const {
-    data: activeOrders,
-    error: activeOrdersError,
-    isLoading: isLoadingActiveOrders,
-    isValidating: isValidatingActiveOrders,
-  } = usePatientOrders(patientUuid, 'ACTIVE');
-
-  const {
-    data: pastOrders,
-    error: pastOrdersError,
-    isLoading: isLoadingPastOrders,
-    isValidating: isValidatingPastOrders,
+    data: allOrders,
+    error: error,
+    isLoading: isLoading,
+    isValidating: isValidating,
   } = usePatientOrders(patientUuid, 'any');
+
+  const pastOrders = allOrders?.filter((order) => {
+    if (order.dateStopped) {
+      return order;
+    }
+
+    if (order.autoExpireDate && order.autoExpireDate < currentDate) {
+      return order;
+    }
+  });
+  const activeOrders = allOrders?.filter((order) => !pastOrders.includes(order));
 
   return (
     <>
@@ -38,14 +43,14 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
           const displayText = t('activeMedicationsDisplayText', 'Active medications');
           const headerTitle = t('activeMedicationsHeaderTitle', 'active medications');
 
-          if (isLoadingActiveOrders) return <DataTableSkeleton role="progressbar" />;
+          if (isLoading) return <DataTableSkeleton role="progressbar" />;
 
-          if (activeOrdersError) return <ErrorState error={activeOrdersError} headerTitle={headerTitle} />;
+          if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
 
           if (activeOrders?.length) {
             return (
               <MedicationsDetailsTable
-                isValidating={isValidatingActiveOrders}
+                isValidating={isValidating}
                 title={t('activeMedicationsTableTitle', 'Active Medications')}
                 medications={activeOrders}
                 showDiscontinueButton={true}
@@ -65,14 +70,14 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
           const displayText = t('pastMedicationsDisplayText', 'Past medications');
           const headerTitle = t('pastMedicationsHeaderTitle', 'past medications');
 
-          if (isLoadingPastOrders) return <DataTableSkeleton role="progressbar" />;
+          if (isLoading) return <DataTableSkeleton role="progressbar" />;
 
-          if (pastOrdersError) return <ErrorState error={pastOrdersError} headerTitle={headerTitle} />;
+          if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
 
           if (pastOrders?.length) {
             return (
               <MedicationsDetailsTable
-                isValidating={isValidatingPastOrders}
+                isValidating={isValidating}
                 title={t('pastMedicationsTableTitle', 'Past Medications')}
                 medications={pastOrders}
                 showDiscontinueButton={true}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
 - Gets all orders and filters out **pastOrders** and **activeOrders** to solve the issue explained in the jira link below

## Screenshots
<!-- Required if you are making UI changes. -->
### Before
![Screenshot from 2023-03-20 11-02-34](https://user-images.githubusercontent.com/104269786/226280764-b6846c3f-3af9-4bbe-8ace-f729126a9673.png)


### After
![image](https://user-images.githubusercontent.com/104269786/226280358-39bfc755-a583-4826-9819-654bda3b39c4.png)



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1973

## Other
<!-- Anything not covered above -->
