### PR TITLE
(fix) Fix the display of medications in the visit summary encounters table

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
@@ -22,7 +22,7 @@ const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications }) =>
               <React.Fragment key={i}>
                 <div className={styles.medicationContainer}>
                   <p className={styles.medicationRecord}>
-                    <strong>{capitalize(medication?.order?.drug?.name)}</strong> &mdash;{' '}
+                    <strong>{capitalize(medication?.order?.drug?.display)}</strong> &mdash;{' '}
                     {medication?.order?.drug?.strength?.toLowerCase()}
                     &mdash; {medication?.order?.doseUnits?.display?.toLowerCase()} &mdash;{' '}
                     <span>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -157,6 +157,7 @@ export interface Order {
     uuid: string;
     name: string;
     strength: string;
+    display: string;
   };
   duration: number;
   durationUnits: {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes an issue with displaying the drug name that is being returned as an element in drug object. 

## Screenshots
![medication-fix](https://user-images.githubusercontent.com/28008754/229129786-e0adab0c-fe51-4b27-9fe9-e1444138837c.gif)
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
