### PR TITLE
(feat) Add correct form-error UI as shown on the designs

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-error.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-error.component.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Button } from '@carbon/react';
+import styles from './form-error.scss';
+import { useTranslation } from 'react-i18next';
+import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+
+interface FormErrorProps {
+  closeWorkspace: () => void;
+}
+
+const FormError: React.FC<FormErrorProps> = ({ closeWorkspace }) => {
+  const { t } = useTranslation();
+
+  const handleOpenFormList = () => {
+    closeWorkspace();
+    launchPatientWorkspace('clinical-forms-workspace');
+  };
+
+  return (
+    <div className={styles.errorContainer}>
+      <div className={styles.formErrorCard}>
+        <p className={styles.errorTitle}>{t('errorTitle', 'There was an error with this form')}</p>
+        <div className={styles.errorMessage}>
+          <span>{t('tryAgainMessage', 'Try opening another form from')}</span>
+          <span className={styles.list} role="button" tabIndex={0} onClick={handleOpenFormList}>
+            {t('thisList', 'this list')}
+          </span>
+        </div>
+        <div className={styles.separator}>{t('or', 'or')}</div>
+        <Button onClick={closeWorkspace} kind="ghost">
+          {t('closeThisPanel', 'Close this panel')}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default FormError;

--- a/packages/esm-form-engine-app/src/form-renderer/form-error.scss
+++ b/packages/esm-form-engine-app/src/form-renderer/form-error.scss
@@ -1,0 +1,74 @@
+@use '@carbon/styles/scss/spacing';
+@use '@carbon/colors';
+@use '@carbon/styles/scss/type';
+
+.errorContainer {
+  display: flex;
+  justify-content: center;
+  margin-top: spacing.$spacing-05;
+}
+
+.formErrorCard {
+  background-color: colors.$gray-10;
+  padding: spacing.$spacing-05;
+  min-width: 23rem;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+}
+
+.errorTitle {
+  @include type.type-style("heading-compact-02");
+  margin-bottom: spacing.$spacing-04;
+}
+
+.errorMessage {
+  @include type.type-style("body-long-01");
+  margin-bottom: spacing.$spacing-05;
+  color: colors.$gray-70;
+  display: flex;
+  align-items: center;
+
+  &>button {
+    padding: 0 0 0 spacing.$spacing-01 !important;
+  }
+}
+
+
+.separator {
+  @include type.type-style('body-01');
+  color: colors.$gray-90;
+  width: 12rem;
+  margin: spacing.$spacing-03 0;
+  overflow: hidden;
+  text-align: center;
+  color: colors.$gray-70;
+}
+
+.separator::before,
+.separator::after {
+  background-color: colors.$gray-40;
+  content: "";
+  display: inline-block;
+  height: 1px;
+  position: relative;
+  vertical-align: middle;
+  width: 50%;
+}
+
+.separator::before {
+  right: 1rem;
+  margin-left: -50%;
+}
+
+.separator::after {
+  left: 1rem;
+  margin-right: -50%;
+}
+
+.list {
+  margin-left: spacing.$spacing-02;
+  color:colors.$blue-60;
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/packages/esm-form-engine-app/src/form-renderer/form-error.test.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-error.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+
+import FormError from './form-error.component';
+
+const mockLaunchPatientWorkspace = launchPatientWorkspace as jest.Mock;
+
+jest.mock('@openmrs/esm-patient-common-lib', () => ({
+  launchPatientWorkspace: jest.fn(),
+}));
+
+describe('FormError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders correctly', () => {
+    const closeWorkspace = jest.fn();
+    render(<FormError closeWorkspace={closeWorkspace} />);
+    expect(screen.getByText('There was an error with this form')).toBeInTheDocument();
+    expect(screen.getByText('Try opening another form from')).toBeInTheDocument();
+    expect(screen.getByText('this list')).toBeInTheDocument();
+    expect(screen.getByText('Close this panel')).toBeInTheDocument();
+  });
+
+  test('calls the closeWorkspace function when the button is clicked', () => {
+    const closeWorkspace = jest.fn();
+    render(<FormError closeWorkspace={closeWorkspace} />);
+    const closeButton = screen.getByRole('button', { name: /close this panel/i });
+    fireEvent.click(closeButton);
+    expect(closeWorkspace).toHaveBeenCalled();
+  });
+
+  test('calls the closeWorkspace and opens the form dashboard function when the this `list` is clicked', () => {
+    const closeWorkspace = jest.fn();
+    render(<FormError closeWorkspace={closeWorkspace} />);
+    const link = screen.getByRole('button', { name: /this list/i });
+    fireEvent.click(link);
+    expect(closeWorkspace).toHaveBeenCalled();
+    expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('clinical-forms-workspace');
+  });
+});

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import useForm from '../hooks/useForm';
 import useSchema from '../hooks/useSchema';
 import { OHRIForm } from '@openmrs/openmrs-form-engine-lib';
-import { InlineNotification, InlineLoading } from '@carbon/react';
+import { InlineLoading } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import styles from './form-renderer.scss';
+import FormError from './form-error.component';
 
 interface FormRendererProps {
   formUuid: string;
@@ -19,18 +20,7 @@ const FormRenderer: React.FC<FormRendererProps> = ({ formUuid, patientUuid, clos
   const { schema, isLoading: schemaLoading, error: schemaError } = useSchema(valueReferenceUuid);
 
   if (formError || schemaError) {
-    return (
-      <InlineNotification
-        kind="error"
-        lowContrast
-        iconDescription={(error: any) =>
-          error?.response?.data?.error?.message ? error.response.data.error.message : error
-        }
-        title={t('error', 'Error loading form')}
-        subtitle={t('errorLoadingForm', 'An error occurred while loading the form')}
-        onClose={closeWorkspace}
-      />
-    );
+    return <FormError closeWorkspace={closeWorkspace} />;
   }
 
   if (schemaLoading) {

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, waitFor, screen } from '@testing-library/react';
+import FormRenderer from './form-renderer.component';
+import useForm from '../hooks/useForm';
+import useSchema from '../hooks/useSchema';
+
+jest.mock('@openmrs/openmrs-form-engine-lib', () => ({
+  OHRIForm: jest
+    .fn()
+    .mockImplementation(() => React.createElement('div', { 'data-testid': 'openmrs form' }, 'FORM ENGINE LIB')),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue: string) => defaultValue,
+  }),
+}));
+
+jest.mock('../hooks/useForm');
+jest.mock('../hooks/useSchema', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('FormRenderer', () => {
+  const defaultProps = {
+    formUuid: 'test-form-uuid',
+    patientUuid: 'test-patient-uuid',
+    closeWorkspace: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useForm as jest.Mock).mockReset();
+    (useSchema as jest.Mock).mockReset();
+  });
+
+  test('renders FormError component when there is an error', () => {
+    (useForm as jest.Mock).mockReturnValue({ form: null, isLoading: false, error: 'Error message' });
+    (useSchema as jest.Mock).mockReturnValue({ schema: null, isLoading: false, error: null });
+
+    render(<FormRenderer {...defaultProps} />);
+    expect(screen.getByText('There was an error with this form')).toBeInTheDocument();
+  });
+
+  test('renders InlineLoading component when loading', () => {
+    (useForm as jest.Mock).mockReturnValue({ form: null, isLoading: true, error: null });
+    (useSchema as jest.Mock).mockReturnValue({ schema: null, isLoading: true, error: null });
+
+    const { getByText } = render(<FormRenderer {...defaultProps} />);
+    expect(getByText('Loading ...')).toBeInTheDocument();
+  });
+
+  test('renders FORM Engine component when schema is available', async () => {
+    const mockForm = {
+      resources: [
+        {
+          name: 'JSON schema',
+          valueReference: 'test-schema-uuid',
+        },
+      ],
+    };
+
+    (useForm as jest.Mock).mockReturnValue({ form: mockForm, isLoading: false, error: null });
+    (useSchema as jest.Mock).mockReturnValue({ schema: { id: 'test-schema' }, isLoading: false, error: null });
+
+    render(<FormRenderer {...defaultProps} />);
+    await waitFor(() => expect(screen.getByText('FORM ENGINE LIB')).toBeInTheDocument());
+  });
+});

--- a/packages/esm-form-engine-app/translations/en.json
+++ b/packages/esm-form-engine-app/translations/en.json
@@ -1,5 +1,7 @@
 {
-  "error": "Error loading form",
-  "errorLoadingForm": "An error occurred while loading the form",
-  "loading": "Loading"
+  "closeThisPanel": "Close this panel",
+  "errorTitle": "There was an error with this form",
+  "loading": "Loading",
+  "or": "or",
+  "tryAgainMessage": "Try opening another form from"
 }

--- a/tools/setupTests.ts
+++ b/tools/setupTests.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/extend-expect';
 
 declare global {
   interface Window {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Add UI as per the design to be shown if there is an error while trying to launch the form [zeplin-design](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/626a6020dd92b8014fbf3235)
Add `import `@testing-library/jest-dom/extend-expect` to squash typescript error on test suites files

## Screenshots
![Kapture 2023-04-08 at 13 08 36](https://user-images.githubusercontent.com/28008754/230715804-aef1fe69-f440-4878-bc1c-f77454148541.gif)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
