### PR TITLE
(fix) fix `usePatientListsForPatient` to return empty array

### DIFF
--- a/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-submission/form-submission.service.ts
@@ -41,7 +41,7 @@ export class FormSubmissionService {
     private readonly singleSpaPropsService: SingleSpaPropsService,
     private readonly visitResourceService: VisitResourceService,
     private readonly patientResourceService: PatientResourceService,
-  ) { }
+  ) {}
 
   public submitPayload(form: Form): Observable<FormSubmissionResult> {
     const isOffline = this.singleSpaPropsService.getProp('isOffline', false);
@@ -116,7 +116,7 @@ export class FormSubmissionService {
     personUpdate: PersonUpdate,
     identifierPayload: IdentifierPayload,
   ): Observable<FormSubmissionResult> {
-    this.submitPatientIdentifier(identifierPayload)
+    this.submitPatientIdentifier(identifierPayload);
     return forkJoin({
       encounter: this.submitEncounter(encounterCreate),
       person: this.submitPersonUpdate(personUpdate),

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
@@ -18,7 +18,7 @@ interface ContactDetailsProps {
 
 const PatientLists: React.FC<{ patientUuid: string }> = ({ patientUuid }) => {
   const { t } = useTranslation();
-  const { cohorts, isLoading } = usePatientListsForPatient(patientUuid);
+  const { cohorts = [], isLoading } = usePatientListsForPatient(patientUuid);
 
   return (
     <>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
- Making sure `usePatientListsForPatient` returns an empty array to prevent the component from crashing
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
