### PR TITLE
(fix) O3-2150: Adds missing translation strings to modules

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
@@ -68,6 +68,8 @@ const ObsSwitchable: React.FC<ObsSwitchableProps> = ({ patientUuid }) => {
             </div>
           );
         }
+        // Ensure we have the emptyStateText translation key
+        // t('emptyStateText', 'There are no {displayText} to display for this patient')
         return <EmptyState displayText={config.resultsName} headerTitle={config.title} />;
       })()}
     </>

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
@@ -69,7 +69,7 @@ const ObsSwitchable: React.FC<ObsSwitchableProps> = ({ patientUuid }) => {
           );
         }
         // Ensure we have the emptyStateText translation key
-        // t('emptyStateText', 'There are no {displayText} to display for this patient')
+        // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
         return <EmptyState displayText={config.resultsName} headerTitle={config.title} />;
       })()}
     </>

--- a/packages/esm-generic-patient-widgets-app/translations/en.json
+++ b/packages/esm-generic-patient-widgets-app/translations/en.json
@@ -1,5 +1,6 @@
 {
   "chartView": "Chart View",
   "displaying": "Displaying",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "tableView": "Table View"
 }

--- a/packages/esm-generic-patient-widgets-app/translations/he.json
+++ b/packages/esm-generic-patient-widgets-app/translations/he.json
@@ -1,5 +1,6 @@
 {
   "chartView": "תצוגת תרשים",
   "displaying": "מציג",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "tableView": "תצוגת טבלה"
 }

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -126,7 +126,7 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
     );
   }
   // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {displayText} to display for this patient')
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchAllergiesForm} />;
 };
 

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -125,6 +125,8 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
       </div>
     );
   }
+  // Ensure we have the emptyStateText translation key
+  // t('emptyStateText', 'There are no {displayText} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchAllergiesForm} />;
 };
 

--- a/packages/esm-patient-allergies-app/translations/en.json
+++ b/packages/esm-patient-allergies-app/translations/en.json
@@ -11,6 +11,7 @@
   "dateOfOnsetAndComments": "Date of onset and comments",
   "discard": "Discard",
   "drug": "Drug",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "environmental": "Environmental",
   "errorFetchingData": "Error fetching allergens and reactions",
   "food": "Food",

--- a/packages/esm-patient-allergies-app/translations/he.json
+++ b/packages/esm-patient-allergies-app/translations/he.json
@@ -13,6 +13,7 @@
   "dateOfFirstOnset": "תאריך תחילת ההתפתחות",
   "discard": "בטל",
   "drug": "תרופה",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "environmental": "סביבתי",
   "errorFetchingData": "שגיאה בקבלת נתוני החומרים האלרגניים והתגובות",
   "food": "מזון",

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
@@ -100,6 +100,8 @@ const AttachmentsOverview: React.FC<{ patientUuid: string }> = ({ patientUuid })
   );
 
   if (!attachments.length) {
+    // Ensure we have the emptyStateText translation key
+    // t('emptyStateText', 'There are no {displayText} to display for this patient')
     return <EmptyState displayText={'attachments'} headerTitle="Attachments" launchForm={showCam} />;
   }
 

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
@@ -101,7 +101,7 @@ const AttachmentsOverview: React.FC<{ patientUuid: string }> = ({ patientUuid })
 
   if (!attachments.length) {
     // Ensure we have the emptyStateText translation key
-    // t('emptyStateText', 'There are no {displayText} to display for this patient')
+    // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
     return <EmptyState displayText={'attachments'} headerTitle="Attachments" launchForm={showCam} />;
   }
 

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -26,6 +26,9 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
   const { t } = useTranslation();
   const overflowMenuRef = React.useRef(null);
 
+  // Ensure we have the emptyStateText translation key
+  // t('emptyStateText', 'There are no {displayText} to display for this patient')
+
   const patientActionsSlotState = React.useMemo(
     () => ({ patientUuid, onClick, onTransition }),
     [patientUuid, onClick, onTransition],

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -27,7 +27,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
   const overflowMenuRef = React.useRef(null);
 
   // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {displayText} to display for this patient')
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
 
   const patientActionsSlotState = React.useMemo(
     () => ({ patientUuid, onClick, onTransition }),

--- a/packages/esm-patient-banner-app/translations/en.json
+++ b/packages/esm-patient-banner-app/translations/en.json
@@ -11,6 +11,7 @@
   "countyDistrict": "District",
   "deceased": "Deceased",
   "district": "District",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "female": "Female",
   "hideDetails": "Hide details",
   "loading": "Loading...",

--- a/packages/esm-patient-banner-app/translations/he.json
+++ b/packages/esm-patient-banner-app/translations/he.json
@@ -4,6 +4,7 @@
   "address": "כתובת",
   "contactDetails": "פרטי יצירת קשר",
   "deceased": "נפטר",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "loading": "טוען...",
   "relationships": "יחסים",
   "showAllDetails": "הצג את כל הפרטים",

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
@@ -122,7 +122,7 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
     );
   }
   // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {displayText} to display for this patient')
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchBiometricsForm} />;
 };
 

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
@@ -121,6 +121,8 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
       </div>
     );
   }
+  // Ensure we have the emptyStateText translation key
+  // t('emptyStateText', 'There are no {displayText} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchBiometricsForm} />;
 };
 

--- a/packages/esm-patient-biometrics-app/translations/en.json
+++ b/packages/esm-patient-biometrics-app/translations/en.json
@@ -3,6 +3,7 @@
   "biometricDisplayed": "Biometric displayed",
   "biometrics": "Biometrics",
   "biometrics_lower": "biometrics",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "goToSummary": "Go to Summary",
   "loading": "Loading",
   "seeAll": "See all",

--- a/packages/esm-patient-biometrics-app/translations/he.json
+++ b/packages/esm-patient-biometrics-app/translations/he.json
@@ -1,0 +1,11 @@
+{
+  "add": "הוסף",
+  "biometricDisplayed": "תצוגת מדדים ביומטריים",
+  "biometrics": "מדדים ביומטריים",
+  "biometrics_lower": "מדדים ביומטריים",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "goToSummary": "עבור לסיכום",
+  "loading": "טוען",
+  "seeAll": "ראה הכל",
+  "weight": "משקל"
+}

--- a/packages/esm-patient-chart-app/src/deceased/base-concept-answer.component.tsx
+++ b/packages/esm-patient-chart-app/src/deceased/base-concept-answer.component.tsx
@@ -34,7 +34,7 @@ const BaseConceptAnswer: React.FC<BaseConceptAnswerProps> = ({ onChange, isPatie
   const { results, currentPage, goTo } = usePagination<ConceptAnswer>(searchResults, 10);
 
   // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {displayText} to display for this patient')
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
   return (
     <div
       className={`${styles.conceptAnswerOverviewWrapper} ${

--- a/packages/esm-patient-chart-app/src/deceased/base-concept-answer.component.tsx
+++ b/packages/esm-patient-chart-app/src/deceased/base-concept-answer.component.tsx
@@ -33,6 +33,8 @@ const BaseConceptAnswer: React.FC<BaseConceptAnswerProps> = ({ onChange, isPatie
 
   const { results, currentPage, goTo } = usePagination<ConceptAnswer>(searchResults, 10);
 
+  // Ensure we have the emptyStateText translation key
+  // t('emptyStateText', 'There are no {displayText} to display for this patient')
   return (
     <div
       className={`${styles.conceptAnswerOverviewWrapper} ${

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -37,6 +37,7 @@
   "edit": "Edit",
   "editPastVisit": "Edit Past Visit",
   "editThisEncounter": "Edit this encounter",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "encounterDeleted": "Encounter deleted",
   "encounters": "Encounters",
   "encounters_link": "Visits",

--- a/packages/esm-patient-chart-app/translations/he.json
+++ b/packages/esm-patient-chart-app/translations/he.json
@@ -36,6 +36,7 @@
   "editPastVisit": "ערוך ביקור עבר",
   "editQueueEntryStatusTooltip": "עריכה",
   "editThisEncounter": "ערוך ביקור זה",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "encounters": "ביקורים",
   "encounterType": "סוג הביקור",
   "end": "סיום",

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -186,7 +186,7 @@ function ConditionsDetailedSummary({ patient }) {
     );
   }
   // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {displayText} to display for this patient')
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchConditionsForm} />;
 }
 

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -185,7 +185,8 @@ function ConditionsDetailedSummary({ patient }) {
       </div>
     );
   }
-
+  // Ensure we have the emptyStateText translation key
+  // t('emptyStateText', 'There are no {displayText} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchConditionsForm} />;
 }
 

--- a/packages/esm-patient-conditions-app/translations/en.json
+++ b/packages/esm-patient-conditions-app/translations/en.json
@@ -18,6 +18,7 @@
   "deleting": "Deleting",
   "edit": "Edit",
   "editCondition": "Edit a Condition",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "endDate": "End date",
   "enterCondition": "Enter condition",
   "errorCreatingCondition": "Error creating condition",

--- a/packages/esm-patient-conditions-app/translations/he.json
+++ b/packages/esm-patient-conditions-app/translations/he.json
@@ -12,6 +12,7 @@
   "conditionSaveError": "שגיאה בשמירת המצב",
   "currentStatus": "מצב נוכחי",
   "dateOfOnset": "תאריך התחלה",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "endDate": "תאריך סיום",
   "enterCondition": "הזן מצב",
   "inactive": "לא פעיל",

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-forms.component.tsx
@@ -57,7 +57,7 @@ const OfflineForms: React.FC<OfflineFormsProps> = ({ canMarkFormsAsOffline }) =>
 
   if (forms?.data?.length === 0) {
     // Ensure we have the emptyStateText translation key
-    // t('emptyStateText', 'There are no {displayText} to display for this patient')
+    // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
     return (
       <div className={styles.contentContainer}>
         <EmptyState

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-forms.component.tsx
@@ -56,6 +56,8 @@ const OfflineForms: React.FC<OfflineFormsProps> = ({ canMarkFormsAsOffline }) =>
       })) ?? [];
 
   if (forms?.data?.length === 0) {
+    // Ensure we have the emptyStateText translation key
+    // t('emptyStateText', 'There are no {displayText} to display for this patient')
     return (
       <div className={styles.contentContainer}>
         <EmptyState

--- a/packages/esm-patient-forms-app/translations/en.json
+++ b/packages/esm-patient-forms-app/translations/en.json
@@ -4,6 +4,7 @@
   "clinicalForm": "Clinical form",
   "completed": "Completed",
   "editForm": "Edit form",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "form": "Form",
   "formName": "Form Name (A-Z)",
   "forms": "Forms",

--- a/packages/esm-patient-forms-app/translations/he.json
+++ b/packages/esm-patient-forms-app/translations/he.json
@@ -2,6 +2,7 @@
   "all": "הכל",
   "clinicalForm": "טופס קליני",
   "completed": "הושלם",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "form": "טופס",
   "forms_link": "טפסים והערות",
   "formName": "שם הטופס (א-ת)",

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
@@ -178,6 +178,8 @@ const ImmunizationsDetailedSummary: React.FC<ImmunizationsDetailedSummaryProps> 
       />
     </div>;
   }
+  // Ensure we have the emptyStateText translation key
+  // t('emptyStateText', 'There are no {displayText} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchImmunizationsForm} />;
 };
 

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
@@ -179,7 +179,7 @@ const ImmunizationsDetailedSummary: React.FC<ImmunizationsDetailedSummaryProps> 
     </div>;
   }
   // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {displayText} to display for this patient')
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchImmunizationsForm} />;
 };
 

--- a/packages/esm-patient-immunizations-app/translations/en.json
+++ b/packages/esm-patient-immunizations-app/translations/en.json
@@ -1,6 +1,7 @@
 {
   "add": "Add",
   "cancel": "Cancel",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "errorSaving": "Error saving vaccination",
   "expirationDate": "Expiration Date",
   "goToSummary": "Go to Summary",

--- a/packages/esm-patient-immunizations-app/translations/he.json
+++ b/packages/esm-patient-immunizations-app/translations/he.json
@@ -1,0 +1,22 @@
+
+{
+  "add": "הוסף",
+  "cancel": "ביטול",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "errorSaving": "שגיאה בשמירת החיסון",
+  "expirationDate": "תאריך תפוגה",
+  "goToSummary": "עבור לסיכום",
+  "immunizations": "חיסונים",
+  "immunizations_link": "חיסונים",
+  "lotNumber": "מספר לוט",
+  "manufacturer": "יצרן",
+  "pleaseSelect": "בחר בבקשה",
+  "recentVaccination": "חיסון אחרון",
+  "save": "שמור",
+  "seeAll": "ראה הכל",
+  "sequence": "סדר",
+  "singleDoseOn": "מנת יחידה בתאריך",
+  "vaccinationDate": "תאריך החיסון",
+  "vaccinationSaved": "החיסון נשמר בהצלחה",
+  "vaccine": "חיסון"
+}

--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
@@ -42,7 +42,7 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, show
     );
   }
   // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {displayText} to display for this patient')
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchOrderBasket} />;
 };
 

--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
@@ -41,7 +41,8 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, show
       />
     );
   }
-
+  // Ensure we have the emptyStateText translation key
+  // t('emptyStateText', 'There are no {displayText} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchOrderBasket} />;
 };
 

--- a/packages/esm-patient-medications-app/translations/en.json
+++ b/packages/esm-patient-medications-app/translations/en.json
@@ -28,6 +28,7 @@
   "editFrequencyComboBoxTitle": "Frequency",
   "editRouteComboBoxTitle": "Route",
   "emptyOrderBasket": "Your basket is empty",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "endDate": "End date",
   "error": "Error",
   "errorCreatingAnEncounter": "Error when creating an encounter",

--- a/packages/esm-patient-medications-app/translations/he.json
+++ b/packages/esm-patient-medications-app/translations/he.json
@@ -28,6 +28,7 @@
   "editFrequencyComboBoxTitle": "תדירות",
   "editRouteComboBoxTitle": "דרך",
   "emptyOrderBasket": "הסל שלך ריק",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "endDate": "תאריך סיום",
   "error": "שגיאה",
   "errorCreatingAnEncounter": "שגיאה ביצירת פגישה",

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -46,6 +46,8 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, showAddNote, pag
     return <ErrorState error={isError} headerTitle={headerTitle} />;
   }
   if (!visitNotes?.length) {
+    // Ensure we have the emptyStateText translation key
+    // t('emptyStateText', 'There are no {displayText} to display for this patient')
     return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchVisitNoteForm} />;
   }
 

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -47,7 +47,7 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, showAddNote, pag
   }
   if (!visitNotes?.length) {
     // Ensure we have the emptyStateText translation key
-    // t('emptyStateText', 'There are no {displayText} to display for this patient')
+    // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
     return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchVisitNoteForm} />;
   }
 

--- a/packages/esm-patient-notes-app/translations/en.json
+++ b/packages/esm-patient-notes-app/translations/en.json
@@ -10,6 +10,7 @@
   "diagnosis": "Diagnosis",
   "discard": "Discard",
   "emptyDiagnosisText": "No diagnosis selected — Enter a diagnosis below",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "enterPrimaryDiagnoses": "Enter Primary diagnoses",
   "enterSecondaryDiagnoses": "Enter Secondary diagnoses",
   "goToSummary": "Go to Summary",

--- a/packages/esm-patient-notes-app/translations/he.json
+++ b/packages/esm-patient-notes-app/translations/he.json
@@ -10,6 +10,7 @@
   "diagnosis": "אבחנה",
   "discard": "בטל",
   "emptyDiagnosisText": "לא נבחרה אבחנה - הכנס אבחנה למטה",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "enterPrimaryDiagnoses": "הזן אבחנות ראשיות",
   "enterSecondaryDiagnoses": "הזן אבחנות משניות",
   "goToSummary": "עבור לסיכום",

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -158,6 +158,8 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
       </div>
     );
   }
+  // Ensure we have the emptyStateText translation key
+  // t('emptyStateText', 'There are no {displayText} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchProgramsForm} />;
 };
 

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -159,7 +159,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
     );
   }
   // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {displayText} to display for this patient')
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchProgramsForm} />;
 };
 

--- a/packages/esm-patient-programs-app/translations/en.json
+++ b/packages/esm-patient-programs-app/translations/en.json
@@ -14,6 +14,7 @@
   "discontinue": "Discontinue",
   "discontinueEnrollment": "Discontinue enrollment",
   "editProgram": "Edit Program",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "enroll": "Enroll",
   "enrollment": "Enrollment",
   "enrollmentLocation": "Enrollment location",

--- a/packages/esm-patient-programs-app/translations/he.json
+++ b/packages/esm-patient-programs-app/translations/he.json
@@ -12,6 +12,7 @@
   "dateCompleted": "תאריך השלמה",
   "dateEnrolled": "תאריך הרשמה",
   "discontinue": "הפסק",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "enroll": "הרשם",
   "enrollment": "הרשמה",
   "enrollmentLocation": "מיקום הרשמה",

--- a/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
+++ b/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
@@ -218,6 +218,8 @@ const Trendline: React.FC<TrendlineProps> = ({
   }
 
   if (obs.length === 0) {
+    // Ensure we have the emptyStateText translation key
+    // t('emptyStateText', 'There are no {displayText} to display for this patient')
     return <EmptyState displayText={t('observationsDisplayText', 'observations')} headerTitle={chartTitle} />;
   }
 

--- a/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
+++ b/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
@@ -219,7 +219,7 @@ const Trendline: React.FC<TrendlineProps> = ({
 
   if (obs.length === 0) {
     // Ensure we have the emptyStateText translation key
-    // t('emptyStateText', 'There are no {displayText} to display for this patient')
+    // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
     return <EmptyState displayText={t('observationsDisplayText', 'observations')} headerTitle={chartTitle} />;
   }
 

--- a/packages/esm-patient-test-results-app/translations/en.json
+++ b/packages/esm-patient-test-results-app/translations/en.json
@@ -2,6 +2,7 @@
   "backToTimeline": "Back to timeline",
   "date": "Date",
   "dateCollected": "Displaying date collected",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "moreResultsAvailable": "More results available",
   "observationsDisplayText": "observations",
   "ordered": "Ordered",

--- a/packages/esm-patient-test-results-app/translations/he.json
+++ b/packages/esm-patient-test-results-app/translations/he.json
@@ -2,6 +2,7 @@
   "backToTimeline": "חזור לציר הזמן",
   "date": "תאריך",
   "dateCollected": "מציג תאריך איסוף",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "moreResultsAvailable": "קיימים עוד תוצאות זמינות",
   "observationsDisplayText": "תצוגת מדדים",
   "ordered": "הוזמן",

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -140,6 +140,8 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
             </div>
           );
         }
+        // Ensure we have the emptyStateText translation key
+        // t('emptyStateText', 'There are no {displayText} to display for this patient')
         return (
           <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchVitalsBiometricsForm} />
         );

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -141,7 +141,7 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
           );
         }
         // Ensure we have the emptyStateText translation key
-        // t('emptyStateText', 'There are no {displayText} to display for this patient')
+        // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
         return (
           <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchVitalsBiometricsForm} />
         );

--- a/packages/esm-patient-vitals-app/translations/en.json
+++ b/packages/esm-patient-vitals-app/translations/en.json
@@ -8,6 +8,7 @@
   "checkForValidity": "Some of the values entered are invalid",
   "diastolic": "diastolic",
   "discard": "Discard",
+  "emptyStateText": "There are no {{displayText}} to display for this patient",
   "goToSummary": "Go to Summary",
   "heartRate": "Heart rate",
   "height": "Height",

--- a/packages/esm-patient-vitals-app/translations/he.json
+++ b/packages/esm-patient-vitals-app/translations/he.json
@@ -9,6 +9,7 @@
   "checkForValidity": "חלק מהערכים שהוזנו אינם תקפים",
   "diastolic": "דיאסטולי",
   "discard": "בטל",
+  "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
   "goToSummary": "עבור לסיכום",
   "heartRate": "קצב לב",
   "height": "גובה",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
 Adds missing translation strings for empty tables to modules. Adds two new he.json files.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-2150

## Other
<!-- Anything not covered above -->
