### PR TITLE
(fix) Patient deceased widget should not break when patient is undefined

### DIFF
--- a/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.component.tsx
@@ -18,7 +18,7 @@ const DeceasedPatientBannerTag: React.FC<DeceasedPatientBannerTagProps> = ({ pat
         definition={
           <div role="tooltip" className={styles.tooltipPadding}>
             <h6 style={{ marginBottom: '0.5rem' }}>{t('deceased', 'Deceased')}</h6>
-            <span>{formatDatetime(parseDate(patient.deceasedDateTime))}</span>
+            <span>{formatDatetime(parseDate(patient?.deceasedDateTime))}</span>
           </div>
         }
       >


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Fixes breaking #1148 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
