### PR TITLE
(fix) O3-2151: Unable to create a drug order in the order basket

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -21,7 +21,7 @@ import { formatDate } from '@openmrs/esm-framework';
 import { CardHeader } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import { compare } from '../utils/compare';
-import { getOrderItems, orderBasketStore } from '../medications/order-basket-store';
+import { getOrderItems, orderBasketStore, orderBasketStoreActions } from '../medications/order-basket-store';
 import { Order } from '../types/order';
 import { OrderBasketItem } from '../types/order-basket-item';
 import styles from './medications-details-table.scss';
@@ -53,7 +53,7 @@ const MedicationsDetailsTable: React.FC<ActiveMedicationsProps> = ({
   const { launchOrderBasket } = useLaunchOrderBasket(patientUuid);
 
   const store = useStore(orderBasketStore);
-  const setItems = useCallback((items) => orderBasketStore.setState((state) => (state.items = items)), []);
+  const setItems = useCallback((items) => orderBasketStoreActions.setOrderBasketItems(items), []);
   const patientOrderItems = useMemo(() => getOrderItems(store.items, patientUuid), [store, patientUuid]);
 
   const tableHeaders = [

--- a/packages/esm-patient-medications-app/src/medications-summary/order-basket-action-button.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/order-basket-action-button.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Tag } from '@carbon/react';
 import { ShoppingCart } from '@carbon/react/icons';
@@ -17,7 +17,7 @@ const OrderBasketActionButton: React.FC = () => {
 
   const isActiveWorkspace = workspaces?.[0]?.name?.match(/order-basket/i);
 
-  const patientOrderItems = getOrderItems(items, patientUuid);
+  const patientOrderItems = useMemo(() => getOrderItems(items, patientUuid), [items, patientUuid]);
 
   const { launchOrderBasket } = useLaunchOrderBasket(patientUuid);
 

--- a/packages/esm-patient-medications-app/src/medications/order-basket-store.ts
+++ b/packages/esm-patient-medications-app/src/medications/order-basket-store.ts
@@ -20,17 +20,14 @@ export const orderBasketStore = createGlobalStore<OrderBasketStore>('drug-order-
 });
 
 export const orderBasketStoreActions = {
-  setOrderBasketItems(
-    store: OrderBasketStore,
-    value: Array<OrderBasketItem> | (() => Array<OrderBasketItem>),
-  ): OrderBasketStore {
+  setOrderBasketItems(value: Array<OrderBasketItem> | (() => Array<OrderBasketItem>)) {
     const patientUuid = getPatientUuidFromUrl();
-    return {
+    orderBasketStore.setState((state) => ({
       items: {
-        ...store.items,
+        ...state.items,
         [patientUuid]: typeof value === 'function' ? value() : value,
       },
-    };
+    }));
   },
 };
 

--- a/packages/esm-patient-medications-app/src/medications/order-basket-store.ts
+++ b/packages/esm-patient-medications-app/src/medications/order-basket-store.ts
@@ -7,12 +7,12 @@ function getPatientUuidFromUrl(): string {
 }
 export interface OrderBasketStore {
   items: {
-    [patientUuid: string]: [];
+    [patientUuid: string]: Array<OrderBasketItem>;
   };
 }
 
 export interface OrderBasketStoreActions {
-  setItems: (value: Array<OrderBasketItem> | (() => Array<OrderBasketItem>)) => void;
+  setOrderBasketItems: (value: Array<OrderBasketItem> | (() => Array<OrderBasketItem>)) => void;
 }
 
 export const orderBasketStore = createGlobalStore<OrderBasketStore>('drug-order-basket', {
@@ -20,7 +20,10 @@ export const orderBasketStore = createGlobalStore<OrderBasketStore>('drug-order-
 });
 
 export const orderBasketStoreActions = {
-  setItems(store: OrderBasketStore, value: Array<OrderBasketItem> | (() => Array<OrderBasketItem>)) {
+  setOrderBasketItems(
+    store: OrderBasketStore,
+    value: Array<OrderBasketItem> | (() => Array<OrderBasketItem>),
+  ): OrderBasketStore {
     const patientUuid = getPatientUuidFromUrl();
     return {
       items: {

--- a/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/medication-order-form.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { FormEventHandler, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Button,
   ButtonSet,
@@ -81,6 +81,11 @@ export default function MedicationOrderForm({ initialOrderBasketItem, onSign, on
   const template = initialOrderBasketItem.template;
   const { isLoading: isLoadingOrderConfig, orderConfigObject, error: errorFetchingOrderConfig } = useOrderConfig();
   const config = useConfig() as ConfigObject;
+
+  const handleFormSubmission = (e) => {
+    e.preventDefault();
+    onSign(orderBasketItem);
+  };
 
   const drugDosingUnits: Array<DosingUnit> = useMemo(
     () =>
@@ -171,7 +176,7 @@ export default function MedicationOrderForm({ initialOrderBasketItem, onSign, on
         </div>
       )}
 
-      <Form className={styles.orderForm} onSubmit={() => onSign(orderBasketItem)} id="drugOrderForm">
+      <Form className={styles.orderForm} onSubmit={handleFormSubmission} id="drugOrderForm">
         {errorFetchingOrderConfig && (
           <InlineNotification
             kind="error"

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket.component.tsx
@@ -22,11 +22,7 @@ const OrderBasket: React.FC<OrderBasketProps> = ({ patientUuid, closeWorkspace }
   const { t } = useTranslation();
 
   const store = useStore(orderBasketStore);
-  const setItems = useCallback(
-    (items: OrderBasketItem[]) =>
-      orderBasketStore.setState((state) => orderBasketStoreActions.setOrderBasketItems(state, items)),
-    [orderBasketStore.setState],
-  );
+  const setItems = useCallback((items: OrderBasketItem[]) => orderBasketStoreActions.setOrderBasketItems(items), []);
   const patientOrderItems = useMemo(() => getOrderItems(store.items, patientUuid), [store, patientUuid]);
 
   const { mutateOrders } = usePatientOrders(patientUuid, 'ACTIVE');

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket.component.tsx
@@ -7,7 +7,7 @@ import { orderDrugs } from './drug-ordering';
 import { ConfigObject } from '../config-schema';
 import { createEmptyEncounter, useOrderEncounter, usePatientOrders } from '../api/api';
 import { OrderBasketItem } from '../types/order-basket-item';
-import { getOrderItems, orderBasketStore } from '../medications/order-basket-store';
+import { getOrderItems, orderBasketStore, orderBasketStoreActions } from '../medications/order-basket-store';
 import MedicationOrderForm from './medication-order-form.component';
 import MedicationsDetailsTable from '../components/medications-details-table.component';
 import OrderBasketItemList from './order-basket-item-list.component';
@@ -22,7 +22,11 @@ const OrderBasket: React.FC<OrderBasketProps> = ({ patientUuid, closeWorkspace }
   const { t } = useTranslation();
 
   const store = useStore(orderBasketStore);
-  const setItems = useCallback((items) => orderBasketStore.setState((state) => (state.items = items)), []);
+  const setItems = useCallback(
+    (items: OrderBasketItem[]) =>
+      orderBasketStore.setState((state) => orderBasketStoreActions.setOrderBasketItems(state, items)),
+    [orderBasketStore.setState],
+  );
   const patientOrderItems = useMemo(() => getOrderItems(store.items, patientUuid), [store, patientUuid]);
 
   const { mutateOrders } = usePatientOrders(patientUuid, 'ACTIVE');
@@ -145,13 +149,11 @@ const OrderBasket: React.FC<OrderBasketProps> = ({ patientUuid, closeWorkspace }
 
   const openMedicationOrderFormForUpdatingExistingOrder = (existingOrderIndex: number) => {
     const order = patientOrderItems[existingOrderIndex];
-    openMedicationOrderForm(order, (finalizedOrder) =>
-      setItems(() => {
-        const newOrders = [...patientOrderItems];
-        newOrders[existingOrderIndex] = finalizedOrder;
-        return newOrders;
-      }),
-    );
+    openMedicationOrderForm(order, (finalizedOrder) => {
+      const newOrders = [...patientOrderItems];
+      newOrders[existingOrderIndex] = finalizedOrder;
+      setItems(newOrders);
+    });
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the setting of the global store for the medications app after shifting the global store from unistore to zustand (PR https://github.com/openmrs/openmrs-esm-core/pull/632 ) .

**P.S.:** Order basket works for multiple users too.

## Screenshots
### Drug ordering

https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/1db395fa-2c9f-44ad-97c8-638cedfaa153

## Related Issue
https://issues.openmrs.org/browse/O3-2151

## Other
<!-- Anything not covered above -->
