### PR TITLE
(fix) O3-2161: Encounter view doesn't work with multiple pages

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/delete-encounter-modal.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/delete-encounter-modal.component.tsx
@@ -15,11 +15,13 @@ const DeleteEncounterConfirmation: React.FC<DeleteEncounterConfirmationProps> = 
   encounterTypeName,
 }) => {
   const { t } = useTranslation();
+  const handleCancel = () => close();
+  const handleDelete = () => onConfirmation?.();
 
   return (
     <>
       <ModalHeader closeModal={close} className={styles.productiveHeading03}>
-        {t('deleteEncounter', 'Delete Encounter')} ?
+        {t('deleteEncounter', 'Delete Encounter')}?
       </ModalHeader>
       <ModalBody>
         <p className={styles.bodyLong01}>
@@ -31,10 +33,10 @@ const DeleteEncounterConfirmation: React.FC<DeleteEncounterConfirmationProps> = 
         </p>
       </ModalBody>
       <ModalFooter>
-        <Button size="lg" kind="secondary" onClick={() => close()}>
+        <Button size="lg" kind="secondary" onClick={handleCancel}>
           {t('cancel', 'Cancel')}
         </Button>
-        <Button size="lg" kind="danger" onClick={() => onConfirmation?.()} autoFocus>
+        <Button autoFocus kind="danger" onClick={handleDelete} size="lg">
           {t('delete', 'Delete')}
         </Button>
       </ModalFooter>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -55,7 +55,7 @@ interface VisitTableProps {
 type FilterProps = {
   rowIds: Array<string>;
   headers: Array<DataTableHeader>;
-  cellsById: any;
+  cellsById: Record<string, Record<string, boolean | string | null | Record<string, unknown>>>;
   inputValue: string;
   getCellId: (row, key) => string;
 };
@@ -166,7 +166,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
               });
               mutateVisits?.();
             })
-            .catch((error) => {
+            .catch(() => {
               showToast({
                 title: t('error', 'Error'),
                 description: `Encounter ${t('failedDeleting', "couldn't be deleted")}`,
@@ -256,103 +256,105 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
                 </TableRow>
               </TableHead>
               <TableBody>
-                {rows.map((row, index) => (
-                  <React.Fragment key={row.id}>
-                    <TableExpandRow {...getRowProps({ row })}>
-                      {row.cells.map((cell) => (
-                        <TableCell key={cell.id}>{cell.value}</TableCell>
-                      ))}
-                      {showAllEncounters ? (
-                        <TableCell className="cds--table-column-menu">
-                          <Layer className={styles.layer}>
-                            <OverflowMenu
-                              data-floating-menu-container
-                              ariaLabel="Encounter table actions menu"
-                              size={desktopLayout ? 'sm' : 'lg'}
-                              flipped
-                            >
-                              <OverflowMenuItem
+                {rows.map((row) => {
+                  const selectedVisit = visits.find((visit) => visit.id === row.id);
+
+                  return (
+                    <React.Fragment key={row.id}>
+                      <TableExpandRow {...getRowProps({ row })}>
+                        {row.cells.map((cell) => (
+                          <TableCell key={cell.id}>{cell.value}</TableCell>
+                        ))}
+                        {showAllEncounters ? (
+                          <TableCell className="cds--table-column-menu">
+                            <Layer className={styles.layer}>
+                              <OverflowMenu
+                                data-floating-menu-container
+                                ariaLabel="Encounter table actions menu"
                                 size={desktopLayout ? 'sm' : 'lg'}
-                                className={styles.menuItem}
-                                itemText={t('goToThisEncounter', 'Go to this encounter')}
-                              />
-                              {userHasAccess(visits[index]?.editPrivilege, session?.user) && visits[index]?.form?.uuid && (
-                                <OverflowMenuItem
-                                  className={styles.menuItem}
-                                  itemText={t('editThisEncounter', 'Edit this encounter')}
-                                  size={desktopLayout ? 'sm' : 'lg'}
-                                  onClick={() => {
-                                    launchWorkspace(
-                                      visits[index]?.form?.uuid,
-                                      visits[index]?.visitUuid,
-                                      visits[index]?.id,
-                                      visits[index]?.form?.display,
-                                      visits[index]?.visitTypeUuid,
-                                      visits[index]?.visitStartDatetime,
-                                      visits[index]?.visitStopDatetime,
-                                    );
-                                  }}
-                                />
-                              )}
-                              {userHasAccess(visits[index]?.editPrivilege, session?.user) && (
-                                <OverflowMenuItem
-                                  size={desktopLayout ? 'sm' : 'lg'}
-                                  className={styles.menuItem}
-                                  itemText={t('deleteThisEncounter', 'Delete this encounter')}
-                                  onClick={() => {
-                                    const rowToDelete = rows.find((rowElement) => rowElement.id === row.id);
-                                    handleDeleteEncounter(rowToDelete.id, rowToDelete.form?.display);
-                                  }}
-                                  hasDivider
-                                  isDelete
-                                />
-                              )}
-                            </OverflowMenu>
-                          </Layer>
-                        </TableCell>
-                      ) : null}
-                    </TableExpandRow>
-                    {row.isExpanded ? (
-                      <TableExpandedRow className={styles.expandedRow} colSpan={headers.length + 2}>
-                        <>
-                          <EncounterObservations observations={visits[index].obs} />
-                          {userHasAccess(visits[index]?.editPrivilege, session?.user) && (
-                            <>
-                              {visits[index]?.form?.uuid && (
-                                <Button
-                                  kind="ghost"
-                                  onClick={() => {
-                                    launchWorkspace(
-                                      visits[index].form.uuid,
-                                      visits[index].visitUuid,
-                                      visits[index].id,
-                                      visits[index].form.display,
-                                      visits[index].visitTypeUuid,
-                                      visits[index]?.visitStartDatetime,
-                                      visits[index]?.visitStopDatetime,
-                                    );
-                                  }}
-                                  renderIcon={(props) => <Edit size={16} {...props} />}
-                                >
-                                  {t('editThisEncounter', 'Edit this encounter')}
-                                </Button>
-                              )}
-                              <Button
-                                kind="danger--ghost"
-                                onClick={() => handleDeleteEncounter(visits[index]?.id, visits[index]?.form?.display)}
-                                renderIcon={(props) => <TrashCan size={16} {...props} />}
+                                flipped
                               >
-                                {t('deleteThisEncounter', 'Delete this encounter')}
-                              </Button>
-                            </>
-                          )}
-                        </>
-                      </TableExpandedRow>
-                    ) : (
-                      <TableExpandedRow className={styles.hiddenRow} colSpan={headers.length + 2} />
-                    )}
-                  </React.Fragment>
-                ))}
+                                <OverflowMenuItem
+                                  size={desktopLayout ? 'sm' : 'lg'}
+                                  className={styles.menuItem}
+                                  itemText={t('goToThisEncounter', 'Go to this encounter')}
+                                />
+                                {userHasAccess(selectedVisit?.editPrivilege, session?.user) &&
+                                  selectedVisit?.form?.uuid && (
+                                    <OverflowMenuItem
+                                      className={styles.menuItem}
+                                      itemText={t('editThisEncounter', 'Edit this encounter')}
+                                      size={desktopLayout ? 'sm' : 'lg'}
+                                      onClick={() => {
+                                        launchWorkspace(
+                                          selectedVisit?.form?.uuid,
+                                          selectedVisit?.visitUuid,
+                                          selectedVisit?.id,
+                                          selectedVisit?.form?.display,
+                                          selectedVisit?.visitTypeUuid,
+                                          selectedVisit?.visitStartDatetime,
+                                          selectedVisit?.visitStopDatetime,
+                                        );
+                                      }}
+                                    />
+                                  )}
+                                {userHasAccess(selectedVisit?.editPrivilege, session?.user) && (
+                                  <OverflowMenuItem
+                                    size={desktopLayout ? 'sm' : 'lg'}
+                                    className={styles.menuItem}
+                                    itemText={t('deleteThisEncounter', 'Delete this encounter')}
+                                    onClick={() => handleDeleteEncounter(selectedVisit.id, selectedVisit.form?.display)}
+                                    hasDivider
+                                    isDelete
+                                  />
+                                )}
+                              </OverflowMenu>
+                            </Layer>
+                          </TableCell>
+                        ) : null}
+                      </TableExpandRow>
+                      {row.isExpanded ? (
+                        <TableExpandedRow className={styles.expandedRow} colSpan={headers.length + 2}>
+                          <>
+                            <EncounterObservations observations={selectedVisit?.obs} />
+                            {userHasAccess(selectedVisit?.editPrivilege, session?.user) && (
+                              <>
+                                {selectedVisit?.form?.uuid && (
+                                  <Button
+                                    kind="ghost"
+                                    onClick={() => {
+                                      launchWorkspace(
+                                        selectedVisit.form.uuid,
+                                        selectedVisit.visitUuid,
+                                        selectedVisit.id,
+                                        selectedVisit.form.display,
+                                        selectedVisit.visitTypeUuid,
+                                        selectedVisit?.visitStartDatetime,
+                                        selectedVisit?.visitStopDatetime,
+                                      );
+                                    }}
+                                    renderIcon={(props) => <Edit size={16} {...props} />}
+                                  >
+                                    {t('editThisEncounter', 'Edit this encounter')}
+                                  </Button>
+                                )}
+                                <Button
+                                  kind="danger--ghost"
+                                  onClick={() => handleDeleteEncounter(selectedVisit?.id, selectedVisit?.form?.display)}
+                                  renderIcon={(props) => <TrashCan size={16} {...props} />}
+                                >
+                                  {t('deleteThisEncounter', 'Delete this encounter')}
+                                </Button>
+                              </>
+                            )}
+                          </>
+                        </TableExpandedRow>
+                      ) : (
+                        <TableExpandedRow className={styles.hiddenRow} colSpan={headers.length + 2} />
+                      )}
+                    </React.Fragment>
+                  );
+                })}
               </TableBody>
             </Table>
           </TableContainer>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -148,7 +148,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
     }));    
   }, [paginatedVisits]);
 
-  const handleEncounterTypeChange = ({ selectedItem }) => setFilter(selectedItem.value);
+  const handleEncounterTypeChange = ({ selectedItem }) => setFilter(selectedItem);
 
   const handleDeleteEncounter = React.useCallback(
     (encounterUuid: string, encounterTypeName?: string) => {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -144,11 +144,11 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
   const tableRows = useMemo(() => {
     return paginatedVisits?.map((encounter) => ({
       ...encounter,
-      datetime: formatDatetime(parseDate(encounter?.datetime)),
-    }));
+      datetime: formatDatetime(parseDate(encounter.datetime)),
+    }));    
   }, [paginatedVisits]);
 
-  const handleEncounterTypeChange = ({ selectedItem }) => setFilter(selectedItem);
+  const handleEncounterTypeChange = ({ selectedItem }) => setFilter(selectedItem.value);
 
   const handleDeleteEncounter = React.useCallback(
     (encounterUuid: string, encounterTypeName?: string) => {
@@ -300,7 +300,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
                                   className={styles.menuItem}
                                   itemText={t('deleteThisEncounter', 'Delete this encounter')}
                                   onClick={() => {
-                                    handleDeleteEncounter(visits[index]?.id, visits[index]?.form?.display);
+                                    handleDeleteEncounter(paginatedVisits[index]?.id, paginatedVisits[index]?.form?.display);
                                   }}
                                   hasDivider
                                   isDelete

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -145,7 +145,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
     return paginatedVisits?.map((encounter) => ({
       ...encounter,
       datetime: formatDatetime(parseDate(encounter.datetime)),
-    }));    
+    })); 
   }, [paginatedVisits]);
 
   const handleEncounterTypeChange = ({ selectedItem }) => setFilter(selectedItem);
@@ -300,7 +300,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
                                   className={styles.menuItem}
                                   itemText={t('deleteThisEncounter', 'Delete this encounter')}
                                   onClick={() => {
-                                    handleDeleteEncounter(paginatedVisits[index]?.id, paginatedVisits[index]?.form?.display);
+                                    handleDeleteEncounter(row.id, row.form?.display)
                                   }}
                                   hasDivider
                                   isDelete

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -145,7 +145,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
     return paginatedVisits?.map((encounter) => ({
       ...encounter,
       datetime: formatDatetime(parseDate(encounter.datetime)),
-    })); 
+    }));
   }, [paginatedVisits]);
 
   const handleEncounterTypeChange = ({ selectedItem }) => setFilter(selectedItem);
@@ -300,7 +300,8 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
                                   className={styles.menuItem}
                                   itemText={t('deleteThisEncounter', 'Delete this encounter')}
                                   onClick={() => {
-                                    handleDeleteEncounter(row.id, row.form?.display)
+                                    const rowToDelete = rows.find((rowElement) => rowElement.id === row.id);
+                                    handleDeleteEncounter(rowToDelete.id, rowToDelete.form?.display);
                                   }}
                                   hasDivider
                                   isDelete

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.resource.tsx
@@ -1,4 +1,3 @@
-import useSWR from 'swr';
 import { openmrsFetch } from '@openmrs/esm-framework';
 
 export function deleteEncounter(encounterUuid: string, abortController: AbortController) {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';
-import { getConfig, useConfig, usePagination } from '@openmrs/esm-framework';
+import { getConfig, usePagination } from '@openmrs/esm-framework';
 import { mockPatient, renderWithSwr } from '../../../../../../../tools/test-helpers';
 import { mockEncounters } from '../../../../__mocks__/visits.mock';
 import VisitsTable from './visits-table.component';
@@ -15,7 +15,6 @@ const testProps = {
 };
 
 const mockedGetConfig = getConfig as jest.Mock;
-const mockedUseConfig = useConfig as jest.Mock;
 const mockedUsePagination = usePagination as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => {
@@ -54,7 +53,6 @@ describe('EncounterList', () => {
 
   it("renders a tabular overview of the patient's clinical encounters", async () => {
     const user = userEvent.setup();
-
     testProps.visits = mockEncounters;
 
     mockedUsePagination.mockImplementationOnce(() => ({
@@ -129,8 +127,8 @@ describe('Delete Encounter', () => {
     renderVisitsTable();
 
     const table = screen.getByRole('table');
-
-    // expect(screen.getAllByRole('button', { name: /expand current row/i }).length).toEqual(3);
+    expect(table).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /expand current row/i }).length).toEqual(3);
     const expandEncounterButton = screen.getAllByRole('button', { name: /expand current row/i });
 
     await waitFor(() => user.click(expandEncounterButton[0]));

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -143,6 +143,5 @@ describe('Delete Encounter', () => {
 });
 
 function renderVisitsTable() {
-  // FIXME: fix types
   renderWithSwr(<VisitsTable {...testProps} />);
 }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -97,10 +97,11 @@ export interface MappedEncounter {
   provider: string;
   visitUuid: string;
   visitType: string;
-  visitTypeUuid: string;
+  visitTypeUuid?: string;
   visitStartDatetime?: string;
   visitStopDatetime?: string;
 }
+
 export interface Encounter {
   uuid: string;
   diagnoses: Array<Diagnosis>;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
I modified the `handleEditEncounter` and `handleDeleteEncounter` functions to enable correct rendering of encounter buttons on the `VisitTable component` of the first encounter on the second page. 

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/a6efa295-de0b-4c95-afd0-75fcc253ee6b

## Related Issue
https://issues.openmrs.org/browse/O3-2161

## Other
<!-- Anything not covered above -->
