### PR TITLE
(feat) Remove right margin from the overdue tag in the vitals header

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
@@ -101,7 +101,7 @@
 }
 
 .link {
-  margin: 0 0.5rem;
+  margin-left: 0.5rem;
   @extend .body-text;
   text-decoration-line: none;
   color: $interactive-01;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Removes the right margin from the overdue tag in the vitals header. Prior to this fix, there was too much space between the tag and the `Vitals history` link to its right.

## Video

https://user-images.githubusercontent.com/8509731/226455650-377a4378-f3eb-4df7-baa3-9d9d1545dead.mp4

