### PR TITLE
(fix)O3-2161:Encounter view doesn't work with multiple pages

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -139,11 +139,11 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
   const tableRows = useMemo(() => {
     return paginatedVisits?.map((encounter) => ({
       ...encounter,
-      datetime: formatDatetime(parseDate(encounter?.datetime)),
-    }));
+      datetime: formatDatetime(parseDate(encounter.datetime)),
+    }));    
   }, [paginatedVisits]);
 
-  const handleEncounterTypeChange = ({ selectedItem }) => setFilter(selectedItem);
+  const handleEncounterTypeChange = ({ selectedItem }) => setFilter(selectedItem.value);
 
   const handleDeleteEncounter = React.useCallback(
     (encounterUuid: string, encounterTypeName?: string) => {
@@ -295,7 +295,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
                                   className={styles.menuItem}
                                   itemText={t('deleteThisEncounter', 'Delete this encounter')}
                                   onClick={() => {
-                                    handleDeleteEncounter(visits[index]?.id, visits[index]?.form?.display);
+                                    handleDeleteEncounter(paginatedVisits[index]?.id, paginatedVisits[index]?.form?.display);
                                   }}
                                   hasDivider
                                   isDelete


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I modified the `handleEditEncounter` and `handleDeleteEncounter` functions to enable correct rendering of encounter buttons on the `VisitTable component` of the first encounter on the second page. 

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/0b1ab386-b733-4170-8568-6f2e6358a116

## Related Issue
https://issues.openmrs.org/browse/O3-2161

## Other
<!-- Anything not covered above -->
