### PR TITLE
(feat) Show add buttons on widgets by default

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -22,10 +22,9 @@ import styles from './allergies-detailed-summary.scss';
 
 interface AllergiesDetailedSummaryProps {
   patient: fhir.Patient;
-  showAddAllergyButton: boolean;
 }
 
-const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ patient, showAddAllergyButton }) => {
+const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ patient }) => {
   const { t } = useTranslation();
   const displayText = t('allergyIntolerances', 'allergy intolerances');
   const headerTitle = t('allergies', 'Allergies');
@@ -79,16 +78,14 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
       <div className={styles.widgetCard}>
         <CardHeader title={headerTitle}>
           <span>{isValidating ? <InlineLoading /> : null}</span>
-          {showAddAllergyButton && (
-            <Button
-              kind="ghost"
-              renderIcon={(props) => <Add size={16} {...props} />}
-              iconDescription="Add allergies"
-              onClick={launchAllergiesForm}
-            >
-              {t('add', 'Add')}
-            </Button>
-          )}
+          <Button
+            kind="ghost"
+            renderIcon={(props) => <Add size={16} {...props} />}
+            iconDescription="Add allergies"
+            onClick={launchAllergiesForm}
+          >
+            {t('add', 'Add')}
+          </Button>
         </CardHeader>
         <DataTable rows={tableRows} headers={tableHeaders} isSortable useZebraStyles size={isTablet ? 'lg' : 'sm'}>
           {({ rows, headers, getHeaderProps, getTableProps }) => (

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
@@ -8,7 +8,6 @@ import AllergiesDetailedSummary from './allergies-detailed-summary.component';
 
 const testProps = {
   patient: mockPatient,
-  showAddAllergyButton: false,
 };
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
@@ -29,10 +29,9 @@ import styles from './allergies-overview.scss';
 interface AllergiesOverviewProps {
   basePath: string;
   patient: fhir.Patient;
-  showAddAllergyButton: boolean;
 }
 
-const AllergiesOverview: React.FC<AllergiesOverviewProps> = ({ patient, showAddAllergyButton, basePath }) => {
+const AllergiesOverview: React.FC<AllergiesOverviewProps> = ({ patient }) => {
   const { t } = useTranslation();
   const displayText = t('allergyIntolerances', 'allergy intolerances');
   const headerTitle = t('allergies', 'Allergies');
@@ -74,16 +73,14 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = ({ patient, showAddA
       <div className={styles.widgetCard}>
         <CardHeader title={headerTitle}>
           <span>{isValidating ? <InlineLoading /> : null}</span>
-          {showAddAllergyButton && (
-            <Button
-              kind="ghost"
-              renderIcon={(props) => <Add size={16} {...props} />}
-              iconDescription="Add allergies"
-              onClick={launchAllergiesForm}
-            >
-              {t('add', 'Add')}
-            </Button>
-          )}
+          <Button
+            kind="ghost"
+            renderIcon={(props) => <Add size={16} {...props} />}
+            iconDescription="Add allergies"
+            onClick={launchAllergiesForm}
+          >
+            {t('add', 'Add')}
+          </Button>
         </CardHeader>
         <DataTable rows={tableRows} headers={tableHeaders} isSortable size={isTablet ? 'lg' : 'sm'} useZebraStyles>
           {({ rows, headers, getHeaderProps, getTableProps }) => (

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.test.tsx
@@ -9,7 +9,6 @@ import AllergiesOverview from './allergies-overview.component';
 const testProps = {
   patient: mockPatient,
   basePath: patientChartBasePath,
-  showAddAllergyButton: false,
 };
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-base.component.tsx
@@ -20,19 +20,12 @@ import { launchVitalsAndBiometricsForm } from '../biometrics-utils';
 
 interface BiometricsBaseProps {
   patientUuid: string;
-  showAddBiometrics: boolean;
   pageSize: number;
   urlLabel: string;
   pageUrl: string;
 }
 
-const BiometricsBase: React.FC<BiometricsBaseProps> = ({
-  patientUuid,
-  showAddBiometrics,
-  pageSize,
-  urlLabel,
-  pageUrl,
-}) => {
+const BiometricsBase: React.FC<BiometricsBaseProps> = ({ patientUuid, pageSize, urlLabel, pageUrl }) => {
   const { t } = useTranslation();
   const displayText = t('biometrics_lower', 'biometrics');
   const headerTitle = t('biometrics', 'Biometrics');
@@ -92,19 +85,17 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({
                 <ChartLineSmooth size={16} />
               </Switch>
             </ContentSwitcher>
-            {showAddBiometrics && (
-              <>
-                <span className={styles.divider}>|</span>
-                <Button
-                  kind="ghost"
-                  renderIcon={(props) => <Add size={16} {...props} />}
-                  iconDescription="Add biometrics"
-                  onClick={launchBiometricsForm}
-                >
-                  {t('add', 'Add')}
-                </Button>
-              </>
-            )}
+            <>
+              <span className={styles.divider}>|</span>
+              <Button
+                kind="ghost"
+                renderIcon={(props) => <Add size={16} {...props} />}
+                iconDescription="Add biometrics"
+                onClick={launchBiometricsForm}
+              >
+                {t('add', 'Add')}
+              </Button>
+            </>
           </div>
         </CardHeader>
         {chartView ? (

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-main.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-main.component.tsx
@@ -4,25 +4,16 @@ import BiometricsBase from './biometrics-base.component';
 
 interface BiometricsProps {
   patientUuid: string;
-  showAddBiometrics: boolean;
   basePath: string;
 }
 
-const BiometricsMain: React.FC<BiometricsProps> = ({ patientUuid, showAddBiometrics, basePath }) => {
+const BiometricsMain: React.FC<BiometricsProps> = ({ patientUuid, basePath }) => {
   const pageSize = 10;
   const { t } = useTranslation();
   const pageUrl: string = `$\{openmrsSpaBase}/patient/${patientUuid}/chart`;
   const urlLabel = t('goToSummary', 'Go to Summary');
 
-  return (
-    <BiometricsBase
-      patientUuid={patientUuid}
-      showAddBiometrics={showAddBiometrics}
-      pageSize={pageSize}
-      urlLabel={urlLabel}
-      pageUrl={pageUrl}
-    />
-  );
+  return <BiometricsBase patientUuid={patientUuid} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />;
 };
 
 export default BiometricsMain;

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.component.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.component.tsx
@@ -4,25 +4,16 @@ import BiometricsBase from './biometrics-base.component';
 
 interface BiometricsProps {
   patientUuid: string;
-  showAddBiometrics: boolean;
   basePath: string;
 }
 
-const BiometricsOverview: React.FC<BiometricsProps> = ({ patientUuid, showAddBiometrics, basePath }) => {
+const BiometricsOverview: React.FC<BiometricsProps> = ({ patientUuid, basePath }) => {
   const { t } = useTranslation();
   const pageSize = 5;
   const pageUrl = `\${openmrsSpaBase}/patient/${patientUuid}/chart/Vitals & Biometrics`;
   const urlLabel = t('seeAll', 'See all');
 
-  return (
-    <BiometricsBase
-      patientUuid={patientUuid}
-      showAddBiometrics={showAddBiometrics}
-      pageSize={pageSize}
-      urlLabel={urlLabel}
-      pageUrl={pageUrl}
-    />
-  );
+  return <BiometricsBase patientUuid={patientUuid} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />;
 };
 
 export default BiometricsOverview;

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.test.tsx
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.test.tsx
@@ -13,7 +13,6 @@ import { mockVitalsSignsConcept } from '../../../../__mocks__/vitals.mock';
 
 const testProps = {
   basePath: patientChartBasePath,
-  showAddBiometrics: true,
   patientUuid: mockPatient.id,
 };
 

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -32,7 +32,6 @@ export interface ActiveMedicationsProps {
   isValidating?: boolean;
   title?: string;
   medications?: Array<Order> | null;
-  showAddNewButton: boolean;
   showDiscontinueButton: boolean;
   showModifyButton: boolean;
   showReorderButton: boolean;
@@ -46,7 +45,6 @@ const MedicationsDetailsTable: React.FC<ActiveMedicationsProps> = ({
   showDiscontinueButton,
   showModifyButton,
   showReorderButton,
-  showAddNewButton,
   patientUuid,
 }) => {
   const { t } = useTranslation();
@@ -155,16 +153,14 @@ const MedicationsDetailsTable: React.FC<ActiveMedicationsProps> = ({
             <InlineLoading />
           </span>
         ) : null}
-        {showAddNewButton && (
-          <Button
-            kind="ghost"
-            renderIcon={(props) => <Add size={16} {...props} />}
-            iconDescription="Launch order basket"
-            onClick={launchOrderBasket}
-          >
-            {t('add', 'Add')}
-          </Button>
-        )}
+        <Button
+          kind="ghost"
+          renderIcon={(props) => <Add size={16} {...props} />}
+          iconDescription="Launch order basket"
+          onClick={launchOrderBasket}
+        >
+          {t('add', 'Add')}
+        </Button>
       </CardHeader>
       <DataTable
         data-floating-menu-container

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -66,7 +66,6 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
                 showDiscontinueButton={true}
                 showModifyButton={true}
                 showReorderButton={false}
-                showAddNewButton={true}
                 patientUuid={patientUuid}
               />
             );
@@ -93,7 +92,6 @@ export default function MedicationsSummary({ patientUuid }: MedicationsSummaryPr
                 showDiscontinueButton={true}
                 showModifyButton={true}
                 showReorderButton={true}
-                showAddNewButton={true}
                 patientUuid={patientUuid}
               />
             );

--- a/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.component.tsx
@@ -10,10 +10,9 @@ import { useLaunchOrderBasket } from '../utils/launchOrderBasket';
 
 interface ActiveMedicationsProps {
   patientUuid: string;
-  showAddMedications: boolean;
 }
 
-const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, showAddMedications }) => {
+const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const config = useConfig<ConfigObject>();
   const displayText = t('activeMedicationsDisplayText', 'Active medications');
@@ -36,7 +35,6 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patientUuid, show
         showDiscontinueButton={true}
         showModifyButton={true}
         showReorderButton={false}
-        showAddNewButton={showAddMedications}
         patientUuid={patientUuid}
       />
     );

--- a/packages/esm-patient-medications-app/src/medications/active-medications.test.tsx
+++ b/packages/esm-patient-medications-app/src/medications/active-medications.test.tsx
@@ -9,7 +9,6 @@ import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 
 const testProps = {
   patientUuid: mockPatient.id,
-  showAddMedications: true,
 };
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket.component.tsx
@@ -196,7 +196,6 @@ const OrderBasket: React.FC<OrderBasketProps> = ({ patientUuid, closeWorkspace }
                   showDiscontinueButton={true}
                   showModifyButton={true}
                   showReorderButton={false}
-                  showAddNewButton={false}
                   patientUuid={patientUuid}
                 />
               );

--- a/packages/esm-patient-notes-app/src/notes/notes-detailed-summary.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-detailed-summary.component.tsx
@@ -4,25 +4,16 @@ import NotesMain from './notes-main.component';
 
 interface NotesDetailedSummaryProps {
   patientUuid: string;
-  showAddNote: boolean;
   basePath: string;
 }
 
-const NotesDetailedSummary: React.FC<NotesDetailedSummaryProps> = ({ patientUuid, showAddNote, basePath }) => {
+const NotesDetailedSummary: React.FC<NotesDetailedSummaryProps> = ({ patientUuid, basePath }) => {
   const pageSize = 10;
   const { t } = useTranslation();
   const pageUrl: string = `$\{openmrsSpaBase}/patient/${patientUuid}/chart`;
   const urlLabel = t('goToSummary', 'Go to Summary');
 
-  return (
-    <NotesMain
-      patientUuid={patientUuid}
-      pageSize={pageSize}
-      pageUrl={pageUrl}
-      showAddNote={showAddNote}
-      urlLabel={urlLabel}
-    />
-  );
+  return <NotesMain patientUuid={patientUuid} pageSize={pageSize} pageUrl={pageUrl} urlLabel={urlLabel} />;
 };
 
 export default NotesDetailedSummary;

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.test.tsx
@@ -9,7 +9,6 @@ import { useVisitNotes } from './visit-notes.resource';
 
 const testProps = {
   patientUuid: mockPatient.id,
-  showAddNote: false,
   pageSize: 10,
   urlLabel: window.spaBase + patientChartBasePath + '/summary',
   pageUrl: 'Go to Summary',

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -16,13 +16,12 @@ import styles from './notes-overview.scss';
 
 interface NotesOverviewProps {
   patientUuid: string;
-  showAddNote: boolean;
   pageSize: number;
   urlLabel: string;
   pageUrl: string;
 }
 
-const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, showAddNote, pageSize, urlLabel, pageUrl }) => {
+const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, pageSize, urlLabel, pageUrl }) => {
   const { t } = useTranslation();
   const { currentVisit } = useVisit(patientUuid);
   const displayText = t('visitNotes', 'Visit notes');
@@ -55,16 +54,14 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, showAddNote, pag
     <div className={styles.widgetCard}>
       <CardHeader title={headerTitle}>
         <span>{isValidating ? <InlineLoading /> : null}</span>
-        {showAddNote && (
-          <Button
-            kind="ghost"
-            renderIcon={(props) => <Add size={16} {...props} />}
-            iconDescription="Add visit note"
-            onClick={launchVisitNoteForm}
-          >
-            {t('add', 'Add')}
-          </Button>
-        )}
+        <Button
+          kind="ghost"
+          renderIcon={(props) => <Add size={16} {...props} />}
+          iconDescription="Add visit note"
+          onClick={launchVisitNoteForm}
+        >
+          {t('add', 'Add')}
+        </Button>
       </CardHeader>
       <PaginatedNotes notes={visitNotes} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />
     </div>

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.component.tsx
@@ -5,25 +5,16 @@ import NotesMain from './notes-main.component';
 interface NotesOverviewProps {
   patientUuid: string;
   patient: fhir.Patient;
-  showAddNote: boolean;
   basePath: string;
 }
 
-const NotesOverview: React.FC<NotesOverviewProps> = ({ patientUuid, patient, showAddNote, basePath }) => {
+const NotesOverview: React.FC<NotesOverviewProps> = ({ patientUuid, patient, basePath }) => {
   const pageSize = 5;
   const { t } = useTranslation();
   const pageUrl = `\${openmrsSpaBase}/patient/${patient.id}/chart/Forms & Notes`;
   const urlLabel = t('seeAll', 'See all');
 
-  return (
-    <NotesMain
-      patientUuid={patientUuid}
-      showAddNote={showAddNote}
-      pageSize={pageSize}
-      urlLabel={urlLabel}
-      pageUrl={pageUrl}
-    />
-  );
+  return <NotesMain patientUuid={patientUuid} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />;
 };
 
 export default NotesOverview;

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
@@ -15,7 +15,6 @@ const testProps = {
   basePath: patientChartBasePath,
   patient: mockPatient,
   patientUuid: mockPatient.id,
-  showAddNote: false,
 };
 
 const mockUseVisitNotes = useVisitNotes as jest.Mock;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-main.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-main.component.tsx
@@ -4,25 +4,16 @@ import VitalsOverview from './vitals-overview.component';
 
 interface VitalsMainProps {
   patientUuid: string;
-  showAddVitals: boolean;
   basePath: string;
 }
 
-const VitalsMain: React.FC<VitalsMainProps> = ({ patientUuid, showAddVitals, basePath }) => {
+const VitalsMain: React.FC<VitalsMainProps> = ({ patientUuid, basePath }) => {
   const pageSize = 10;
   const { t } = useTranslation();
   const pageUrl: string = `$\{openmrsSpaBase}/patient/${patientUuid}/chart`;
   const urlLabel = t('goToSummary', 'Go to Summary');
 
-  return (
-    <VitalsOverview
-      patientUuid={patientUuid}
-      showAddVitals={showAddVitals}
-      pageSize={pageSize}
-      urlLabel={urlLabel}
-      pageUrl={pageUrl}
-    />
-  );
+  return <VitalsOverview patientUuid={patientUuid} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />;
 };
 
 export default VitalsMain;

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -22,7 +22,6 @@ import { launchVitalsForm } from './vitals-utils';
 
 interface VitalsOverviewProps {
   patientUuid: string;
-  showAddVitals: boolean;
   pageSize: number;
   urlLabel: string;
   pageUrl: string;
@@ -33,7 +32,7 @@ export function launchFormEntry(formUuid: string, encounterUuid?: string, formNa
   launchPatientWorkspace('patient-form-entry-workspace', { workspaceTitle: formName });
 }
 
-const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVitals, pageSize, urlLabel, pageUrl }) => {
+const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, pageSize, urlLabel, pageUrl }) => {
   const { t } = useTranslation();
   const config = useConfig() as ConfigObject;
   const displayText = t('vitalSigns', 'Vital signs');
@@ -111,19 +110,17 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVit
                       <ChartLineSmooth size={16} />
                     </Switch>
                   </ContentSwitcher>
-                  {showAddVitals && (
-                    <>
-                      <span className={styles.divider}>|</span>
-                      <Button
-                        kind="ghost"
-                        renderIcon={Add}
-                        iconDescription="Add vitals"
-                        onClick={launchVitalsBiometricsForm}
-                      >
-                        {t('add', 'Add')}
-                      </Button>
-                    </>
-                  )}
+                  <>
+                    <span className={styles.divider}>|</span>
+                    <Button
+                      kind="ghost"
+                      renderIcon={Add}
+                      iconDescription="Add vitals"
+                      onClick={launchVitalsBiometricsForm}
+                    >
+                      {t('add', 'Add')}
+                    </Button>
+                  </>
                 </div>
               </CardHeader>
               {chartView ? (

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -15,7 +15,6 @@ import VitalsOverview from './vitals-overview.component';
 
 const testProps = {
   patientUuid: mockPatient.id,
-  showAddVitals: false,
   pageSize: 5,
   pageUrl: '',
   urlLabel: '',

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-summary.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-summary.component.tsx
@@ -4,25 +4,16 @@ import VitalsOverview from './vitals-overview.component';
 
 interface VitalsOverviewProps {
   patientUuid: string;
-  showAddVitals: boolean;
   basePath: string;
 }
 
-const VitalsSummary: React.FC<VitalsOverviewProps> = ({ patientUuid, showAddVitals, basePath }) => {
+const VitalsSummary: React.FC<VitalsOverviewProps> = ({ patientUuid, basePath }) => {
   const pageSize = 5;
   const { t } = useTranslation();
   const pageUrl = `\${openmrsSpaBase}/patient/${patientUuid}/chart/Vitals & Biometrics`;
   const urlLabel = t('seeAll', 'See all');
 
-  return (
-    <VitalsOverview
-      patientUuid={patientUuid}
-      showAddVitals={showAddVitals}
-      pageSize={pageSize}
-      urlLabel={urlLabel}
-      pageUrl={pageUrl}
-    />
-  );
+  return <VitalsOverview patientUuid={patientUuid} pageSize={pageSize} urlLabel={urlLabel} pageUrl={pageUrl} />;
 };
 
 export default VitalsSummary;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Show the `Add +` button on widgets for now. We'll find a better way to toggle these by permission or some other criteria in future. The display of these buttons was previously handled by logic in `index.ts` and moving those bits over to `routes.json` means they don't work at the moment.

<img width="953" alt="Screenshot 2023-06-24 at 1 50 17 AM" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/be16e8ce-72fc-4516-95dd-cfc7a8dd599d">