### PR TITLE
O3-2311: Resolve resource limitation issues in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "16.x"
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -69,7 +69,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "16.x"
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,19 +12,18 @@ jobs:
   test-on-PR:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
       - name: Copy test environment variables
-        run: |
-          cp example.env .env
-          sed -i 's/8080/8180/g' .env
+        run: cp example.env .env
 
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: "18.x"
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -32,11 +31,21 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps
 
+      - name: Build apps
+        run: yarn turbo run build --color --concurrency=5
+
       - name: Run dev server
-        run: yarn start --sources 'packages/esm-*-app/' --port 8180 & # Refer to O3-1994
+        run: bash e2e/support/github/run-e2e-docker-env.sh
+
+      - name: Wait for OpenMRS instance to start
+        run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 10; done
 
       - name: Run E2E tests
         run: yarn test-e2e
+
+      - name: Stop dev server
+        if: "!cancelled()"
+        run: docker stop $(docker ps -a -q)
 
       - name: Upload Report
         uses: actions/upload-artifact@v3
@@ -48,21 +57,19 @@ jobs:
 
   test-on-push:
     if: ${{ github.event_name == 'push' }}
-    timeout-minutes: 60
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
       - name: Copy test environment variables
-        run: |
-          cp example.env .env
-          sed -i 's/8080/8180/g' .env
+        run: cp example.env .env
 
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: "18.x"
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -70,19 +77,21 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps
 
-      - name: Run db and web containers
-        run: |
-          cd e2e/support
-          docker-compose up -d
-
-      - name: Wait for OpenMRS instance to start
-        run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:9000/openmrs/login.htm)" != "200" ]]; do sleep 10; done
+      - name: Build apps
+        run: yarn turbo run build --color --concurrency=5
 
       - name: Run dev server
-        run: yarn start --sources 'packages/esm-*-app/' --backend "http://localhost:9000" --port 8180 & # Refer to O3-1994
+        run: bash e2e/support/github/run-e2e-docker-env.sh
+
+      - name: Wait for OpenMRS instance to start
+        run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 10; done
 
       - name: Run E2E tests
         run: yarn test-e2e
+
+      - name: Stop dev server
+        if: "!cancelled()"
+        run: docker stop $(docker ps -a -q)
 
       - name: Upload report
         uses: actions/upload-artifact@v3

--- a/e2e/support/github/Dockerfile
+++ b/e2e/support/github/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.3
+FROM --platform=$BUILDPLATFORM node:18-alpine as dev
+
+ARG APP_SHELL_VERSION=next
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY . .
+
+RUN npm_config_legacy_peer_deps=true npm install -g openmrs@${APP_SHELL_VERSION:-next}
+ARG CACHE_BUST
+RUN npm_config_legacy_peer_deps=true openmrs assemble --manifest --mode config --config spa-assemble-config.json --target ./spa
+
+FROM --platform=$BUILDPLATFORM openmrs/openmrs-reference-application-3-frontend:nightly as frontend
+FROM nginx:1.23-alpine
+
+RUN apk update && \
+  apk upgrade && \
+  # add more utils for sponge to support our startup script
+  apk add --no-cache moreutils
+
+# clear any default files installed by nginx
+RUN rm -rf /usr/share/nginx/html/*
+
+COPY --from=frontend /etc/nginx/nginx.conf /etc/nginx/nginx.conf
+# this assumes that NOTHING in the framework is in a subdirectory
+COPY --from=frontend /usr/share/nginx/html/* /usr/share/nginx/html/
+COPY --from=frontend /usr/local/bin/startup.sh /usr/local/bin/startup.sh
+RUN chmod +x /usr/local/bin/startup.sh
+
+COPY --from=dev /app/spa/ /usr/share/nginx/html/
+
+CMD ["/usr/local/bin/startup.sh"]

--- a/e2e/support/github/docker-compose.yml
+++ b/e2e/support/github/docker-compose.yml
@@ -2,6 +2,18 @@
 version: "3.7"
 
 services:
+  gateway:
+    image: openmrs/openmrs-reference-application-3-gateway:${TAG:-nightly}
+    ports:
+      - "8080:80"
+
+  frontend:
+    build:
+      context: .
+    environment:
+      SPA_PATH: /openmrs/spa
+      API_URL: /openmrs
+
   backend:
     image: openmrs/openmrs-reference-application-3-backend:${TAG:-nightly}
     depends_on:
@@ -19,8 +31,6 @@ services:
       timeout: 5s
     volumes:
       - openmrs-data:/openmrs/data
-    ports:
-      - 9000:8080
 
   # MariaDB
   db:

--- a/e2e/support/github/run-e2e-docker-env.sh
+++ b/e2e/support/github/run-e2e-docker-env.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash -eu
+
+# get the dir containing the script
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# create a temporary working directory
+working_dir=$(mktemp -d "${TMPDIR:-/tmp/}openmrs-e2e-frontends.XXXXXXXXXX")
+# get a list of all the apps in this workspace
+apps=$(yarn workspaces list --json | jq -r 'if ((.location == ".") or (.location | test("-app") | not)) then halt else .name end')
+# this array will hold all of the packed app names
+app_names=()
+
+echo "Creating packed archives of apps..."
+# for each app
+for app in $apps
+do
+  # @openmrs/esm-whatever -> _openmrs_esm_whatever
+  app_name=$(echo "$app" | tr '[:punct:]' '_');
+  # add to our array
+  app_names+=("$app_name.tgz");
+  # run yarn pack for our app and add it to the working directory
+  yarn workspace "$app" pack -o "$working_dir/$app_name.tgz" >/dev/null;
+done;
+echo "Created packed app archives" 
+
+echo "Creating dynamic spa-assemble-config.json..."
+# dynamically assemble our list of frontend modules, prepending the login app and
+# primary navigation apps; apps will all be in the /app directory of the Docker
+# container
+jq -n \
+  --arg apps "$apps" \
+  --arg app_names "$(echo ${app_names[@]})" \
+  '{"@openmrs/esm-primary-navigation-app": "next", "@openmrs/esm-home-app": "next"} + (
+    ($apps | split("\n")) as $apps | ($app_names | split(" ") | map("/app/" + .)) as $app_files
+    | [$apps, $app_files]
+    | transpose
+    | map({"key": .[0], "value": .[1]})
+    | from_entries
+  )' | jq '{"frontendModules": .}' > "$working_dir/spa-assemble-config.json"
+echo "Created dynamic spa-assemble-config.json"
+
+echo "Copying Docker configuration..."
+cp "$script_dir/Dockerfile" "$working_dir/Dockerfile"
+cp "$script_dir/docker-compose.yml" "$working_dir/docker-compose.yml"
+
+cd $working_dir
+echo "Starting Docker containers..."
+# CACHE_BUST to ensure the assemble step is always run
+docker compose build --build-arg CACHE_BUST=$(date +%s) frontend
+docker compose up -d


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
With this PR, we can avoid resource limitation issues in GitHub actions. When the e2e tests are running, it will automatically create a lightweight prod version of the front end (as a docker image), only containing the patient-chart MFs and the necessary MFs. So it can run with less RAM. That docker image will be used to create the frontend instance of the e2e docker-compose stack. This will also reduce the loading durations.

However, it takes around 35 minutes to complete the job. I'm working on to reducing it by using the pre-filled backend images.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="328" alt="image" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/27498587/cd9af323-b322-4f54-9bb5-87cde60e94a1">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-2311

## Other
<!-- Anything not covered above -->
Currently, the e2e Github action workflow is disabled. We can enable it after optimizing it.
