### PR TITLE
(feat) Handle obs group questions in visits table

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
@@ -11,27 +11,58 @@ interface EncounterObservationsProps {
 const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observations }) => {
   const { t } = useTranslation();
 
-  const observationsList = useMemo(() => {
-    return (
-      observations &&
-      observations.map((obs: Observation) => {
-        const [question, answer] = obs.display.split(':');
+  const obsWithGroupMembers = useMemo(
+    () =>
+      observations
+        ?.filter((obs) => obs.groupMembers)
+        .map(({ groupMembers }) => ({
+          members: groupMembers,
+        })),
+    [observations],
+  );
+
+  const obsWithoutGroupMembers = useMemo(() => observations?.filter((obs) => !obs.groupMembers), [observations]);
+
+  const observationsList = useMemo(
+    () =>
+      observations?.map(({ display }) => {
+        const [question, answer] = display.split(':');
         return { question, answer };
-      })
-    );
-  }, [observations]);
+      }),
+    [observations],
+  );
 
   if (!observations) {
     return <SkeletonText />;
   }
 
-  if (observationsList?.length) {
+  if (obsWithoutGroupMembers.length) {
     return (
       <div className={styles.observation}>
-        {observationsList.map((obs, i) => (
+        {observationsList?.map(({ question, answer }, i) => (
           <React.Fragment key={i}>
-            <span className={styles.caption01}>{obs.question}: </span>
-            <span className={`${styles.bodyShort02} ${styles.text01}`}>{obs.answer}</span>
+            <span className={styles.caption01}>{question}: </span>
+            <span className={`${styles.bodyShort02} ${styles.text01}`}>{answer}</span>
+          </React.Fragment>
+        ))}
+      </div>
+    );
+  }
+
+  if (obsWithGroupMembers.length) {
+    const groupMembers = obsWithGroupMembers.flatMap(({ members }) =>
+      members.map(({ display }) => {
+        const [question, answer] = display?.split(':');
+        return { question, answer };
+      }),
+    );
+
+    return (
+      <div className={styles.observation}>
+        {groupMembers?.map(({ question, answer }, i) => (
+          <React.Fragment key={i}>
+            <span className={styles.caption01}>{question}: </span>
+            <span className={`${styles.bodyShort02} ${styles.text01}`}>{answer}</span>
           </React.Fragment>
         ))}
       </div>
@@ -39,8 +70,8 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
   }
 
   return (
-    <div className={styles.encounterEmptyState}>
-      <p className={styles.caption01}>{t('noObservationsFound', 'No observations found')}</p>
+    <div className={styles.observation}>
+      <p>{t('noObservationsFound', 'No observations found')}</p>
     </div>
   );
 };

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/styles.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/styles.scss
@@ -1,10 +1,5 @@
 @use '@carbon/styles/scss/spacing';
 
-.encounterEmptyState {
-  text-align: center;
-  margin: 0 spacing.$spacing-05 spacing.$spacing-05 spacing.$spacing-05;
-}
-
 .observation {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -97,6 +97,11 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
       header: t('dateAndTime', 'Date & time'),
       key: 'datetime',
     },
+    showAllEncounters && {
+      id: 2,
+      header: t('visitType', 'Visit type'),
+      key: 'visitType',
+    },
     {
       id: 3,
       header: t('encounterType', 'Encounter type'),
@@ -108,16 +113,6 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
       key: 'provider',
     },
   ];
-
-  if (showAllEncounters) {
-    tableHeaders.push({
-      id: 2,
-      header: t('visitType', 'Visit type'),
-      key: 'visitType',
-    });
-
-    tableHeaders.sort((a, b) => (a.id > b.id ? 1 : -1));
-  }
 
   const launchWorkspace = (
     formUuid: string,

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.scss
@@ -19,7 +19,6 @@
   &:global(.cds--data-table-container) {
     background: none !important;
   }
-
 }
 
 .filterContainer {
@@ -35,7 +34,6 @@
 .search {
   max-width: 16rem;
 }
-
 
 .menuItem {
   max-width: none;
@@ -87,4 +85,12 @@
 .helper {
   @include type.type-style('body-compact-01');
   color: $text-02;
+}
+
+.layer {
+  height: 100%;
+
+  :global(.cds--btn--primary) {
+    background-color: unset;
+  }
 }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -3,13 +3,7 @@ import { openmrsFetch, OpenmrsResource, Visit } from '@openmrs/esm-framework';
 
 export function useVisits(patientUuid: string) {
   const customRepresentation =
-    'custom:(uuid,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis),form:(uuid,display),encounterDatetime,' +
-    'orders:full,' +
-    'obs:(uuid,concept:(uuid,display,conceptClass:(uuid,display)),' +
-    'display,groupMembers:(uuid,concept:(uuid,display),' +
-    'value:(uuid,display)),value),encounterType:(uuid,display),' +
-    'encounterProviders:(uuid,display,encounterRole:(uuid,display),' +
-    'provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient';
+    'custom:(uuid,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis),form:(uuid,display),encounterDatetime,orders:full,obs:full,encounterType:(uuid,display),encounterProviders:(uuid,display,encounterRole:(uuid,display),provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient';
 
   const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
     `/ws/rest/v1/visit?patient=${patientUuid}&v=${customRepresentation}`,
@@ -142,6 +136,7 @@ export interface Observation {
       uuid: string;
       display: string;
     };
+    display: string;
   }>;
   value: any;
   obsDatetime?: string;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Provides a better approach for handling obs group questions from an encounter. Specifically, this PR extracts the individual group members from the parent obsGroup collection and renders their associated labels and answers as individual entries in the observations list.

## Screenshots

> Before
 
<img width="942" alt="Screenshot 2023-03-22 at 1 29 20 PM" src="https://user-images.githubusercontent.com/8509731/226919419-efe7eff7-8863-4e31-8626-da9b6bd0d979.png">

> After

<img width="952" alt="Screenshot 2023-03-22 at 1 29 40 PM" src="https://user-images.githubusercontent.com/8509731/226919456-90c61bc9-b69c-49be-979f-6ab987b788cd.png">

## Issue

https://issues.openmrs.org/browse/O3-1773


