### PR TITLE
(fix) Resolving Duplicate completed form display issue in configurable form view

### DIFF
--- a/__mocks__/forms.mock.ts
+++ b/__mocks__/forms.mock.ts
@@ -76,3 +76,54 @@ export const mockPatientEncounters = [
     },
   },
 ];
+
+export const mockConfigurableForms = [
+  {
+    form: {
+      uuid: '03767614-1384-4ce3-aea9-27e2f4e67d01',
+      encounterType: {
+        uuid: 'f091b067-bea5-4657-8445-cfec05dc46a2',
+        display: 'Gender Based Violence Screening',
+      },
+      name: 'Gender Based Violence Screening',
+      display: 'Gender Based Violence Screening',
+      version: '1',
+      published: true,
+      retired: false,
+      formCategory: 'available',
+    },
+    associatedEncounters: [],
+  },
+  {
+    form: {
+      uuid: '7b1ec2d5-a4ad-4ffc-a0d3-ff1ea68e293c',
+      encounterType: {
+        uuid: '4224f8bf-11b2-4e47-a958-1dbdfd7fa41d',
+        display: 'Alcohol and Drug Abuse Screening',
+      },
+      name: 'Alcohol and Drug Abuse Screening(CAGE-AID/CRAFFT)',
+      display: 'Alcohol and Drug Abuse Screening(CAGE-AID/CRAFFT)',
+      version: '1',
+      published: true,
+      retired: false,
+      formCategory: 'completed',
+    },
+    associatedEncounters: [],
+  },
+  {
+    form: {
+      uuid: 'c483f10f-d9ee-4b0d-9b8c-c24c1ec24701',
+      encounterType: {
+        uuid: '54df6991-13de-4efc-a1a9-2d5ac1b72ff8',
+        display: 'Enhanced Adherence Screening',
+      },
+      name: 'Enhanced Adherence Screening',
+      display: 'Enhanced Adherence Screening',
+      version: '1',
+      published: true,
+      retired: false,
+      formCategory: 'available',
+    },
+    associatedEncounters: [],
+  },
+];

--- a/packages/esm-patient-forms-app/src/forms/configurable-forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/configurable-forms.component.tsx
@@ -21,6 +21,7 @@ interface ConfigurableFormsProps {
   pageUrl: string;
   urlLabel: string;
   error: Error;
+  mutateForms: () => void;
 }
 
 const ConfigurableForms: React.FC<ConfigurableFormsProps> = ({
@@ -33,6 +34,7 @@ const ConfigurableForms: React.FC<ConfigurableFormsProps> = ({
   pageUrl,
   urlLabel,
   error,
+  mutateForms,
 }) => {
   const [selectedFormCategoryIndex, setSelectedFormCategoryIndex] = useState(0);
   const isTablet = useLayoutType() === 'tablet';
@@ -88,6 +90,7 @@ const ConfigurableForms: React.FC<ConfigurableFormsProps> = ({
             pageSize={pageSize}
             pageUrl={pageUrl}
             urlLabel={urlLabel}
+            mutateForms={mutateForms}
           />
         )}
       </div>

--- a/packages/esm-patient-forms-app/src/forms/configurable-forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/configurable-forms.component.tsx
@@ -9,6 +9,7 @@ import { CompletedFormInfo } from '../types';
 import EmptyFormView from './empty-form.component';
 import FormView from './form-view.component';
 import styles from './forms.scss';
+import uniqBy from 'lodash-es/uniqBy';
 
 interface ConfigurableFormsProps {
   formsToDisplay: Array<CompletedFormInfo>;
@@ -38,7 +39,10 @@ const ConfigurableForms: React.FC<ConfigurableFormsProps> = ({
   const { t } = useTranslation();
 
   const configurableForms =
-    formsToDisplay?.flatMap((form) => ({ formCategory: form.form.formCategory, ...form })) ?? [];
+    uniqBy(
+      formsToDisplay?.flatMap((form) => ({ formCategory: form.form.formCategory, ...form })),
+      (displayForm) => displayForm?.form?.uuid,
+    ) ?? [];
   const formCategories = Array.from(new Set(configurableForms?.flatMap(({ form }) => form.formCategory)));
   const configFormsToDisplay = groupBy<Record<string, CompletedFormInfo>>(configurableForms, 'formCategory');
 
@@ -70,7 +74,7 @@ const ConfigurableForms: React.FC<ConfigurableFormsProps> = ({
             selectedIndex={0}
           >
             {formCategories?.map((form, index) => (
-              <Switch name={index} text={capitalize(form)} />
+              <Switch key={form} name={index} text={capitalize(form)} />
             ))}
           </ContentSwitcher>
         </div>

--- a/packages/esm-patient-forms-app/src/forms/configurable-forms.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/configurable-forms.test.tsx
@@ -13,6 +13,7 @@ const testProps = {
   pageUrl: '/patient/1234',
   urlLabel: 'Go to patient dashboard',
   error: null,
+  mutateForms: jest.fn(),
 };
 
 jest.mock('@openmrs/esm-framework', () => {

--- a/packages/esm-patient-forms-app/src/forms/configurable-forms.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/configurable-forms.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import ConfigurableForms from './configurable-forms.component';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { mockPatient } from '../../../../__mocks__/patient.mock';
+import { mockConfigurableForms } from '../../../../__mocks__/forms.mock';
+
+const testProps = {
+  headerTitle: 'Configurable Forms',
+  isValidating: false,
+  patientUuid: 'test-patient-uuid',
+  patient: mockPatient,
+  pageSize: 10,
+  pageUrl: '/patient/1234',
+  urlLabel: 'Go to patient dashboard',
+  error: null,
+};
+
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+
+  return {
+    ...originalModule,
+    formatDatetime: jest.fn().mockImplementation((date) => date),
+    usePagination: jest.fn().mockImplementation((data) => ({
+      currentPage: 1,
+      goTo: () => {},
+      results: data,
+    })),
+  };
+});
+jest.mock('lodash/debounce', () => jest.fn((fn) => fn));
+describe('ConfigurableForms', () => {
+  test('should render ConfigurableForms component', async () => {
+    render(<ConfigurableForms {...testProps} formsToDisplay={mockConfigurableForms as Array<any>} />);
+
+    expect(await screen.findByRole('heading', { name: 'Configurable Forms' })).toBeInTheDocument();
+    const completedTab = await screen.findByRole('tab', { name: 'Completed' });
+    const availableTab = await screen.findByRole('tab', { name: 'Available' });
+    expect(completedTab).toBeInTheDocument();
+    expect(availableTab).toBeInTheDocument();
+
+    const formListTable = screen.getByRole('table');
+    const tableRows = screen.getAllByRole('row', { within: formListTable });
+    expect(tableRows.length).toBe(3);
+
+    // should be able to perform search
+    const searchInput = screen.getByRole('searchbox', { name: 'Filter table' });
+    expect(searchInput).toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: 'Enhanced Adherence Screening' } });
+    expect(searchInput).toHaveValue('Enhanced Adherence Screening');
+
+    const searchedRow = screen.getByRole('row', { name: /Enhanced Adherence Screening/ });
+    expect(searchedRow).toBeInTheDocument();
+
+    // should display empty state when no forms are available
+    fireEvent.change(searchInput, { target: { value: 'Non-existent Form' } });
+    expect(screen.getByText('No matching forms to display')).toBeInTheDocument();
+
+    // should be able to clear search
+    fireEvent.change(searchInput, { target: { value: '' } });
+    expect(searchInput).toHaveValue('');
+
+    // should be able to navigate to patient dashboard
+    const patientDashboardLink = screen.getByRole('link', { name: 'Go to patient dashboard' });
+    expect(patientDashboardLink).toBeInTheDocument();
+    expect(patientDashboardLink).toHaveAttribute('href', '/patient/1234');
+
+    // should be able to toggle between tabs
+    fireEvent.click(availableTab);
+    expect(availableTab).toHaveAttribute('aria-selected', 'true');
+    expect(completedTab).toHaveAttribute('aria-selected', 'false');
+    fireEvent.click(completedTab);
+    expect(completedTab).toHaveAttribute('aria-selected', 'true');
+    expect(availableTab).toHaveAttribute('aria-selected', 'false');
+
+    // should display completed forms
+    const completedFormListTable = screen.getByRole('table');
+    const completedTableRows = screen.getAllByRole('row', { within: completedFormListTable });
+    expect(completedTableRows.length).toBe(2);
+    expect(screen.getByRole('row', { name: /Alcohol and Drug Abuse Screening/i })).toBeInTheDocument();
+  });
+});

--- a/packages/esm-patient-forms-app/src/forms/forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms.component.tsx
@@ -82,6 +82,7 @@ const Forms: React.FC<FormsProps> = ({ patientUuid, patient, pageSize, pageUrl, 
         pageUrl={pageUrl}
         urlLabel={urlLabel}
         error={error}
+        mutateForms={mutateForms}
       />
     );
   }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This resolves an existing problem where configurable forms are duplicated when switching between 'completed' and 'available' categories. Additionally, it includes enhancements to the mutate function. Now, once a form has been successfully completed, the function will automatically update and move it from the 'available' to 'completed' section, ensuring our list remains accurate and up-to-date.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
