### PR TITLE
(fix) resolves valid route with grouped chart dashboards

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
@@ -46,8 +46,11 @@ const ChartReview: React.FC<ChartReviewProps> = ({ patientUuid, patient, view })
     )
     .flat();
   const dashboards = ungroupedDashboards.concat(groupedDashboards) as Array<DashboardConfig>;
+  const filteredDashboards = dashboards.filter((dashboard) => {
+    if ('path' in dashboard) return dashboard;
+  });
 
-  const defaultDashboard = dashboards[0];
+  const defaultDashboard = filteredDashboards[0];
   const dashboard = dashboards.find((dashboard) => dashboard.path === view);
 
   if (!defaultDashboard) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
When the patient chart has only folders, the combined array of ungrouped and grouped dashboards has an empty path on index 0 which doesn't resolve. This PR adds a filter to remove dashboards without the `path` key to ensure the index 0 is valid 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
