### PR TITLE
Resolve template literals in the src prop of the logo config

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -13,6 +13,7 @@ import {
   useConfig,
   showModal,
   ExtensionSlot,
+  interpolateUrl,
 } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { MappedQueuePriority, useVisitQueueEntry } from '../visit/queue-entry/queue.resource';
@@ -179,7 +180,7 @@ const VisitHeader: React.FC = () => {
       <ConfigurableLink className={styles.navLogo} to="${openmrsSpaBase}/home">
         <div className={styles.divider}>
           {logo?.src ? (
-            <img className={styles.logo} src={logo.src} alt={logo.alt} width={110} height={40} />
+            <img className={styles.logo} src={interpolateUrl(logo.src)} alt={logo.alt} width={110} height={40} />
           ) : logo?.name ? (
             logo.name
           ) : (

--- a/packages/esm-patient-vitals-app/src/vitals/print/print.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/print/print.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useConfig, useSession } from '@openmrs/esm-framework';
+import { interpolateUrl, useConfig, useSession } from '@openmrs/esm-framework';
 import styles from './print.scss';
 
 interface PrintComponentProps {
@@ -26,7 +26,7 @@ export function PrintComponent({ subheader, patientDetails }: PrintComponentProp
     <div className={styles.printPage}>
       <header className={styles.header}>
         {logo?.src ? (
-          <img className={styles.logo} src={logo.src} alt={logo.alt} width={110} height={40} />
+          <img className={styles.logo} src={interpolateUrl(logo.src)} alt={logo.alt} width={110} height={40} />
         ) : logo?.name ? (
           logo.name
         ) : (


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Ensures that any encountered template literals within `logo.src` are resolved if supported.
```
"${openmrsSpaBase}/ohri_logo_light.svg" => /openmrs/spa/ohri_logo_light.svg
```
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
