### PR TITLE
O3-1679: Test results header in the "Test Results" dashboard appearing twice

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
@@ -19,6 +19,8 @@ export interface DashboardConfig {
   slot: string;
   title: string;
   columns: number;
+  hideDashboardTitle: boolean;
+  
 }
 
 interface DashboardViewProps {
@@ -54,7 +56,7 @@ export function DashboardView({ dashboard, patientUuid, patient }: DashboardView
   return (
     <>
       <ExtensionSlot state={state} extensionSlotName="top-of-all-patient-dashboards-slot" />
-      {dashboard.title && <h1 className={styles.dashboardTitle}>{dashboard.title}</h1>}
+      {!dashboard.hideDashboardTitle && dashboard.title && <h1 className={styles.dashboardTitle}>{dashboard.title}</h1>}
       <ExtensionSlot
         key={dashboard.slot}
         extensionSlotName={dashboard.slot}

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
@@ -20,7 +20,6 @@ export interface DashboardConfig {
   title: string;
   columns: number;
   hideDashboardTitle: boolean;
-  
 }
 
 interface DashboardViewProps {

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
@@ -19,7 +19,7 @@ export interface DashboardConfig {
   slot: string;
   title: string;
   columns: number;
-  hideDashboardTitle: boolean;
+  hideDashboardTitle?: boolean;
 }
 
 interface DashboardViewProps {

--- a/packages/esm-patient-test-results-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-test-results-app/src/dashboard.meta.tsx
@@ -2,4 +2,5 @@ export const dashboardMeta = {
   slot: 'patient-chart-test-results-dashboard-slot',
   columns: 1,
   title: 'Test Results',
+  hideDashboardTitle: true 
 };

--- a/packages/esm-patient-test-results-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-test-results-app/src/dashboard.meta.tsx
@@ -2,5 +2,5 @@ export const dashboardMeta = {
   slot: 'patient-chart-test-results-dashboard-slot',
   columns: 1,
   title: 'Test Results',
-  hideDashboardTitle: true 
+  hideDashboardTitle: true,
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
 For changes to apps
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
Patient test results title was duplicated as Test results and Results. The required title is Results only.

## Screenshots

Before

![before](https://user-images.githubusercontent.com/94807133/230898211-795cf36a-ebea-40c8-acac-d4331ec80a16.png)




After

![after](https://user-images.githubusercontent.com/94807133/230898327-e5210608-05ea-49fd-bc27-3b4fe5cf59a6.png)

## Related Issue
https://issues.openmrs.org/browse/O3-1679

## Other
<!-- Anything not covered above -->
