### PR TITLE
(fix) Exports should reference the result of getSync / getAsync

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "git-blame.gitWebUrl": ""
+    "git-blame.gitWebUrl": "",
+    "angular.enable-strict-mode-prompt": false
 }

--- a/packages/esm-patient-forms-app/src/index.ts
+++ b/packages/esm-patient-forms-app/src/index.ts
@@ -46,7 +46,7 @@ export function startupApp() {
 export const formsDetailedOverview = () =>
   getAsyncLifecycle(() => import('./forms/forms-detailed-overview.component'), options);
 
-export const formsAndNotesDashboardLink = () =>
+export const formsAndNotesDashboardLink =
   // t('forms_link', 'Forms & Notes')
   getSyncLifecycle(
     createDashboardLink({


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes an issue where the `Forms and notes` frontend module is not loaded in the UI. The root cause is that the named exports for the components in the app entry point (src/index.ts) don't export the result of getAsyncLifecycle and getSyncLifecycle. This PR fixes those exports so that they return the expected values.
i