### PR TITLE
(docs) O3-1993: Added missing yarn install command in the readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ In addition to these widgets, two other microfrontends exist that encapsulate cr
 
 Check out the developer documentation [here](http://o3-dev.docs.openmrs.org).
 
-This monorepo uses [yarn](https://yarnpkg.com) and [lerna](https://github.com/lerna/lerna). 
+This monorepo uses [yarn](https://yarnpkg.com) and [lerna](https://github.com/lerna/lerna).
+
+To install the dependencies, run:
+```bash
+yarn install
+```
 
 To start a dev server for a specific microfrontend, run:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This monorepo uses [yarn](https://yarnpkg.com) and [lerna](https://github.com/le
 
 To install the dependencies, run:
 ```bash
-yarn install
+yarn
 ```
 
 To start a dev server for a specific microfrontend, run:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds the missing yarn install command in the setup section of readme.

## Related Issue
https://issues.openmrs.org/browse/O3-1993


