### PR TITLE
(fix) O3-2150: Translate attachments empty state

### DIFF
--- a/packages/esm-patient-attachments-app/translations/en.json
+++ b/packages/esm-patient-attachments-app/translations/en.json
@@ -16,6 +16,7 @@
   "delete": "Delete",
   "deleteAttachmentConfirmationText": "Are you sure you want to delete this {attachmentType}? This action can't be undone.",
   "deleteImage": "Delete image",
+  "emptyStateText": "There are no {displayText} to display for this patient",
   "error": "Error",
   "errorUploading": "Error uploading a file",
   "failed": "failed",

--- a/packages/esm-patient-attachments-app/translations/en.json
+++ b/packages/esm-patient-attachments-app/translations/en.json
@@ -16,7 +16,7 @@
   "delete": "Delete",
   "deleteAttachmentConfirmationText": "Are you sure you want to delete this {attachmentType}? This action can't be undone.",
   "deleteImage": "Delete image",
-  "emptyStateText": "There are no {displayText} to display for this patient",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "error": "Error",
   "errorUploading": "Error uploading a file",
   "failed": "failed",

--- a/packages/esm-patient-attachments-app/translations/he.json
+++ b/packages/esm-patient-attachments-app/translations/he.json
@@ -15,7 +15,7 @@
   "delete": "מחק",
   "deleteAttachmentConfirmationText": "",
   "deleteImage": "מחק תמונה",
-  "emptyStateText": "אין {displayText} להצגה עבור מטופל זה",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "error": "שגיאה",
   "errorUploading": "שגיאה בהעלאת קובץ",
   "failed": "נכשל",

--- a/packages/esm-patient-attachments-app/translations/he.json
+++ b/packages/esm-patient-attachments-app/translations/he.json
@@ -15,6 +15,7 @@
   "delete": "מחק",
   "deleteAttachmentConfirmationText": "",
   "deleteImage": "מחק תמונה",
+  "emptyStateText": "אין {displayText} להצגה עבור מטופל זה",
   "error": "שגיאה",
   "errorUploading": "שגיאה בהעלאת קובץ",
   "failed": "נכשל",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Adds the missing string to the translation. In empty tables, the text was always displayed in English.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-2150

## Other
<!-- Anything not covered above -->
