### PR TITLE
(feat) Offline tools dashboard UI enhancements

### DIFF
--- a/packages/esm-patient-forms-app/src/index.ts
+++ b/packages/esm-patient-forms-app/src/index.ts
@@ -78,6 +78,7 @@ function setupOpenMRS() {
         load: getAsyncLifecycle(() => import('./offline-forms/offline-forms-overview-card.component'), options),
         online: true,
         offline: true,
+        order: 1,
       },
       {
         name: 'offline-tools-page-forms-link',

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-forms-overview-card.component.tsx
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-forms-overview-card.component.tsx
@@ -14,8 +14,9 @@ const OfflineFormsOverviewCard: React.FC = () => {
     <Layer>
       <Tile className={styles.overviewCard}>
         <div className={styles.headerContainer}>
-          <h3 className={styles.productiveHeading01}>Forms</h3>
+          <h3 className={styles.heading}>{t('forms', 'Forms')}</h3>
           <Button
+            className={styles.viewButton}
             kind="ghost"
             renderIcon={(props) => <ArrowRight size={16} {...props} />}
             size="sm"

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-forms-overview-card.scss
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-forms-overview-card.scss
@@ -4,7 +4,13 @@
 
 .overviewCard {
   border: 1px solid $ui-03;
+  height: 8.625rem;
 
+  .heading {
+    @extend .productiveHeading01;
+    color: $text-02;
+  }
+  
   .headerContainer {
     display: flex;
     justify-content: space-between;
@@ -14,6 +20,11 @@
   .contentContainer {
     display: flex;
     justify-content: space-between;
-    margin-top: spacing.$spacing-05;
+    margin-top: spacing.$spacing-06;
+  }
+
+  .viewButton {
+    margin-top: -(spacing.$spacing-02);
+    margin-right: -(spacing.$spacing-05);
   }
 }

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-forms.component.tsx
@@ -29,6 +29,7 @@ import { useDynamicFormDataEntries } from './offline-form-helpers';
 import { Form } from '../types';
 import { useValidOfflineFormEncounters } from './use-offline-form-encounters';
 import styles from './offline-forms.styles.scss';
+import { EmptyState } from '@openmrs/esm-patient-common-lib';
 
 export interface OfflineFormsProps {
   canMarkFormsAsOffline: boolean;
@@ -53,6 +54,17 @@ const OfflineForms: React.FC<OfflineFormsProps> = ({ canMarkFormsAsOffline }) =>
         formName: form.name,
         availableOffline: <OfflineFormToggle form={form} disabled={!canMarkFormsAsOffline} />,
       })) ?? [];
+
+  if (forms?.data?.length === 0) {
+    return (
+      <div className={styles.contentContainer}>
+        <EmptyState
+          displayText={t('offlineForms__lower', 'offline forms')}
+          headerTitle={t('offlineForms', 'Offline forms')}
+        />
+      </div>
+    );
+  }
 
   return (
     <>

--- a/packages/esm-patient-forms-app/src/root.scss
+++ b/packages/esm-patient-forms-app/src/root.scss
@@ -4,12 +4,10 @@
 
 .productiveHeading01 {
   @include type.type-style("heading-compact-01");
-  margin-bottom: spacing.$spacing-03;
 }
 
 .productiveHeading03 {
   @include type.type-style("heading-03");
-  margin-bottom: spacing.$spacing-03;
 }
 
 .productiveHeading04 {

--- a/packages/esm-patient-forms-app/translations/en.json
+++ b/packages/esm-patient-forms-app/translations/en.json
@@ -16,6 +16,8 @@
   "noFormsToDisplay": "There are no forms to display.",
   "noMatchingFormsAvailable": "There are no {formCategory} forms to display",
   "noMatchingFormsToDisplay": "No matching forms to display",
+  "offlineForms": "Offline forms",
+  "offlineForms__lower": "offline forms",
   "offlineFormsOverviewCardAvailableOffline": "Available offline",
   "offlineFormsTableFormAvailableOffline": "Offline",
   "offlineFormsTableFormNameHeader": "Form name",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Provides a bunch of visual enhancements to the Offline Tools UI. These include:

- Changing the order of the forms card slot so it always appears second on the list.
- Adding an empty state to the offline forms table.
- Tweaking the appearance of the offline forms card content.

## Screenshots

<img width="997" alt="Screenshot 2023-04-03 at 11 26 40 AM" src="https://user-images.githubusercontent.com/8509731/229454119-9f6f4f51-be91-4b05-9578-2343650d4cdd.png">
