### PR TITLE
(fix) O3-2282: Show phone number in contact details panel

### DIFF
--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
@@ -88,7 +88,7 @@ const Address: React.FC<{ address?: fhir.Address }> = ({ address }) => {
       <p className={styles.heading}>{t('address', 'Address')}</p>
       <ul>
         {address ? (
-          <>
+          <React.Fragment>
             {Object.entries(address)
               .filter(([key]) => !['use', 'id'].some((k) => k === key))
               .map(([key, value]) =>
@@ -107,7 +107,7 @@ const Address: React.FC<{ address?: fhir.Address }> = ({ address }) => {
                   </li>
                 ),
               )}
-          </>
+          </React.Fragment>
         ) : (
           '--'
         )}
@@ -131,12 +131,16 @@ const Contact: React.FC<{ telecom: Array<fhir.ContactPoint>; patientUuid: string
         <InlineLoading description={`${t('loading', 'Loading')} ...`} role="progressbar" />
       ) : (
         <ul>
-          {contactAttributes?.length > 0 ? (
-            contactAttributes.map(({ attributeType, value, uuid }) => (
-              <li key={uuid}>
-                {attributeType.display} : {value}
-              </li>
-            ))
+          {value ? (
+            <React.Fragment>
+              <li>{value}</li>
+              {contactAttributes?.length > 0 &&
+                contactAttributes.map(({ attributeType, value, uuid }) => (
+                  <li key={uuid}>
+                    {attributeType.display}: {value}
+                  </li>
+                ))}
+            </React.Fragment>
           ) : (
             <li>--</li>
           )}

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
@@ -129,6 +129,7 @@ describe('ContactDetails', () => {
     expect(screen.getByText(/Amanda Robinson/)).toBeInTheDocument();
     expect(screen.getByText(/Sibling/i)).toBeInTheDocument();
     expect(screen.getByText(/24 yrs/i)).toBeInTheDocument();
+    expect(screen.getByText(/\+0123456789/i)).toBeInTheDocument();
     expect(screen.getByText(/Next of Kin Contact Phone Number/i)).toBeInTheDocument();
     expect(screen.getByText(/0700-000-000/)).toBeInTheDocument();
     expect(screen.getByText(/Patient Lists/)).toBeInTheDocument();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue where the patient's phone number recorded during registration would not show up in the Contact section of the Contact Details panel in the patient banner.

## Screenshots

![Contact](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/3e0830e1-46fa-4bcd-82f2-6a53dc3fa2f9)

## Related Issue

https://issues.openmrs.org/browse/O3-2282

## Other
*None*
<!-- Anything not covered above -->
