### PR TITLE
(fix) Remove patient header z-index override in tablet mode

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
@@ -41,7 +41,7 @@ $actionPanelOffset: 3rem;
         &:hover {
           background-color: $color-gray-30;
         }
-  
+
         &:focus {
           border-color: $interactive-01;
         }
@@ -58,12 +58,12 @@ $actionPanelOffset: 3rem;
     background: #ededed;
     left: 0;
     bottom: 0;
-    z-index: 1000;
+    z-index: 8000;
     width: 100%;
     display: flex;
     justify-content: stretch;
   }
-  
+
   .chartExtensions {
     background-color: $ui-02;
     flex-basis: 0.75%;

--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
@@ -10,7 +10,7 @@
 
   a {
     @include type.type-style('heading-compact-02');
-    
+
 
     &:hover {
       color: inherit;
@@ -122,8 +122,5 @@
   .dynamicWidth {
     width: 100%;
   }
-
-  :global(.cds--header){
-    z-index: 5;
-  }
 }
+


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- The `z-index` of the patient header was overridden to 5 which is lower compared with the overflow menus which makes the menus show up on top of the patient header in tablet mode.
- Updates the `sideRail` z-index to `8000` as the patient header.

## Screenshots
<!-- Required if you are making UI changes. -->
![Screenshot from 2023-06-06 09-40-18](https://github.com/openmrs/openmrs-esm-patient-chart/assets/104269786/442b548c-ac7e-41e1-a139-3038c3aeee8e)

## Screencasts
[Screencast from 2023-06-06 09-40-41.webm](https://github.com/openmrs/openmrs-esm-patient-chart/assets/104269786/be47b624-baf5-4f83-ba80-5e3d79421144)

[Screencast from 2023-06-06 09-51-45.webm](https://github.com/openmrs/openmrs-esm-patient-chart/assets/104269786/81052fa6-a415-4195-a501-c901bf2ce1d6)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
