### PR TITLE
(fix) Ensure routes.json is part of dist for esm-form-entry-app

### DIFF
--- a/packages/esm-form-entry-app/package.json
+++ b/packages/esm-form-entry-app/package.json
@@ -81,6 +81,7 @@
     "@types/jasminewd2": "~2.0.3",
     "@types/webpack-env": "^1.17.0",
     "codelyzer": "^6.0.0",
+    "copy-webpack-plugin": "^11.0.0",
     "jasmine-core": "~3.6.0",
     "jasmine-spec-reporter": "~5.0.0",
     "karma": "~6.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5441,6 +5441,7 @@ __metadata:
     "@types/jasminewd2": ~2.0.3
     "@types/webpack-env": ^1.17.0
     codelyzer: ^6.0.0
+    copy-webpack-plugin: ^11.0.0
     hammerjs: ^2.0.8
     jasmine-core: ~3.6.0
     jasmine-spec-reporter: ~5.0.0


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Adds the copy step to the form-entry-app so that we copy (and enrich) routes.json and so the form-entry-app will be found in the `routes.registry.json`.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
