### PR TITLE
(fix) fix setting provider and location values on form-entry launch

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -121,7 +121,7 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
 
     return forkJoin({
       formSchema: this.fetchCompiledFormSchema(this.formUuid, language).pipe(take(1)),
-      user: this.openmrsApi.getCurrentUser().pipe(take(1)),
+      session: this.openmrsApi.getCurrentSession().pipe(take(1)),
       encounter: encounterOrSyncItemId
         ? this.getEncounterToEdit(encounterOrSyncItemId).pipe(take(1))
         : of<Encounter>(null),

--- a/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
@@ -6,7 +6,7 @@ import { ConfigResourceService } from '../services/config-resource.service';
 import { MonthlyScheduleResourceService } from '../services/monthly-scheduled-resource.service';
 import { SingleSpaPropsService } from '../single-spa-props/single-spa-props.service';
 import { Encounter, FormSchema } from '../types';
-import { LoggedInUser } from '@openmrs/esm-framework';
+import { Session } from '@openmrs/esm-framework';
 import { isFunction } from 'lodash-es';
 
 /**
@@ -20,7 +20,7 @@ export interface CreateFormParams {
   /**
    * The currently signed-in user.
    */
-  user: LoggedInUser;
+  session: Session;
   /**
    * An optional encounter.
    * If provided, this encounter will be edited by the form.
@@ -114,7 +114,7 @@ export class FormCreationService {
     this.dataSources.registerDataSource('rawPrevEnc', createFormParams.previousEncounter, false);
     const rawPrevObs = await dataSources.recentObs(patient.id);
     this.dataSources.registerDataSource('rawPrevObs', rawPrevObs, false);
-    this.dataSources.registerDataSource('userLocation', createFormParams.user.sessionLocation);
+    this.dataSources.registerDataSource('userLocation', createFormParams.session.sessionLocation);
 
     // TODO monthlySchedule should be converted to a "standard" configurableDataSource
     const config = this.configResourceService.getConfig();
@@ -232,7 +232,7 @@ export class FormCreationService {
   }
 
   private setDefaultValues(form: Form, createFormParams: CreateFormParams) {
-    const { user } = createFormParams;
+    const { session } = createFormParams;
 
     // Encounter date and time.
     const currentDate = moment().format();
@@ -243,28 +243,28 @@ export class FormCreationService {
 
     // User location.
     const encounterLocation = form.searchNodeByQuestionId('location', 'encounterLocation');
-    if (encounterLocation.length > 0 && user?.sessionLocation) {
-      encounterLocation[0].control.setValue(user.sessionLocation.uuid);
+    if (encounterLocation.length > 0 && session?.sessionLocation) {
+      encounterLocation[0].control.setValue(session.sessionLocation.uuid);
     }
 
     // Provider.
     const encounterProvider = form.searchNodeByQuestionId('provider', 'encounterProvider');
-    if (encounterProvider.length > 0 && user?.currentProvider) {
-      encounterProvider[0].control.setValue(user.currentProvider.uuid);
+    if (encounterProvider.length > 0 && session?.currentProvider) {
+      encounterProvider[0].control.setValue(session.currentProvider.uuid);
     }
   }
 
   private setUpPayloadProcessingInformation(form: Form, createFormParams: CreateFormParams) {
-    const { user, formSchema, encounter } = createFormParams;
+    const { session, formSchema, encounter } = createFormParams;
     const patientUuid = this.singleSpaPropsService.getPropOrThrow('patientUuid');
     const visitUuid = this.singleSpaPropsService.getPropOrThrow('visitUuid');
 
     try {
-      if (user) {
+      if (session) {
         form.valueProcessingInfo.personUuid = patientUuid;
         form.valueProcessingInfo.patientUuid = patientUuid;
         form.valueProcessingInfo.formUuid = formSchema.uuid;
-        form.valueProcessingInfo.providerUuid = user.currentProvider?.uuid;
+        form.valueProcessingInfo.providerUuid = session.currentProvider?.uuid;
 
         if (formSchema.encounterType) {
           form.valueProcessingInfo.encounterTypeUuid = formSchema.encounterType.uuid;

--- a/packages/esm-form-entry-app/src/app/openmrs-api/openmrs-esm-api.service.ts
+++ b/packages/esm-form-entry-app/src/app/openmrs-api/openmrs-esm-api.service.ts
@@ -1,14 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-import { getCurrentUser, LoggedInUser, openmrsObservableFetch, Session } from '@openmrs/esm-framework';
+import { getCurrentUser, openmrsObservableFetch, Session } from '@openmrs/esm-framework';
 
 @Injectable()
 export class OpenmrsEsmApiService {
   constructor() {}
 
-  public getCurrentUser(): Observable<LoggedInUser> {
-    return getCurrentUser().pipe(map((session: Session) => session.user));
+  public getCurrentSession(): Observable<Session> {
+    return getCurrentUser();
   }
 
   public openmrsFetch(url): Observable<any> {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes a bug that occurs when a user launches the form engine and both provider and location aren't set automatically. This happens because the `getCurrentUser` function is intended to return a session object instead of `User` object. I have provided a fix for that. But we will need to rename [getCurrentUser](https://github.com/openmrs/openmrs-esm-core/blob/304fd2e7d7f20e85cf8151453e67baddf84794ab/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L71) function to `getCurrentSession` or something close to what the function does.

## Screenshots
![userLocation](https://user-images.githubusercontent.com/28008754/227663191-3d106925-4328-4db7-8981-bfd73841b39d.gif)
