### PR TITLE
(Fix) O3-1959: Test results showing two times when it is today's dateTime.

### DIFF
--- a/packages/esm-patient-test-results-app/src/panel-view/panel.component.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-view/panel.component.tsx
@@ -101,6 +101,7 @@ const LabSetPanel: React.FC<LabSetPanelProps> = ({ panel, observations, activePa
           <p className={styles.subtitleText}>
             {formatDate(date, {
               mode: 'wide',
+              time: false, // Exclude time since we are displaying it on the next line
             })}{' '}
             &bull; {`${date.getUTCHours()}:${date.getUTCMinutes()}`}
           </p>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Removes the time that comes with `formatDate`

## Screenshots
- Bug
<img width="1349" alt="Screenshot 2023-04-06 at 23 03 30" src="https://user-images.githubusercontent.com/30952856/230495546-d348a655-96ea-4705-b242-72124335a12a.png">

- Fixed
<img width="680" alt="Screenshot 2023-04-06 at 23 08 38" src="https://user-images.githubusercontent.com/30952856/230495604-f365ee33-f6e3-487a-a4b5-cd7bfb34ed3e.png">


## Related Issue
- https://issues.openmrs.org/projects/O3/issues/O3-1959

