### PR TITLE
(fix) O3-2031: Remove unused configuration properties from useVisitNotes

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -94,6 +94,10 @@ export const esmPatientChartSchema = {
     _description: 'The UUID of the visit attribute that contains the visit queue number.',
     _default: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
   },
+  vitalsEncounterUuid: {
+    _type: Type.UUID,
+    _default: '67a71486-1a54-468f-ac3e-7091a9a79584',
+  },
 };
 
 export interface ChartConfig {
@@ -107,6 +111,7 @@ export interface ChartConfig {
   }>;
   showServiceQueueFields: boolean;
   visitQueueNumberAttributeUuid: string;
+  vitalsEncounterUuid: string;
 }
 
 export const configSchema = {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -46,6 +46,7 @@ import type { HtmlFormEntryForm } from '@openmrs/esm-patient-forms-app/src/confi
 import { MappedEncounter } from '../visit-summary.component';
 import EncounterObservations from '../../encounter-observations';
 import styles from './visits-table.scss';
+import { ChartConfig } from '../../../../config-schema';
 
 interface VisitTableProps {
   visits: Array<MappedEncounter>;
@@ -63,6 +64,7 @@ type FilterProps = {
 
 const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, patientUuid }) => {
   const visitCount = 20;
+  const config = useConfig() as ChartConfig;
   const { t } = useTranslation();
   const desktopLayout = isDesktop(useLayoutType());
 
@@ -242,27 +244,21 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
                                     visits[index]?.visitTypeUuid,
                                   )
                                 }
-                              >
-                                {t('editThisEncounter', 'Edit this encounter')}
-                              </OverflowMenuItem>
+                              />
                               <OverflowMenuItem
                                 size={desktopLayout ? 'sm' : 'lg'}
                                 className={styles.menuItem}
                                 id="#goToEncounter"
                                 itemText={t('goToThisEncounter', 'Go to this encounter')}
-                              >
-                                {t('editThisEncounter', 'Edit this encounter')}
-                              </OverflowMenuItem>
+                              />
                               <OverflowMenuItem
                                 size={desktopLayout ? 'sm' : 'lg'}
                                 className={styles.menuItem}
-                                id="#editEncounter"
+                                id="#deleteEncounter"
                                 itemText={t('deleteThisEncounter', 'Delete this encounter')}
                                 hasDivider
                                 isDelete
-                              >
-                                itemText={t('deleteThisEncounter', 'Delete this encounter')}
-                              </OverflowMenuItem>
+                              />
                             </OverflowMenu>
                           </Layer>
                         </TableCell>

--- a/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
@@ -20,7 +20,7 @@ interface UseVisitNotes {
 
 export function useVisitNotes(patientUuid: string): UseVisitNotes {
   const {
-    visitNoteConfig: { encounterNoteTextConceptUuid, problemListConceptUuid, visitDiagnosesConceptUuid },
+    visitNoteConfig: { encounterNoteTextConceptUuid, visitDiagnosesConceptUuid },
   } = useConfig();
 
   const customRepresentation =


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Removes the unused **problemListConceptUuid** config property from useVistNotes to improve clarity and reduce potential confusion
 
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
- https://issues.openmrs.org/browse/O3-2031

## Other
<!-- Anything not covered above -->
