### PR TITLE
(chore) Ohri-UgandaEmr MUAC vital inputs status color codes.

### DIFF
--- a/packages/esm-patient-vitals-app/src/config-schema.ts
+++ b/packages/esm-patient-vitals-app/src/config-schema.ts
@@ -63,6 +63,11 @@ export const configSchema = {
       _type: Type.String,
       _default: 'Vitals',
     },
+    useMuacColors: {
+      _type: Type.Boolean,
+      _default: true,
+      _description: 'Whether to show/use MUAC color codes. If set to true, the input will show status colors.',
+    },
   },
   biometrics: biometricsConfigSchema,
 };
@@ -84,6 +89,7 @@ export interface ConfigObject {
     encounterTypeUuid: string;
     formUuid: string;
     formName: string;
+    useMuacColors: boolean;
   };
   biometrics: BiometricsConfigObject;
 }

--- a/packages/esm-patient-vitals-app/src/config-schema.ts
+++ b/packages/esm-patient-vitals-app/src/config-schema.ts
@@ -65,7 +65,7 @@ export const configSchema = {
     },
     useMuacColors: {
       _type: Type.Boolean,
-      _default: true,
+      _default: false,
       _description: 'Whether to show/use MUAC color codes. If set to true, the input will show status colors.',
     },
   },

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -10,10 +10,11 @@ import {
   ExtensionSlot,
   usePatient,
   useVisit,
+  age,
 } from '@openmrs/esm-framework';
 import { DefaultWorkspaceProps, useVitalsConceptMetadata } from '@openmrs/esm-patient-common-lib';
 import { Button, ButtonSet, Column, Form, Row, Stack } from '@carbon/react';
-import { calculateBMI, isInNormalRange } from './vitals-biometrics-form.utils';
+import { calculateBMI, isInNormalRange, extractNumbers } from './vitals-biometrics-form.utils';
 import { savePatientVitals, useVitals } from '../vitals.resource';
 import { ConfigObject } from '../../config-schema';
 import VitalsBiometricInput from './vitals-biometrics-input.component';
@@ -46,11 +47,66 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
   const [patientBMI, setPatientBMI] = useState<number>();
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const encounterUuid = currentVisit?.encounters?.find((enc) => enc?.form?.uuid === config.vitals.formUuid)?.uuid;
+  const [colorCode, setColorcode] = useState(undefined);
 
   const isBMIInNormalRange = (value: number | undefined | string) => {
     if (value === undefined || value === '') return true;
     return value >= 18.5 && value <= 24.9;
   };
+
+  function getColorCode(age, muac) {
+    let color = '';
+    switch (true) {
+      // children 5 years and below with a muac equal to 14
+      case age <= 5 && muac <= 11.5 && muac > 0:
+        setColorcode('red');
+        break;
+      case age < 5 && muac > 11.5 && muac < 12.5:
+        setColorcode('yellow');
+        break;
+      case age < 5 && muac > 12.5:
+        setColorcode('green');
+        break;
+      // above 5 but less than 10
+      case age > 5 && age < 10 && muac <= 13.5 && muac > 0:
+        setColorcode('red');
+        break;
+      case age > 5 && age < 10 && muac > 13.5 && muac < 14.5:
+        setColorcode('yellow');
+        break;
+      case age > 5 && age < 10 && muac > 14.5:
+        setColorcode('green');
+        break;
+      //above 10 but less than 18
+      case age > 10 && age < 18 && muac <= 16.5 && muac > 0:
+        setColorcode('red');
+        break;
+      case age > 10 && age < 18 && muac > 16.5 && muac < 19.0:
+        setColorcode('yellow');
+        break;
+      case age > 10 && age < 18 && muac > 19.0:
+        setColorcode('green');
+        break;
+      // above 18
+      case age > 18 && muac <= 19.5 && muac > 0:
+        setColorcode('red');
+        break;
+      case age > 18 && muac > 19.0 && muac < 22.0:
+        setColorcode('yellow');
+        break;
+      case age > 18 && muac > 22.0:
+        setColorcode('green');
+        break;
+    }
+    return color;
+  }
+
+  useEffect(() => {
+    getColorCode(
+      extractNumbers(age(patient.patient?.birthDate)),
+      parseInt(patientVitalAndBiometrics?.midUpperArmCircumference),
+    );
+  }, [patient.patient?.birthDate, patientVitalAndBiometrics?.midUpperArmCircumference]);
 
   const concepts = {
     midUpperArmCircumferenceRange: conceptRanges.get(config.concepts.midUpperArmCircumferenceUuid),
@@ -411,6 +467,7 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
             <Column className={styles.column}>
               <VitalsBiometricInput
                 title={t('muac', 'MUAC')}
+                colorCode={colorCode}
                 onInputChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                   setPatientVitalAndBiometrics({
                     ...patientVitalAndBiometrics,

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -14,7 +14,7 @@ import {
 } from '@openmrs/esm-framework';
 import { DefaultWorkspaceProps, useVitalsConceptMetadata } from '@openmrs/esm-patient-common-lib';
 import { Button, ButtonSet, Column, Form, Row, Stack } from '@carbon/react';
-import { calculateBMI, isInNormalRange, extractNumbers } from './vitals-biometrics-form.utils';
+import { calculateBMI, isInNormalRange, extractNumbers, getColorCode } from './vitals-biometrics-form.utils';
 import { savePatientVitals, useVitals } from '../vitals.resource';
 import { ConfigObject } from '../../config-schema';
 import VitalsBiometricInput from './vitals-biometrics-input.component';
@@ -55,57 +55,11 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
     return value >= 18.5 && value <= 24.9;
   };
 
-  function getColorCode(age, muac) {
-    let color = '';
-    switch (true) {
-      // children 5 years and below with a muac equal to 14
-      case age <= 5 && muac <= 11.5 && muac > 0:
-        setColorcode('red');
-        break;
-      case age < 5 && muac > 11.5 && muac < 12.5:
-        setColorcode('yellow');
-        break;
-      case age < 5 && muac > 12.5:
-        setColorcode('green');
-        break;
-      // above 5 but less than 10
-      case age > 5 && age < 10 && muac <= 13.5 && muac > 0:
-        setColorcode('red');
-        break;
-      case age > 5 && age < 10 && muac > 13.5 && muac < 14.5:
-        setColorcode('yellow');
-        break;
-      case age > 5 && age < 10 && muac > 14.5:
-        setColorcode('green');
-        break;
-      //above 10 but less than 18
-      case age > 10 && age < 18 && muac <= 16.5 && muac > 0:
-        setColorcode('red');
-        break;
-      case age > 10 && age < 18 && muac > 16.5 && muac < 19.0:
-        setColorcode('yellow');
-        break;
-      case age > 10 && age < 18 && muac > 19.0:
-        setColorcode('green');
-        break;
-      // above 18
-      case age > 18 && muac <= 19.5 && muac > 0:
-        setColorcode('red');
-        break;
-      case age > 18 && muac > 19.0 && muac < 22.0:
-        setColorcode('yellow');
-        break;
-      case age > 18 && muac > 22.0:
-        setColorcode('green');
-        break;
-    }
-    return color;
-  }
-
   useEffect(() => {
     getColorCode(
       extractNumbers(age(patient.patient?.birthDate)),
       parseInt(patientVitalAndBiometrics?.midUpperArmCircumference),
+      setColorcode,
     );
   }, [patient.patient?.birthDate, patientVitalAndBiometrics?.midUpperArmCircumference]);
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -48,7 +48,7 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const encounterUuid = currentVisit?.encounters?.find((enc) => enc?.form?.uuid === config.vitals.formUuid)?.uuid;
   const useMuacColorStatus = config.vitals.useMuacColors;
-  const [colorCode, setColorcode] = useState(undefined);
+  const [colorCode, setColorCode] = useState('');
 
   const isBMIInNormalRange = (value: number | undefined | string) => {
     if (value === undefined || value === '') return true;
@@ -59,7 +59,7 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
     getColorCode(
       extractNumbers(age(patient.patient?.birthDate)),
       parseInt(patientVitalAndBiometrics?.midUpperArmCircumference),
-      setColorcode,
+      setColorCode,
     );
   }, [patient.patient?.birthDate, patientVitalAndBiometrics?.midUpperArmCircumference]);
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -47,6 +47,7 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
   const [patientBMI, setPatientBMI] = useState<number>();
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const encounterUuid = currentVisit?.encounters?.find((enc) => enc?.form?.uuid === config.vitals.formUuid)?.uuid;
+  const useMuacColorStatus = config.vitals.useMuacColors;
   const [colorCode, setColorcode] = useState(undefined);
 
   const isBMIInNormalRange = (value: number | undefined | string) => {
@@ -467,6 +468,7 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
             <Column className={styles.column}>
               <VitalsBiometricInput
                 title={t('muac', 'MUAC')}
+                useMuacColors={useMuacColorStatus}
                 colorCode={colorCode}
                 onInputChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                   setPatientVitalAndBiometrics({

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.utils.ts
@@ -1,4 +1,3 @@
-import inRange from 'lodash/inRange';
 import isNumber from 'lodash/isNumber';
 import { ConceptMetadata } from '@openmrs/esm-patient-common-lib';
 
@@ -29,4 +28,51 @@ export function extractNumbers(str) {
     return null;
   }
   return parseInt(match[0], 10);
+}
+
+export function getColorCode(age, muac, setColorcode) {
+  let color = '';
+  switch (true) {
+    // children 5 years and below with a muac equal to 14
+    case age <= 5 && muac <= 11.5 && muac > 0:
+      setColorcode('red');
+      break;
+    case age < 5 && muac > 11.5 && muac < 12.5:
+      setColorcode('yellow');
+      break;
+    case age < 5 && muac > 12.5:
+      setColorcode('green');
+      break;
+    // above 5 but less than 10
+    case age > 5 && age < 10 && muac <= 13.5 && muac > 0:
+      setColorcode('red');
+      break;
+    case age > 5 && age < 10 && muac > 13.5 && muac < 14.5:
+      setColorcode('yellow');
+      break;
+    case age > 5 && age < 10 && muac > 14.5:
+      setColorcode('green');
+      break;
+    //above 10 but less than 18
+    case age > 10 && age < 18 && muac <= 16.5 && muac > 0:
+      setColorcode('red');
+      break;
+    case age > 10 && age < 18 && muac > 16.5 && muac < 19.0:
+      setColorcode('yellow');
+      break;
+    case age > 10 && age < 18 && muac > 19.0:
+      setColorcode('green');
+      break;
+    // above 18
+    case age > 18 && muac <= 19.5 && muac > 0:
+      setColorcode('red');
+      break;
+    case age > 18 && muac > 19.0 && muac < 22.0:
+      setColorcode('yellow');
+      break;
+    case age > 18 && muac > 22.0:
+      setColorcode('green');
+      break;
+  }
+  return color;
 }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.utils.ts
@@ -21,7 +21,7 @@ export function isInNormalRange(conceptMetadata: Array<ConceptMetadata>, concept
 }
 
 //convert age into an integer (whole number)
-export function extractNumbers(str) {
+export function extractNumbers(str: string) {
   const regex = /\d+/g;
   const match = str.match(regex);
   if (!match) {
@@ -30,49 +30,47 @@ export function extractNumbers(str) {
   return parseInt(match[0], 10);
 }
 
-export function getColorCode(age, muac, setColorcode) {
-  let color = '';
+export function getColorCode(age: number, muac: number, setColorCode: (color) => void) {
   switch (true) {
     // children 5 years and below with a muac equal to 14
     case age <= 5 && muac <= 11.5 && muac > 0:
-      setColorcode('red');
+      setColorCode('red');
       break;
     case age < 5 && muac > 11.5 && muac < 12.5:
-      setColorcode('yellow');
+      setColorCode('yellow');
       break;
     case age < 5 && muac > 12.5:
-      setColorcode('green');
+      setColorCode('green');
       break;
     // above 5 but less than 10
     case age > 5 && age < 10 && muac <= 13.5 && muac > 0:
-      setColorcode('red');
+      setColorCode('red');
       break;
     case age > 5 && age < 10 && muac > 13.5 && muac < 14.5:
-      setColorcode('yellow');
+      setColorCode('yellow');
       break;
     case age > 5 && age < 10 && muac > 14.5:
-      setColorcode('green');
+      setColorCode('green');
       break;
     //above 10 but less than 18
     case age > 10 && age < 18 && muac <= 16.5 && muac > 0:
-      setColorcode('red');
+      setColorCode('red');
       break;
     case age > 10 && age < 18 && muac > 16.5 && muac < 19.0:
-      setColorcode('yellow');
+      setColorCode('yellow');
       break;
     case age > 10 && age < 18 && muac > 19.0:
-      setColorcode('green');
+      setColorCode('green');
       break;
     // above 18
     case age > 18 && muac <= 19.5 && muac > 0:
-      setColorcode('red');
+      setColorCode('red');
       break;
     case age > 18 && muac > 19.0 && muac < 22.0:
-      setColorcode('yellow');
+      setColorCode('yellow');
       break;
     case age > 18 && muac > 22.0:
-      setColorcode('green');
+      setColorCode('green');
       break;
   }
-  return color;
 }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.utils.ts
@@ -20,3 +20,13 @@ export function isInNormalRange(conceptMetadata: Array<ConceptMetadata>, concept
     ? Number(value) >= Number(concept.lowAbsolute) && Number(value) <= Number(concept.hiAbsolute)
     : true;
 }
+
+//convert age into an integer (whole number)
+export function extractNumbers(str) {
+  const regex = /\d+/g;
+  const match = str.match(regex);
+  if (!match) {
+    return null;
+  }
+  return parseInt(match[0], 10);
+}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -7,6 +7,7 @@ import styles from './vitals-biometrics-input.scss';
 interface VitalsBiometricInputProps {
   title: string;
   colorCode?: string;
+  useMuacColors?: boolean;
   onInputChange(evnt): void;
   textFields: Array<{
     name: string;
@@ -37,6 +38,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
   disabled,
   inputIsNormal,
   colorCode,
+  useMuacColors,
 }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
@@ -52,7 +54,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
       <div
         className={`${styles.textInputContainer} ${disabled && styles.disableInput} ${
           !inputIsNormal && styles.danger
-        } ${colorCode}`}
+        } ${useMuacColors ? colorCode : undefined}`}
         style={{ ...textFieldStyles }}
       >
         <div className={styles.centerDiv}>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -6,6 +6,7 @@ import styles from './vitals-biometrics-input.scss';
 
 interface VitalsBiometricInputProps {
   title: string;
+  colorCode?: string;
   onInputChange(evnt): void;
   textFields: Array<{
     name: string;
@@ -35,6 +36,7 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
   placeholder,
   disabled,
   inputIsNormal,
+  colorCode,
 }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
@@ -48,7 +50,9 @@ const VitalsBiometricInput: React.FC<VitalsBiometricInputProps> = ({
     <div className={styles.inputContainer} style={{ width: textFieldWidth }}>
       <p className={styles.vitalsBiometricInputLabel01}>{title}</p>
       <div
-        className={`${styles.textInputContainer} ${disabled && styles.disableInput} ${!inputIsNormal && styles.danger}`}
+        className={`${styles.textInputContainer} ${disabled && styles.disableInput} ${
+          !inputIsNormal && styles.danger
+        } ${colorCode}`}
         style={{ ...textFieldStyles }}
       >
         <div className={styles.centerDiv}>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.scss
@@ -50,6 +50,28 @@
 background-color: $ui-01;
 }
 
+.textInputContainer {
+  &:global(.red) {
+    background-color: red;
+
+    input {
+      background-color: red;
+    }
+  }
+  &:global(.green) {
+    background-color: green;
+
+    input {
+      background-color: green;
+    }
+  }
+  &:global(.yellow) {
+    background-color: yellow;
+     input {
+      background-color: yellow;
+     }
+  }
+}
 .textarea {
   border: none;
   @extend .bodyLong01;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.scss
@@ -1,5 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/colors';
 @import '~@openmrs/esm-styleguide/src/vars';
 
 .label01 {
@@ -52,23 +53,23 @@ background-color: $ui-01;
 
 .textInputContainer {
   &:global(.red) {
-    background-color: #ffd7d9;
+    background-color: colors.$red-20;
 
     input {
-      background-color: #ffd7d9;
+      background-color: colors.$red-20;
     }
   }
   &:global(.green) {
-    background-color: #defbe6;
+    background-color: colors.$green-20;
 
     input {
-      background-color: #defbe6;
+      background-color: colors.$green-20;
     }
   }
   &:global(.yellow) {
-    background-color: #fff8a1;
+    background-color: colors.$yellow-10;
      input {
-      background-color: #fff8a1;
+      background-color: colors.$yellow-10;
      }
   }
 }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-input.scss
@@ -52,23 +52,23 @@ background-color: $ui-01;
 
 .textInputContainer {
   &:global(.red) {
-    background-color: red;
+    background-color: #ffd7d9;
 
     input {
-      background-color: red;
+      background-color: #ffd7d9;
     }
   }
   &:global(.green) {
-    background-color: green;
+    background-color: #defbe6;
 
     input {
-      background-color: green;
+      background-color: #defbe6;
     }
   }
   &:global(.yellow) {
-    background-color: yellow;
+    background-color: #fff8a1;
      input {
-      background-color: yellow;
+      background-color: #fff8a1;
      }
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds a configuration property that determines whether to colour-code the `Mid Upper Arm Circumference (MUAC)` input in the Vitals and Biometrics form based on the value provided. 

## Screenshots

<img width="1440" alt="Screenshot 2023-05-24 at 08 23 01" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/30952856/088f812b-df95-4338-8b52-c7ae8dfcf4dd">


> Loom recording https://www.loom.com/share/0d004895399b49888c0ba53b26780b9f


