### PR TITLE
Include location provider

### DIFF
--- a/packages/esm-form-entry-app/src/app/app.module.ts
+++ b/packages/esm-form-entry-app/src/app/app.module.ts
@@ -1,11 +1,11 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { NgModule } from '@angular/core';
-
+import { LOCALE_ID, NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
 import { EmptyRouteComponent } from './empty-route/empty-route.component';
 import { FeWrapperComponent } from './fe-wrapper/fe-wrapper.component';
 import { FormEntryModule } from '@openmrs/ngx-formentry';
+
 import { ReactiveFormsModule } from '@angular/forms';
 import { OpenmrsApiModule } from './openmrs-api/openmrs-api.module';
 import { FormSchemaService } from './form-schema/form-schema.service';
@@ -18,6 +18,31 @@ import { LoaderComponent } from './loader/loader.component';
 import { SingleSpaPropsService } from './single-spa-props/single-spa-props.service';
 import { FormCreationService } from './form-creation/form-creation.service';
 import { TranslateModule, TranslateService, TranslateStore } from '@ngx-translate/core';
+import { Encounter, FormSchema } from './types';
+import { Session } from '@openmrs/esm-framework';
+
+export interface CreateFormParams {
+  /**
+   * The form schema to be used.
+   */
+  formSchema: FormSchema;
+  /**
+   * The currently signed-in user.
+   */
+  session: Session;
+  /**
+   * An optional encounter.
+   * If provided, this encounter will be edited by the form.
+   * This can be an offline encounter form the sync queue which hasn't been synchronized yet.
+   */
+  encounter?: Encounter;
+  /**
+   * A previous encounter for displaying previously entered data.
+   */
+  previousEncounter?: Encounter;
+}
+
+let session: CreateFormParams = null;
 
 @NgModule({
   declarations: [AppComponent, EmptyRouteComponent, FeWrapperComponent, LoaderComponent],
@@ -42,6 +67,10 @@ import { TranslateModule, TranslateService, TranslateStore } from '@ngx-translat
     SingleSpaPropsService,
     TranslateService,
     TranslateStore,
+    {
+      provide: LOCALE_ID,
+      useValue: (window as any).i18next.language.toLowerCase() ? (window as any).i18next.language.toLowerCase() : 'en',
+    },
   ],
   bootstrap: [AppComponent],
 })

--- a/packages/esm-form-entry-app/src/app/app.module.ts
+++ b/packages/esm-form-entry-app/src/app/app.module.ts
@@ -18,31 +18,6 @@ import { LoaderComponent } from './loader/loader.component';
 import { SingleSpaPropsService } from './single-spa-props/single-spa-props.service';
 import { FormCreationService } from './form-creation/form-creation.service';
 import { TranslateModule, TranslateService, TranslateStore } from '@ngx-translate/core';
-import { Encounter, FormSchema } from './types';
-import { Session } from '@openmrs/esm-framework';
-
-export interface CreateFormParams {
-  /**
-   * The form schema to be used.
-   */
-  formSchema: FormSchema;
-  /**
-   * The currently signed-in user.
-   */
-  session: Session;
-  /**
-   * An optional encounter.
-   * If provided, this encounter will be edited by the form.
-   * This can be an offline encounter form the sync queue which hasn't been synchronized yet.
-   */
-  encounter?: Encounter;
-  /**
-   * A previous encounter for displaying previously entered data.
-   */
-  previousEncounter?: Encounter;
-}
-
-let session: CreateFormParams = null;
 
 @NgModule({
   declarations: [AppComponent, EmptyRouteComponent, FeWrapperComponent, LoaderComponent],


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Alter app.module providers so it incorporates the LOCATE_ID (default 'en').
This enables, for example, on the datepicker the correct display depending on the user location.

## Screenshots
<img width="306" alt="image" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/106243905/6e4eb15a-04d8-49a8-80a3-f2a8c5417aa3"> </br>
With language 'fr' selected

 </br>
 </br>
 </br>


<img width="257" alt="image" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/106243905/278094e8-41d9-4068-afa5-ce83bcc6aa53"> </br>
With language 'en' selected
