### PR TITLE
(fix) Allow modifying the visit date to accommodate the new encounter date on all encounters tab

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -126,5 +126,7 @@ export function mapEncounters(visit) {
     visitUuid: visit?.uuid,
     visitType: visit?.visitType?.name,
     visitTypeUuid: visit?.visitType.uuid,
+    visitStartDatetime: visit?.startDatetime,
+    visitStopDatetime: visit?.stopDatetime,
   }));
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Visit start/stop dates weren't being passed to form entry engine when editing an encounter from the "All encounters" tab on visits widget. This caused issues when editing the encounter date if it fell outside the designated visit range.

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/68599335/599dbc16-efc0-4e21-966e-95ac536064aa)