### PR TITLE
(fix) Fix error container height

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -2,13 +2,11 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { InlineLoading } from '@carbon/react';
 import { OHRIForm } from '@openmrs/openmrs-form-engine-lib';
-
+import { Visit } from '@openmrs/esm-framework';
 import useForm from '../hooks/useForm';
 import useSchema from '../hooks/useSchema';
 import FormError from './form-error.component';
-
 import styles from './form-renderer.scss';
-import { Visit } from '@openmrs/esm-framework';
 
 interface FormRendererProps {
   formUuid: string;
@@ -34,7 +32,11 @@ const FormRenderer: React.FC<FormRendererProps> = ({ formUuid, patientUuid, visi
   }
 
   if (formLoadError || schemaLoadError) {
-    return <FormError closeWorkspace={closeWorkspace} />;
+    return (
+      <div className={styles.errorContainer}>
+        <FormError closeWorkspace={closeWorkspace} />
+      </div>
+    );
   }
 
   return (

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.scss
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.scss
@@ -12,3 +12,7 @@
   align-items: center;
   min-height: 50%;
 }
+
+.errorContainer {
+  height: 100vh;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x]  My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Tangential to https://github.com/openmrs/openmrs-form-engine-lib/pull/87, this PR makes it so that the height of the error container spans the entirety of the viewport, effectively making it match other error states in the workspace.

## Screenshots

<img width="1665" alt="error-container" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/4792a109-216d-4219-ae8d-c1030cb77cbb">
