### PR TITLE
(fix) KH-141: Filling 5 address fields shows only 4 fields in the patient banner.

### DIFF
--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
@@ -14,6 +14,7 @@ interface ContactDetailsProps {
 const Address: React.FC<{ address?: fhir.Address }> = ({ address }) => {
   const { t } = useTranslation();
 
+  const getAddressKey = (url) => url.split('#')[1];
   /*
     DO NOT REMOVE THIS COMMENT UNLESS YOU UNDERSTAND WHY IT IS HERE
 
@@ -37,12 +38,20 @@ const Address: React.FC<{ address?: fhir.Address }> = ({ address }) => {
         {address ? (
           <>
             {Object.entries(address)
-              .filter(([key]) => !['use', 'extension', 'id'].some((k) => k === key))
-              .map(([key, value]) => (
-                <li>
-                  {t(key)}: {value}
-                </li>
-              ))}
+              .filter(([key]) => !['use', 'id'].some((k) => k === key))
+              .map(([key, value]) =>
+                key === 'extension' ? (
+                  address?.extension[0]?.extension.map((add, i) => (
+                    <li>
+                      {t(getAddressKey(add.url))}: {add.valueString}
+                    </li>
+                  ))
+                ) : (
+                  <li>
+                    {t(key)}: {value}
+                  </li>
+                ),
+              )}
           </>
         ) : (
           '--'


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This PR displays the Address lines if they are available.

## Screenshots
- <img width="1077" alt="Screenshot 2023-04-06 at 16 22 25" src="https://user-images.githubusercontent.com/30952856/230399336-e1eccbad-5836-4c5f-afb3-ebb46e0c6488.png">
- <img width="1147" alt="Screenshot 2023-04-06 at 16 22 48" src="https://user-images.githubusercontent.com/30952856/230399304-987cb5d8-77ed-486a-8cec-1e4ef1d7aa6b.png">


## Related Issue
- https://issues.openmrs.org/browse/KH-141

