### PR TITLE
(fix) O3-2031: Remove unused configuration properties from useVisitNotes

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -5,14 +5,6 @@ export const esmPatientChartSchema = {
     _default: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     _type: Type.ConceptUuid,
   },
-  problemListConceptUuid: {
-    _default: '1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-    _type: Type.ConceptUuid,
-  },
-  diagnosisOrderConceptUuid: {
-    _default: '159946AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-    _type: Type.ConceptUuid,
-  },
   notesConceptUuids: {
     _type: Type.Array,
     _default: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'],

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
@@ -22,8 +22,6 @@ jest.mock('@openmrs/esm-framework', () => {
       return {
         notesConceptUuids: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'some-uuid2'],
         visitDiagnosisConceptUuid: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-        problemListConceptUuid: '1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-        diagnosisOrderConceptUuid: '159946AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
       };
     }),
   };

--- a/packages/esm-patient-notes-app/src/notes/visit-note-config-schema.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-note-config-schema.ts
@@ -21,14 +21,6 @@ export default {
     _type: Type.ConceptUuid,
     _default: 'c75f120a-04ec-11e3-8780-2b40bef9a44b',
   },
-  problemListConceptUuid: {
-    _default: '1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-    _type: Type.ConceptUuid,
-  },
-  diagnosisOrderConceptUuid: {
-    _default: '159946AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-    _type: Type.ConceptUuid,
-  },
 };
 
 export interface VisitNoteConfigObject {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
@@ -20,7 +20,7 @@ interface UseVisitNotes {
 
 export function useVisitNotes(patientUuid: string): UseVisitNotes {
   const {
-    visitNoteConfig: { encounterNoteTextConceptUuid, problemListConceptUuid, visitDiagnosesConceptUuid },
+    visitNoteConfig: { encounterNoteTextConceptUuid, visitDiagnosesConceptUuid },
   } = useConfig();
 
   const customRepresentation =


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Removes the unused **problemListConceptUuid** config property from useVistNotes to improve clarity and reduce potential confusion
 
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
- https://issues.openmrs.org/browse/O3-2031

## Other
<!-- Anything not covered above -->
