### PR TITLE
(fix) Fix how obs from an encounter get displayed in the visits table

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
@@ -23,10 +23,21 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
 
   const obsWithoutGroupMembers = useMemo(() => observations?.filter((obs) => !obs.groupMembers), [observations]);
 
+  function splitObsDisplay(display) {
+    const colonIndex = display.indexOf(':');
+    if (colonIndex === -1) {
+      return [display, ''];
+    } else {
+      const title = display.substring(0, colonIndex).trim();
+      const text = display.substring(colonIndex + 1).trim();
+      return [title, text];
+    }
+  }
+
   const observationsList = useMemo(
     () =>
       observations?.map(({ display }) => {
-        const [question, answer] = display.split(':');
+        const [question, answer] = splitObsDisplay(display);
         return { question, answer };
       }),
     [observations],
@@ -41,7 +52,7 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
       <div className={styles.observation}>
         {observationsList?.map(({ question, answer }, i) => (
           <React.Fragment key={i}>
-            <span className={styles.caption01}>{question}: </span>
+            <span className={styles.caption01}>{question}</span>
             <span className={`${styles.bodyShort02} ${styles.text01}`}>{answer}</span>
           </React.Fragment>
         ))}
@@ -52,7 +63,7 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
   if (obsWithGroupMembers.length) {
     const groupMembers = obsWithGroupMembers.flatMap(({ members }) =>
       members.map(({ display }) => {
-        const [question, answer] = display?.split(':');
+        const [question, answer] = splitObsDisplay(display);
         return { question, answer };
       }),
     );
@@ -61,7 +72,7 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
       <div className={styles.observation}>
         {groupMembers?.map(({ question, answer }, i) => (
           <React.Fragment key={i}>
-            <span className={styles.caption01}>{question}: </span>
+            <span className={styles.caption01}>{question}</span>
             <span className={`${styles.bodyShort02} ${styles.text01}`}>{answer}</span>
           </React.Fragment>
         ))}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes an issue where observations from an encounter would not get displayed properly in the visits table if their display property contains a colon.

## Screenshots

> Note how the visit note gets displayed correctly in both screenshots

<img width="959" alt="Screenshot 2023-03-26 at 3 21 57 PM" src="https://user-images.githubusercontent.com/8509731/227775542-9746a490-767a-49c1-9a20-e69839fcd112.png">

<img width="949" alt="Screenshot 2023-03-26 at 3 22 19 PM" src="https://user-images.githubusercontent.com/8509731/227775547-6034392f-cb79-4a85-928c-bf78c5998979.png">
