### PR TITLE
(feat) Dashboard Extension uses the `moduleName` as the namespace for translation

### DIFF
--- a/packages/esm-patient-allergies-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-allergies-app/src/dashboard.meta.ts
@@ -2,4 +2,5 @@ export const dashboardMeta = {
   slot: 'patient-chart-allergies-dashboard-slot',
   columns: 1,
   path: 'Allergies',
+  title: 'Allergies',
 };

--- a/packages/esm-patient-allergies-app/src/index.ts
+++ b/packages/esm-patient-allergies-app/src/index.ts
@@ -42,14 +42,11 @@ export const allergiesDetailedSummary = getAsyncLifecycle(
   options,
 );
 
-// t('allergies_link', 'Allergies')
+// t('Allergies')
 export const allergiesDashboardLink = getSyncLifecycle(
   createDashboardLink({
     ...dashboardMeta,
-    title: () =>
-      Promise.resolve(
-        window.i18next?.t('allergies_link', { defaultValue: 'Allergies', ns: moduleName }) ?? 'Allergies',
-      ),
+    moduleName,
   }),
   options,
 );

--- a/packages/esm-patient-appointments-app/src/index.ts
+++ b/packages/esm-patient-appointments-app/src/index.ts
@@ -25,7 +25,10 @@ export const appointmentsDetailedSummary = getAsyncLifecycle(
   options,
 );
 
-export const appointmentsSummaryDashboardLink = getSyncLifecycle(createDashboardLink(dashboardMeta), options);
+export const appointmentsSummaryDashboardLink = getSyncLifecycle(
+  createDashboardLink({ ...dashboardMeta, moduleName }),
+  options,
+);
 
 export const appointmentsFormWorkspace = getAsyncLifecycle(
   () => import('./appointments/appointments-form/appointments-form.component'),

--- a/packages/esm-patient-attachments-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-attachments-app/src/dashboard.meta.ts
@@ -2,4 +2,5 @@ export const dashboardMeta = {
   slot: 'patient-chart-attachments-dashboard-slot',
   columns: 1,
   path: 'Attachments',
+  title: 'Attachments',
 };

--- a/packages/esm-patient-attachments-app/src/index.ts
+++ b/packages/esm-patient-attachments-app/src/index.ts
@@ -16,14 +16,11 @@ export const attachmentsOverview = getAsyncLifecycle(() => import('./attachments
   moduleName,
 });
 
-// t('attachments_link', 'Attachments')
+// t('Attachments')
 export const attachmentsSummaryResultsDashboard = getSyncLifecycle(
   createDashboardLink({
     ...dashboardMeta,
-    title: () =>
-      Promise.resolve(
-        window.i18next?.t('attachments_link', { defaultValue: 'Attachments', ns: moduleName }) ?? 'Attachments',
-      ),
+    moduleName,
   }),
   {
     featureName: 'attachments-dashboard-link',

--- a/packages/esm-patient-biometrics-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-biometrics-app/src/dashboard.meta.ts
@@ -2,4 +2,5 @@ export const dashboardMeta = {
   slot: 'patient-chart-vitals-biometrics-dashboard-slot',
   columns: 1,
   path: 'Vitals & Biometrics',
+  title: 'Vitals & Biometrics',
 };

--- a/packages/esm-patient-biometrics-app/src/index.ts
+++ b/packages/esm-patient-biometrics-app/src/index.ts
@@ -43,15 +43,11 @@ export const biometricsDetailedSummary = getAsyncLifecycle(
 );
 
 export const vitalsAndBiometricsDashboardLink =
-  // t('biometrics_link', 'Vitals & Biometrics')
+  // t('Vitals & Biometrics')
   getSyncLifecycle(
     createDashboardLink({
       ...dashboardMeta,
-      title: () =>
-        Promise.resolve(
-          window.i18next?.t('biometrics_link', { defaultValue: 'Vitals & Biometrics', ns: moduleName }) ??
-            'Vitals & Biometrics',
-        ),
+      moduleName,
     }),
     options,
   );

--- a/packages/esm-patient-chart-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-chart-app/src/dashboard.meta.ts
@@ -2,10 +2,12 @@ export const summaryDashboardMeta = {
   slot: 'patient-chart-summary-dashboard-slot',
   columns: 4,
   path: 'Patient Summary',
+  title: 'Patient Summary',
 };
 
 export const encountersDashboardMeta = {
   slot: 'patient-chart-encounters-dashboard-slot',
   columns: 1,
   path: 'Visits',
+  title: 'Visits',
 };

--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -63,14 +63,11 @@ export function startupApp() {
 export const root = getAsyncLifecycle(() => import('./root.component'), { featureName: 'patient-chart', moduleName });
 
 export const patientSummaryDashboardLink =
-  // t('summary_link', 'Patient Summary')
+  // t('Patient Summary')
   getSyncLifecycle(
     createDashboardLink({
       ...summaryDashboardMeta,
-      title: () =>
-        Promise.resolve(
-          window.i18next?.t('summary_link', { defaultValue: 'Patient Summary', ns: moduleName }) ?? 'Patient Summary',
-        ),
+      moduleName,
     }),
     {
       featureName: 'summary-dashboard',
@@ -139,12 +136,11 @@ export const addPastVisitPatientSearchActionButton = getAsyncLifecycle(
 );
 
 export const encountersSummaryDashboardLink =
-  // t('encounters_link', 'Visits')
+  // t('Visits')
   getSyncLifecycle(
     createDashboardLink({
       ...encountersDashboardMeta,
-      title: () =>
-        Promise.resolve(window.i18next?.t('encounters_link', { defaultValue: 'Visits', ns: moduleName }) ?? 'Visits'),
+      moduleName,
     }),
     { featureName: 'encounter', moduleName },
   );

--- a/packages/esm-patient-chart-app/src/side-nav/generic-dashboard.component.tsx
+++ b/packages/esm-patient-chart-app/src/side-nav/generic-dashboard.component.tsx
@@ -45,7 +45,12 @@ export default function GenericDashboard({ basePath }: GenericDashboardProps) {
   const config = useConfig<GenericDashboardConfig>();
   return (
     <BrowserRouter>
-      <DashboardExtension path={config.path} title={config.title} basePath={basePath} />
+      <DashboardExtension
+        path={config.path}
+        title={config.title}
+        basePath={basePath}
+        moduleName="@openmrs/esm-patient-chart-app"
+      />
     </BrowserRouter>
   );
 }

--- a/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/DashboardExtension.tsx
@@ -1,44 +1,34 @@
-import React, { useMemo, useEffect, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import last from 'lodash-es/last';
 import { ConfigurableLink } from '@openmrs/esm-framework';
+import { useTranslation } from 'react-i18next';
 
 export interface DashboardExtensionProps {
   path: string;
-  title: string | (() => string | Promise<string>);
+  title: string;
   basePath: string;
+  moduleName?: string;
 }
 
-export const DashboardExtension = ({ path, title, basePath }: DashboardExtensionProps) => {
+export const DashboardExtension = ({
+  path,
+  title,
+  basePath,
+  moduleName = '@openmrs/esm-patient-chart-app',
+}: DashboardExtensionProps) => {
+  const { t } = useTranslation(moduleName);
   const location = useLocation();
   const navLink = useMemo(() => decodeURIComponent(last(location.pathname.split('/'))), [location.pathname]);
-  const [resolvedTitle, setResolvedTitle] = useState<string | undefined>();
-
-  useEffect(() => {
-    if (typeof title === 'function') {
-      Promise.resolve(title())
-        .then((resolvedValue) => {
-          setResolvedTitle(resolvedValue);
-        })
-        .catch((e: Error) => {
-          throw e;
-        });
-    } else {
-      setResolvedTitle(title);
-    }
-  }, [title]);
 
   return (
-    title &&
-    resolvedTitle && (
-      <div key={path}>
-        <ConfigurableLink
-          to={`${basePath}/${encodeURIComponent(path)}`}
-          className={`cds--side-nav__link ${path === navLink && 'active-left-nav-link'}`}
-        >
-          {resolvedTitle}
-        </ConfigurableLink>
-      </div>
-    )
+    <div key={path}>
+      <ConfigurableLink
+        to={`${basePath}/${encodeURIComponent(path)}`}
+        className={`cds--side-nav__link ${path === navLink && 'active-left-nav-link'}`}
+      >
+        {t(title)}
+      </ConfigurableLink>
+    </div>
   );
 };

--- a/packages/esm-patient-common-lib/src/dashboards/createDashboardLink.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/createDashboardLink.tsx
@@ -7,7 +7,7 @@ export const createDashboardLink = (db: DashboardLinkConfig) => {
   return ({ basePath }: { basePath: string }) => {
     return (
       <BrowserRouter>
-        <DashboardExtension basePath={basePath} title={db.title} path={db.path} />
+        <DashboardExtension basePath={basePath} title={db.title} path={db.path} moduleName={db.moduleName} />
       </BrowserRouter>
     );
   };

--- a/packages/esm-patient-common-lib/src/types/index.ts
+++ b/packages/esm-patient-common-lib/src/types/index.ts
@@ -9,7 +9,8 @@ export interface DashbardConfig {
 
 export interface DashboardLinkConfig {
   path: string;
-  title: string | (() => string | Promise<string>);
+  title: string;
+  moduleName: string;
 }
 
 export interface DashboardConfig extends DashboardLinkConfig {

--- a/packages/esm-patient-conditions-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-conditions-app/src/dashboard.meta.ts
@@ -2,4 +2,5 @@ export const dashboardMeta = {
   slot: 'patient-chart-conditions-dashboard-slot',
   columns: 1,
   path: 'Conditions',
+  title: 'Conditions',
 };

--- a/packages/esm-patient-conditions-app/src/index.ts
+++ b/packages/esm-patient-conditions-app/src/index.ts
@@ -29,14 +29,11 @@ export const conditionsDetailedSummary = getAsyncLifecycle(
 export const conditionsWidget = getAsyncLifecycle(() => import('./conditions/conditions-widget.component'), options);
 
 export const conditionsDashboardLink =
-  // t('conditions_link', 'Conditions')
+  // t('Conditions')
   getSyncLifecycle(
     createDashboardLink({
       ...dashboardMeta,
-      title: () =>
-        Promise.resolve(
-          window.i18next?.t('conditions_link', { defaultValue: 'Conditions', ns: moduleName }) ?? 'Conditions',
-        ),
+      moduleName,
     }),
     options,
   );

--- a/packages/esm-patient-forms-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-forms-app/src/dashboard.meta.ts
@@ -2,4 +2,5 @@ export const dashboardMeta = {
   slot: 'patient-chart-form-dashboard-slot',
   columns: 1,
   path: 'Forms & Notes',
+  title: 'Forms & Notes',
 };

--- a/packages/esm-patient-forms-app/src/index.ts
+++ b/packages/esm-patient-forms-app/src/index.ts
@@ -49,14 +49,11 @@ export const formsDetailedOverview = getAsyncLifecycle(
 );
 
 export const formsAndNotesDashboardLink =
-  // t('forms_link', 'Forms & Notes')
+  // t('Forms & Notes')
   getSyncLifecycle(
     createDashboardLink({
       ...dashboardMeta,
-      title: () =>
-        Promise.resolve(
-          window.i18next?.t('forms_link', { defaultValue: 'Forms & Notes', ns: moduleName }) ?? 'Forms & Notes',
-        ),
+      moduleName,
     }),
     options,
   );

--- a/packages/esm-patient-immunizations-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-immunizations-app/src/dashboard.meta.ts
@@ -2,4 +2,5 @@ export const dashboardMeta = {
   slot: 'patient-chart-immunizations-dashboard-slot',
   columns: 1,
   path: 'Immunizations',
+  title: 'Immunizations',
 };

--- a/packages/esm-patient-immunizations-app/src/index.ts
+++ b/packages/esm-patient-immunizations-app/src/index.ts
@@ -27,14 +27,11 @@ export const immunizationsDetailedSummary = getAsyncLifecycle(
 );
 
 export const immunizationsDashboardLink =
-  // t('immunizations_link', 'Immunizations')
+  // t('Immunizations')
   getSyncLifecycle(
     createDashboardLink({
       ...dashboardMeta,
-      title: () =>
-        Promise.resolve(
-          window.i18next?.t('immunizations_link', { defaultValue: 'Immunizations', ns: moduleName }) ?? 'Immunizations',
-        ),
+      moduleName,
     }),
     options,
   );

--- a/packages/esm-patient-medications-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-medications-app/src/dashboard.meta.ts
@@ -2,4 +2,5 @@ export const dashboardMeta = {
   slot: 'patient-chart-orders-dashboard-slot',
   columns: 1,
   path: 'Medications',
+  title: 'Medications',
 };

--- a/packages/esm-patient-medications-app/src/index.ts
+++ b/packages/esm-patient-medications-app/src/index.ts
@@ -23,14 +23,11 @@ export const activeMedications = getAsyncLifecycle(() => import('./medications/a
 export const orderBasketWorkspace = getAsyncLifecycle(() => import('./medications/root-order-basket'), options);
 
 export const medicationsDashboardLink =
-  // t('medications_link', 'Medications')
+  // t('Medications')
   getSyncLifecycle(
     createDashboardLink({
       ...dashboardMeta,
-      title: () =>
-        Promise.resolve(
-          window.i18next?.t('medications_link', { defaultValue: 'Medications', ns: moduleName }) ?? 'Medications',
-        ),
+      moduleName,
     }),
     options,
   );

--- a/packages/esm-patient-programs-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-programs-app/src/dashboard.meta.ts
@@ -2,4 +2,5 @@ export const dashboardMeta = {
   slot: 'patient-chart-programs-dashboard-slot',
   columns: 1,
   path: 'Programs',
+  title: 'Programs',
 };

--- a/packages/esm-patient-programs-app/src/index.ts
+++ b/packages/esm-patient-programs-app/src/index.ts
@@ -24,12 +24,11 @@ export const programsDetailedSummary = getAsyncLifecycle(
 );
 
 export const programsDashboardLink =
-  // t('programs_link', 'Programs')
+  // t('Programs')
   getSyncLifecycle(
     createDashboardLink({
       ...dashboardMeta,
-      title: () =>
-        Promise.resolve(window.i18next?.t('programs_link', { defaultValue: 'Programs', ns: moduleName }) ?? 'Programs'),
+      moduleName,
     }),
     options,
   );

--- a/packages/esm-patient-test-results-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-test-results-app/src/dashboard.meta.ts
@@ -2,5 +2,6 @@ export const dashboardMeta = {
   slot: 'patient-chart-test-results-dashboard-slot',
   columns: 1,
   path: 'Test Results',
+  title: 'Test Results',
   hideDashboardTitle: true,
 };

--- a/packages/esm-patient-test-results-app/src/index.ts
+++ b/packages/esm-patient-test-results-app/src/index.ts
@@ -32,14 +32,11 @@ export const externalOverview = getAsyncLifecycle(() => import('./overview/exter
 export const resultsViewer = getAsyncLifecycle(() => import('./results-viewer'), options);
 
 export const testResultsDashboardLink =
-  // t('testResults_link', 'Test Results')
+  // t('Test Results')
   getSyncLifecycle(
     createDashboardLink({
       ...dashboardMeta,
-      title: () =>
-        Promise.resolve(
-          window.i18next?.t('testResults_link', { defaultValue: 'Test Results', ns: moduleName }) ?? 'Test Results',
-        ),
+      moduleName,
     }),
     options,
   );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR introduces improvement by using the moduleName as the namespace for `useTranslation` hook. This will also help in any re-renders by `useTranslation` hook inside the `DashboardExtension` which was not possible earlier  by changing the prop of an extension.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
