### PR TITLE
(feat) Tweak form engine loading UI

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-error.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-error.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Button } from '@carbon/react';
-import styles from './form-error.scss';
 import { useTranslation } from 'react-i18next';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import styles from './form-error.scss';
 
 interface FormErrorProps {
   closeWorkspace: () => void;

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -15,11 +15,12 @@ interface FormRendererProps {
 
 const FormRenderer: React.FC<FormRendererProps> = ({ formUuid, patientUuid, closeWorkspace }) => {
   const { t } = useTranslation();
-  const { form, isLoading: formLoading, error: formError } = useForm(formUuid);
-  const valueReferenceUuid = form?.resources.find((resource) => resource.name === 'JSON schema')?.valueReference;
-  const { schema, isLoading: schemaLoading, error: schemaError } = useSchema(valueReferenceUuid);
+  const { form, formLoadError } = useForm(formUuid);
 
-  if (schemaLoading) {
+  const valueReferenceUuid = form?.resources.find((resource) => resource.name === 'JSON schema')?.valueReference;
+  const { schema, isLoadingSchema, schemaLoadError } = useSchema(valueReferenceUuid);
+
+  if (isLoadingSchema) {
     return (
       <div className={styles.loaderContainer}>
         <InlineLoading className={styles.loading} description={`${t('loading', 'Loading')} ...`} />
@@ -27,12 +28,9 @@ const FormRenderer: React.FC<FormRendererProps> = ({ formUuid, patientUuid, clos
     );
   }
 
-  if (formError || schemaError) {
+  if (formLoadError || schemaLoadError) {
     return <FormError closeWorkspace={closeWorkspace} />;
   }
-
-  console.log('form: ', form);
-  console.log('schema: ', schema);
 
   return (
     <>{schema && <OHRIForm patientUUID={patientUuid} formJson={schema} mode="enter" handleClose={closeWorkspace} />}</>

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import useForm from '../hooks/useForm';
-import useSchema from '../hooks/useSchema';
-import { OHRIForm } from '@openmrs/openmrs-form-engine-lib';
 import { InlineLoading } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import styles from './form-renderer.scss';
+import { OHRIForm } from '@openmrs/openmrs-form-engine-lib';
 import FormError from './form-error.component';
+import useForm from '../hooks/useForm';
+import useSchema from '../hooks/useSchema';
+import styles from './form-renderer.scss';
 
 interface FormRendererProps {
   formUuid: string;
@@ -19,13 +19,20 @@ const FormRenderer: React.FC<FormRendererProps> = ({ formUuid, patientUuid, clos
   const valueReferenceUuid = form?.resources.find((resource) => resource.name === 'JSON schema')?.valueReference;
   const { schema, isLoading: schemaLoading, error: schemaError } = useSchema(valueReferenceUuid);
 
+  if (schemaLoading) {
+    return (
+      <div className={styles.loaderContainer}>
+        <InlineLoading className={styles.loading} description={`${t('loading', 'Loading')} ...`} />
+      </div>
+    );
+  }
+
   if (formError || schemaError) {
     return <FormError closeWorkspace={closeWorkspace} />;
   }
 
-  if (schemaLoading) {
-    return <InlineLoading className={styles.loading} description={`${t('loading', 'Loading')} ...`} />;
-  }
+  console.log('form: ', form);
+  console.log('schema: ', schema);
 
   return (
     <>{schema && <OHRIForm patientUUID={patientUuid} formJson={schema} mode="enter" handleClose={closeWorkspace} />}</>

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.scss
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.scss
@@ -1,9 +1,13 @@
 @use '@carbon/styles/scss/spacing';
 @import '~@openmrs/esm-styleguide/src/vars';
 
+.loaderContainer {
+  height: 100vh;   
+}
+
 .loading {
-    display: flex;
-    background-color: $openmrs-background-grey;
-    justify-content: center;
-    min-height: spacing.$spacing-09;
-  }
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 50%;
+}

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
@@ -35,16 +35,17 @@ describe('FormRenderer', () => {
   });
 
   test('renders FormError component when there is an error', () => {
-    (useForm as jest.Mock).mockReturnValue({ form: null, isLoading: false, error: 'Error message' });
-    (useSchema as jest.Mock).mockReturnValue({ schema: null, isLoading: false, error: null });
+    (useForm as jest.Mock).mockReturnValue({ form: null, isLoadingForm: false, formLoadError: 'Error message' });
+    (useSchema as jest.Mock).mockReturnValue({ schema: null, isLoadingSchema: false, schemaLoadError: null });
 
     render(<FormRenderer {...defaultProps} />);
+
     expect(screen.getByText('There was an error with this form')).toBeInTheDocument();
   });
 
   test('renders InlineLoading component when loading', () => {
-    (useForm as jest.Mock).mockReturnValue({ form: null, isLoading: true, error: null });
-    (useSchema as jest.Mock).mockReturnValue({ schema: null, isLoading: true, error: null });
+    (useForm as jest.Mock).mockReturnValue({ form: null, isLoadingForm: true, formLoadError: null });
+    (useSchema as jest.Mock).mockReturnValue({ schema: null, isLoadingSchema: true, schemaLoadError: null });
 
     const { getByText } = render(<FormRenderer {...defaultProps} />);
     expect(getByText('Loading ...')).toBeInTheDocument();

--- a/packages/esm-form-engine-app/src/hooks/useForm.tsx
+++ b/packages/esm-form-engine-app/src/hooks/useForm.tsx
@@ -1,10 +1,13 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
 import useSWR from 'swr';
+import { openmrsFetch } from '@openmrs/esm-framework';
 import { Form } from '../types';
 
 const useForm = (formUuid: string) => {
-  const { data, error, isLoading } = useSWR<{ data: Form }>(`/ws/rest/v1/form/${formUuid}?v=full`, openmrsFetch);
-  return { form: data?.data, error, isLoading };
+  const url = `/ws/rest/v1/form/${formUuid}?v=full`;
+
+  const { data, error, isLoading } = useSWR<{ data: Form }>(formUuid ? url : null, openmrsFetch);
+
+  return { form: data?.data, formLoadError: error, isLoadingForm: isLoading };
 };
 
 export default useForm;

--- a/packages/esm-form-engine-app/src/hooks/useSchema.tsx
+++ b/packages/esm-form-engine-app/src/hooks/useSchema.tsx
@@ -3,11 +3,10 @@ import { openmrsFetch } from '@openmrs/esm-framework';
 import { OHRIFormSchema } from '@openmrs/openmrs-form-engine-lib';
 
 const useSchema = (valueReferenceUuid: string) => {
-  const { data, isLoading, error } = useSWR<{ data: OHRIFormSchema }>(
-    valueReferenceUuid ? `/ws/rest/v1/clobdata/${valueReferenceUuid}` : null,
-    openmrsFetch,
-  );
-  return { schema: data?.data, isLoading, error };
+  const url = `/ws/rest/v1/clobdata/${valueReferenceUuid}`;
+  const { data, isLoading, error } = useSWR<{ data: OHRIFormSchema }>(valueReferenceUuid ? url : null, openmrsFetch);
+
+  return { schema: data?.data, isLoadingSchema: isLoading, schemaLoadError: error };
 };
 
 export default useSchema;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Tweaks the form loading UI so that the loading spinner's container fills the vertical viewport and the spinner gets centred on the page. Additionally, this PR also makes some useful refactors with the aim of cleaning up some of the related code.

## Video

https://user-images.githubusercontent.com/8509731/231287709-668b2c56-6c53-4954-b2a3-63459648211f.mp4

