### PR TITLE
(chore) Release `v5.0.0`

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "4.6.0",
+  "version": "5.0.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/packages/esm-form-engine-app/package.json
+++ b/packages/esm-form-engine-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-form-engine-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Forms engine microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-form-engine-app.js",

--- a/packages/esm-form-engine-app/package.json
+++ b/packages/esm-form-engine-app/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-form-entry-app/package.json
+++ b/packages/esm-form-entry-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-form-entry-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Form engine entry capabilities for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-form-entry-app.js",

--- a/packages/esm-generic-patient-widgets-app/package.json
+++ b/packages/esm-generic-patient-widgets-app/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "^18.2.0",
     "react-i18next": "11.x",

--- a/packages/esm-generic-patient-widgets-app/package.json
+++ b/packages/esm-generic-patient-widgets-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-generic-patient-widgets-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Generic widgets for the patient chart",
   "browser": "dist/openmrs-esm-generic-patient-widgets-app.js",

--- a/packages/esm-patient-allergies-app/package.json
+++ b/packages/esm-patient-allergies-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-allergies-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient allergies microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-allergies-app.js",

--- a/packages/esm-patient-allergies-app/package.json
+++ b/packages/esm-patient-allergies-app/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "^18.2.0",
     "react-i18next": "11.x",

--- a/packages/esm-patient-appointments-app/package.json
+++ b/packages/esm-patient-appointments-app/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "^18.2.0",
     "react-i18next": "11.x",

--- a/packages/esm-patient-appointments-app/package.json
+++ b/packages/esm-patient-appointments-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-appointments-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient appointments microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-appointments-app.js",

--- a/packages/esm-patient-attachments-app/package.json
+++ b/packages/esm-patient-attachments-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-attachments-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient attachments microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-attachments-app.js",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@carbon/react": "^1.12.0",
-    "@openmrs/esm-patient-common-lib": "^4.4.0",
+    "@openmrs/esm-patient-common-lib": "^5.0.0",
     "lodash-es": "^4.17.15",
     "react-grid-gallery": "^0.5.5",
     "react-html5-camera-photo": "^1.5.4"

--- a/packages/esm-patient-attachments-app/package.json
+++ b/packages/esm-patient-attachments-app/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "^18.2.0",
     "react-i18next": "11.x",

--- a/packages/esm-patient-banner-app/package.json
+++ b/packages/esm-patient-banner-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-banner-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient banner microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-banner-app.js",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@carbon/react": "^1.12.0",
-    "@openmrs/esm-patient-common-lib": "^4.4.0",
+    "@openmrs/esm-patient-common-lib": "^5.0.0",
     "lodash-es": "^4.17.15"
   },
   "peerDependencies": {

--- a/packages/esm-patient-banner-app/package.json
+++ b/packages/esm-patient-banner-app/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-biometrics-app/package.json
+++ b/packages/esm-patient-biometrics-app/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "^18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-biometrics-app/package.json
+++ b/packages/esm-patient-biometrics-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-biometrics-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient biometrics microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-biometrics-app.js",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@carbon/charts-react": "^1.5.2",
     "@carbon/react": "^1.12.0",
-    "@openmrs/esm-patient-common-lib": "^4.4.0",
+    "@openmrs/esm-patient-common-lib": "^5.0.0",
     "d3": "^7.6.1",
     "lodash-es": "^4.17.15"
   },

--- a/packages/esm-patient-chart-app/package.json
+++ b/packages/esm-patient-chart-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-chart-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient dashboard microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-chart-app.js",

--- a/packages/esm-patient-common-lib/package.json
+++ b/packages/esm-patient-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-common-lib",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Library for common patient chart components",
   "browser": "dist/openmrs-esm-patient-common-lib.js",

--- a/packages/esm-patient-conditions-app/package.json
+++ b/packages/esm-patient-conditions-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-conditions-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient conditions microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-conditions-app.js",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@carbon/react": "^1.12.0",
-    "@openmrs/esm-patient-common-lib": "^4.4.0",
+    "@openmrs/esm-patient-common-lib": "^5.0.0",
     "lodash-es": "^4.17.15"
   },
   "peerDependencies": {

--- a/packages/esm-patient-conditions-app/package.json
+++ b/packages/esm-patient-conditions-app/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-flags-app/package.json
+++ b/packages/esm-patient-flags-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-flags-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "An OpenMRS frontend module for managing patient flags",
   "browser": "dist/openmrs-esm-patient-flags-app.js",

--- a/packages/esm-patient-flags-app/package.json
+++ b/packages/esm-patient-flags-app/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-forms-app/package.json
+++ b/packages/esm-patient-forms-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-forms-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient forms microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-forms-app.js",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@carbon/react": "^1.12.0",
-    "@openmrs/esm-patient-common-lib": "^4.4.0",
+    "@openmrs/esm-patient-common-lib": "^5.0.0",
     "lodash-es": "^4.17.15"
   },
   "peerDependencies": {

--- a/packages/esm-patient-forms-app/package.json
+++ b/packages/esm-patient-forms-app/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-immunizations-app/package.json
+++ b/packages/esm-patient-immunizations-app/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-immunizations-app/package.json
+++ b/packages/esm-patient-immunizations-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-immunizations-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient immunizations microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-immunizations-app.js",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@carbon/react": "^1.12.0",
-    "@openmrs/esm-patient-common-lib": "^4.4.0",
+    "@openmrs/esm-patient-common-lib": "^5.0.0",
     "lodash-es": "^4.17.15"
   },
   "peerDependencies": {

--- a/packages/esm-patient-medications-app/package.json
+++ b/packages/esm-patient-medications-app/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-medications-app/package.json
+++ b/packages/esm-patient-medications-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-medications-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient medications microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-medications-app.js",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@carbon/react": "^1.12.0",
-    "@openmrs/esm-patient-common-lib": "^4.4.0",
+    "@openmrs/esm-patient-common-lib": "^5.0.0",
     "lodash-es": "^4.17.15"
   },
   "peerDependencies": {

--- a/packages/esm-patient-notes-app/package.json
+++ b/packages/esm-patient-notes-app/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-notes-app/package.json
+++ b/packages/esm-patient-notes-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-notes-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient notes microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-notes-app.js",
@@ -34,7 +34,7 @@
     "url": "https://github.com/openmrs/openmrs-esm-patient-chart/issues"
   },
   "dependencies": {
-    "@openmrs/esm-patient-common-lib": "^4.4.0",
+    "@openmrs/esm-patient-common-lib": "^5.0.0",
     "lodash-es": "^4.17.15"
   },
   "peerDependencies": {

--- a/packages/esm-patient-programs-app/package.json
+++ b/packages/esm-patient-programs-app/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-programs-app/package.json
+++ b/packages/esm-patient-programs-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-programs-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient programs microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-programs-app.js",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@carbon/react": "^1.12.0",
-    "@openmrs/esm-patient-common-lib": "^4.4.0",
+    "@openmrs/esm-patient-common-lib": "^5.0.0",
     "lodash-es": "^4.17.15"
   },
   "peerDependencies": {

--- a/packages/esm-patient-test-results-app/package.json
+++ b/packages/esm-patient-test-results-app/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "react": "18.x",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",

--- a/packages/esm-patient-test-results-app/package.json
+++ b/packages/esm-patient-test-results-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-test-results-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient test results microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-test-results-app.js",
@@ -37,7 +37,7 @@
     "@carbon/charts": "^1.5.2",
     "@carbon/charts-react": "^1.5.2",
     "@carbon/react": "^1.12.0",
-    "@openmrs/esm-patient-common-lib": "^4.4.0",
+    "@openmrs/esm-patient-common-lib": "^5.0.0",
     "d3": "^7.6.1",
     "lodash-es": "^4.17.15"
   },

--- a/packages/esm-patient-vitals-app/package.json
+++ b/packages/esm-patient-vitals-app/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "4.x",
+    "@openmrs/esm-patient-common-lib": "5.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-vitals-app/package.json
+++ b/packages/esm-patient-vitals-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-patient-vitals-app",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "license": "MPL-2.0",
   "description": "Patient vitals microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-patient-vitals-app.js",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@carbon/charts-react": "^1.5.2",
     "@carbon/react": "^1.12.0",
-    "@openmrs/esm-patient-common-lib": "^4.4.0",
+    "@openmrs/esm-patient-common-lib": "^5.0.0",
     "d3": "^7.6.1",
     "lodash-es": "^4.17.15"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5560,7 +5560,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x
@@ -5672,7 +5672,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: ^18.2.0
     react-i18next: 11.x
@@ -5717,7 +5717,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: ^18.2.0
     react-i18next: 11.x
@@ -5734,7 +5734,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: ^18.2.0
     react-i18next: 11.x
@@ -5755,7 +5755,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: ^18.2.0
     react-i18next: 11.x
@@ -5774,7 +5774,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x
@@ -5795,7 +5795,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: ^18.x
     react-i18next: 11.x
@@ -5913,7 +5913,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x
@@ -5930,7 +5930,7 @@ __metadata:
     webpack: ^5.75.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x
@@ -5949,7 +5949,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x
@@ -5968,7 +5968,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x
@@ -5987,7 +5987,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x
@@ -6005,7 +6005,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x
@@ -6024,7 +6024,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x
@@ -6046,7 +6046,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     react: 18.x
     react-i18next: 11.x
     react-router-dom: 6.x
@@ -6066,7 +6066,7 @@ __metadata:
     webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 4.x
+    "@openmrs/esm-patient-common-lib": 5.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x

--- a/yarn.lock
+++ b/yarn.lock
@@ -5748,7 +5748,7 @@ __metadata:
   resolution: "@openmrs/esm-patient-attachments-app@workspace:packages/esm-patient-attachments-app"
   dependencies:
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-patient-common-lib": ^4.4.0
+    "@openmrs/esm-patient-common-lib": ^5.0.0
     lodash-es: ^4.17.15
     react-grid-gallery: ^0.5.5
     react-html5-camera-photo: ^1.5.4
@@ -5769,7 +5769,7 @@ __metadata:
   resolution: "@openmrs/esm-patient-banner-app@workspace:packages/esm-patient-banner-app"
   dependencies:
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-patient-common-lib": ^4.4.0
+    "@openmrs/esm-patient-common-lib": ^5.0.0
     lodash-es: ^4.17.15
     webpack: ^5.74.0
   peerDependencies:
@@ -5789,7 +5789,7 @@ __metadata:
   dependencies:
     "@carbon/charts-react": ^1.5.2
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-patient-common-lib": ^4.4.0
+    "@openmrs/esm-patient-common-lib": ^5.0.0
     d3: ^7.6.1
     lodash-es: ^4.17.15
     webpack: ^5.74.0
@@ -5889,7 +5889,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-patient-common-lib@^4.4.0, @openmrs/esm-patient-common-lib@workspace:packages/esm-patient-common-lib":
+"@openmrs/esm-patient-common-lib@^5.0.0, @openmrs/esm-patient-common-lib@workspace:packages/esm-patient-common-lib":
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-patient-common-lib@workspace:packages/esm-patient-common-lib"
   dependencies:
@@ -5908,7 +5908,7 @@ __metadata:
   resolution: "@openmrs/esm-patient-conditions-app@workspace:packages/esm-patient-conditions-app"
   dependencies:
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-patient-common-lib": ^4.4.0
+    "@openmrs/esm-patient-common-lib": ^5.0.0
     lodash-es: ^4.17.15
     webpack: ^5.74.0
   peerDependencies:
@@ -5944,7 +5944,7 @@ __metadata:
   resolution: "@openmrs/esm-patient-forms-app@workspace:packages/esm-patient-forms-app"
   dependencies:
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-patient-common-lib": ^4.4.0
+    "@openmrs/esm-patient-common-lib": ^5.0.0
     lodash-es: ^4.17.15
     webpack: ^5.74.0
   peerDependencies:
@@ -5963,7 +5963,7 @@ __metadata:
   resolution: "@openmrs/esm-patient-immunizations-app@workspace:packages/esm-patient-immunizations-app"
   dependencies:
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-patient-common-lib": ^4.4.0
+    "@openmrs/esm-patient-common-lib": ^5.0.0
     lodash-es: ^4.17.15
     webpack: ^5.74.0
   peerDependencies:
@@ -5982,7 +5982,7 @@ __metadata:
   resolution: "@openmrs/esm-patient-medications-app@workspace:packages/esm-patient-medications-app"
   dependencies:
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-patient-common-lib": ^4.4.0
+    "@openmrs/esm-patient-common-lib": ^5.0.0
     lodash-es: ^4.17.15
     webpack: ^5.74.0
   peerDependencies:
@@ -6000,7 +6000,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-patient-notes-app@workspace:packages/esm-patient-notes-app"
   dependencies:
-    "@openmrs/esm-patient-common-lib": ^4.4.0
+    "@openmrs/esm-patient-common-lib": ^5.0.0
     lodash-es: ^4.17.15
     webpack: ^5.74.0
   peerDependencies:
@@ -6019,7 +6019,7 @@ __metadata:
   resolution: "@openmrs/esm-patient-programs-app@workspace:packages/esm-patient-programs-app"
   dependencies:
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-patient-common-lib": ^4.4.0
+    "@openmrs/esm-patient-common-lib": ^5.0.0
     lodash-es: ^4.17.15
     webpack: ^5.74.0
   peerDependencies:
@@ -6040,7 +6040,7 @@ __metadata:
     "@carbon/charts": ^1.5.2
     "@carbon/charts-react": ^1.5.2
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-patient-common-lib": ^4.4.0
+    "@openmrs/esm-patient-common-lib": ^5.0.0
     d3: ^7.6.1
     lodash-es: ^4.17.15
     webpack: ^5.74.0
@@ -6060,7 +6060,7 @@ __metadata:
   dependencies:
     "@carbon/charts-react": ^1.5.2
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-patient-common-lib": ^4.4.0
+    "@openmrs/esm-patient-common-lib": ^5.0.0
     d3: ^7.6.1
     lodash-es: ^4.17.15
     webpack: ^5.74.0


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.
## Summary

Patient Chart `v5.0.0` is a `major` release that includes performance improvements plus a host of new features and bug fixes.

Being a `major` release, `v5.0.0` introduces a breaking change. We recommend reading the [Core v5 migration guide](https://o3-docs.vercel.app/docs/migration-guide) to understand the rationale behind this breaking change and its impact on your application.

## Highlights

### Performance improvements

We have migrated all the frontend modules in Patient Chart to leverage the new module loading mechanism introduced in [Core v5](https://github.com/openmrs/openmrs-esm-core/releases/tag/v5.0.0). Frontend modules now declare their static and dynamic metadata upfront, and the framework uses this information to load only the static bits when the application gets loaded for the first time while loading the dynamic bits is deferred to later when they are needed. This change delivers significant improvements to initial load time. Check out the [migration guide](https://o3-docs.vercel.app/docs/migration-guide) to get a closer look at the internals of the new module loading mechanism.

### Translation support for the left nav menu

`v5.0.0` adds support for internationalising dashboard titles in the left nav. Each dashboard can specify a `title` string property that represents the dashboard's name. This `title` then gets passed to the `DashboardExtension` component which invokes the `t` function from the `useTranslation` hook, passing in the `title`. To round things off, the frontend module's `moduleName` gets passed as the `namespace` argument of `useTranslation`, letting it know where to look for the corresponding translations.  This mechanism makes it easy to translate your dashboard names.

### Migrating React forms to use RHF and Zod for schema validation

`v5.0.0` ushers in React Hook Forms (RHF) for handling forms. RHF is a performant forms solution that reduces the boilerplate code you need to write when constructing forms. RHF is also performant and supports a host of schema validation solutions. Zod is a schema validation library that integrates well with RHF and TypeScript. RHF's simple API and Zod’s declarative schema approach make your code easier to read and maintain. RHF and Zod present a robust approach to handling forms in React. `v5.0.0` ports the `Conditions` and `Visit notes` forms to use RHF and Zod, with more custom React forms in the pipeline.

### Initial support for patient flags and improved RDE capabilities

This release establishes the groundwork for patient flags and improved RDE capabilities. Patient flags are visual components that enable healthcare providers to see relevant patient information with a glance in the Patient chart. `v5.0.0` also adds improved retrospective data entry capabilities to the Patient Chart. Both patient flags and RDE improvements are a work in progress, and we will be adding more features to them in subsequent releases.