### PR TITLE
(fix) O3-2029: Required visit attribute's default value shouldn't be the first choice

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
@@ -138,7 +138,7 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
             invalid={required && isMissingRequiredAttributes && !visitAttributes[uuid]}
             invalidText={t('fieldRequired', 'This field is required')}
           >
-            <SelectItem text={t('selectAnOption', 'Select an option')} value={null} disabled={required} />
+            <SelectItem text={t('selectAnOption', 'Select an option')} value={null} />
             {answers.map((ans, indx) => (
               <SelectItem key={indx} text={ans.display} value={ans.uuid} />
             ))}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR introduces the fix for the visit attribute dropdown, where the first value is selected, yet it throws an error that the field is required. I have removed the disabled attribute for the `Select an option` item, when the field is required.

## Screenshots
![image](https://user-images.githubusercontent.com/51502471/230007730-4c0daef6-55d6-4994-938f-ecc29861972f.png)

Fixed
![image](https://user-images.githubusercontent.com/51502471/230007809-18cef704-dd35-44bb-9de2-5eaa5fa1f5c0.png)


## Related Issue
https://issues.openmrs.org/browse/O3-2029

## Other
<!-- Anything not covered above -->
