### PR TITLE
(fix) Vitals header should wrap when a workspace is open on desktop

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.component.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import dayjs from 'dayjs';
 import isToday from 'dayjs/plugin/isToday';
+dayjs.extend(isToday);
 import { useTranslation } from 'react-i18next';
 import { Button, InlineLoading, Tag } from '@carbon/react';
 import { ArrowRight, Time } from '@carbon/react/icons';
@@ -10,14 +11,13 @@ import {
   launchPatientWorkspace,
   useVisitOrOfflineVisit,
   useVitalsConceptMetadata,
+  useWorkspaces,
 } from '@openmrs/esm-patient-common-lib';
 import { ConfigObject } from '../../config-schema';
 import { assessValue, getReferenceRangesForConcept, interpretBloodPressure, useVitals } from '../vitals.resource';
 import { launchVitalsForm } from '../vitals-utils';
 import VitalsHeaderItem from './vitals-header-item.component';
 import styles from './vitals-header.scss';
-
-dayjs.extend(isToday);
 
 interface VitalsHeaderProps {
   patientUuid: string;
@@ -38,6 +38,11 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
   const [showDetailsPanel, setShowDetailsPanel] = useState(false);
   const toggleDetailsPanel = () => setShowDetailsPanel(!showDetailsPanel);
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
+  const { workspaces } = useWorkspaces();
+
+  const isWorkspaceOpen = useCallback(() => {
+    return Boolean(workspaces?.length);
+  }, [workspaces]);
 
   const launchVitalsAndBiometricsForm = useCallback(
     (e) => {
@@ -100,7 +105,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, showRecordVita
             </Button>
           </div>
         </div>
-        <div className={styles['row-container']}>
+        <div className={`${styles['row-container']} ${isWorkspaceOpen() && styles['workspace-open']}`}>
           <div className={styles.row}>
             <VitalsHeaderItem
               interpretation={assessValue(

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.scss
@@ -36,7 +36,7 @@
 }
 
 
-:global(.omrs-breakpoint-lt-desktop) {
+:global(.omrs-breakpoint-lt-desktop), .workspace-open {
   .row {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-header/vitals-header.test.tsx
@@ -38,6 +38,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
       conceptMetadata: mockConceptMetadata,
     })),
     useVisitOrOfflineVisit: jest.fn().mockImplementation(() => ({ currentVisit: mockCurrentVisit })),
+    useWorkspaces: jest.fn().mockImplementation(() => ({ workspaces: [] })),
   };
 });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes an issue where the items in the vitals header would get squished up when the user launches a workspace. Ideally, the workspace should use responsive styling when:

- The viewport changes from desktop to tablet.
- A workspace gets launched.

## Videos

> Before

https://user-images.githubusercontent.com/8509731/227793125-aa116307-7faa-4b14-821e-a517e195c365.mp4

> After

https://user-images.githubusercontent.com/8509731/227793031-1fecf6fb-80a8-4aa7-a0df-a13b8a3d687b.mp4

