### PR TITLE
(fix) Remove deprecated `extensionSlotName` prop

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
@@ -109,7 +109,7 @@ const ObsGraph: React.FC<ObsGraphProps> = ({ patientUuid }) => {
       </div>
       {config.interpretationSlot ? (
         <div>
-          <ExtensionSlot extensionSlotName={config.interpretationSlot} style={{ gridTemplateColumns: '1fr' }} />
+          <ExtensionSlot name={config.interpretationSlot} style={{ gridTemplateColumns: '1fr' }} />
         </div>
       ) : null}
     </>

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
@@ -172,11 +172,7 @@ function AllergyForm({ closeWorkspace, promptBeforeClosing, patientUuid }: Defau
     <Form>
       {isTablet ? (
         <Row className={styles.header}>
-          <ExtensionSlot
-            className={styles.content}
-            extensionSlotName="patient-details-header-slot"
-            state={patientState}
-          />
+          <ExtensionSlot className={styles.content} name="patient-details-header-slot" state={patientState} />
         </Row>
       ) : null}
       <div className={`${styles.form} ${isTablet ? styles.tablet : styles.desktop}`}>

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -46,7 +46,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
 
   const patientAvatar = (
     <div className={styles.patientAvatar} role="img">
-      <ExtensionSlot extensionSlotName="patient-photo-slot" state={patientPhotoSlotState} />
+      <ExtensionSlot name="patient-photo-slot" state={patientPhotoSlotState} />
     </div>
   );
 
@@ -101,7 +101,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
             <div className={styles.flexRow}>
               <span className={styles.patientName}>{patientName}</span>
               <ExtensionSlot
-                extensionSlotName="patient-banner-tags-slot"
+                name="patient-banner-tags-slot"
                 state={{ patientUuid, patient }}
                 className={styles.flexRow}
               />
@@ -120,7 +120,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
                 >
                   <ExtensionSlot
                     onClick={closeDropdownMenu}
-                    extensionSlotName="patient-actions-slot"
+                    name="patient-actions-slot"
                     key="patient-actions-slot"
                     className={styles.overflowMenuItemList}
                     state={patientActionsSlotState}

--- a/packages/esm-patient-chart-app/src/deceased/deceased-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/deceased/deceased-form.component.tsx
@@ -66,7 +66,7 @@ const MarkPatientDeceasedForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
       <div>
         {isTablet && (
           <Row className={styles.headerGridRow}>
-            <ExtensionSlot extensionSlotName="visit-form-header-slot" className={styles.dataGridRow} state={state} />
+            <ExtensionSlot name="visit-form-header-slot" className={styles.dataGridRow} state={state} />
           </Row>
         )}
         <div className={styles.container}>

--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
@@ -12,9 +12,9 @@ export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
   return (
     <aside className={styles.sideRail}>
       <div className={styles.container}>
-        <ExtensionSlot className={styles.chartExtensions} extensionSlotName={'action-menu-chart-items-slot'} />
+        <ExtensionSlot className={styles.chartExtensions} name={'action-menu-chart-items-slot'} />
         {layout === 'small-desktop' || layout === 'large-desktop' ? <div className={styles.divider}></div> : null}
-        <ExtensionSlot className={styles.nonChartExtensions} extensionSlotName={'action-menu-non-chart-items-slot'} />
+        <ExtensionSlot className={styles.nonChartExtensions} name={'action-menu-non-chart-items-slot'} />
       </div>
     </aside>
   );

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
@@ -65,11 +65,11 @@ export function DashboardView({ dashboard, patientUuid, patient }: DashboardView
 
   return (
     <>
-      <ExtensionSlot state={state} extensionSlotName="top-of-all-patient-dashboards-slot" />
+      <ExtensionSlot state={state} name="top-of-all-patient-dashboards-slot" />
       {!dashboard.hideDashboardTitle && resolvedTitle && <h1 className={styles.dashboardTitle}>{resolvedTitle}</h1>}
       <ExtensionSlot
         key={dashboard.slot}
-        extensionSlotName={dashboard.slot}
+        name={dashboard.slot}
         className={styles.dashboard}
         style={{ gridTemplateColumns }}
       >

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
@@ -45,14 +45,14 @@ const PatientChart: React.FC = () => {
             windowSize.size === 'normal' && active ? styles.closeWorkspace : styles.activeWorkspace
           }`}
         >
-          <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
+          <ExtensionSlot name="breadcrumbs-slot" />
           {isLoadingPatient ? (
             <Loader />
           ) : (
             <>
               <aside>
-                <ExtensionSlot extensionSlotName="patient-header-slot" state={state} />
-                <ExtensionSlot extensionSlotName="patient-info-slot" state={state} />
+                <ExtensionSlot name="patient-header-slot" state={state} />
+                <ExtensionSlot name="patient-info-slot" state={state} />
               </aside>
               <div className={styles.grid}>
                 <div className={styles.chartReview}>

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -210,7 +210,7 @@ const VisitHeader: React.FC = () => {
           <HeaderGlobalBar>
             {systemVisitEnabled && (
               <>
-                <ExtensionSlot extensionSlotName="visit-header-right-slot" />
+                <ExtensionSlot name="visit-header-right-slot" />
                 {!hasActiveVisit && !isDeceased && (
                   <Button className={styles.startVisitButton} onClick={launchStartVisitForm} size="lg">
                     {startVisitLabel ? startVisitLabel : t('startAVisit', 'Start a visit')}

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -269,7 +269,7 @@ const StartVisitForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWor
       <div>
         {isTablet && (
           <Row className={styles.headerGridRow}>
-            <ExtensionSlot extensionSlotName="visit-form-header-slot" className={styles.dataGridRow} state={state} />
+            <ExtensionSlot name="visit-form-header-slot" className={styles.dataGridRow} state={state} />
           </Row>
         )}
         <Stack gap={1} className={styles.container}>
@@ -319,7 +319,7 @@ const StartVisitForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWor
 
           {/* Upcoming appointments. This get shown when upcoming appointments are configured */}
           {config.showUpcomingAppointments && (
-            <ExtensionSlot state={upcomingAppointmentState} extensionSlotName="upcoming-appointment-slot" />
+            <ExtensionSlot state={upcomingAppointmentState} name="upcoming-appointment-slot" />
           )}
 
           {/* This field lets the user select a location for the visit. The location is required for the visit to be saved. Defaults to the active session location */}
@@ -425,7 +425,7 @@ const StartVisitForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWor
           </section>
 
           {/* Queue location and queue fields. These get shown when queue location and queue fields are configured */}
-          {config.showServiceQueueFields && <ExtensionSlot extensionSlotName="add-queue-entry-slot" />}
+          {config.showServiceQueueFields && <ExtensionSlot name="add-queue-entry-slot" />}
         </Stack>
       </div>
       <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/tests-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/tests-summary.component.tsx
@@ -13,7 +13,7 @@ const TestsSummary = ({ patientUuid, encounters }: { patientUuid: string; encoun
 
   return (
     <ExtensionSlot
-      extensionSlotName="test-results-filtered-overview-slot"
+      name="test-results-filtered-overview-slot"
       state={{ filter, patientUuid } as ExternalOverviewProps}
     />
   );

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
@@ -17,7 +17,7 @@ jest.mock('@openmrs/esm-framework', () => {
 
   return {
     ...originalModule,
-    ExtensionSlot: jest.fn().mockImplementation((ext) => ext.extensionSlotName),
+    ExtensionSlot: jest.fn().mockImplementation((ext) => ext.name),
     useConfig: jest.fn(() => {
       return {
         notesConceptUuids: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'some-uuid2'],

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -25,7 +25,7 @@ jest.mock('@openmrs/esm-framework', () => {
     useLayoutType: jest.fn(),
     // useConfig: jest.fn().mockImplementation(() => ({ showAllEncountersTab: true })),
     userHasAccess: jest.fn().mockImplementation((privilege, _) => (privilege ? false : true)),
-    ExtensionSlot: jest.fn().mockImplementation((ext) => ext.extensionSlotName),
+    ExtensionSlot: jest.fn().mockImplementation((ext) => ext.name),
   };
 });
 

--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.component.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.component.tsx
@@ -71,7 +71,7 @@ const WorkspaceWindow: React.FC<ContextWorkspaceParams> = () => {
       >
         <HeaderName prefix="">{workspaceTitle}</HeaderName>
         <HeaderGlobalBar className={styles.headerGlobalBar}>
-          <ExtensionSlot extensionSlotName={patientChartWorkspaceHeaderSlot} />
+          <ExtensionSlot name={patientChartWorkspaceHeaderSlot} />
           {isDesktop(layout) && (
             <>
               <Button

--- a/packages/esm-patient-common-lib/src/nav-group/DashboardGroupExtension.tsx
+++ b/packages/esm-patient-common-lib/src/nav-group/DashboardGroupExtension.tsx
@@ -18,7 +18,7 @@ export const DashboardGroupExtension = ({ title, slotName, basePath, isExpanded 
   return (
     <Accordion>
       <AccordionItem open={isExpanded ?? true} title={title} style={{ border: 'none' }}>
-        <ExtensionSlot extensionSlotName={slotName ?? title} state={{ basePath }} />
+        <ExtensionSlot name={slotName ?? title} state={{ basePath }} />
       </AccordionItem>
     </Accordion>
   );

--- a/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
@@ -68,9 +68,7 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({ patientUuid, closeWorksp
 
   return (
     <div>
-      {showForm && selectedForm && patientUuid && patient && (
-        <ExtensionSlot extensionSlotName="form-widget-slot" state={state} />
-      )}
+      {showForm && selectedForm && patientUuid && patient && <ExtensionSlot name="form-widget-slot" state={state} />}
     </div>
   );
 };

--- a/packages/esm-patient-forms-app/src/forms/form-entry.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.test.tsx
@@ -19,7 +19,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => ({
 }));
 
 jest.mock('@openmrs/esm-framework', () => ({
-  ExtensionSlot: jest.fn().mockImplementation((ext) => ext.extensionSlotName),
+  ExtensionSlot: jest.fn().mockImplementation((ext) => ext.name),
   usePatient: jest.fn(),
 }));
 

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -249,7 +249,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, patie
     <Form className={styles.form}>
       {isTablet && (
         <Row className={styles.headerGridRow}>
-          <ExtensionSlot extensionSlotName="visit-form-header-slot" className={styles.dataGridRow} state={state} />
+          <ExtensionSlot name="visit-form-header-slot" className={styles.dataGridRow} state={state} />
         </Row>
       )}
       <Stack className={styles.formContainer} gap={2}>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -148,7 +148,7 @@ const VitalsAndBiometricForms: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
   if (config.vitals.useFormEngine) {
     return (
       <ExtensionSlot
-        extensionSlotName="form-widget-slot"
+        name="form-widget-slot"
         state={{
           view: 'form',
           formUuid: config.vitals.formUuid,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Removes the deprecated `extensionSlotName` prop and replaces it with `name`.