### PR TITLE
(fix) O3-2181: Vitals & Biometrics forms fails if value is set to ""

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals.resource.tsx
@@ -179,7 +179,7 @@ export function savePatientVitals(
 
 function createObsObject(vitals: PatientVitalsAndBiometrics, concepts: ConfigObject['concepts']): Array<ObsRecord> {
   return Object.entries(vitals)
-    .filter(([_, result]) => result != null)
+    .filter(([_, result]) => Boolean(result))
     .map(([name, result]) => {
       return {
         concept: concepts[name + 'Uuid'],


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- This generally neglects an `obs` that is `empty` or `null` or `undefined` 
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
- https://issues.openmrs.org/browse/O3-2181

## Other
<!-- Anything not covered above -->
