### PR TITLE
(fix) O3-2025: Visit enabled system setting should be referenced using "visit.enabled"

### DIFF
--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -98,17 +98,14 @@ export function postOrder(body: OrderPost, abortController?: AbortController) {
 }
 
 export function useSystemVisitSetting() {
-  const config = useConfig() as ConfigObject;
   const { data, isLoading, error } = useSWRImmutable<FetchResponse<{ value: 'true' | 'false' }>, Error>(
-    config?.visitEnabledSystemSettingUUID
-      ? `/ws/rest/v1/systemsetting/${config?.visitEnabledSystemSettingUUID}?v=custom:(value)`
-      : null,
+    `/ws/rest/v1/systemsetting/visit.enabled?v=custom:(value)`,
     openmrsFetch,
   );
 
   const results = useMemo(
     () => ({
-      systemVisitEnabled: data?.data?.value === 'true',
+      systemVisitEnabled: (data?.data?.value ?? 'true').toLowerCase() === 'true',
       errorFetchingSystemVisitSetting: error,
       isLoadingSystemVisitSetting: isLoading,
     }),

--- a/packages/esm-patient-medications-app/src/config-schema.ts
+++ b/packages/esm-patient-medications-app/src/config-schema.ts
@@ -34,11 +34,6 @@ export const configSchema = {
     _description: "UUID for the 'Drug' order type to fetch medications",
     _default: '131168f4-15f5-102d-96e4-000c29c2a5d7',
   },
-  visitEnabledSystemSettingUUID: {
-    _type: Type.UUID,
-    _description: "UUID for the system setting's property 'visit.enabled'",
-    _default: '9c594c46-482d-48b3-9643-05641111fc9f',
-  },
 };
 
 export interface ConfigObject {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Updates the Visit enabled system settings by name and if it's not set, defaults to true.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
- https://issues.openmrs.org/browse/O3-2025

## Other
<!-- Anything not covered above -->
