### PR TITLE
(fix) Fix note text line endings

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/notes-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/notes-summary.component.tsx
@@ -11,7 +11,7 @@ const NotesSummary: React.FC<NotesSummaryProps> = ({ notes }) => {
   const { t } = useTranslation();
 
   return (
-    <React.Fragment>
+    <>
       {notes.length ? (
         notes.map((note: Note, i) => (
           <div className={styles.notesContainer} key={i}>
@@ -25,7 +25,7 @@ const NotesSummary: React.FC<NotesSummaryProps> = ({ notes }) => {
       ) : (
         <p className={`${styles.bodyLong01} ${styles.text02}`}>{t('noNotesFound', 'No notes found')}</p>
       )}
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.scss
@@ -152,6 +152,7 @@
   background-color: $ui-01;
   padding: 1rem;
   width: 100% !important;
+  white-space: pre-wrap;
 }
 
 .metadata {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes an issue where line endings in visit note text don't get rendered by applying a `white-space: pre-wrap` CSS property to the containing paragraph element. 

## Screenshots

> Before

<img width="1800" alt="Screenshot 2023-03-30 at 9 25 29 PM" src="https://user-images.githubusercontent.com/8509731/228930068-55876bdd-06bb-451c-b333-d907a6b51081.png">

> After

<img width="1800" alt="Screenshot 2023-03-30 at 9 14 06 PM" src="https://user-images.githubusercontent.com/8509731/228930096-bec31fb9-e7bb-4df4-89c2-8e52c2ab5bb5.png">
