### PR TITLE
(fix) 03-1952: Do not show the Edit Encounter button for undeveloped forms

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -298,30 +298,34 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
                       <TableExpandedRow className={styles.expandedRow} colSpan={headers.length + 2}>
                         <>
                           <EncounterObservations observations={visits[index].obs} />
-                          <Button
-                            kind="ghost"
-                            onClick={() =>
-                              launchWorkspace(
-                                visits[index].form.uuid,
-                                visits[index].visitUuid,
-                                visits[index].id,
-                                visits[index].form.display,
-                                visits[index].visitTypeUuid,
-                              )
-                            }
-                            renderIcon={(props) => <Edit size={16} {...props} />}
-                            style={{ marginLeft: '-1rem', marginTop: '0.5rem' }}
-                          >
-                            {t('editEncounter', 'Edit encounter')}
-                          </Button>
-                          <Button
-                            kind="danger--ghost"
-                            onClick={() => handleDeleteEncounter(visits[index].id, visits[index].form.display)}
-                            renderIcon={(props) => <TrashCan size={16} {...props} />}
-                            style={{ marginLeft: '-1rem', marginTop: '0.5rem' }}
-                          >
-                            {t('deleteThisEncounter', 'Delete this encounter')}
-                          </Button>
+                          {visits[index]?.form?.uuid && (
+                            <Button
+                              kind="ghost"
+                              onClick={() =>
+                                launchWorkspace(
+                                  visits[index].form.uuid,
+                                  visits[index].visitUuid,
+                                  visits[index].id,
+                                  visits[index].form.display,
+                                  visits[index].visitTypeUuid,
+                                )
+                              }
+                              renderIcon={(props) => <Edit size={16} {...props} />}
+                              style={{ marginLeft: '-1rem', marginTop: '0.5rem' }}
+                            >
+                              {t('editEncounter', 'Edit encounter')}
+                            </Button>
+                          )}
+                          {visits[index]?.form?.display && (
+                            <Button
+                              kind="danger--ghost"
+                              onClick={() => handleDeleteEncounter(visits[index].id, visits[index].form.display)}
+                              renderIcon={(props) => <TrashCan size={16} {...props} />}
+                              style={{ marginLeft: '-1rem', marginTop: '0.5rem' }}
+                            >
+                              {t('deleteThisEncounter', 'Delete this encounter')}
+                            </Button>
+                          )}
                         </>
                       </TableExpandedRow>
                     ) : (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This pull request addresses the issue O3-1952, which is related to editing visits. The reported issue stated that an error message was displayed at the bottom of the page when trying to edit a visit, and this was caused by the absence of a form UUID for some forms that have not been developed yet. To fix this, a condition has been added to check for the presence of a form UUID before launching the form for editing.This ensures that only forms that have been developed and have a valid UUID can be edited without encountering errors.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
- https://issues.openmrs.org/browse/O3-1952

## Other
<!-- Anything not covered above -->
