### PR TITLE
(bug) Fix bug on launching vitals form to use form-engine

### DIFF
--- a/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
@@ -27,7 +27,7 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({ patientUuid, closeWorksp
       patient,
       encounterUuid: selectedForm?.encounterUuid ?? null,
       closeWorkspace: () => {
-        mutateForm();
+        typeof mutateForm === 'function' && mutateForm();
         closeWorkspace();
       },
     }),

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-utils.ts
@@ -1,17 +1,24 @@
 import { Visit } from '@openmrs/esm-framework';
-import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
 import { ConfigObject } from '../config-schema';
 import { patientVitalsBiometricsFormWorkspace } from '../constants';
 import { launchFormEntry } from './vitals-overview.component';
+import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
 
+/**
+ * Launches the appropriate workspace based on the current visit and configuration.
+ * @param currentVisit - The current visit.
+ * @param config - The configuration object.
+ */
 export function launchVitalsForm(currentVisit: Visit, config: ConfigObject) {
-  if (currentVisit && config.vitals.useFormEngine) {
-    launchFormEntry(config.vitals.formUuid, '', config.vitals.formName);
-  }
-  if (currentVisit) {
-    launchPatientWorkspace(patientVitalsBiometricsFormWorkspace);
-  }
   if (!currentVisit) {
     launchStartVisitPrompt();
+    return;
+  }
+
+  if (config.vitals.useFormEngine) {
+    const { formUuid, formName } = config.vitals;
+    launchFormEntry(formUuid, '', formName);
+  } else {
+    launchPatientWorkspace(patientVitalsBiometricsFormWorkspace);
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Add conditional check before calling the mutate function
Fix bug where opening the vitals form launched both the form-entry and the normal vitals form provided by `esm-vitals-app`. Please not on the GIF below i am using the Billy form Uuid just for testing purposes

## Screenshots
![Kapture 2023-04-10 at 13 18 40](https://user-images.githubusercontent.com/28008754/230883227-4fae0e23-aaa0-49d3-9982-03a277164558.gif)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
