### PR TITLE
(feat) Temporarily allow overriding logo on the patient chart's visit header

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -95,7 +95,24 @@ export const esmPatientChartSchema = {
     _type: Type.Boolean,
     _description: 'Whether start visit form should display upcoming appointments',
     _default: false,
-  }
+  },
+  logo: {
+    src: {
+      _type: Type.String,
+      _default: null,
+      _description: 'A path or URL to an image. Defaults to the OpenMRS SVG sprite.',
+    },
+    alt: {
+      _type: Type.String,
+      _default: 'Logo',
+      _description: 'Alt text, shown on hover',
+    },
+    name: {
+      _type: Type.String,
+      _default: null,
+      _description: 'The organization name displayed when image is absent',
+    },
+  },
 };
 
 export interface ChartConfig {
@@ -111,6 +128,10 @@ export interface ChartConfig {
   visitQueueNumberAttributeUuid: string;
   defaultFacilityUrl: string;
   showUpcomingAppointments: boolean;
+  logo: {
+    src: string;
+    alt: string;
+  };
 }
 
 export const configSchema = {

--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -131,6 +131,7 @@ export interface ChartConfig {
   logo: {
     src: string;
     alt: string;
+    name: string;
   };
 }
 

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -141,7 +141,7 @@ const VisitHeader: React.FC = () => {
   const [showVisitHeader, setShowVisitHeader] = useState(true);
   const [isSideMenuExpanded, setIsSideMenuExpanded] = useState(false);
   const navMenuItems = useAssignedExtensions('patient-chart-dashboard-slot').map((extension) => extension.id);
-  const { startVisitLabel, endVisitLabel } = useConfig();
+  const { startVisitLabel, endVisitLabel, logo } = useConfig();
 
   const showHamburger = useLayoutType() !== 'large-desktop' && navMenuItems.length > 0;
 
@@ -188,9 +188,15 @@ const VisitHeader: React.FC = () => {
           )}
           <ConfigurableLink className={styles.navLogo} to="${openmrsSpaBase}/home">
             <div className={styles.divider}>
-              <svg role="img" width={110} height={40}>
-                <use xlinkHref="#omrs-logo-white"></use>
-              </svg>
+              {logo?.src ? (
+                <img className={styles.logo} src={logo.src} alt={logo.alt} width={110} height={40} />
+              ) : logo?.name ? (
+                logo.name
+              ) : (
+                <svg role="img" width={110} height={40}>
+                  <use xlinkHref="#omrs-logo-white"></use>
+                </svg>
+              )}
             </div>
           </ConfigurableLink>
           <div className={styles.navDivider} />

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -250,6 +250,7 @@ const VisitHeader: React.FC = () => {
     endVisitLabel,
     openModal,
     currentVisit,
+    logo,
   ]);
 
   return <HeaderContainer render={render} />;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR allows implementer override the openmrs logo on the patient chart's header.

## Screenshots
<img width="1226" alt="image" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/63aaf4a1-de52-4bb1-ab61-8c5ea5aeb2b9">

<img width="868" alt="image" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/0aa7191e-16e0-4182-b2bf-7a82009f2c3d">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
