### PR TITLE
(fix) O3-2152: Fix patient-banner actions dropdown

### DIFF
--- a/packages/esm-patient-banner-app/src/banner/patient-banner.scss
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.scss
@@ -116,3 +116,17 @@
   @include type.type-style("body-compact-01");
   color: $interactive-01;
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .overflowMenuContainer {
+    & > div {
+      margin-left: unset;
+      margin-right: -1.5rem;
+      & > div {
+        left: unset;
+        right: -6.025rem;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The action button in the patient dashboard was being hidden behind other UI elements. This pull request fixes the button and dropdown.

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/68945262/29e58632-1d85-4c5a-bb41-8259527260e0)

## Related Issue
https://issues.openmrs.org/browse/O3-2152

## Other
<!-- Anything not covered above -->
