### PR TITLE
(fix) single-spa should be marked as MF shared

### DIFF
--- a/packages/esm-patient-chart-app/package.json
+++ b/packages/esm-patient-chart-app/package.json
@@ -46,7 +46,9 @@
     "react": "18.x",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
-    "rxjs": "6.x"
+    "rxjs": "6.x",
+    "single-spa": "5.x",
+    "single-spa-react": "5.x"
   },
   "devDependencies": {
     "@types/uuid": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5674,6 +5674,8 @@ __metadata:
     react-i18next: 11.x
     react-router-dom: 6.x
     rxjs: 6.x
+    single-spa: 5.x
+    single-spa-react: 5.x
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

For the newish workspace support that doesn't rely on the extension system, we're using both single-spa and single-spa-react directly in the patient-chart-app. However, these are not marked as peer dependencies, so they are actually bundled and loaded into the patient chart. This causes us to have multiple instances of single-spa on the page, which leads to broken behaviour during navigation.

This PR just marks both single-spa and single-spa-react as peer dependencies so that, at runtime, they are resolved as Webpack MF shares; this prevents duplication of single-spa. We still have duplicate versions of single-spa-react, but this seems to be harmless.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
