### PR TITLE
(fix) Exports should reference the result of getSync / getAsync

### DIFF
--- a/packages/esm-patient-appointments-app/src/index.ts
+++ b/packages/esm-patient-appointments-app/src/index.ts
@@ -15,19 +15,29 @@ export function startupApp() {
   defineConfigSchema(moduleName, {});
 }
 
-export const appointmentsOverview = () =>
-  getAsyncLifecycle(() => import('./appointments/appointments-overview.component'), options);
+export const appointmentsOverview = getAsyncLifecycle(
+  () => import('./appointments/appointments-overview.component'),
+  options,
+);
 
-export const appointmentsDetailedSummary = () =>
-  getAsyncLifecycle(() => import('./appointments/appointments-detailed-summary.component'), options);
+export const appointmentsDetailedSummary = getAsyncLifecycle(
+  () => import('./appointments/appointments-detailed-summary.component'),
+  options,
+);
 
-export const appointmentsSummaryDashboardLink = () => getSyncLifecycle(createDashboardLink(dashboardMeta), options);
+export const appointmentsSummaryDashboardLink = getSyncLifecycle(createDashboardLink(dashboardMeta), options);
 
-export const appointmentsFormWorkspace = () =>
-  getAsyncLifecycle(() => import('./appointments/appointments-form/appointments-form.component'), options);
+export const appointmentsFormWorkspace = getAsyncLifecycle(
+  () => import('./appointments/appointments-form/appointments-form.component'),
+  options,
+);
 
-export const appointmentsCancelConfirmationDialog = () =>
-  getAsyncLifecycle(() => import('./appointments/appointments-cancel-modal.component'), options);
+export const appointmentsCancelConfirmationDialog = getAsyncLifecycle(
+  () => import('./appointments/appointments-cancel-modal.component'),
+  options,
+);
 
-export const upcomingAppointmentsWidget = () =>
-  getAsyncLifecycle(() => import('./appointments/upcoming-appointments-card.component'), options);
+export const upcomingAppointmentsWidget = getAsyncLifecycle(
+  () => import('./appointments/upcoming-appointments-card.component'),
+  options,
+);

--- a/packages/esm-patient-attachments-app/src/index.ts
+++ b/packages/esm-patient-attachments-app/src/index.ts
@@ -11,42 +11,43 @@ export function startupApp() {
   defineConfigSchema(moduleName, attachmentsConfigSchema);
 }
 
-export const attachmentsOverview = () =>
-  getAsyncLifecycle(() => import('./attachments/attachments-overview.component'), {
-    featureName: 'patient-attachments',
-    moduleName,
-  });
+export const attachmentsOverview = getAsyncLifecycle(() => import('./attachments/attachments-overview.component'), {
+  featureName: 'patient-attachments',
+  moduleName,
+});
 
 // t('attachments_link', 'Attachments')
-export const attachmentsSummaryResultsDashboard = () =>
-  getSyncLifecycle(
-    createDashboardLink({
-      ...dashboardMeta,
-      title: () =>
-        Promise.resolve(
-          window.i18next?.t('attachments_link', { defaultValue: 'Attachments', ns: moduleName }) ?? 'Attachments',
-        ),
-    }),
-    {
-      featureName: 'attachments-dashboard-link',
-      moduleName,
-    },
-  );
+export const attachmentsSummaryResultsDashboard = getSyncLifecycle(
+  createDashboardLink({
+    ...dashboardMeta,
+    title: () =>
+      Promise.resolve(
+        window.i18next?.t('attachments_link', { defaultValue: 'Attachments', ns: moduleName }) ?? 'Attachments',
+      ),
+  }),
+  {
+    featureName: 'attachments-dashboard-link',
+    moduleName,
+  },
+);
 
-export const capturePhotoModal = () =>
-  getAsyncLifecycle(() => import('./camera-media-uploader/camera-media-uploader.component'), {
+export const capturePhotoModal = getAsyncLifecycle(
+  () => import('./camera-media-uploader/camera-media-uploader.component'),
+  {
     featureName: 'capture-photo-modal',
     moduleName,
-  });
+  },
+);
 
-export const capturePhotoWidget = () =>
-  getAsyncLifecycle(() => import('./camera-media-uploader/capture-photo.component'), {
-    featureName: 'capture-photo-widget',
-    moduleName,
-  });
+export const capturePhotoWidget = getAsyncLifecycle(() => import('./camera-media-uploader/capture-photo.component'), {
+  featureName: 'capture-photo-widget',
+  moduleName,
+});
 
-export const deleteAttachmentModal = () =>
-  getAsyncLifecycle(() => import('./attachments/delete-attachment-confirmation-modal.component'), {
+export const deleteAttachmentModal = getAsyncLifecycle(
+  () => import('./attachments/delete-attachment-confirmation-modal.component'),
+  {
     featureName: 'delete-attachment-modal',
     moduleName,
-  });
+  },
+);

--- a/packages/esm-patient-biometrics-app/src/index.ts
+++ b/packages/esm-patient-biometrics-app/src/index.ts
@@ -32,13 +32,17 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const biometricsOverview = () =>
-  getAsyncLifecycle(() => import('./biometrics/biometrics-overview.component'), options);
+export const biometricsOverview = getAsyncLifecycle(
+  () => import('./biometrics/biometrics-overview.component'),
+  options,
+);
 
-export const biometricsDetailedSummary = () =>
-  getAsyncLifecycle(() => import('./biometrics/biometrics-main.component'), options);
+export const biometricsDetailedSummary = getAsyncLifecycle(
+  () => import('./biometrics/biometrics-main.component'),
+  options,
+);
 
-export const vitalsAndBiometricsDashboardLink = () =>
+export const vitalsAndBiometricsDashboardLink =
   // t('biometrics_link', 'Vitals & Biometrics')
   getSyncLifecycle(
     createDashboardLink({
@@ -52,4 +56,4 @@ export const vitalsAndBiometricsDashboardLink = () =>
     options,
   );
 
-export const weightTile = () => getAsyncLifecycle(() => import('./biometrics/weight-tile.component'), options);
+export const weightTile = getAsyncLifecycle(() => import('./biometrics/weight-tile.component'), options);

--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -79,61 +79,67 @@ export const patientSummaryDashboardLink = () =>
     },
   );
 
-export const startVisitActionButton = () =>
-  getAsyncLifecycle(() => import('./actions-buttons/start-visit.component'), {
+export const startVisitActionButton = getAsyncLifecycle(() => import('./actions-buttons/start-visit.component'), {
+  featureName: 'patient-actions-slot',
+  moduleName,
+});
+
+export const stopVisitActionButton = getAsyncLifecycle(() => import('./actions-buttons/stop-visit.component'), {
+  featureName: 'patient-actions-slot',
+  moduleName,
+});
+
+export const markPatientAliveActionButton = getAsyncLifecycle(
+  () => import('./actions-buttons/mark-patient-alive.component'),
+  {
     featureName: 'patient-actions-slot',
     moduleName,
-  });
+  },
+);
 
-export const stopVisitActionButton = () =>
-  getAsyncLifecycle(() => import('./actions-buttons/stop-visit.component'), {
+export const stopVisitPatientSearchActionButton = getAsyncLifecycle(
+  () => import('./actions-buttons/stop-visit.component'),
+  {
     featureName: 'patient-actions-slot',
     moduleName,
-  });
+  },
+);
 
-export const markPatientAliveActionButton = () =>
-  getAsyncLifecycle(() => import('./actions-buttons/mark-patient-alive.component'), {
-    featureName: 'patient-actions-slot',
-    moduleName,
-  });
+export const cancelVisitActionButton = getAsyncLifecycle(() => import('./actions-buttons/cancel-visit.component'), {
+  featureName: 'patient-actions-slot',
+  moduleName,
+});
 
-export const stopVisitPatientSearchActionButton = () =>
-  getAsyncLifecycle(() => import('./actions-buttons/stop-visit.component'), {
-    featureName: 'patient-actions-slot',
-    moduleName,
-  });
-
-export const cancelVisitActionButton = () =>
-  getAsyncLifecycle(() => import('./actions-buttons/cancel-visit.component'), {
-    featureName: 'patient-actions-slot',
-    moduleName,
-  });
-
-export const markPatientDeceasedActionButton = () =>
-  getAsyncLifecycle(() => import('./actions-buttons/mark-patient-deceased.component'), {
+export const markPatientDeceasedActionButton = getAsyncLifecycle(
+  () => import('./actions-buttons/mark-patient-deceased.component'),
+  {
     featureName: 'patient-actions-slot-deceased-button',
     moduleName,
-  });
+  },
+);
 
-export const cancelVisitPatientSearchActionButton = () =>
-  getAsyncLifecycle(() => import('./actions-buttons/cancel-visit.component'), {
+export const cancelVisitPatientSearchActionButton = getAsyncLifecycle(
+  () => import('./actions-buttons/cancel-visit.component'),
+  {
     featureName: 'patient-actions-slot-cancel-visit-button',
     moduleName,
-  });
+  },
+);
 
-export const addPastVisitActionButton = () =>
-  getAsyncLifecycle(() => import('./actions-buttons/add-past-visit.component'), {
-    featureName: 'patient-actions-slot-add-past-visit-button',
-    moduleName,
-  });
+export const addPastVisitActionButton = getAsyncLifecycle(() => import('./actions-buttons/add-past-visit.component'), {
+  featureName: 'patient-actions-slot-add-past-visit-button',
+  moduleName,
+});
 
-export const addPastVisitPatientSearchActionButton = () =>
-  getAsyncLifecycle(() => import('./actions-buttons/add-past-visit.component'), {
+export const addPastVisitPatientSearchActionButton = getAsyncLifecycle(
+  () => import('./actions-buttons/add-past-visit.component'),
+  {
     featureName: 'patient-search-actions-slot-add-past-visit-button',
     moduleName,
-  });
+  },
+);
 
-export const encountersSummaryDashboardLink = () =>
+export const encountersSummaryDashboardLink =
   // t('encounters_link', 'Visits')
   getSyncLifecycle(
     createDashboardLink({
@@ -144,86 +150,89 @@ export const encountersSummaryDashboardLink = () =>
     { featureName: 'encounter', moduleName },
   );
 
-export const pastVisitsDetailOverview = () =>
-  getAsyncLifecycle(() => import('./visit/visits-widget/visit-detail-overview.component'), {
+export const pastVisitsDetailOverview = getAsyncLifecycle(
+  () => import('./visit/visits-widget/visit-detail-overview.component'),
+  {
     featureName: 'visits-detail-slot',
     moduleName,
-  });
+  },
+);
 
-export const pastVisitsOverview = () =>
-  getAsyncLifecycle(() => import('./visit/past-visit-overview.component'), {
-    featureName: 'past-visits-overview',
-    moduleName,
-  });
+export const pastVisitsOverview = getAsyncLifecycle(() => import('./visit/past-visit-overview.component'), {
+  featureName: 'past-visits-overview',
+  moduleName,
+});
 
-export const startVisitForm = () =>
-  getAsyncLifecycle(() => import('./visit/visit-form/visit-form.component'), {
-    featureName: 'start-visit-form',
-    moduleName,
-  });
+export const startVisitForm = getAsyncLifecycle(() => import('./visit/visit-form/visit-form.component'), {
+  featureName: 'start-visit-form',
+  moduleName,
+});
 
-export const markPatientDeceasedForm = () =>
-  getAsyncLifecycle(() => import('./deceased/deceased-form.component'), {
-    featureName: 'mark-patient-deceased-form',
-    moduleName,
-  });
+export const markPatientDeceasedForm = getAsyncLifecycle(() => import('./deceased/deceased-form.component'), {
+  featureName: 'mark-patient-deceased-form',
+  moduleName,
+});
 
-export const patientDetailsTile = () =>
-  getAsyncLifecycle(() => import('./patient-details-tile/patient-details-tile.component'), {
+export const patientDetailsTile = getAsyncLifecycle(
+  () => import('./patient-details-tile/patient-details-tile.component'),
+  {
     featureName: 'patient-details-tile',
     moduleName,
-  });
+  },
+);
 
-export const genericNavGroup = () =>
-  getAsyncLifecycle(() => import('./side-nav/generic-nav-group.component'), { featureName: 'Nav group', moduleName });
+export const genericNavGroup = getAsyncLifecycle(() => import('./side-nav/generic-nav-group.component'), {
+  featureName: 'Nav group',
+  moduleName,
+});
 
-export const genericDashboard = () =>
-  getAsyncLifecycle(() => import('./side-nav/generic-dashboard.component'), { featureName: 'Dashboard', moduleName });
+export const genericDashboard = getAsyncLifecycle(() => import('./side-nav/generic-dashboard.component'), {
+  featureName: 'Dashboard',
+  moduleName,
+});
 
-export const cancelVisitDialog = () =>
-  getAsyncLifecycle(() => import('./visit/visit-prompt/cancel-visit-dialog.component'), {
-    featureName: 'start visit',
-    moduleName,
-  });
+export const cancelVisitDialog = getAsyncLifecycle(() => import('./visit/visit-prompt/cancel-visit-dialog.component'), {
+  featureName: 'start visit',
+  moduleName,
+});
 
-export const startVisitDialog = () =>
-  getAsyncLifecycle(() => import('./visit/visit-prompt/start-visit-dialog.component'), {
-    featureName: 'start visit',
-    moduleName,
-  });
+export const startVisitDialog = getAsyncLifecycle(() => import('./visit/visit-prompt/start-visit-dialog.component'), {
+  featureName: 'start visit',
+  moduleName,
+});
 
-export const endVisitDialog = () =>
-  getAsyncLifecycle(() => import('./visit/visit-prompt/end-visit-dialog.component'), {
-    featureName: 'end visit',
-    moduleName,
-  });
+export const endVisitDialog = getAsyncLifecycle(() => import('./visit/visit-prompt/end-visit-dialog.component'), {
+  featureName: 'end visit',
+  moduleName,
+});
 
-export const confirmDeceasedDialog = () =>
-  getAsyncLifecycle(() => import('./deceased/confirmation-dialog.component'), {
-    featureName: 'confirm death',
-    moduleName,
-  });
+export const confirmDeceasedDialog = getAsyncLifecycle(() => import('./deceased/confirmation-dialog.component'), {
+  featureName: 'confirm death',
+  moduleName,
+});
 
-export const confirmAliveDialog = () =>
-  getAsyncLifecycle(() => import('./deceased/mark-alive-modal.component'), {
-    featureName: 'confirm alive',
-    moduleName,
-  });
+export const confirmAliveDialog = getAsyncLifecycle(() => import('./deceased/mark-alive-modal.component'), {
+  featureName: 'confirm alive',
+  moduleName,
+});
 
-export const startVisitButtonPatientSearch = () =>
-  getAsyncLifecycle(() => import('./visit/start-visit-button.component'), {
-    featureName: 'start-visit-button-patient-search',
-    moduleName,
-  });
+export const startVisitButtonPatientSearch = getAsyncLifecycle(() => import('./visit/start-visit-button.component'), {
+  featureName: 'start-visit-button-patient-search',
+  moduleName,
+});
 
-export const visitAttributeTags = () =>
-  getAsyncLifecycle(() => import('./patient-banner-tags/visit-attribute-tags.component'), {
+export const visitAttributeTags = getAsyncLifecycle(
+  () => import('./patient-banner-tags/visit-attribute-tags.component'),
+  {
     featureName: 'visit-attribute-tags',
     moduleName,
-  });
+  },
+);
 
-export const deleteEncounterModal = () =>
-  getAsyncLifecycle(() => import('./visit/visits-widget/past-visits-components/delete-encounter-modal.component'), {
+export const deleteEncounterModal = getAsyncLifecycle(
+  () => import('./visit/visits-widget/past-visits-components/delete-encounter-modal.component'),
+  {
     featureName: 'delete-encounter-modal',
     moduleName,
-  });
+  },
+);

--- a/packages/esm-patient-conditions-app/src/index.ts
+++ b/packages/esm-patient-conditions-app/src/index.ts
@@ -16,16 +16,19 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const conditionsOverview = () =>
-  getAsyncLifecycle(() => import('./conditions/conditions-overview.component'), options);
+export const conditionsOverview = getAsyncLifecycle(
+  () => import('./conditions/conditions-overview.component'),
+  options,
+);
 
-export const conditionsDetailedSummary = () =>
-  getAsyncLifecycle(() => import('./conditions/conditions-detailed-summary.component'), options);
+export const conditionsDetailedSummary = getAsyncLifecycle(
+  () => import('./conditions/conditions-detailed-summary.component'),
+  options,
+);
 
-export const conditionsWidget = () =>
-  getAsyncLifecycle(() => import('./conditions/conditions-widget.component'), options);
+export const conditionsWidget = getAsyncLifecycle(() => import('./conditions/conditions-widget.component'), options);
 
-export const conditionsDashboardLink = () =>
+export const conditionsDashboardLink =
   // t('conditions_link', 'Conditions')
   getSyncLifecycle(
     createDashboardLink({
@@ -37,8 +40,12 @@ export const conditionsDashboardLink = () =>
     }),
     options,
   );
-export const conditionsFormWorkspace = () =>
-  getAsyncLifecycle(() => import('./conditions/conditions-form.component'), options);
+export const conditionsFormWorkspace = getAsyncLifecycle(
+  () => import('./conditions/conditions-form.component'),
+  options,
+);
 
-export const conditionsDeleteConfirmationDialog = () =>
-  getAsyncLifecycle(() => import('./conditions/delete-condition-modal.component'), options);
+export const conditionsDeleteConfirmationDialog = getAsyncLifecycle(
+  () => import('./conditions/delete-condition-modal.component'),
+  options,
+);

--- a/packages/esm-patient-forms-app/src/index.ts
+++ b/packages/esm-patient-forms-app/src/index.ts
@@ -59,16 +59,21 @@ export const formsAndNotesDashboardLink = () =>
     options,
   );
 
-export const offlineFormOverviewCard = () =>
-  getAsyncLifecycle(() => import('./offline-forms/offline-forms-overview-card.component'), options);
+export const offlineFormOverviewCard = getAsyncLifecycle(
+  () => import('./offline-forms/offline-forms-overview-card.component'),
+  options,
+);
 
-export const offlineFormsNavLink = () =>
-  getSyncLifecycle(() => OfflineToolsNavLink({ page: 'forms', title: 'Offline forms' }), options);
+export const offlineFormsNavLink = getSyncLifecycle(
+  () => OfflineToolsNavLink({ page: 'forms', title: 'Offline forms' }),
+  options,
+);
 
-export const offlineForms = () => getAsyncLifecycle(() => import('./offline-forms/offline-forms.component'), options);
+export const offlineForms = getAsyncLifecycle(() => import('./offline-forms/offline-forms.component'), options);
 
-export const clinicalFormActionMenu = () =>
-  getAsyncLifecycle(() => import('./clinical-form-action-button.component'), options);
+export const clinicalFormActionMenu = getAsyncLifecycle(
+  () => import('./clinical-form-action-button.component'),
+  options,
+);
 
-export const clinicalFormsWorkspace = () =>
-  getAsyncLifecycle(() => import('./forms/forms-workspace.component'), options);
+export const clinicalFormsWorkspace = getAsyncLifecycle(() => import('./forms/forms-workspace.component'), options);

--- a/packages/esm-patient-immunizations-app/src/index.ts
+++ b/packages/esm-patient-immunizations-app/src/index.ts
@@ -16,13 +16,17 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const immunizationsOverview = () =>
-  getAsyncLifecycle(() => import('./immunizations/immunizations-overview.component'), options);
+export const immunizationsOverview = getAsyncLifecycle(
+  () => import('./immunizations/immunizations-overview.component'),
+  options,
+);
 
-export const immunizationsDetailedSummary = () =>
-  getAsyncLifecycle(() => import('./immunizations/immunizations-detailed-summary.component'), options);
+export const immunizationsDetailedSummary = getAsyncLifecycle(
+  () => import('./immunizations/immunizations-detailed-summary.component'),
+  options,
+);
 
-export const immunizationsDashboardLink = () =>
+export const immunizationsDashboardLink =
   // t('immunizations_link', 'Immunizations')
   getSyncLifecycle(
     createDashboardLink({
@@ -35,5 +39,7 @@ export const immunizationsDashboardLink = () =>
     options,
   );
 
-export const immunizationsForm = () =>
-  getAsyncLifecycle(() => import('./immunizations/immunizations-form.component'), options);
+export const immunizationsForm = getAsyncLifecycle(
+  () => import('./immunizations/immunizations-form.component'),
+  options,
+);

--- a/packages/esm-patient-medications-app/src/index.ts
+++ b/packages/esm-patient-medications-app/src/index.ts
@@ -16,15 +16,13 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const medicationsSummary = () =>
-  getAsyncLifecycle(() => import('./medications/root-medication-summary'), options);
+export const medicationsSummary = getAsyncLifecycle(() => import('./medications/root-medication-summary'), options);
 
-export const activeMedications = () =>
-  getAsyncLifecycle(() => import('./medications/active-medications.component'), options);
+export const activeMedications = getAsyncLifecycle(() => import('./medications/active-medications.component'), options);
 
-export const orderBasketWorkspace = () => getAsyncLifecycle(() => import('./medications/root-order-basket'), options);
+export const orderBasketWorkspace = getAsyncLifecycle(() => import('./medications/root-order-basket'), options);
 
-export const medicationsDashboardLink = () =>
+export const medicationsDashboardLink =
   // t('medications_link', 'Medications')
   getSyncLifecycle(
     createDashboardLink({
@@ -37,5 +35,7 @@ export const medicationsDashboardLink = () =>
     options,
   );
 
-export const orderBasketActionMenu = () =>
-  getAsyncLifecycle(() => import('./medications-summary/order-basket-action-button.component'), options);
+export const orderBasketActionMenu = getAsyncLifecycle(
+  () => import('./medications-summary/order-basket-action-button.component'),
+  options,
+);

--- a/packages/esm-patient-notes-app/src/index.ts
+++ b/packages/esm-patient-notes-app/src/index.ts
@@ -19,12 +19,13 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const notesOverview = () => getAsyncLifecycle(() => import('./notes/notes-overview.component'), options);
+export const notesOverview = getAsyncLifecycle(() => import('./notes/notes-overview.component'), options);
 
-export const notesDetailedSummary = () =>
-  getAsyncLifecycle(() => import('./notes/notes-detailed-summary.component'), options);
+export const notesDetailedSummary = getAsyncLifecycle(
+  () => import('./notes/notes-detailed-summary.component'),
+  options,
+);
 
-export const visitNotesActionButton = () =>
-  getAsyncLifecycle(() => import('./visit-note-action-button.component'), options);
+export const visitNotesActionButton = getAsyncLifecycle(() => import('./visit-note-action-button.component'), options);
 
-export const visitNotesForm = () => getAsyncLifecycle(() => import('./notes/visit-notes-form.component'), options);
+export const visitNotesForm = getAsyncLifecycle(() => import('./notes/visit-notes-form.component'), options);

--- a/packages/esm-patient-programs-app/src/index.ts
+++ b/packages/esm-patient-programs-app/src/index.ts
@@ -16,13 +16,14 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const programsOverview = () =>
-  getAsyncLifecycle(() => import('./programs/programs-overview.component'), options);
+export const programsOverview = getAsyncLifecycle(() => import('./programs/programs-overview.component'), options);
 
-export const programsDetailedSummary = () =>
-  getAsyncLifecycle(() => import('./programs/programs-detailed-summary.component'), options);
+export const programsDetailedSummary = getAsyncLifecycle(
+  () => import('./programs/programs-detailed-summary.component'),
+  options,
+);
 
-export const programsDashboardLink = () =>
+export const programsDashboardLink =
   // t('programs_link', 'Programs')
   getSyncLifecycle(
     createDashboardLink({
@@ -33,4 +34,4 @@ export const programsDashboardLink = () =>
     options,
   );
 
-export const programsForm = () => getAsyncLifecycle(() => import('./programs/programs-form.component'), options);
+export const programsForm = getAsyncLifecycle(() => import('./programs/programs-form.component'), options);

--- a/packages/esm-patient-test-results-app/src/index.ts
+++ b/packages/esm-patient-test-results-app/src/index.ts
@@ -27,12 +27,11 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const externalOverview = () =>
-  getAsyncLifecycle(() => import('./overview/external-overview.component'), options);
+export const externalOverview = getAsyncLifecycle(() => import('./overview/external-overview.component'), options);
 
-export const resultsViewer = () => getAsyncLifecycle(() => import('./results-viewer'), options);
+export const resultsViewer = getAsyncLifecycle(() => import('./results-viewer'), options);
 
-export const testResultsDashboardLink = () =>
+export const testResultsDashboardLink =
   // t('testResults_link', 'Test Results')
   getSyncLifecycle(
     createDashboardLink({

--- a/packages/esm-patient-vitals-app/src/index.ts
+++ b/packages/esm-patient-vitals-app/src/index.ts
@@ -19,12 +19,13 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const vitalsSummary = () => getAsyncLifecycle(() => import('./vitals/vitals-summary.component'), options);
+export const vitalsSummary = getAsyncLifecycle(() => import('./vitals/vitals-summary.component'), options);
 
-export const vitalsMain = () => getAsyncLifecycle(() => import('./vitals/vitals-main.component'), options);
+export const vitalsMain = getAsyncLifecycle(() => import('./vitals/vitals-main.component'), options);
 
-export const vitalsHeader = () =>
-  getAsyncLifecycle(() => import('./vitals/vitals-header/vitals-header.component'), options);
+export const vitalsHeader = getAsyncLifecycle(() => import('./vitals/vitals-header/vitals-header.component'), options);
 
-export const vitalsAndBiometricsForm = () =>
-  getAsyncLifecycle(() => import('./vitals/vitals-biometrics-form/vitals-biometrics-form.component'), options);
+export const vitalsAndBiometricsForm = getAsyncLifecycle(
+  () => import('./vitals/vitals-biometrics-form/vitals-biometrics-form.component'),
+  options,
+);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

`const export = () => getSyncLifecycle()` should be `const export = getSyncLifecycle()`, etc.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
