### PR TITLE
(feat) Add an extension slot for additional visit summary items

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
@@ -24,6 +24,7 @@ jest.mock('@openmrs/esm-framework', () => {
         visitDiagnosisConceptUuid: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
       };
     }),
+    useConnectedExtensions: jest.fn(() => []),
   };
 });
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -26,6 +26,7 @@ jest.mock('@openmrs/esm-framework', () => {
     // useConfig: jest.fn().mockImplementation(() => ({ showAllEncountersTab: true })),
     userHasAccess: jest.fn().mockImplementation((privilege, _) => (privilege ? false : true)),
     ExtensionSlot: jest.fn().mockImplementation((ext) => ext.name),
+    useConnectedExtensions: jest.fn(() => []),
   };
 });
 


### PR DESCRIPTION
NB All the other tabs will disable themselves if there is no data to display. These extensions currently don't support that functionality.

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Adds an extension slot to the Visit Summary component to allow additional panels to be rendered.

I didn't convert the existing tabs into panels because I didn't have a good strategy to support the `disabled` property for the existing panels (which hides them when they don't have any contents).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
