### PR TITLE
(fix) O3-1955: Error message upon fetching of the order templates by users witho…

### DIFF
--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search/order-basket-search-results.component.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { Button, ClickableTile, Tile, SkeletonText, InlineNotification, ButtonSkeleton } from '@carbon/react';
 import { ShoppingCart } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
-import { useConfig, useLayoutType } from '@openmrs/esm-framework';
+import { useConfig, useLayoutType, UserHasAccess } from '@openmrs/esm-framework';
 import { OrderBasketItem } from '../../types/order-basket-item';
 import { ConfigObject } from '../../config-schema';
 import styles from './order-basket-search-results.scss';
@@ -136,22 +136,24 @@ const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({ drug, onSea
                 {drug?.strength && <>&mdash; {drug?.strength.toLowerCase()}</>}{' '}
                 {drug?.dosageForm?.display && <>&mdash; {drug?.dosageForm?.display.toLowerCase()}</>}
               </p>
-              {fetchingDrugOrderTemplatesError ? (
-                <p>
-                  <span className={styles.errorLabel}>
-                    {t('errorFetchingDrugOrderTemplates', 'Error fetching drug order templates')}
-                  </span>
-                </p>
-              ) : (
-                <p>
-                  {orderItem?.frequency?.value && (
-                    <span className={styles.label01}>{orderItem?.frequency?.value.toLowerCase()}</span>
-                  )}
-                  {orderItem?.route?.value && (
-                    <span className={styles.label01}>&mdash; {orderItem?.route?.value.toLowerCase()}</span>
-                  )}
-                </p>
-              )}
+              <UserHasAccess privilege="Manage OrderTemplates">
+                {fetchingDrugOrderTemplatesError ? (
+                  <p>
+                    <span className={styles.errorLabel}>
+                      {t('errorFetchingDrugOrderTemplates', 'Error fetching drug order templates')}
+                    </span>
+                  </p>
+                ) : (
+                  <p>
+                    {orderItem?.frequency?.value && (
+                      <span className={styles.label01}>{orderItem?.frequency?.value.toLowerCase()}</span>
+                    )}
+                    {orderItem?.route?.value && (
+                      <span className={styles.label01}>&mdash; {orderItem?.route?.value.toLowerCase()}</span>
+                    )}
+                  </p>
+                )}
+              </UserHasAccess>
             </div>
             <Button
               className={styles.addToBasketButton}


### PR DESCRIPTION
…ut the Manage Order privilledge

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
For the drug order template to be fetched the user has to first log out of his account and search for a drug via the admin account, thereafter his account is able to retrieve the template. Only the user logged in as the admin has the privillege of viewing the drug details. 




## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-1955

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
