### PR TITLE
O3-1998: Allergy Table shows wrong Onset date

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -44,10 +44,6 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
     },
     { key: 'reaction', header: t('reaction', 'Reaction') },
     {
-      key: 'onsetDate',
-      header: t('since', 'Since'),
-    },
-    {
       key: 'lastUpdated',
       header: t('lastUpdated', 'Last updated'),
     },
@@ -74,7 +70,6 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
           </span>
         ),
       },
-      onsetDate: formatDate(parseDate(allergy.onsetDate), { day: false, time: false }) ?? '--',
       lastUpdated: allergy.lastUpdated ? formatDate(parseDate(allergy.lastUpdated), { time: false }) : '--',
       reaction: allergy.reactionManifestations?.join(', '),
       note: allergy?.note ?? '--',

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -44,7 +44,7 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
     },
     { key: 'reaction', header: t('reaction', 'Reaction') },
     {
-      key: 'recordedDate',
+      key: 'onsetDate',
       header: t('since', 'Since'),
     },
     {
@@ -74,7 +74,7 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
           </span>
         ),
       },
-      recordedDate: formatDate(parseDate(allergy.recordedDate), { day: false, time: false }) ?? '--',
+      onsetDate: formatDate(parseDate(allergy.onsetDate), { day: false, time: false }) ?? '--',
       lastUpdated: allergy.lastUpdated ? formatDate(parseDate(allergy.lastUpdated), { time: false }) : '--',
       reaction: allergy.reactionManifestations?.join(', '),
       note: allergy?.note ?? '--',

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
@@ -58,13 +58,13 @@ describe('AllergiesDetailedSummary: ', () => {
 
     expect(screen.getByRole('heading', { name: /allergies/i })).toBeInTheDocument();
 
-    const expectedColumnHeaders = [/allergen/i, /severity/i, /reaction/i, /since/i, /last updated/i, /note/i];
+    const expectedColumnHeaders = [/allergen/i, /severity/i, /reaction/i, /last updated/i, /note/i];
     const expectedAllergies = [
-      /ACE inhibitors unable-to-assess Anaphylaxis May 2021/i,
-      /Fish low Anaphylaxis, Angioedema, Fever, Hives Apr 2021 -- Some Comments/i,
-      /Penicillins high Diarrhea, Cough, Musculoskeletal pain, Mental status change, Angioedema Jan 2021 -- Patient allergies have been noted down/i,
-      /Morphine high Mental status change Nov 2020 -- Comments/i,
-      /Aspirin high Mental status change Nov 2020 -- Comments/i,
+      /ACE inhibitors unable-to-assess Anaphylaxis/i,
+      /Fish low Anaphylaxis, Angioedema, Fever, Hives -- Some Comments/i,
+      /Penicillins high Diarrhea, Cough, Musculoskeletal pain, Mental status change, Angioedema -- Patient allergies have been noted down/i,
+      /Morphine high Mental status change -- Comments/i,
+      /Aspirin high Mental status change -- Comments/i,
     ];
 
     expectedColumnHeaders.forEach((header) =>

--- a/packages/esm-patient-allergies-app/translations/en.json
+++ b/packages/esm-patient-allergies-app/translations/en.json
@@ -34,7 +34,6 @@
   "severityAndOnsetDate": "Severity and date of onset",
   "severityandReaction": "Severity",
   "severityOfWorstReaction": "Severity of worst reaction",
-  "since": "Since",
   "tryReopeningTheForm": "Please try launching the form again",
   "typeAdditionalComments": "Type any additional comments here",
   "typeAllergenName": "Please type in the name of the allergen",


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/O3-1998
1. Enter an allergy; enter a date of onset sometime in the past. Save the allergy.
2. View the Allergies summary table: See it shows "Today" under "Since", not the "Date of first onset". This is wrong. 

Blocker for Faimer.
