### PR TITLE
(i18n) Missing FR label added

### DIFF
--- a/packages/esm-generic-patient-widgets-app/translations/fr.json
+++ b/packages/esm-generic-patient-widgets-app/translations/fr.json
@@ -1,5 +1,6 @@
 {
   "chartView": "Vue graphique",
   "displaying": "En cours d'affichage",
+  "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
   "tableView": "Vue tabulaire"
 }

--- a/packages/esm-patient-allergies-app/translations/fr.json
+++ b/packages/esm-patient-allergies-app/translations/fr.json
@@ -13,6 +13,7 @@
   "dateOfFirstOnset": "Date du premier début",
   "discard": "Abandonner",
   "drug": "Drogue",
+  "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
   "environmental": "Environnemental",
   "errorFetchingData": "Erreur en récupérant les allergènes et les réactions",
   "food": "Nourriture",

--- a/packages/esm-patient-attachments-app/translations/fr.json
+++ b/packages/esm-patient-attachments-app/translations/fr.json
@@ -15,6 +15,7 @@
   "delete": "Effacer",
   "deleteAttachmentConfirmationText": "",
   "deleteImage": "Effacer l'image",
+  "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
   "error": "Erreur",
   "errorUploading": "Erreur en téléchargeant l'image",
   "failed": "échec",

--- a/packages/esm-patient-banner-app/translations/fr.json
+++ b/packages/esm-patient-banner-app/translations/fr.json
@@ -4,6 +4,7 @@
   "address": "Adresse",
   "contactDetails": "Coordonnées",
   "deceased": "Décédé",
+  "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
   "loading": "En cours de chargement",
   "relationships": "Relations",
   "showDetails": "Afficher les détails",

--- a/packages/esm-patient-biometrics-app/translations/fr.json
+++ b/packages/esm-patient-biometrics-app/translations/fr.json
@@ -1,1 +1,3 @@
-{}
+{
+    "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient."
+}

--- a/packages/esm-patient-chart-app/translations/fr.json
+++ b/packages/esm-patient-chart-app/translations/fr.json
@@ -42,6 +42,7 @@
   "editPastVisit": "Editer une visite passée",
   "editQueueEntryStatusTooltip": "Editer",
   "editThisEncounter": "Editer cette rencontre",
+  "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
   "encounters": "Rencontres",
   "encounterType": "Type de rencontre",
   "end": "Fin",

--- a/packages/esm-patient-conditions-app/translations/fr.json
+++ b/packages/esm-patient-conditions-app/translations/fr.json
@@ -12,6 +12,7 @@
   "conditionSaveError": "Erreur en enregistrant la condition",
   "currentStatus": "Statut actuel",
   "dateOfOnset": "Date de début",
+  "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
   "endDate": "Date de fin",
   "enterCondition": "Entrer une condition",
   "inactive": "Inactif",

--- a/packages/esm-patient-forms-app/translations/fr.json
+++ b/packages/esm-patient-forms-app/translations/fr.json
@@ -2,6 +2,7 @@
   "all": "Tout",
   "clinicalForm": "Formulaire clinique",
   "completed": "Complété",
+  "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
   "form": "Formulaire",
   "forms_link": "Formulaires et notes",
   "formName": "Nom du formulaire (A-Z)",

--- a/packages/esm-patient-immunizations-app/translations/fr.json
+++ b/packages/esm-patient-immunizations-app/translations/fr.json
@@ -1,3 +1,4 @@
 {
+    "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
     "immunizations_link": "Immunizations"
 }

--- a/packages/esm-patient-notes-app/translations/fr.json
+++ b/packages/esm-patient-notes-app/translations/fr.json
@@ -10,6 +10,7 @@
   "diagnosis": "Diagnostic",
   "discard": "Abandonner",
   "emptyDiagnosisText": "Aucun diagnostic sélectionné - Entrez un diagnostic ci-dessous",
+  "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
   "enterPrimaryDiagnoses": "Mettre les diagnostics principaux",
   "enterSecondaryDiagnoses": "Mettre les diagnostics secondaires",
   "goToSummary": "Allerr à la vue d'ensemble",

--- a/packages/esm-patient-programs-app/translations/fr.json
+++ b/packages/esm-patient-programs-app/translations/fr.json
@@ -12,6 +12,7 @@
   "dateCompleted": "Date de fin",
   "dateEnrolled": "Date d'enregistrement",
   "discontinue": "Cesser",
+  "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
   "enroll": "Enregistrer",
   "enrollment": "Enregistrement",
   "enrollmentLocation": "Lieu d'enregistrement",

--- a/packages/esm-patient-test-results-app/translations/fr.json
+++ b/packages/esm-patient-test-results-app/translations/fr.json
@@ -2,6 +2,7 @@
   "backToTimeline": "Retour à la chronologie",
   "date": "Date",
   "dateCollected": "Affichage de la date collectée",
+  "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
   "moreResultsAvailable": "Plus de résultats disponibles",
   "observationsDisplayText": "observations",
   "ordered": "Commandé",

--- a/packages/esm-patient-vitals-app/translations/fr.json
+++ b/packages/esm-patient-vitals-app/translations/fr.json
@@ -9,6 +9,7 @@
   "checkForValidity": "Certaines des valeurs saisies ne sont pas valides.",
   "diastolic": "diastolique",
   "discard": "Abandonner",
+  "emptyStateText": "Il n'y a pas de {{displayText}} à afficher pour ce patient.",
   "goToSummary": "Aller à la vue d'ensemble",
   "heartRate": "Rythme cardiaque",
   "height": "Hauteur",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

This pull request fixes an issue where French labels were missing in several microfrontend apps. I have added the necessary translations to ensure a consistent user experience for French-speaking users. Please review and provide feedback. Thank you!

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

CC: @icrc-psousa 