### PR TITLE
(feat) Add ability to launch form in edit mode and handle error if form does not have associated JSON schema

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
-import { InlineLoading } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
+import { InlineLoading } from '@carbon/react';
 import { OHRIForm } from '@openmrs/openmrs-form-engine-lib';
-import FormError from './form-error.component';
+
 import useForm from '../hooks/useForm';
 import useSchema from '../hooks/useSchema';
+import FormError from './form-error.component';
+
 import styles from './form-renderer.scss';
 
 interface FormRendererProps {
   formUuid: string;
   patientUuid: string;
   closeWorkspace: () => void;
+  encounterUuid?: string;
 }
 
-const FormRenderer: React.FC<FormRendererProps> = ({ formUuid, patientUuid, closeWorkspace }) => {
+const FormRenderer: React.FC<FormRendererProps> = ({ formUuid, patientUuid, closeWorkspace, encounterUuid }) => {
   const { t } = useTranslation();
   const { form, formLoadError } = useForm(formUuid);
 
@@ -33,7 +36,17 @@ const FormRenderer: React.FC<FormRendererProps> = ({ formUuid, patientUuid, clos
   }
 
   return (
-    <>{schema && <OHRIForm patientUUID={patientUuid} formJson={schema} mode="enter" handleClose={closeWorkspace} />}</>
+    <>
+      {schema && (
+        <OHRIForm
+          encounterUUID={encounterUuid}
+          patientUUID={patientUuid}
+          formJson={schema}
+          handleClose={closeWorkspace}
+          onSubmit={() => closeWorkspace()}
+        />
+      )}
+    </>
   );
 };
 

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.scss
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.scss
@@ -1,8 +1,9 @@
+@use '@carbon/colors';
 @use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@use '@carbon/styles/scss/type';
 
 .loaderContainer {
-  height: 100vh;   
+  height: 100vh;
 }
 
 .loading {

--- a/packages/esm-form-engine-app/translations/en.json
+++ b/packages/esm-form-engine-app/translations/en.json
@@ -4,5 +4,9 @@
   "loading": "Loading",
   "or": "or",
   "thisList": "this list",
-  "tryAgainMessage": "Try opening another form from"
+  "tryAgainMessage": "Try opening another form from",
+  "emptyIcon": "Empty icon",
+  "errorLoadingForm": "An error occurred while loading the form",
+  "errorLoadingFormMessage": "An error occurred while loading the form",
+  "missingJSONSchema": "The specified form is missing JSON schema"
 }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -124,7 +124,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
     const htmlForm = htmlFormEntryFormsConfig?.find((form) => form.formUuid === formUuid);
     if (isEmpty(htmlForm)) {
       formEntrySub.next({ formUuid, visitUuid, encounterUuid, visitTypeUuid });
-      launchPatientWorkspace('patient-form-entry-workspace', { workspaceTitle: formName });
+      launchPatientWorkspace('patient-form-entry-workspace', { workspaceTitle: formName, formUuid, encounterUuid });
     } else {
       navigate({
         to: `\${openmrsBase}/htmlformentryui/htmlform/${htmlForm.formUiPage}.page?patientId=${patientUuid}&visitId=${visitUuid}&encounterId=${encounterUuid}&definitionUiResource=${htmlForm.formUiResource}&returnUrl=${window.location.href}`,

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -9,7 +9,6 @@ export function useVisits(patientUuid: string) {
     `/ws/rest/v1/visit?patient=${patientUuid}&v=${customRepresentation}`,
     openmrsFetch,
   );
-
   return {
     visits: data ? data?.data?.results : null,
     isError: error,

--- a/packages/esm-patient-forms-app/src/form-entry-interop.ts
+++ b/packages/esm-patient-forms-app/src/form-entry-interop.ts
@@ -34,5 +34,10 @@ export function launchFormEntry(
   mutateForm?: () => void,
 ) {
   formEntrySub.next({ formUuid, encounterUuid });
-  launchPatientWorkspace('patient-form-entry-workspace', { workspaceTitle: formName, mutateForm, formUuid });
+  launchPatientWorkspace('patient-form-entry-workspace', {
+    workspaceTitle: formName,
+    mutateForm,
+    formUuid,
+    encounterUuid,
+  });
 }

--- a/packages/esm-patient-forms-app/src/forms/form-view.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-view.test.tsx
@@ -78,6 +78,8 @@ describe('FormView', () => {
     expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('patient-form-entry-workspace', {
       workspaceTitle: 'POC COVID 19 Assessment Form v1.1',
       formUuid: '0a9fc16e-4c00-4842-a1e4-e4bafeb6e226',
+      mutateForm: undefined,
+      encounterUuid: '',
     });
   });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Add ability to launch the form in edit mode
Add UI to alert users in cases where the form associated JSON schema is missing

## Screenshots
![Kapture 2023-04-08 at 15 13 49](https://user-images.githubusercontent.com/28008754/230720475-b3b76ba0-942c-4065-8827-8c55d214bf55.gif)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
