### PR TITLE
(fix) Dashboard path should be derived from path not title

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { useExtensionStore } from '@openmrs/esm-framework';
+import { ConfigObject, useExtensionStore } from '@openmrs/esm-framework';
 import { useNavGroups } from '@openmrs/esm-patient-common-lib';
 import { DashboardView, DashboardConfig } from './dashboard-view.component';
 import { basePath } from '../../constants';
 
 function makePath(target: DashboardConfig, params: Record<string, string> = {}) {
-  const parts = `${basePath}/${encodeURIComponent(target.title)}`.split('/');
+  const parts = `${basePath}/${encodeURIComponent(target.path)}`.split('/');
 
   Object.keys(params).forEach((key) => {
     for (let i = 0; i < parts.length; i++) {
@@ -19,7 +19,7 @@ function makePath(target: DashboardConfig, params: Record<string, string> = {}) 
   return parts.join('/');
 }
 
-function getDashboardDefinition(meta, config) {
+function getDashboardDefinition(meta: object, config: ConfigObject) {
   return { ...meta, ...config };
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, when directed to the patient chart, it uses the `title` property of the default dashboard to determine the URL. Since the title might be a function (to allow translations), this can result in the page redirecting to `/chart/undefined`. This fixes that, so the default landing page will, once again, be the first link on the patient chart.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
