### PR TITLE
(feat) KHP3-3791: Add ability to create an identifier once a form is submitted

### DIFF
--- a/packages/esm-form-entry-app/src/app/types/index.ts
+++ b/packages/esm-form-entry-app/src/app/types/index.ts
@@ -451,3 +451,8 @@ export interface PatientModel {
   gendercreatconstant?: number;
   identifiers: Array<Identifier>;
 }
+
+export interface IdentifierPayload {
+  newIdentifiers: Array<any>;
+  currentIdentifiers: Array<any>;
+}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -15,7 +15,7 @@ import {
   Stack,
   Tile,
 } from '@carbon/react';
-import { WarningFilled } from '@carbon/react/icons' ;
+import { WarningFilled } from '@carbon/react/icons';
 import { showToast, useLayoutType, useSession } from '@openmrs/esm-framework';
 import {
   CodedCondition,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Add ability to create and edit identifier using the form. This is to support features related to enrollment and HTS forms for KenyaEMR. In the event the form contains patient identifier fields

## Screenshots
![patientIdentifier](https://github.com/openmrs/openmrs-esm-patient-chart/assets/28008754/34fda6f0-fcd5-4f9b-a746-4b530a5209db)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
