### PR TITLE
(fix) Fix the appearance of the start date column in the medications table

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -132,7 +132,7 @@ const MedicationsDetailsTable: React.FC<ActiveMedicationsProps> = ({
       sortKey: dayjs(medication.dateActivated).toDate(),
       content: (
         <div className={styles.startDateColumn}>
-          <p>{formatDate(new Date(medication.dateActivated))}</p>
+          <span>{formatDate(new Date(medication.dateActivated))}</span>
           <InfoTooltip orderer={medication.orderer?.person?.display ?? '--'} />
         </div>
       ),
@@ -220,7 +220,7 @@ const MedicationsDetailsTable: React.FC<ActiveMedicationsProps> = ({
   );
 };
 
-function InfoTooltip({ orderer }) {
+function InfoTooltip({ orderer }: { orderer: string }) {
   return (
     <IconButton
       className={styles.tooltip}

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.scss
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.scss
@@ -1,9 +1,11 @@
+@use '@carbon/styles/scss/colors';
+@use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
 @import "../root";
 
 .widgetCard {
-  border: 1px solid $ui-03;
+  border: 1px solid colors.$gray-20;
+  border-bottom: none;
 }
 
 .row {
@@ -12,7 +14,7 @@
   }
 
   p {
-    padding: 0.25rem 0;
+    padding: spacing.$spacing-02 0;
   }
 }
 
@@ -23,12 +25,13 @@
 }
 
 .startDateColumn {
-  height: 100%;
+  @include type.type-style("body-compact-01");
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: space-between;
-  padding: 0.25rem 0;
+  min-height: spacing.$spacing-11;
+  padding-bottom: spacing.$spacing-02;
 
   span {
     margin: 0rem;
@@ -41,10 +44,6 @@
 
 .tooltip {
   margin: 0rem -0.5rem -0.625rem;
-  svg {
-    fill: black;
-  }
-  
 }
 
 .menuItem {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the appearance of the `Start date` column in the `MedicationsDetailsTable` component. Specifically, it tweaks the typography and spacing applied to elements in the column to better match the available [designs](https://zpl.io/V4RNGXX).

## Screenshots

> Before

![Medications table (before)](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/b1df6a44-05a5-40fb-884b-6957a14c9e23)


> After

<img width="941" alt="Medications table (after)" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/83ea2fb2-8f0e-4d15-85a9-7136b9f54333">

## Related Issue
*None*
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
*None*
<!-- Anything not covered above -->
