### PR TITLE
(fix) Use sessionStorage instead of localStorage for form engine

### DIFF
--- a/packages/esm-form-entry-app/src/app/app.component.spec.ts
+++ b/packages/esm-form-entry-app/src/app/app.component.spec.ts
@@ -6,7 +6,7 @@ import { FormEntryModule } from '@openmrs/ngx-formentry';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FormSchemaService } from './form-schema/form-schema.service';
 import { OpenmrsApiModule } from './openmrs-api/openmrs-api.module';
-import { LocalStorageService } from './local-storage/local-storage.service';
+import { SessionStorageService } from './storage/session-storage.service';
 import { FormDataSourceService } from './form-data-source/form-data-source.service';
 import { FormSubmissionService } from './form-submission/form-submission.service';
 import { FormSubmittedComponent } from './form-submitted/form-submitted.component';
@@ -16,7 +16,7 @@ describe('AppComponent', () => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, FormEntryModule, ReactiveFormsModule, OpenmrsApiModule],
       declarations: [AppComponent, FeWrapperComponent, FormSubmittedComponent],
-      providers: [FormSchemaService, LocalStorageService, FormDataSourceService, FormSubmissionService],
+      providers: [FormSchemaService, SessionStorageService, FormDataSourceService, FormSubmissionService],
     }).compileComponents();
   }));
 

--- a/packages/esm-form-entry-app/src/app/app.module.ts
+++ b/packages/esm-form-entry-app/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { FormEntryModule } from '@openmrs/ngx-formentry';
 import { ReactiveFormsModule } from '@angular/forms';
 import { OpenmrsApiModule } from './openmrs-api/openmrs-api.module';
 import { FormSchemaService } from './form-schema/form-schema.service';
-import { LocalStorageService } from './local-storage/local-storage.service';
+import { SessionStorageService } from './storage/session-storage.service';
 import { FormDataSourceService } from './form-data-source/form-data-source.service';
 import { FormSubmissionService } from './form-submission/form-submission.service';
 import { MonthlyScheduleResourceService } from './services/monthly-scheduled-resource.service';
@@ -33,7 +33,7 @@ import { TranslateModule, TranslateService, TranslateStore } from '@ngx-translat
   ],
   providers: [
     FormSchemaService,
-    LocalStorageService,
+    SessionStorageService,
     FormDataSourceService,
     FormSubmissionService,
     FormCreationService,

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.spec.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.spec.ts
@@ -9,7 +9,7 @@ import { OpenmrsEsmApiService } from '../openmrs-api/openmrs-esm-api.service';
 import { of } from 'rxjs';
 import { FormSchemaService } from '../form-schema/form-schema.service';
 import { OpenmrsApiModule } from '../openmrs-api/openmrs-api.module';
-import { LocalStorageService } from '../local-storage/local-storage.service';
+import { SessionStorageService } from '../storage/session-storage.service';
 import { FormDataSourceService } from '../form-data-source/form-data-source.service';
 import { FormSubmissionService } from '../form-submission/form-submission.service';
 import { FormSubmittedComponent } from '../form-submitted/form-submitted.component';
@@ -27,7 +27,7 @@ describe('FeWrapperComponent', () => {
           provide: OpenmrsEsmApiService,
         },
         FormSchemaService,
-        LocalStorageService,
+        SessionStorageService,
         FormDataSourceService,
         FormSubmissionService,
       ],

--- a/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.spec.ts
@@ -5,7 +5,7 @@ import { FormDataSourceService } from './form-data-source.service';
 import { ProviderResourceService } from '../openmrs-api/provider-resource.service';
 import { FakeProviderResourceService } from '../openmrs-api/provider-resource.service.mock';
 import { LocationResourceService } from '../openmrs-api/location-resource.service';
-import { LocalStorageService } from '../local-storage/local-storage.service';
+import { SessionStorageService } from '../storage/session-storage.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { OpenmrsApiModule } from '../openmrs-api/openmrs-api.module';
 
@@ -14,7 +14,7 @@ describe('Service: FormDataSourceService', () => {
     TestBed.configureTestingModule({
       imports: [OpenmrsApiModule, HttpClientTestingModule],
       providers: [
-        LocalStorageService,
+        SessionStorageService,
         FormDataSourceService,
         {
           provide: ProviderResourceService,

--- a/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
@@ -8,7 +8,7 @@ import { FetchResponse, fhirBaseUrl, FHIRResource, openmrsFetch } from '@openmrs
 import { ProviderResourceService } from '../openmrs-api/provider-resource.service';
 import { LocationResourceService } from '../openmrs-api/location-resource.service';
 import { ConceptResourceService } from '../openmrs-api/concept-resource.service';
-import { LocalStorageService } from '../local-storage/local-storage.service';
+import { SessionStorageService } from '../storage/session-storage.service';
 import type { Concept, FormSchema, Location, Observation, Provider, Questions } from '../types';
 
 @Injectable()
@@ -17,7 +17,7 @@ export class FormDataSourceService {
     private providerResourceService: ProviderResourceService,
     private locationResourceService: LocationResourceService,
     private conceptResourceService: ConceptResourceService,
-    private localStorageService: LocalStorageService,
+    private localStorageService: SessionStorageService,
   ) {}
 
   public getDataSources(formSchema: FormSchema) {

--- a/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.spec.ts
@@ -3,13 +3,13 @@ import { BehaviorSubject } from 'rxjs';
 import { FormSchemaService } from './form-schema.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormResourceService } from '../openmrs-api/form-resource.service';
-import { LocalStorageService } from '../local-storage/local-storage.service';
+import { SessionStorageService } from '../storage/session-storage.service';
 import { FormSchemaCompiler } from '@openmrs/ngx-formentry';
 
 describe('Service: FormSchemaService', () => {
   let formSchemaService: FormSchemaService;
   let formsResourceService: FormResourceService;
-  let localStorageService: LocalStorageService;
+  let localStorageService: SessionStorageService;
 
   // mock data for formMetaData
   const formMetaData: any = {
@@ -60,12 +60,12 @@ describe('Service: FormSchemaService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [],
-      providers: [FormSchemaService, LocalStorageService, FormSchemaCompiler, FormResourceService],
+      providers: [FormSchemaService, SessionStorageService, FormSchemaCompiler, FormResourceService],
       imports: [HttpClientTestingModule],
     });
     formSchemaService = TestBed.get(FormSchemaService);
     formsResourceService = TestBed.get(FormResourceService);
-    localStorageService = TestBed.get(LocalStorageService);
+    localStorageService = TestBed.get(SessionStorageService);
   });
 
   afterEach(() => {

--- a/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts
@@ -4,7 +4,7 @@ import { concat, first, map, take, tap } from 'rxjs/operators';
 
 import { FormResourceService } from '../openmrs-api/form-resource.service';
 import { FormSchemaCompiler } from '@openmrs/ngx-formentry';
-import { LocalStorageService } from '../local-storage/local-storage.service';
+import { SessionStorageService } from '../storage/session-storage.service';
 import { FormMetadataObject, FormSchema, FormSchemaAndTranslations, Questions } from '../types';
 import { TranslateService } from '@ngx-translate/core';
 import { merge } from 'lodash-es';
@@ -13,7 +13,7 @@ import { merge } from 'lodash-es';
 export class FormSchemaService {
   constructor(
     private formsResourceService: FormResourceService,
-    private localStorage: LocalStorageService,
+    private localStorage: SessionStorageService,
     private formSchemaCompiler: FormSchemaCompiler,
     private translateService: TranslateService,
   ) {}

--- a/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.spec.ts
@@ -8,7 +8,7 @@ import { EncounterResourceService } from '../openmrs-api/encounter-resource.serv
 import { PersonAttribuAdapter, Form, EncounterAdapter, FormEntryModule } from '@openmrs/ngx-formentry';
 import { PersonResourceService } from '../openmrs-api/person-resource.service';
 import { FormDataSourceService } from '../form-data-source/form-data-source.service';
-import { LocalStorageService } from '../local-storage/local-storage.service';
+import { SessionStorageService } from '../storage/session-storage.service';
 
 describe('Service: FormSubmissionService', () => {
   // sample field error
@@ -79,7 +79,7 @@ describe('Service: FormSubmissionService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [],
-      providers: [FormSubmissionService, FormDataSourceService, LocalStorageService],
+      providers: [FormSubmissionService, FormDataSourceService, SessionStorageService],
       imports: [HttpClientTestingModule, OpenmrsApiModule, FormEntryModule],
     });
   });

--- a/packages/esm-form-entry-app/src/app/openmrs-api/encounter-resource.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/openmrs-api/encounter-resource.service.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TestBed } from '@angular/core/testing';
 
 import { EncounterResourceService } from './encounter-resource.service';
-import { LocalStorageService } from '../local-storage/local-storage.service';
+import { SessionStorageService } from '../storage/session-storage.service';
 import { OpenmrsApiModule } from './openmrs-api.module';
 
 describe('EncounterResourceService', () => {
@@ -10,7 +10,7 @@ describe('EncounterResourceService', () => {
   let service: EncounterResourceService;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [LocalStorageService],
+      providers: [SessionStorageService],
       imports: [HttpClientTestingModule, OpenmrsApiModule],
     });
 

--- a/packages/esm-form-entry-app/src/app/openmrs-api/form-resource.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/openmrs-api/form-resource.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { FormResourceService } from './form-resource.service';
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
-import { LocalStorageService } from '../local-storage/local-storage.service';
+import { SessionStorageService } from '../storage/session-storage.service';
 import { WindowRef } from '../window-ref';
 // Load the implementations that should be tested
 
@@ -14,7 +14,7 @@ describe('FormResourceService Unit Tests', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       declarations: [],
-      providers: [FormResourceService, LocalStorageService, WindowRef],
+      providers: [FormResourceService, SessionStorageService, WindowRef],
     });
 
     formsResourceService = TestBed.get(FormResourceService);

--- a/packages/esm-form-entry-app/src/app/storage/session-storage.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/storage/session-storage.service.spec.ts
@@ -1,65 +1,61 @@
-import { LocalStorageService } from './local-storage.service';
+import { SessionStorageService } from './session-storage.service';
 
 describe('LocalStorageService Tests', () => {
-  let service: LocalStorageService;
+  let service: SessionStorageService;
   const keyName = 'localStorageServiceTest.value';
   const value = 'some value to be stored';
   const objectValue = {
     property1: 'localStorage wrapper',
     property2: 'another property',
   };
-  beforeEach(() => {
-    service = new LocalStorageService();
-  });
 
   beforeEach(() => {
-    window.localStorage.clear();
+    service = new SessionStorageService();
   });
 
   afterEach(() => {
-    window.localStorage.clear();
+    window.sessionStorage.clear();
   });
 
   it('should store a given value', () => {
     service.setItem(keyName, value);
     let v;
     try {
-      v = window.localStorage.getItem(keyName);
+      v = window.sessionStorage.getItem(keyName);
     } catch (e) {
       console.error('Error getting item', e);
     }
     expect(v).toEqual(value, 'setItem() should store values');
   });
-  it('should return the correct length of localStorage', () => {
+
+  it('should return the correct length of storage', () => {
     window.localStorage.setItem(keyName, 'some value');
     expect(service.storageLength).toEqual(1);
   });
 
   it('should store javascript object literals', () => {
     service.setObject(keyName, objectValue);
-    const stored = window.localStorage.getItem(keyName);
+    const stored = window.sessionStorage.getItem(keyName);
     expect(JSON.parse(stored)).toEqual(objectValue, 'setObject()');
   });
+
   it('should retrieve a stored value', () => {
     try {
-      window.localStorage.setItem(keyName, value);
+      window.sessionStorage.setItem(keyName, value);
     } catch (e) {
       console.error('Error getting item', e);
     }
     expect(service.getItem(keyName)).toEqual(value, 'getItem()');
   });
+
   it('should remove an existing item', () => {
-    window.localStorage.setItem(keyName, 'some value');
+    window.sessionStorage.setItem(keyName, 'some value');
     service.remove(keyName);
-    expect(window.localStorage.getItem(keyName)).toBeNull();
-  });
-  it('should clear localStorage', () => {
-    service.clear();
-    expect(window.localStorage.length).toEqual(0);
+    expect(window.sessionStorage.getItem(keyName)).toBeNull();
   });
 
   it('should retrieve the stored javascript object literal', () => {
-    window.localStorage.setItem(keyName, JSON.stringify(objectValue));
+    window.sessionStorage.setItem(keyName, JSON.stringify(objectValue));
     expect(service.getObject(keyName)).toEqual(objectValue, 'getObject()');
   });
 });

--- a/packages/esm-form-entry-app/src/app/storage/session-storage.service.ts
+++ b/packages/esm-form-entry-app/src/app/storage/session-storage.service.ts
@@ -1,17 +1,19 @@
 import { Injectable } from '@angular/core';
 
+const storage = window.sessionStorage;
+
 @Injectable()
-export class LocalStorageService {
+export class SessionStorageService {
   public getItem(keyName: string): string {
-    return window.localStorage.getItem(keyName);
+    return storage.getItem(keyName);
   }
 
   public setItem(keyName: string, value: string): void {
-    window.localStorage.setItem(keyName, value);
+    storage.setItem(keyName, value);
   }
 
   public getObject<T = any>(keyName: string): T | null {
-    const stored = window.localStorage.getItem(keyName);
+    const stored = storage.getItem(keyName);
     try {
       return JSON.parse(stored);
     } catch (error) {
@@ -21,18 +23,14 @@ export class LocalStorageService {
   }
 
   public setObject(keyName: string, value: unknown) {
-    window.localStorage.setItem(keyName, JSON.stringify(value));
+    storage.setItem(keyName, JSON.stringify(value));
   }
 
   public remove(keyName: string): void {
-    window.localStorage.removeItem(keyName);
-  }
-
-  public clear(): void {
-    window.localStorage.clear();
+    storage.removeItem(keyName);
   }
 
   get storageLength(): number {
-    return window.localStorage.length;
+    return storage.length;
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, the AMPATH form engine uses `localStorage` to store data, including compiled versions of the complete form. This is useful as large forms can take a while to compute. However, `localStorage` is probably not the right place for this because we need to update the form when changes happen on the backend [(O3-1977)](https://issues.openmrs.org/browse/O3-1977).

This isn't a complete solution to that ticket, which needs some more thought, but this does move everything to using `sessionStorage` instead of `localStorage`, which means that reloading a form can be done by closing and reopening the browser window, rather than messing with browser history or the dev tools.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1977

## Other
<!-- Anything not covered above -->
