### PR TITLE
(fix) Restore success toast shown after starting a visit

### DIFF
--- a/packages/esm-form-engine-app/translations/en.json
+++ b/packages/esm-form-engine-app/translations/en.json
@@ -3,5 +3,6 @@
   "errorTitle": "There was an error with this form",
   "loading": "Loading",
   "or": "or",
+  "thisList": "this list",
   "tryAgainMessage": "Try opening another form from"
 }

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -45,11 +45,11 @@ import {
   PatientProgram,
 } from '@openmrs/esm-patient-common-lib';
 import BaseVisitType from './base-visit-type.component';
-import styles from './visit-form.scss';
 import { MemoizedRecommendedVisitType } from './recommended-visit-type.component';
 import { ChartConfig } from '../../config-schema';
 import VisitAttributeTypeFields from './visit-attribute-type.component';
 import { saveQueueEntry } from '../hooks/useServiceQueue';
+import styles from './visit-form.scss';
 
 const StartVisitForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWorkspace, promptBeforeClosing }) => {
   const { t } = useTranslation();
@@ -170,10 +170,9 @@ const StartVisitForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWor
               showToast({
                 critical: true,
                 kind: 'success',
-                description: t(
-                  'visitStartedSuccessfully',
-                  `${response?.data?.visitType?.display} started successfully`,
-                ),
+                description: t('visitStartedSuccessfully', '{visit} started successfully', {
+                  visit: response?.data?.visitType?.display ?? `Visit`,
+                }),
                 title: t('visitStarted', 'Visit started'),
               });
             }

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -77,7 +77,7 @@ describe('Visit Form', () => {
 
     renderVisitForm();
 
-    const saveButton = screen.getByRole('button', { name: /Start Visit/i });
+    const saveButton = screen.getByRole('button', { name: /start visit/i });
 
     await waitFor(() => user.click(saveButton));
 
@@ -91,7 +91,7 @@ describe('Visit Form', () => {
     expect(errorAlert).not.toBeInTheDocument();
   });
 
-  it('starts a new visit upon successful submission of the', async () => {
+  it('starts a new visit upon successful submission of the form', async () => {
     const user = userEvent.setup();
 
     renderVisitForm();
@@ -132,7 +132,7 @@ describe('Visit Form', () => {
     expect(showToast).toHaveBeenCalledTimes(1);
     expect(showToast).toHaveBeenCalledWith({
       critical: true,
-      description: 'Facility Visit started successfully',
+      description: expect.stringContaining('started successfully'),
       kind: 'success',
       title: 'Visit started',
     });

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -113,7 +113,7 @@
   "visits": "visits",
   "Visits": "Visits",
   "visitStarted": "Visit started",
-  "visitStartedSuccessfully": "",
+  "visitStartedSuccessfully": "{visit} started successfully",
   "visitSummaries": "Visit summaries",
   "visitType": "Visit type",
   "workspaceModalText": "Launching a new form in the workspace could cause you to lose unsaved work on the {formName} form.",

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -206,7 +206,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, patie
 
           showToast({
             critical: true,
-            description: t('visitNoteNowVisible', 'It is now visible on the Encounters     page'),
+            description: t('visitNoteNowVisible', 'It is now visible on the Encounters page'),
             kind: 'success',
             title: t('visitNoteSaved', 'Visit note saved'),
           });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Restores the success toast notification shown after starting a visit successfully. 