### PR TITLE
(fix) Remove useOmrsRestPatient hook

### DIFF
--- a/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.component.tsx
@@ -2,18 +2,14 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tag, DefinitionTooltip } from '@carbon/react';
 import { formatDatetime, parseDate } from '@openmrs/esm-framework';
-import { useOmrsRestPatient } from '../hooks/usePatientAttributes';
 import styles from './deceased-patient-tag.scss';
 
 interface DeceasedPatientBannerTagProps {
   patient: Pick<fhir.Patient, 'deceasedDateTime'>;
-  patientUuid: string;
 }
-const DeceasedPatientBannerTag: React.FC<DeceasedPatientBannerTagProps> = ({ patient, patientUuid }) => {
+const DeceasedPatientBannerTag: React.FC<DeceasedPatientBannerTagProps> = ({ patient }) => {
   const { t } = useTranslation();
-  const { person } = useOmrsRestPatient(patientUuid);
-
-  const isDeceased = person?.dead || patient.deceasedDateTime;
+  const isDeceased = Boolean(patient?.deceasedDateTime);
 
   return (
     isDeceased && (

--- a/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.test.tsx
@@ -6,14 +6,14 @@ import { mockPatient } from '../../../../__mocks__/patient.mock';
 
 describe('DeceasedPatientTag', () => {
   it('does not render Deceased tag for patients who are still alive', () => {
-    const patient = { ...mockPatient, deceasedDateTime: null };
-    render(<DeceasedPatientBannerTag patient={patient} patientUuid={mockDeceasedPatient.id} />);
+    const patient = { ...mockPatient, deceasedDateTime: '' };
+    render(<DeceasedPatientBannerTag patient={patient} />);
     expect(screen.queryByRole('tooltip', { name: / 04-Apr-1972, 12:00\s+AM/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Deceased/ })).not.toBeInTheDocument();
   });
 
   it('renders a deceased tag in the patient banner for patients who died', () => {
-    render(<DeceasedPatientBannerTag patient={mockDeceasedPatient} patientUuid={mockDeceasedPatient.id} />);
+    render(<DeceasedPatientBannerTag patient={mockDeceasedPatient} />);
 
     expect(screen.getByRole('tooltip', { name: / 04-Apr-1972, 12:00\s+AM/i }));
     expect(screen.getByRole('button', { name: /Deceased/ })).toBeInTheDocument();

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { Button, Tag } from '@carbon/react';
 import { ChevronDown, ChevronUp, OverflowMenuVertical } from '@carbon/react/icons';
 import { ExtensionSlot, age, formatDate, parseDate, useConfig } from '@openmrs/esm-framework';
-import { useOmrsRestPatient } from '../hooks/usePatientAttributes';
 import ContactDetails from '../contact-details/contact-details.component';
 import CustomOverflowMenuComponent from '../ui-components/overflow-menu.component';
 import styles from './patient-banner.scss';
@@ -40,8 +39,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
     setShowContactDetails((value) => !value);
   }, []);
 
-  const { person } = useOmrsRestPatient(patientUuid);
-  const isDeceased = Boolean(person?.dead || patient.deceasedDateTime);
+  const isDeceased = Boolean(patient?.deceasedDateTime);
 
   const patientAvatar = (
     <div className={styles.patientAvatar} role="img">
@@ -130,7 +128,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
           </div>
           <div className={styles.demographics}>
             <span>{getGender(patient.gender)}</span> &middot; <span>{age(patient.birthDate)}</span> &middot;{' '}
-            <span>{formatDate(parseDate(patient?.birthDate), { mode: 'wide', time: false })}</span>
+            <span>{formatDate(parseDate(patient.birthDate), { mode: 'wide', time: false })}</span>
           </div>
           <div className={styles.row}>
             <div className={styles.identifiers}>

--- a/packages/esm-patient-banner-app/src/hooks/usePatientAttributes.tsx
+++ b/packages/esm-patient-banner-app/src/hooks/usePatientAttributes.tsx
@@ -45,21 +45,3 @@ export const usePatientContactAttributes = (patientUuid: string) => {
     isLoading,
   };
 };
-
-export function useOmrsRestPatient(patientUuid: string) {
-  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: PersonFetchResponse }, Error>(
-    `/ws/rest/v1/patient/${patientUuid}`,
-    openmrsFetch,
-  );
-  const result = useMemo(() => {
-    return {
-      person: data?.data?.person ?? null,
-      personError: error,
-      isPersonLoading: isLoading,
-      isPersonError: error,
-      isPersonValidating: isValidating,
-      mutate,
-    };
-  }, [data, error, isLoading, isValidating, mutate]);
-  return result;
-}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Removes the `useOmrsRestPatient` which was duplicating the work of the `usePatient` hook from the esm-framewor

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
