### PR TITLE
(fix) Add `slots` array for the `resultsViewer` extension

### DIFF
--- a/packages/esm-patient-test-results-app/src/routes.json
+++ b/packages/esm-patient-test-results-app/src/routes.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "results-viewer",
-      "slot": "patient-chart-results-viewer-slot",
+      "slots": ["patient-chart-results-viewer-slot", "patient-chart-test-results-dashboard-slot"],
       "component": "resultsViewer",
       "meta": {
         "columnSpan": 4


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Following the addition of [support](https://github.com/openmrs/openmrs-contrib-json-schemas/pull/2) for the `slots` array, we can now tweak the extension config for the `resultsViewer` extension in the test results frontend module to leverage it.