### PR TITLE
(fix) Update fallback on-close of the patient chart

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -151,13 +151,9 @@ const VisitHeader: React.FC = () => {
 
   const hasActiveVisit = !isLoading && !visitNotLoaded;
 
-  const onClosePatientChart = useCallback(() => {
-    const originPage = localStorage.getItem('fromPage');
-    localStorage.removeItem('fromPage');
-
-    setShowVisitHeader((prevState) => !prevState);
-    originPage ? navigate({ to: `${window.spaBase}/${originPage}` }) : navigate({ to: `${window.spaBase}/home` });
-  }, []);
+  const onClosePatientChart = () => {
+    window.history.back();
+  };
 
   const openModal = useCallback((patientUuid) => {
     const dispose = showModal('end-visit-dialog', {
@@ -240,7 +236,6 @@ const VisitHeader: React.FC = () => {
   }, [
     hasActiveVisit,
     isSideMenuExpanded,
-    onClosePatientChart,
     patient,
     showHamburger,
     showVisitHeader,

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
@@ -106,7 +106,8 @@ describe('Visit Header', () => {
 
     // Should close the visit-header
     await user.click(closeButton);
-    expect(navigate).toHaveBeenCalledWith({ to: '/spa/home' });
+    const currentUrl = window.location;
+    expect(currentUrl).not.toContain('/chart/');
   });
 
   test('should display a truncated name when the patient name is very long', async () => {
@@ -155,7 +156,8 @@ describe('Visit Header', () => {
 
     // Should close the visit-header
     await user.click(closeButton);
-    expect(navigate).toHaveBeenCalledWith({ to: '/spa/home' });
+    const currentUrl = window.location;
+    expect(currentUrl).not.toContain('/chart/');
   });
 });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- This imitates the browser's back button. I did this in the patient [registration](https://github.com/openmrs/openmrs-esm-patient-management/pull/700) and thought it might apply to the patient chart too

## Screencasts
<!-- Required if you are making UI changes. -->
[Screencast from 2023-05-22 14-10-22.webm](https://github.com/openmrs/openmrs-esm-patient-chart/assets/104269786/cf1253cd-b16f-4ad4-8945-d538a6e89a1e)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

