### PR TITLE
(fix) Fix forms widget content switcher

### DIFF
--- a/packages/esm-patient-forms-app/src/forms/forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.tsx
@@ -16,6 +16,12 @@ import styles from './forms.scss';
 
 type FormsCategory = 'All' | 'Completed' | 'Recommended';
 
+enum ContentSwitcherIndices {
+  All = 0,
+  Recommended = 1,
+  Completed = 2,
+}
+
 interface FormsProps {
   patientUuid: string;
   patient: fhir.Patient;
@@ -34,7 +40,7 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
   const isTablet = layout === 'tablet';
   const isDesktop = layout === 'small-desktop' || layout === 'large-desktop';
   const [formsCategory, setFormsCategory] = useState<FormsCategory>(showRecommendedFormsTab ? 'Recommended' : 'All');
-  const { isValidating, data, error, mutateForms } = useForms(patientUuid, undefined, undefined, isOffline);
+  const { isValidating, data, error, mutateForms } = useForms(patientUuid);
   const session = useSession();
   let formsToDisplay = isOffline
     ? data?.filter((formInfo) => isValidOfflineFormEncounter(formInfo.form, htmlFormEntryForms))
@@ -104,8 +110,8 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
         ) : null}
         <div className={styles.contextSwitcherContainer}>
           <ContentSwitcher
-            onChange={(event) => setFormsCategory(event.name as any)}
-            selectedIndex={formsCategory}
+            onChange={({ name }: { name: FormsCategory }) => setFormsCategory(name)}
+            selectedIndex={ContentSwitcherIndices[formsCategory]}
             size={isTablet ? 'md' : 'sm'}
           >
             <Switch name={'All'} text={t('all', 'All')} />


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes the forms widget ContentSwitcher so that clicking on a switcher tab selects it as the active tab and applies the appropriate styling.

## Screenshots

> Prior to this fix (note how none of the switcher tabs is highlighted despite the `All` tab being active) 

<img width="947" alt="Screenshot 2023-03-20 at 10 58 39 PM" src="https://user-images.githubusercontent.com/8509731/226452108-d3f45180-97e9-40c3-b9b2-ff667bdcf05d.png">

> Fixed

https://user-images.githubusercontent.com/8509731/226451653-c563d433-0e79-403b-ae1e-f7531c70b4cf.mp4



