### PR TITLE
(feat) Allow more horizontal space for vitals header items

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header-item.scss
@@ -8,7 +8,6 @@
   flex-direction: column;
   margin: 0.5rem 0rem;
   min-inline-size: max-content;
-  width: 100%;
 }
 
 .abnormal-value {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
@@ -40,6 +40,7 @@
   .row {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
+    column-gap: 5rem;
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Allows more breathing room for vitals header items on both desktop and tablet.

## Screenshots

> Before

<img width="1499" alt="Screenshot 2023-03-21 at 10 02 23 AM" src="https://user-images.githubusercontent.com/8509731/226538051-fa3fff95-a79d-4d6b-8566-b63be9a49277.png">

<img width="995" alt="Screenshot 2023-03-21 at 10 02 42 AM" src="https://user-images.githubusercontent.com/8509731/226538056-1eafa3b9-fe8f-46dc-b3ec-08247dbd26bd.png">

> After

https://user-images.githubusercontent.com/8509731/226537537-b9c5b717-2f59-425f-8922-6c7ee65a90e4.mp4


