### PR TITLE
(fix) O3-2007: Fix the visit header patient name hover height.

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.scss
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.scss
@@ -2,39 +2,39 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @import '~@openmrs/esm-styleguide/src/vars';
- 
+
 .topNavHeader {
   top: var(--omrs-offline-banner-height);
   @include brand-02(background-color);
 }
- 
+
 .headerGlobalBarCloseButton {
   @include brand-02(background-color);
 }
- 
+
 .headerName {
   display: flex;
 }
- 
+
 .navLogo {
   margin-right: spacing.$spacing-06;
   margin-left: spacing.$spacing-04;
 }
- 
+
 .startVisitButton {
   @include brand-03(background-color);
 }
- 
+
 .patientDetails {
   display: flex;
   align-items: center;
   color: $ui-02;
-  padding: 0 spacing.$spacing-05;
- 
+  padding: spacing.$spacing-04 spacing.$spacing-05;
+
   &:hover {
     background-color: colors.$teal-90;
   }
- 
+
   :global(.cds--popover--bottom .cds--popover-content) {
     text-align: center
   }
@@ -49,18 +49,18 @@
     margin-right: spacing.$spacing-05;
     padding-right: 0.5rem;
   }
-  
+
   .tooltipPatientName {
     @include type.type-style('productive-heading-01');
-    color:$ui-02; 
+    color:$ui-02;
   }
-  
+
   .longPatientNameBtn {
     background-color: transparent;
     border: none;
     outline: none;
   }
-  
+
   .patientInfo {
     color: $color-gray-30;
     @include type.type-style('body-compact-01');
@@ -73,21 +73,21 @@
   color:$color-gray-30;
   margin-top:spacing.$spacing-03;
 }
- 
+
 .tooltip :global(.cds--tooltip__trigger.cds--tooltip__trigger--definition) {
   border-bottom: none;
 }
- 
+
 .navDivider {
   background-color: colors.$teal-20;
   width: 0.05rem;
   height: 2.25rem;
 }
- 
+
 .tag {
   margin: 0.25rem 0;
 }
- 
+
 .priorityTag {
   @extend .tag;
   @include type.type-style('label-01');


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This PR fixes the hover background height on the patient chart visit header patient details

## Screenshots
- Before
<img width="378" alt="Screenshot 2023-03-29 at 15 58 21" src="https://user-images.githubusercontent.com/30952856/228552887-66e419ec-a1ab-47ba-b546-7a154d783766.png">

- After fix
<img width="377" alt="Screenshot 2023-03-29 at 16 19 10" src="https://user-images.githubusercontent.com/30952856/228552900-8641ef21-0740-4ec2-858c-d3fda44a6c7d.png">


## Related Issue
- https://issues.openmrs.org/browse/O3-2007

