### PR TITLE
(feat) O3-2160: Delete this encounter button on visits does not update the table

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -22,6 +22,7 @@ interface VisitSummaryProps {
   visitTypeUuid: string;
   visitStartDatetime?: string;
   visitStopDatetime?: string;
+  mutateEncounters: () => void;
 }
 
 export interface MappedEncounter {
@@ -44,6 +45,7 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({
   visitTypeUuid,
   visitStartDatetime,
   visitStopDatetime,
+  mutateEncounters,
 }) => {
   const config = useConfig();
   const { t } = useTranslation();
@@ -164,6 +166,7 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({
               visits={mapEncounters(encounters, visitUuid, visitTypeUuid, visitStartDatetime, visitStopDatetime)}
               showAllEncounters={false}
               patientUuid={patientUuid}
+              mutateVisits={mutateEncounters}
             />
           </TabPanel>
         </TabPanels>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -47,6 +47,7 @@ interface VisitTableProps {
   visits: Array<MappedEncounter>;
   showAllEncounters?: boolean;
   patientUuid: string;
+  mutateVisits: () => void;
 }
 
 type FilterProps = {
@@ -57,7 +58,7 @@ type FilterProps = {
   getCellId: (row, key) => string;
 };
 
-const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, patientUuid }) => {
+const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, patientUuid, mutateVisits }) => {
   const visitCount = 20;
   const { t } = useTranslation();
   const desktopLayout = isDesktop(useLayoutType());
@@ -153,6 +154,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
                 description: `Encounter ${t('successfullyDeleted', 'successfully deleted')}`,
                 kind: 'success',
               });
+              mutateVisits?.();
             })
             .catch((error) => {
               showToast({
@@ -165,7 +167,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
         },
       });
     },
-    [t],
+    [t, mutateVisits],
   );
 
   const handleFilter = ({ rowIds, headers, cellsById, inputValue, getCellId }: FilterProps): Array<string> => {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -26,7 +26,7 @@ export interface FormattedEncounter {
 
 function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentProps) {
   const { t } = useTranslation();
-  const { visits, isError, isLoading } = useVisits(patientUuid);
+  const { visits, isError, isLoading, mutateVisits } = useVisits(patientUuid);
   const { showAllEncountersTab } = useConfig();
 
   const visitsWithEncounters = visits
@@ -81,6 +81,7 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
                     visitTypeUuid={visit.visitType.uuid}
                     visitStartDatetime={visit.startDatetime}
                     visitStopDatetime={visit.stopDatetime}
+                    mutateEncounters={mutateVisits}
                   />
                 </div>
               ))
@@ -94,7 +95,12 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
             ) : isError ? (
               <ErrorState headerTitle={t('visits', 'visits')} error={isError} />
             ) : visits?.length ? (
-              <VisitsTable visits={visitsWithEncounters} showAllEncounters patientUuid={patientUuid} />
+              <VisitsTable
+                visits={visitsWithEncounters}
+                showAllEncounters
+                patientUuid={patientUuid}
+                mutateVisits={mutateVisits}
+              />
             ) : (
               <EmptyState headerTitle={t('visits', 'visits')} displayText={t('Visits', 'Visits')} />
             )}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -5,7 +5,7 @@ export function useVisits(patientUuid: string) {
   const customRepresentation =
     'custom:(uuid,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis),form:(uuid,display),encounterDatetime,orders:full,obs:full,encounterType:(uuid,display),encounterProviders:(uuid,display,encounterRole:(uuid,display),provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient';
 
-  const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
+  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<Visit> } }, Error>(
     `/ws/rest/v1/visit?patient=${patientUuid}&v=${customRepresentation}`,
     openmrsFetch,
   );
@@ -14,6 +14,7 @@ export function useVisits(patientUuid: string) {
     isError: error,
     isLoading,
     isValidating,
+    mutateVisits: mutate,
   };
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR introduces the feat of re-fetching visits (and updating visits table on the patient chart) when deleting an encounter from the visits table from the patient chart.

## Screenshots
https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/5b8832e6-2d5f-4845-8ec1-4963f190e98e


## Related Issue
https://issues.openmrs.org/browse/O3-2160

## Other
<!-- Anything not covered above -->
