### PR TITLE
(fix) Overflow menu items in the visits table  should close onClick 

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -271,37 +271,35 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
                                 className={styles.menuItem}
                                 itemText={t('goToThisEncounter', 'Go to this encounter')}
                               />
+                              {userHasAccess(visits[index]?.editPrivilege, session?.user) && visits[index]?.form?.uuid && (
+                                <OverflowMenuItem
+                                  className={styles.menuItem}
+                                  itemText={t('editThisEncounter', 'Edit this encounter')}
+                                  size={desktopLayout ? 'sm' : 'lg'}
+                                  onClick={() => {
+                                    launchWorkspace(
+                                      visits[index]?.form?.uuid,
+                                      visits[index]?.visitUuid,
+                                      visits[index]?.id,
+                                      visits[index]?.form?.display,
+                                      visits[index]?.visitTypeUuid,
+                                      visits[index]?.visitStartDatetime,
+                                      visits[index]?.visitStopDatetime,
+                                    );
+                                  }}
+                                />
+                              )}
                               {userHasAccess(visits[index]?.editPrivilege, session?.user) && (
-                                <>
-                                  {visits[index]?.form?.uuid && (
-                                    <OverflowMenuItem
-                                      className={styles.menuItem}
-                                      itemText={t('editThisEncounter', 'Edit this encounter')}
-                                      size={desktopLayout ? 'sm' : 'lg'}
-                                      onClick={() => {
-                                        launchWorkspace(
-                                          visits[index]?.form?.uuid,
-                                          visits[index]?.visitUuid,
-                                          visits[index]?.id,
-                                          visits[index]?.form?.display,
-                                          visits[index]?.visitTypeUuid,
-                                          visits[index]?.visitStartDatetime,
-                                          visits[index]?.visitStopDatetime,
-                                        );
-                                      }}
-                                    />
-                                  )}
-                                  <OverflowMenuItem
-                                    size={desktopLayout ? 'sm' : 'lg'}
-                                    className={styles.menuItem}
-                                    itemText={t('deleteThisEncounter', 'Delete this encounter')}
-                                    onClick={() => {
-                                      handleDeleteEncounter(visits[index]?.id, visits[index]?.form?.display);
-                                    }}
-                                    hasDivider
-                                    isDelete
-                                  />
-                                </>
+                                <OverflowMenuItem
+                                  size={desktopLayout ? 'sm' : 'lg'}
+                                  className={styles.menuItem}
+                                  itemText={t('deleteThisEncounter', 'Delete this encounter')}
+                                  onClick={() => {
+                                    handleDeleteEncounter(visits[index]?.id, visits[index]?.form?.display);
+                                  }}
+                                  hasDivider
+                                  isDelete
+                                />
                               )}
                             </OverflowMenu>
                           </Layer>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- This fixes the issue where overflow menu items don't close on click. 
<!-- Overflow menu items seem to expect one parent being the OverflowMenu that , once you wrap them let's say inside React fragments, they won't close on click -->

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
This is related to this [PR](https://github.com/openmrs/openmrs-esm-patient-chart/pull/1190)