### PR TITLE
(fix) 03-1995: Fix patient conditions sorting on "onSetDate".

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
 import {
   Button,
   DataTable,
@@ -16,10 +17,11 @@ import {
   Tile,
 } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
-import { formatDate, parseDate, useLayoutType } from '@openmrs/esm-framework';
+import { formatDate, parseDate, useLayoutType, formatDatetime } from '@openmrs/esm-framework';
 import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { Condition, useConditions } from './conditions.resource';
 import { ConditionsActionMenu } from './conditions-action-menu.component';
+import { compare } from './utils';
 import styles from './conditions-detailed-summary.scss';
 
 function ConditionsDetailedSummary({ patient }) {
@@ -63,19 +65,30 @@ function ConditionsDetailedSummary({ patient }) {
     [t],
   );
 
-  const tableRows: Array<Condition> = useMemo(() => {
+  const tableRows = useMemo(() => {
     return filteredConditions?.map((condition) => {
       return {
         ...condition,
         id: condition.id,
         condition: condition.display,
-        onsetDateTime: condition.onsetDateTime
-          ? formatDate(parseDate(condition.onsetDateTime), { time: false, day: false })
-          : '--',
+        onsetDateTime: {
+          sortKey: condition.onsetDateTime ?? '',
+          content: condition.onsetDateTime
+            ? formatDate(parseDate(condition.onsetDateTime), { time: false, day: false })
+            : '--',
+        },
         status: condition.clinicalStatus,
       };
     });
   }, [filteredConditions]);
+
+  const sortRow = (cellA, cellB, { sortDirection, sortStates }) => {
+    return sortDirection === sortStates.DESC
+      ? compare(cellB.sortKey, cellA.sortKey)
+      : compare(cellA.sortKey, cellB.sortKey);
+  };
+
+  console.log(tableRows, '----', filteredConditions);
 
   const launchConditionsForm = useCallback(
     () => launchPatientWorkspace('conditions-form-workspace', { workspaceTitle: 'Record a Condition' }),
@@ -117,13 +130,14 @@ function ConditionsDetailedSummary({ patient }) {
         </CardHeader>
         <DataTable
           rows={tableRows}
+          sortRow={sortRow}
           headers={headers}
           isSortable
           size={isTablet ? 'lg' : 'sm'}
           useZebraStyles
           overflowMenuOnHover={isDesktop}
         >
-          {({ rows, headers, getHeaderProps, getTableProps }) => (
+          {({ rows, headers, getHeaderProps, getTableProps, getRowProps }) => (
             <>
               <TableContainer>
                 <Table {...getTableProps()}>
@@ -145,7 +159,7 @@ function ConditionsDetailedSummary({ patient }) {
                   </TableHead>
                   <TableBody>
                     {rows.map((row) => (
-                      <TableRow key={row.id}>
+                      <TableRow key={row.id} {...getRowProps({ row })}>
                         {row.cells.map((cell) => (
                           <TableCell key={cell.id}>{cell.value?.content ?? cell.value}</TableCell>
                         ))}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -88,8 +88,6 @@ function ConditionsDetailedSummary({ patient }) {
       : compare(cellA.sortKey, cellB.sortKey);
   };
 
-  console.log(tableRows, '----', filteredConditions);
-
   const launchConditionsForm = useCallback(
     () => launchPatientWorkspace('conditions-form-workspace', { workspaceTitle: 'Record a Condition' }),
     [],

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import dayjs from 'dayjs';
 import {
   Button,
   DataTable,
@@ -17,7 +16,7 @@ import {
   Tile,
 } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
-import { formatDate, parseDate, useLayoutType, formatDatetime } from '@openmrs/esm-framework';
+import { formatDate, parseDate, useLayoutType } from '@openmrs/esm-framework';
 import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { Condition, useConditions } from './conditions.resource';
 import { ConditionsActionMenu } from './conditions-action-menu.component';

--- a/packages/esm-patient-conditions-app/src/conditions/utils.ts
+++ b/packages/esm-patient-conditions-app/src/conditions/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Enables a comparison of arbitrary values with support for undefined/null.
+ * Requires the `<` and `>` operators to return something reasonable for the provided values.
+ */
+export function compare<T>(x?: T, y?: T) {
+  if (x == undefined && y == undefined) {
+    return 0;
+  } else if (x == undefined) {
+    return -1;
+  } else if (y == undefined) {
+    return 1;
+  } else if (x < y) {
+    return -1;
+  } else if (x > y) {
+    return 1;
+  } else {
+    return 0;
+  }
+}

--- a/packages/esm-patient-conditions-app/src/conditions/utils.ts
+++ b/packages/esm-patient-conditions-app/src/conditions/utils.ts
@@ -1,19 +1,23 @@
+import { parseDate } from '@openmrs/esm-framework';
 /**
  * Enables a comparison of arbitrary values with support for undefined/null.
  * Requires the `<` and `>` operators to return something reasonable for the provided values.
  */
-export function compare<T>(x?: T, y?: T) {
-  if (x == undefined && y == undefined) {
+export function compare<T extends string>(x?: T, y?: T) {
+  if (x === y || (!x && !y)) {
     return 0;
-  } else if (x == undefined) {
+  } else if (!x) {
     return -1;
-  } else if (y == undefined) {
-    return 1;
-  } else if (x < y) {
-    return -1;
-  } else if (x > y) {
+  } else if (!y) {
     return 1;
   } else {
-    return 0;
+    const xDate = parseDate(x);
+    const yDate = parseDate(y);
+
+    if (xDate === yDate) {
+      return 0;
+    }
+
+    return xDate < yDate ? -1 : 1;
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This PR fixes the sorting bug we had when we sort on `onSetDate` on the patient chart conditions table. This was reported by the `faimer team`. The date string we show on the UI was not properly sorting since it is just alphabetical, so there was need to specify the sortKey which is the actual dateTime string.

## Screenshots
<img width="1375" alt="Screenshot 2023-03-27 at 00 58 50" src="https://user-images.githubusercontent.com/30952856/227807251-e3769e81-8462-474b-8dff-6dd37b28c937.png">


- Loom recording
https://www.loom.com/share/10a1246a12d74fc8ba7a02e7a3d45270




## Related Issue
- https://issues.openmrs.org/browse/O3-1995

