### PR TITLE
(fix) add `form-widget-slot` to `routes.json` to enable openmrs-react  forms to launch

### DIFF
--- a/packages/esm-form-engine-app/src/index.ts
+++ b/packages/esm-form-engine-app/src/index.ts
@@ -19,3 +19,5 @@ export function startupApp() {
     load: getAsyncLifecycle(() => import('./form-renderer/form-renderer.component'), options),
   });
 }
+
+export const formRenderer = getAsyncLifecycle(() => import('./form-renderer/form-renderer.component'), options);

--- a/packages/esm-form-engine-app/src/routes.json
+++ b/packages/esm-form-engine-app/src/routes.json
@@ -3,6 +3,12 @@
   "backendDependencies": {
     "webservices.rest": "^2.2.0"
   },
-  "extensions": [],
+  "extensions": [
+    {
+      "name": "react-form-engine-widge",
+      "component": "formRenderer",
+      "slot": "form-widget-slot"
+    }
+  ],
   "pages": []
 }

--- a/packages/esm-form-engine-app/src/routes.json
+++ b/packages/esm-form-engine-app/src/routes.json
@@ -5,7 +5,7 @@
   },
   "extensions": [
     {
-      "name": "react-form-engine-widge",
+      "name": "react-form-engine-widget",
       "component": "formRenderer",
       "slot": "form-widget-slot"
     }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds `form-widget-slot` to `routes.json` to address an issue with the `startupApp` function not being called in the `form-engine-app` when the extensions array is empty. This is a temporary fix until we can use form-renderer with the registerWorkspace functionality. See the GIF below for a demonstration.

Might i be missing something here @samuelmale cc @ibacher 

## Screenshots
### Fix
![OpenMRS react-form fix](https://github.com/openmrs/openmrs-esm-patient-chart/assets/28008754/39ab5bd8-783f-43f2-9349-58b238cb82b2)
### Bug
![OpenMRS react-form fix](https://github.com/openmrs/openmrs-esm-patient-chart/assets/28008754/c9865689-2023-4a87-9393-6a80efcc9518)
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
