### PR TITLE
(fix) Debounce order basket search by 300ms 

### DIFF
--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search/drug-search.component.tsx
@@ -5,7 +5,7 @@ import { useLayoutType } from '@openmrs/esm-framework';
 import OrderBasketSearchResults from './order-basket-search-results.component';
 import { OrderBasketItem } from '../../types/order-basket-item';
 import styles from './order-basket-search.scss';
-import { debounce } from 'lodash';
+import debounce  from 'lodash-es/debounce';
 
 export interface OrderBasketSearchProps {
   onSearchResultClicked: (searchResult: OrderBasketItem, directlyAddToBasket: boolean) => void;
@@ -35,7 +35,6 @@ export default function OrderBasketSearch({ onSearchResultClicked }: OrderBasket
       <Search
         size="lg"
         light={isTablet}
-        // value={searchTerm}
         placeholder={t('searchFieldPlaceholder', 'Search for a drug or orderset (e.g. "Aspirin")')}
         labelText={t('searchFieldPlaceholder', 'Search for a drug or orderset (e.g. "Aspirin")')}
         onChange={handleSearchTermChange}

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search/drug-search.component.tsx
@@ -5,6 +5,7 @@ import { useLayoutType } from '@openmrs/esm-framework';
 import OrderBasketSearchResults from './order-basket-search-results.component';
 import { OrderBasketItem } from '../../types/order-basket-item';
 import styles from './order-basket-search.scss';
+import { debounce } from 'lodash';
 
 export interface OrderBasketSearchProps {
   onSearchResultClicked: (searchResult: OrderBasketItem, directlyAddToBasket: boolean) => void;
@@ -14,20 +15,36 @@ export default function OrderBasketSearch({ onSearchResultClicked }: OrderBasket
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const [searchTerm, setSearchTerm] = useState('');
+  
+  const handleSearchTermChange = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
+    const input = event?.target?.value?.trim();
+  
+    if (!input) {
+      setSearchTerm('');
+    }
+  
+    setSearchTerm(input);
+  }, 300);
+
+  const resetSearchTerm = () => { 
+    setSearchTerm ('');
+  }
+  // eslint-disable-next-line no-console
+console.log(searchTerm);
 
   return (
     <div className={styles.searchPopupContainer}>
       <Search
         size="lg"
         light={isTablet}
-        value={searchTerm}
+        // value={searchTerm}
         placeholder={t('searchFieldPlaceholder', 'Search for a drug or orderset (e.g. "Aspirin")')}
         labelText={t('searchFieldPlaceholder', 'Search for a drug or orderset (e.g. "Aspirin")')}
-        onChange={(e) => setSearchTerm(e.currentTarget?.value ?? '')}
+        onChange={handleSearchTermChange}
       />
       <OrderBasketSearchResults
         searchTerm={searchTerm}
-        setSearchTerm={setSearchTerm}
+        onSearchTermClear={resetSearchTerm}
         onSearchResultClicked={onSearchResultClicked}
       />
     </div>

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search/drug-search.component.tsx
@@ -29,8 +29,6 @@ export default function OrderBasketSearch({ onSearchResultClicked }: OrderBasket
   const resetSearchTerm = () => { 
     setSearchTerm ('');
   }
-  // eslint-disable-next-line no-console
-console.log(searchTerm);
 
   return (
     <div className={styles.searchPopupContainer}>

--- a/packages/esm-patient-medications-app/src/order-basket/order-basket-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/order-basket/order-basket-search/order-basket-search-results.component.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Button, ClickableTile, Tile, SkeletonText, InlineNotification, ButtonSkeleton } from '@carbon/react';
+import React, { useMemo } from 'react';
+import { Button, ClickableTile, Tile, SkeletonText, ButtonSkeleton } from '@carbon/react';
 import { ShoppingCart } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
 import { useConfig, useLayoutType, UserHasAccess } from '@openmrs/esm-framework';
@@ -8,36 +8,23 @@ import { ConfigObject } from '../../config-schema';
 import styles from './order-basket-search-results.scss';
 import { getTemplateOrderBasketItem, useDrugSearch, useDrugTemplate } from './drug-search.resource';
 import { Drug } from '../../types/order';
-import debounce from 'lodash/debounce';
 
 export interface OrderBasketSearchResultsProps {
   searchTerm: string;
-  setSearchTerm: (value: string) => void;
+  onSearchTermClear: () => void;
   onSearchResultClicked: (searchResult: OrderBasketItem, directlyAddToBasket: boolean) => void;
 }
 
 export default function OrderBasketSearchResults({
   searchTerm,
-  setSearchTerm,
+  onSearchTermClear,
   onSearchResultClicked,
 }: OrderBasketSearchResultsProps) {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
-  const [currentTerm, setCurrentTerm] = useState(searchTerm);
+  const { drugs, isLoading, error } = useDrugSearch(searchTerm);
 
-  useEffect(() => {
-    const debouncedSetCurrentTerm = debounce((term) => {
-      setCurrentTerm(term);
-    }, 300);
-
-    debouncedSetCurrentTerm(searchTerm);
-
-    return () => debouncedSetCurrentTerm.cancel();
-  }, [searchTerm]);
-
-  const { drugs, isLoading, error } = useDrugSearch(currentTerm);
-
-  if (!currentTerm) {
+  if (!searchTerm) {
     return null;
   }
 
@@ -50,8 +37,8 @@ export default function OrderBasketSearchResults({
       <Tile className={styles.emptyState}>
         <div>
           <h4 className={styles.productiveHeading01}>
-            {t('errorFetchingDrugResults', 'Error fetching results for "{currentTerm}"', {
-              currentTerm,
+            {t('errorFetchingDrugResults', 'Error fetching results for "{searchTerm}"', {
+              searchTerm,
             })}
           </h4>
           <p className={styles.bodyShort01}>
@@ -68,13 +55,13 @@ export default function OrderBasketSearchResults({
         <div className={styles.container}>
           <div className={styles.orderBasketSearchResultsHeader}>
             <span className={styles.searchResultsCount}>
-              {t('searchResultsMatchesForTerm', '{count} result{plural} for "{currentTerm}"', {
+              {t('searchResultsMatchesForTerm', '{count} result{plural} for "{searchTerm}"', {
                 count: drugs?.length,
-                currentTerm,
+                searchTerm,
                 plural: drugs?.length > 1 ? 's' : '',
               })}
             </span>
-            <Button kind="ghost" onClick={() => setSearchTerm('')} size={isTablet ? 'md' : 'sm'}>
+            <Button kind="ghost" onClick={onSearchTermClear} size={isTablet ? 'md' : 'sm'}>
               {t('clearSearchResults', 'Clear Results')}
             </Button>
           </div>
@@ -88,13 +75,13 @@ export default function OrderBasketSearchResults({
         <Tile className={styles.emptyState}>
           <div>
             <h4 className={styles.productiveHeading01}>
-              {t('noResultsForDrugSearch', 'No results to display for "{currentTerm}"', {
-                currentTerm,
+              {t('noResultsForDrugSearch', 'No results to display for "{searchTerm}"', {
+                searchTerm,
               })}
             </h4>
             <p className={styles.bodyShort01}>
               <span>{t('tryTo', 'Try to')}</span>{' '}
-              <span className={styles.link} role="link" tabIndex={0} onClick={() => setSearchTerm('')}>
+              <span className={styles.link} role="link" tabIndex={0} onClick={onSearchTermClear}>
                 {t('searchAgain', 'search again')}
               </span>{' '}
               <span>{t('usingADifferentTerm', 'using a different term')}</span>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds debounce capabilities to the Order Basket search bar to limit the number of calls fired to the API as the user types in a search term.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/548cdf5d-f984-40d9-906d-7ae504e9af6f

## Related Issue
*None*
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
*None*
<!-- Anything not covered above -->
