### PR TITLE
(fix) fix bug on closing forms launch from form dashboard

### DIFF
--- a/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
@@ -40,8 +40,8 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({ patientUuid, closeWorksp
       currentVisit?.visitType?.uuid,
       patientUuid,
       patient,
-      closeWorkspace,
       mutateForm,
+      closeWorkspace,
     ],
   );
 

--- a/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
@@ -33,15 +33,23 @@ export type FormsListProps = {
 
 const FormsList: React.FC<FormsListProps> = ({ currentVisit, htmlFormEntryForms, patient, patientUuid }) => {
   const { t } = useTranslation();
-  const { data, error } = useForms(patientUuid);
+  const { data, error, mutateForms } = useForms(patientUuid);
 
   const isTablet = useLayoutType() === 'tablet';
 
   const handleFormOpen = useCallback(
     (formUuid, encounterUuid, formName) => {
-      launchFormEntryOrHtmlForms(currentVisit, formUuid, patient, htmlFormEntryForms, encounterUuid, formName);
+      launchFormEntryOrHtmlForms(
+        currentVisit,
+        formUuid,
+        patient,
+        htmlFormEntryForms,
+        encounterUuid,
+        formName,
+        mutateForms,
+      );
     },
-    [currentVisit, htmlFormEntryForms, patient],
+    [currentVisit, htmlFormEntryForms, mutateForms, patient],
   );
 
   const tableHeaders = [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue where a function invocation that got run before closing the workspace was not working as expected. More specifically, the `mutateForms` introduced in https://github.com/openmrs/openmrs-esm-patient-chart/pull/1049 wasn't being passed correctly to the form engine when launching a workspace. This PR ensures that the function exists before its invocation.