### PR TITLE
(fix) 03-2028: Test Results page switches patients.

### DIFF
--- a/packages/esm-patient-test-results-app/src/panel-timeline/helpers.tsx
+++ b/packages/esm-patient-test-results-app/src/panel-timeline/helpers.tsx
@@ -11,8 +11,6 @@ function getPatientUuidFromUrl(): string {
   return match && match[1];
 }
 
-const patientUuid = getPatientUuidFromUrl();
-
 export const parseTime: (sortedTimes: Array<string>) => ParsedTimeType = (sortedTimes) => {
   const yearColumns: Array<{ year: string; size: number }> = [],
     dayColumns: Array<{ year: string; day: string; size: number }> = [],
@@ -117,6 +115,7 @@ export const TimelineCell: React.FC<{
 };
 
 export const RowStartCell = ({ title, range, units, shadow = false, testUuid, isString = false }) => {
+  const patientUuid = getPatientUuidFromUrl();
   return (
     <div
       className={styles['row-start-cell']}


### PR DESCRIPTION

## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This PR fixes the issue of the `patientUuid` not updating in the trendline when a patient is switching by calling the patientUuid inside a component that rerenders when the url changes.

## Screenshots
 - [loom recording of the fix](https://www.loom.com/share/13723f7e7f434cf6aaa17b1e7fb4cb99)
## Related Issue
- https://issues.openmrs.org/browse/O3-2028

