### PR TITLE
(bug) Fix bug on starting a visit where there is only one visit-type

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.component.tsx
@@ -30,6 +30,10 @@ const BaseVisitType: React.FC<BaseVisitTypeProps> = ({ onChange, visitTypes }) =
 
   const { results, currentPage, goTo } = usePagination(searchResults, 5);
 
+  if (results?.length === 1) {
+    onChange(results[0].uuid);
+  }
+
   return (
     <div className={`${styles.visitTypeOverviewWrapper} ${isTablet ? styles.tablet : styles.desktop}`}>
       {visitTypes.length ? (
@@ -40,7 +44,6 @@ const BaseVisitType: React.FC<BaseVisitTypeProps> = ({ onChange, visitTypes }) =
                 onChange={(event) => handleSearch(event.target.value)}
                 placeholder={t('searchForAVisitType', 'Search for a visit type')}
                 labelText=""
-                light={isTablet}
               />
             </Layer>
           ) : (
@@ -48,7 +51,6 @@ const BaseVisitType: React.FC<BaseVisitTypeProps> = ({ onChange, visitTypes }) =
               onChange={(event) => handleSearch(event.target.value)}
               placeholder={t('searchForAVisitType', 'Search for a visit type')}
               labelText=""
-              light={isTablet}
             />
           )}
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -76,13 +76,7 @@ const StartVisitForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWor
     blockSavingForm: boolean;
   }>(null);
   const [selectedLocation, setSelectedLocation] = useState(() => (sessionLocation ? sessionLocation : ''));
-  const [visitType, setVisitType] = useState<string | null>(() => {
-    if (locations?.length && sessionUser?.sessionLocation?.uuid) {
-      return allVisitTypes?.length === 1 ? allVisitTypes[0].uuid : null;
-    }
-
-    return null;
-  });
+  const [visitType, setVisitType] = useState<string | null>(null);
   const visitQueueNumberAttributeUuid = config.visitQueueNumberAttributeUuid;
 
   const handleSubmit = useCallback(


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Fixes a bug of being unable to start a visit when there is only one visit type returned from the backend. Retains the normal workflow where visit types are many.

## Screenshots
![Kapture 2023-04-08 at 16 48 19](https://user-images.githubusercontent.com/28008754/230724946-b7424d6b-de66-46f3-8f1b-ac1211a7f2f6.gif)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
