### PR TITLE
(fix) O3-2150: Adds missing translation 'record' strings to modules

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
@@ -68,8 +68,8 @@ const ObsSwitchable: React.FC<ObsSwitchableProps> = ({ patientUuid }) => {
             </div>
           );
         }
-        // Ensure we have the emptyStateText translation key
-        // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+        // Ensure we have emptyStateText and record translation keys
+        // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
         return <EmptyState displayText={config.resultsName} headerTitle={config.title} />;
       })()}
     </>

--- a/packages/esm-generic-patient-widgets-app/translations/en.json
+++ b/packages/esm-generic-patient-widgets-app/translations/en.json
@@ -2,5 +2,6 @@
   "chartView": "Chart View",
   "displaying": "Displaying",
   "emptyStateText": "There are no {{displayText}} to display for this patient",
+  "record": "Record",
   "tableView": "Table View"
 }

--- a/packages/esm-generic-patient-widgets-app/translations/he.json
+++ b/packages/esm-generic-patient-widgets-app/translations/he.json
@@ -2,5 +2,6 @@
   "chartView": "תצוגת תרשים",
   "displaying": "מציג",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "tableView": "תצוגת טבלה"
 }

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -125,8 +125,8 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
       </div>
     );
   }
-  // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+  // Ensure we have emptyStateText and record translation keys
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchAllergiesForm} />;
 };
 

--- a/packages/esm-patient-allergies-app/translations/en.json
+++ b/packages/esm-patient-allergies-app/translations/en.json
@@ -25,6 +25,7 @@
   "otherNonCodedAllergicReaction": "Other non-coded allergic reaction",
   "reaction": "Reaction",
   "reactions": "Reactions",
+  "record": "Record",
   "saveAndClose": "Save and close",
   "seeAll": "See all",
   "selectAllergens": "Select the allergens",

--- a/packages/esm-patient-allergies-app/translations/he.json
+++ b/packages/esm-patient-allergies-app/translations/he.json
@@ -14,6 +14,7 @@
   "discard": "בטל",
   "drug": "תרופה",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "environmental": "סביבתי",
   "errorFetchingData": "שגיאה בקבלת נתוני החומרים האלרגניים והתגובות",
   "food": "מזון",

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
@@ -100,8 +100,8 @@ const AttachmentsOverview: React.FC<{ patientUuid: string }> = ({ patientUuid })
   );
 
   if (!attachments.length) {
-    // Ensure we have the emptyStateText translation key
-    // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+    // Ensure we have emptyStateText and record translation keys
+    // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
     return <EmptyState displayText={'attachments'} headerTitle="Attachments" launchForm={showCam} />;
   }
 

--- a/packages/esm-patient-attachments-app/translations/en.json
+++ b/packages/esm-patient-attachments-app/translations/en.json
@@ -33,6 +33,7 @@
   "image": "Image",
   "imageDescription": "Image description",
   "name": "name",
+  "record": "Record",
   "successfullyDeleted": "successfully deleted",
   "type": "Type",
   "uploadComplete": "Upload complete",

--- a/packages/esm-patient-attachments-app/translations/he.json
+++ b/packages/esm-patient-attachments-app/translations/he.json
@@ -16,6 +16,7 @@
   "deleteAttachmentConfirmationText": "",
   "deleteImage": "מחק תמונה",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "error": "שגיאה",
   "errorUploading": "שגיאה בהעלאת קובץ",
   "failed": "נכשל",

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -26,8 +26,8 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
   const { t } = useTranslation();
   const overflowMenuRef = React.useRef(null);
 
-  // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+  // Ensure we have emptyStateText and record translation keys
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
 
   const patientActionsSlotState = React.useMemo(
     () => ({ patientUuid, onClick, onTransition }),

--- a/packages/esm-patient-banner-app/translations/en.json
+++ b/packages/esm-patient-banner-app/translations/en.json
@@ -18,6 +18,7 @@
   "male": "Male",
   "other": "Other",
   "postalCode": "Postal code",
+  "record": "Record",
   "relationships": "Relationships",
   "showDetails": "Show details",
   "started": "Started",

--- a/packages/esm-patient-banner-app/translations/he.json
+++ b/packages/esm-patient-banner-app/translations/he.json
@@ -5,6 +5,7 @@
   "contactDetails": "פרטי יצירת קשר",
   "deceased": "נפטר",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "loading": "טוען...",
   "relationships": "יחסים",
   "showAllDetails": "הצג את כל הפרטים",

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
@@ -121,8 +121,8 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
       </div>
     );
   }
-  // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+  // Ensure we have emptyStateText and record translation keys
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchBiometricsForm} />;
 };
 

--- a/packages/esm-patient-biometrics-app/translations/en.json
+++ b/packages/esm-patient-biometrics-app/translations/en.json
@@ -6,6 +6,7 @@
   "emptyStateText": "There are no {{displayText}} to display for this patient",
   "goToSummary": "Go to Summary",
   "loading": "Loading",
+  "record": "Record",
   "seeAll": "See all",
   "weight": "Weight"
 }

--- a/packages/esm-patient-biometrics-app/translations/he.json
+++ b/packages/esm-patient-biometrics-app/translations/he.json
@@ -4,6 +4,7 @@
   "biometrics": "מדדים ביומטריים",
   "biometrics_lower": "מדדים ביומטריים",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "goToSummary": "עבור לסיכום",
   "loading": "טוען",
   "seeAll": "ראה הכל",

--- a/packages/esm-patient-chart-app/src/deceased/base-concept-answer.component.tsx
+++ b/packages/esm-patient-chart-app/src/deceased/base-concept-answer.component.tsx
@@ -33,8 +33,8 @@ const BaseConceptAnswer: React.FC<BaseConceptAnswerProps> = ({ onChange, isPatie
 
   const { results, currentPage, goTo } = usePagination<ConceptAnswer>(searchResults, 10);
 
-  // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+  // Ensure we have emptyStateText and record translation keys
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
   return (
     <div
       className={`${styles.conceptAnswerOverviewWrapper} ${

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -105,6 +105,7 @@
   "queueAddedSuccessfully": "Patient has been added to the queue successfully.",
   "queueEntryError": "Error adding patient to the queue",
   "recommended": "Recommended",
+  "record": "Record",
   "refills": "Refills",
   "refreshToTryAgain": "Please refresh to try again",
   "searchForAVisitType": "Search for a visit type",

--- a/packages/esm-patient-chart-app/translations/he.json
+++ b/packages/esm-patient-chart-app/translations/he.json
@@ -37,6 +37,7 @@
   "editQueueEntryStatusTooltip": "עריכה",
   "editThisEncounter": "ערוך ביקור זה",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "encounters": "ביקורים",
   "encounterType": "סוג הביקור",
   "end": "סיום",

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -185,8 +185,8 @@ function ConditionsDetailedSummary({ patient }) {
       </div>
     );
   }
-  // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+  // Ensure we have emptyStateText and record translation keys
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchConditionsForm} />;
 }
 

--- a/packages/esm-patient-conditions-app/translations/en.json
+++ b/packages/esm-patient-conditions-app/translations/en.json
@@ -27,6 +27,7 @@
   "noConditionsToDisplay": "No conditions to display",
   "noResultsFor": "No results for",
   "onsetDate": "Onset date",
+  "record": "Record",
   "saveAndClose": "Save & close",
   "saving": "Saving",
   "searchConditions": "Search conditions",

--- a/packages/esm-patient-conditions-app/translations/he.json
+++ b/packages/esm-patient-conditions-app/translations/he.json
@@ -13,6 +13,7 @@
   "currentStatus": "מצב נוכחי",
   "dateOfOnset": "תאריך התחלה",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "endDate": "תאריך סיום",
   "enterCondition": "הזן מצב",
   "inactive": "לא פעיל",

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-forms.component.tsx
@@ -56,8 +56,8 @@ const OfflineForms: React.FC<OfflineFormsProps> = ({ canMarkFormsAsOffline }) =>
       })) ?? [];
 
   if (forms?.data?.length === 0) {
-    // Ensure we have the emptyStateText translation key
-    // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+    // Ensure we have emptyStateText and record translation keys
+    // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
     return (
       <div className={styles.contentContainer}>
         <EmptyState

--- a/packages/esm-patient-forms-app/translations/en.json
+++ b/packages/esm-patient-forms-app/translations/en.json
@@ -28,6 +28,7 @@
   "offlinePatientsTableSearchPlaceholder": "Search this list",
   "offlineToggle": "Offline toggle",
   "recommended": "Recommended",
+  "record": "Record",
   "searchForAForm": "Search for a form",
   "searchThisList": "Search this list",
   "seeAll": "See all"

--- a/packages/esm-patient-forms-app/translations/he.json
+++ b/packages/esm-patient-forms-app/translations/he.json
@@ -3,6 +3,7 @@
   "clinicalForm": "טופס קליני",
   "completed": "הושלם",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "form": "טופס",
   "forms_link": "טפסים והערות",
   "formName": "שם הטופס (א-ת)",

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
@@ -178,8 +178,8 @@ const ImmunizationsDetailedSummary: React.FC<ImmunizationsDetailedSummaryProps> 
       />
     </div>;
   }
-  // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+  // Ensure we have emptyStateText and record translation keys
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchImmunizationsForm} />;
 };
 

--- a/packages/esm-patient-immunizations-app/translations/en.json
+++ b/packages/esm-patient-immunizations-app/translations/en.json
@@ -11,6 +11,7 @@
   "manufacturer": "Manufacturer",
   "pleaseSelect": "Please select",
   "recentVaccination": "Recent vaccination",
+  "record": "Record",
   "save": "Save",
   "seeAll": "See all",
   "sequence": "Sequence",

--- a/packages/esm-patient-immunizations-app/translations/he.json
+++ b/packages/esm-patient-immunizations-app/translations/he.json
@@ -3,6 +3,7 @@
   "add": "הוסף",
   "cancel": "ביטול",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "errorSaving": "שגיאה בשמירת החיסון",
   "expirationDate": "תאריך תפוגה",
   "goToSummary": "עבור לסיכום",

--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
@@ -41,8 +41,8 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, show
       />
     );
   }
-  // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+  // Ensure we have emptyStateText and record translation keys
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchOrderBasket} />;
 };
 

--- a/packages/esm-patient-medications-app/translations/en.json
+++ b/packages/esm-patient-medications-app/translations/en.json
@@ -71,6 +71,7 @@
   "prnReasonPlaceholder": "Reason to take medicine",
   "quantity": "Quantity",
   "quantityToDispense": "Quantity to dispense",
+  "record": "Record",
   "refills": "Refills",
   "removeFromBasket": "Remove from basket",
   "renewedOrdersfalseone": "{count} order(s) being renewed (continued)",

--- a/packages/esm-patient-medications-app/translations/he.json
+++ b/packages/esm-patient-medications-app/translations/he.json
@@ -29,6 +29,7 @@
   "editRouteComboBoxTitle": "דרך",
   "emptyOrderBasket": "הסל שלך ריק",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "endDate": "תאריך סיום",
   "error": "שגיאה",
   "errorCreatingAnEncounter": "שגיאה ביצירת פגישה",

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -46,8 +46,8 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, showAddNote, pag
     return <ErrorState error={isError} headerTitle={headerTitle} />;
   }
   if (!visitNotes?.length) {
-    // Ensure we have the emptyStateText translation key
-    // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+    // Ensure we have emptyStateText and record translation keys
+    // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
     return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchVisitNoteForm} />;
   }
 

--- a/packages/esm-patient-notes-app/translations/en.json
+++ b/packages/esm-patient-notes-app/translations/en.json
@@ -20,6 +20,7 @@
   "note": "Note",
   "noVisitNoteToDisplay": "No visit note to display",
   "primaryDiagnosisInputPlaceholder": "Choose a primary diagnosis",
+  "record": "Record",
   "saveAndClose": "Save and close",
   "searchForPrimaryDiagnosis": "Search for a primary diagnosis",
   "searchForSecondaryDiagnosis": "Search for a secondary diagnosis",

--- a/packages/esm-patient-notes-app/translations/he.json
+++ b/packages/esm-patient-notes-app/translations/he.json
@@ -11,6 +11,7 @@
   "discard": "בטל",
   "emptyDiagnosisText": "לא נבחרה אבחנה - הכנס אבחנה למטה",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "enterPrimaryDiagnoses": "הזן אבחנות ראשיות",
   "enterSecondaryDiagnoses": "הזן אבחנות משניות",
   "goToSummary": "עבור לסיכום",

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -158,8 +158,8 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
       </div>
     );
   }
-  // Ensure we have the emptyStateText translation key
-  // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+  // Ensure we have emptyStateText and record translation keys
+  // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchProgramsForm} />;
 };
 

--- a/packages/esm-patient-programs-app/translations/en.json
+++ b/packages/esm-patient-programs-app/translations/en.json
@@ -31,6 +31,7 @@
   "programEnrollmentSaveError": "Error saving program enrollment",
   "programName": "Program name",
   "programs": "Program enrollments",
+  "record": "Record",
   "required": "Required",
   "saveAndClose": "Save and close",
   "seeAll": "See all",

--- a/packages/esm-patient-programs-app/translations/he.json
+++ b/packages/esm-patient-programs-app/translations/he.json
@@ -13,6 +13,7 @@
   "dateEnrolled": "תאריך הרשמה",
   "discontinue": "הפסק",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "enroll": "הרשם",
   "enrollment": "הרשמה",
   "enrollmentLocation": "מיקום הרשמה",

--- a/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
+++ b/packages/esm-patient-test-results-app/src/trendline/trendline.component.tsx
@@ -218,8 +218,8 @@ const Trendline: React.FC<TrendlineProps> = ({
   }
 
   if (obs.length === 0) {
-    // Ensure we have the emptyStateText translation key
-    // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+    // Ensure we have emptyStateText and record translation keys
+    // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
     return <EmptyState displayText={t('observationsDisplayText', 'observations')} headerTitle={chartTitle} />;
   }
 

--- a/packages/esm-patient-test-results-app/translations/en.json
+++ b/packages/esm-patient-test-results-app/translations/en.json
@@ -8,6 +8,7 @@
   "ordered": "Ordered",
   "recentResults": "Recent Results",
   "recentTestResults": "recent test results",
+  "record": "Record",
   "referenceRange": "Reference range",
   "resetTreeText": "Reset tree",
   "resulted": "Resulted",

--- a/packages/esm-patient-test-results-app/translations/he.json
+++ b/packages/esm-patient-test-results-app/translations/he.json
@@ -3,6 +3,7 @@
   "date": "תאריך",
   "dateCollected": "מציג תאריך איסוף",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "moreResultsAvailable": "קיימים עוד תוצאות זמינות",
   "observationsDisplayText": "תצוגת מדדים",
   "ordered": "הוזמן",

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -140,8 +140,8 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
             </div>
           );
         }
-        // Ensure we have the emptyStateText translation key
-        // t('emptyStateText', 'There are no {{displayText}} to display for this patient')
+        // Ensure we have emptyStateText and record translation keys
+        // t('emptyStateText', 'There are no {{displayText}} to display for this patient'); t('record', 'Record');
         return (
           <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchVitalsBiometricsForm} />
         );

--- a/packages/esm-patient-vitals-app/translations/en.json
+++ b/packages/esm-patient-vitals-app/translations/en.json
@@ -19,6 +19,7 @@
   "numericInputError": "Must be a number within acceptable ranges",
   "oxygenSaturation": "Oxygen Saturation",
   "pulse": "Pulse",
+  "record": "Record",
   "recordBiometrics": "Record biometrics",
   "recordVitals": "Record vitals",
   "respirationRate": "Respiration Rate",

--- a/packages/esm-patient-vitals-app/translations/he.json
+++ b/packages/esm-patient-vitals-app/translations/he.json
@@ -10,6 +10,7 @@
   "diastolic": "דיאסטולי",
   "discard": "בטל",
   "emptyStateText": "אין {{displayText}} להצגה עבור מטופל זה",
+  "record": "רשומה",
   "goToSummary": "עבור לסיכום",
   "heartRate": "קצב לב",
   "height": "גובה",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Adds missing translation 'record' strings to modules

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-2150

## Other
<!-- Anything not covered above -->
