### PR TITLE
(fix): KH-142: Remove the time for today's dates.

### DIFF
--- a/packages/esm-patient-test-results-app/src/panel-timeline/helpers.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-timeline/helpers.tsx
@@ -21,7 +21,7 @@ export const parseTime: (sortedTimes: Array<string>) => ParsedTimeType = (sorted
   sortedTimes.forEach((datetime) => {
     const parsedDate = parseDate(datetime);
     const year = parsedDate.getFullYear().toString();
-    const date = formatDate(parsedDate, { mode: 'wide', year: false });
+    const date = formatDate(parsedDate, { mode: 'wide', year: false, time: false });
     const time = formatTime(parsedDate);
 
     const yearColumn = yearColumns.find(({ year: innerYear }) => year === innerYear);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This PR fixes the bug we had in the test results timeline view where `today's` date was duplicating time.

## Screenshots
- Bug
<img width="571" alt="Screenshot 2023-04-18 at 02 05 04" src="https://user-images.githubusercontent.com/30952856/232632832-e09e7f48-bffa-47a7-a1fc-2d6363c472c1.png">

- Fix
<img width="537" alt="Screenshot 2023-04-18 at 02 10 48" src="https://user-images.githubusercontent.com/30952856/232632874-207533da-7106-4a1d-9f9a-3bc6d11fd187.png">


## Related Issue
- https://issues.openmrs.org/browse/O3-1844

