### PR TITLE
(feat): Ability to configure address labels on patient banner

### DIFF
--- a/packages/esm-patient-banner-app/src/config-schema.ts
+++ b/packages/esm-patient-banner-app/src/config-schema.ts
@@ -14,8 +14,14 @@ export const configSchema = {
       _default: [],
     },
   },
+  customAddressLabel: {
+    _type: Type.Object,
+    _description: 'Whether to use custom labels for addresses',
+    _default: {},
+  },
 };
 
 export interface ConfigObject {
   contactAttributeType: Array<string>;
+  customAddressLabel: Object;
 }

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { InlineLoading } from '@carbon/react';
+import { useConfig } from '@openmrs/esm-framework';
 import { useRelationships } from './relationships.resource';
 import { usePatientContactAttributes } from '../hooks/usePatientAttributes';
+import { ConfigObject } from '../config-schema';
 import styles from './contact-details.scss';
 
 interface ContactDetailsProps {
@@ -14,6 +16,7 @@ interface ContactDetailsProps {
 
 const Address: React.FC<{ address?: fhir.Address }> = ({ address }) => {
   const { t } = useTranslation();
+  const { customAddressLabel } = useConfig() as ConfigObject;
 
   const getAddressKey = (url) => url.split('#')[1];
   /*
@@ -44,12 +47,13 @@ const Address: React.FC<{ address?: fhir.Address }> = ({ address }) => {
                 key === 'extension' ? (
                   address?.extension[0]?.extension.map((add, i) => (
                     <li>
-                      {t(getAddressKey(add.url))}: {add.valueString}
+                      {customAddressLabel ? t(customAddressLabel[getAddressKey(add.url)]) : t(getAddressKey(add.url))}:{' '}
+                      {add.valueString}
                     </li>
                   ))
                 ) : (
                   <li>
-                    {t(key)}: {value}
+                    {customAddressLabel ? t(customAddressLabel[key]) : t(key)}: {value}
                   </li>
                 ),
               )}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
We use address fields to mean specific things for our users. By just pulling actual address field names, they may not understand their meaning in the context they are being used for. eg address4 to us means "Ward" 

## Screenshots
Without config
![Screenshot from 2023-05-26 14-35-50](https://github.com/openmrs/openmrs-esm-patient-chart/assets/4432218/1c503ccb-b671-42d8-a615-0a271ed0d718)

With config
![Screenshot from 2023-05-26 14-40-42](https://github.com/openmrs/openmrs-esm-patient-chart/assets/4432218/926a42b3-957a-48cc-a338-e85cd4c64faf)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
sample config
` "@openmrs/esm-patient-banner-app": {
    "customAddressLabel": {
      "district": "County",
      "address4": "Ward",
      "state": "Sub county",
      "city": "Village",
      "address1":"Postal Address",
      "address6":"Location",
      "address5":"Sub Location",
      "address2":"Landmark"
    }
  }`
