### PR TITLE
(fix)disable start visit on a deceased patient

### DIFF
--- a/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useConfig, useVisit } from '@openmrs/esm-framework';
+import { useConfig, usePatient, useVisit } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 
 interface StartVisitOverflowMenuItemProps {
@@ -10,11 +10,15 @@ interface StartVisitOverflowMenuItemProps {
 const StartVisitOverflowMenuItem: React.FC<StartVisitOverflowMenuItemProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const { currentVisit } = useVisit(patientUuid);
+  const { patient } = usePatient(patientUuid);
   const handleClick = React.useCallback(() => launchPatientWorkspace('start-visit-workspace-form'), []);
   const { startVisitLabel } = useConfig();
+  
+  const isDeceased = Boolean(patient?.deceasedDateTime);
+  const deceased = (!isDeceased && currentVisit);
 
   return (
-    !currentVisit && (
+    deceased && (
       <li className="cds--overflow-menu-options__option">
         <button
           className="cds--overflow-menu-options__btn"

--- a/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
@@ -13,12 +13,12 @@ const StartVisitOverflowMenuItem: React.FC<StartVisitOverflowMenuItemProps> = ({
   const { patient } = usePatient(patientUuid);
   const handleClick = React.useCallback(() => launchPatientWorkspace('start-visit-workspace-form'), []);
   const { startVisitLabel } = useConfig();
-  
-  const isDeceased = Boolean(patient?.deceasedDateTime);
-  const deceased = (!isDeceased && currentVisit);
 
+  const isDeceased = Boolean(patient?.deceasedDateTime);
+ 
   return (
-    deceased && (
+    !currentVisit &&
+    !isDeceased && (
       <li className="cds--overflow-menu-options__option">
         <button
           className="cds--overflow-menu-options__btn"

--- a/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useConfig, usePatient, useVisit } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
@@ -11,11 +11,11 @@ const StartVisitOverflowMenuItem: React.FC<StartVisitOverflowMenuItemProps> = ({
   const { t } = useTranslation();
   const { currentVisit } = useVisit(patientUuid);
   const { patient } = usePatient(patientUuid);
-  const handleClick = React.useCallback(() => launchPatientWorkspace('start-visit-workspace-form'), []);
+  const handleClick = useCallback(() => launchPatientWorkspace('start-visit-workspace-form'), []);
   const { startVisitLabel } = useConfig();
 
   const isDeceased = Boolean(patient?.deceasedDateTime);
- 
+
   return (
     !currentVisit &&
     !isDeceased && (

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -166,6 +166,9 @@ const VisitHeader: React.FC = () => {
     });
   }, []);
 
+  const isDeceased = Boolean(patient?.deceasedDateTime);
+  const deceased = (!isDeceased && currentVisit) || (!isDeceased && !currentVisit)
+ 
   const render = useCallback(() => {
     if (!showVisitHeader) {
       return null;
@@ -205,7 +208,7 @@ const VisitHeader: React.FC = () => {
           </div>
           <HeaderGlobalBar>
             <ExtensionSlot extensionSlotName="visit-header-right-slot" />
-            {!hasActiveVisit && (
+            {!hasActiveVisit && deceased && (
               <Button className={styles.startVisitButton} onClick={launchStartVisitForm} size="lg">
                 {startVisitLabel ? startVisitLabel : t('startAVisit', 'Start a visit')}
               </Button>

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -207,7 +207,7 @@ const VisitHeader: React.FC = () => {
           </div>
           <HeaderGlobalBar>
             <ExtensionSlot extensionSlotName="visit-header-right-slot" />
-            {!currentVisit && !isDeceased && (
+            {!hasActiveVisit && !isDeceased && (
               <Button className={styles.startVisitButton} onClick={launchStartVisitForm} size="lg">
                 {startVisitLabel ? startVisitLabel : t('startAVisit', 'Start a visit')}
               </Button>
@@ -240,19 +240,20 @@ const VisitHeader: React.FC = () => {
 
     return null;
   }, [
-    showVisitHeader,
+    hasActiveVisit,
+    isSideMenuExpanded,
+    onClosePatientChart,
     patient,
     showHamburger,
-    isSideMenuExpanded,
-    isDeceased,
+    showVisitHeader,
     startVisitLabel,
     t,
-    currentVisit,
-    endVisitLabel,
-    onClosePatientChart,
     toggleSideMenu,
+    endVisitLabel,
     openModal,
+    currentVisit,
     logo,
+    isDeceased,
   ]);
 
   return <HeaderContainer render={render} />;

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -167,7 +167,7 @@ const VisitHeader: React.FC = () => {
   }, []);
 
   const isDeceased = Boolean(patient?.deceasedDateTime);
-  const deceased = (!isDeceased && currentVisit) || (!isDeceased && !currentVisit)
+  const deceased = (!isDeceased && currentVisit) || (!isDeceased && !currentVisit);
  
   const render = useCallback(() => {
     if (!showVisitHeader) {

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -167,8 +167,7 @@ const VisitHeader: React.FC = () => {
   }, []);
 
   const isDeceased = Boolean(patient?.deceasedDateTime);
-  const deceased = (!isDeceased && currentVisit) || (!isDeceased && !currentVisit);
- 
+
   const render = useCallback(() => {
     if (!showVisitHeader) {
       return null;
@@ -208,7 +207,7 @@ const VisitHeader: React.FC = () => {
           </div>
           <HeaderGlobalBar>
             <ExtensionSlot extensionSlotName="visit-header-right-slot" />
-            {!hasActiveVisit && deceased && (
+            {!currentVisit && !isDeceased && (
               <Button className={styles.startVisitButton} onClick={launchStartVisitForm} size="lg">
                 {startVisitLabel ? startVisitLabel : t('startAVisit', 'Start a visit')}
               </Button>
@@ -241,18 +240,18 @@ const VisitHeader: React.FC = () => {
 
     return null;
   }, [
-    hasActiveVisit,
-    isSideMenuExpanded,
-    onClosePatientChart,
+    showVisitHeader,
     patient,
     showHamburger,
-    showVisitHeader,
+    isSideMenuExpanded,
+    isDeceased,
     startVisitLabel,
     t,
-    toggleSideMenu,
-    endVisitLabel,
-    openModal,
     currentVisit,
+    endVisitLabel,
+    onClosePatientChart,
+    toggleSideMenu,
+    openModal,
     logo,
   ]);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Using the useOmrsRestPatient hook by passing the patient's id as a parameter I conditionally rendered the start visit button based on the patient's status. If the patient is active, show the start visit button and if the patient is deceased hide the start visit button.
## Screenshots


https://user-images.githubusercontent.com/33891016/236354258-74940acb-3c20-4731-ba9b-85a211354605.mp4


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
