### PR TITLE
(feat)Disable start visit button on a deceased patient

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -211,11 +211,12 @@ const VisitHeader: React.FC = () => {
             {systemVisitEnabled && (
               <>
                 <ExtensionSlot extensionSlotName="visit-header-right-slot" />
-                {!hasActiveVisit && (
-                  <Button className={styles.startVisitButton} onClick={launchStartVisitForm} size="lg">
-                    {startVisitLabel ? startVisitLabel : t('startAVisit', 'Start a visit')}
-                  </Button>
-                )}
+                {!hasActiveVisit &&
+                  !isDeceased && (
+                    <Button className={styles.startVisitButton} onClick={launchStartVisitForm} size="lg">
+                      {startVisitLabel ? startVisitLabel : t('startAVisit', 'Start a visit')}
+                    </Button>
+                  )}
                 {currentVisit !== null && endVisitLabel && (
                   <>
                     <HeaderGlobalAction
@@ -259,6 +260,7 @@ const VisitHeader: React.FC = () => {
     openModal,
     currentVisit,
     logo,
+    isDeceased,
     systemVisitEnabled,
   ]);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
I introduced a new variable `isDeceased` that determines whether the patient is deceased or not based on the deceasedDateTime property. I then added a condition !isDeceased inside the render function to check if the patient is not deceased before showing the "Start a visit" button.

By including `isDeceased` in the dependencies array of the useCallback hook, the function will be re-evaluated whenever the `isDeceased`value changes, ensuring that the button's visibility is updated accordingly.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/307258f0-b924-4184-8fbd-92786e23a5e6



## Related Issue
https://github.com/openmrs/openmrs-esm-patient-chart/pull/1159

## Other
<!-- Anything not covered above -->
