### PR TITLE
(fix) Dashboard View should not use wrap property

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
@@ -61,7 +61,7 @@ export function DashboardView({ dashboard, patientUuid, patient }: DashboardView
         className={styles.dashboard}
         style={{ gridTemplateColumns }}
       >
-        <Extension state={state} wrap={wrapItem} />
+        <Extension state={state}>{wrapItem}</Extension>
       </ExtensionSlot>
     </>
   );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Trivial: we've deprecated the `wrap` property and now use this style for wrapping an extension. This just removes a warning from the console.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
