### PR TITLE
O3-2075 Fix to display Dashboard from  the JSON application configura…

### DIFF
--- a/packages/esm-patient-chart-app/src/side-nav/generic-dashboard.component.tsx
+++ b/packages/esm-patient-chart-app/src/side-nav/generic-dashboard.component.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Type, useConfig } from '@openmrs/esm-framework';
+import { BrowserRouter } from 'react-router-dom';
 import { DashboardExtension } from '@openmrs/esm-patient-common-lib';
 
 export const genericDashboardConfigSchema = {
@@ -34,5 +35,9 @@ interface GenericDashboardProps {
 
 export default function GenericDashboard({ basePath }: GenericDashboardProps) {
   const config = useConfig() as GenericDashboardConfig;
-  return <DashboardExtension title={config.title} basePath={basePath} />;
+  return (
+    <BrowserRouter>
+      <DashboardExtension title={config.title} basePath={basePath} />
+    </BrowserRouter>
+  );
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This fix was created based on the [add dashboard via configuration](https://talk.openmrs.org/t/is-there-any-way-to-add-a-new-dashboard-via-config-instead-of-editing-one-of-the-existing/39479/8) discussion and subsequent created [O3-2075](https://issues.openmrs.org/browse/O3-2075) issue. In a nutshell, the issue was related to creating a dashboard from JSON configuration, which was not working as expected.


## Screenshots
Before fix:
![image](https://user-images.githubusercontent.com/3305166/234882135-a646fcdd-9dad-4fe9-89ee-1585f31b4b40.png)
After fix: 
![image](https://user-images.githubusercontent.com/3305166/234882726-ff48f203-399e-4e63-980e-7103861ee69d.png)

 

## Related Issue
https://issues.openmrs.org/browse/O3-2075

## Other
A small disclaimer, this is my first pull request. I have done my best to check the style guide and run the unit tests, but I may have missed some things because I lack experience with OpenMRS and ReactJs.
