### PR TITLE
(fix) O3-2158: Clear order basket search input and trap focus when search gets reset.

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
@@ -1,4 +1,4 @@
-import React, { useRef,useState } from 'react';
+import React, { useRef, useState } from 'react';
 import debounce from 'lodash-es/debounce';
 import { useTranslation } from 'react-i18next';
 import { Layer, Search } from '@carbon/react';
@@ -6,6 +6,7 @@ import { useLayoutType } from '@openmrs/esm-framework';
 import type { OrderBasketItem } from '@openmrs/esm-patient-common-lib';
 import OrderBasketSearchResults from './order-basket-search-results.component';
 import styles from './order-basket-search.scss';
+import { useDebounce } from './drug-search.resource';
 
 export interface OrderBasketSearchProps {
   onSearchResultClicked: (searchResult: OrderBasketItem, directlyAddToBasket: boolean) => void;
@@ -15,20 +16,16 @@ export default function OrderBasketSearch({ onSearchResultClicked }: OrderBasket
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm);
   const searchInputRef = useRef(null);
 
-  const handleSearchTermChange = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
-    const input = event?.target?.value?.trim();
-
-    if (!input) {
-      setSearchTerm('');
-    }
-
-    setSearchTerm(input);
-  }, 300);
-
-  const resetSearchTerm = () => {
+  const focusAndClearSearchInput = () => {
     setSearchTerm('');
+    searchInputRef.current?.focus();
+  };
+
+  const handleSearchTermChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value ?? '');
   };
 
   return (
@@ -40,13 +37,13 @@ export default function OrderBasketSearch({ onSearchResultClicked }: OrderBasket
           labelText={t('searchFieldPlaceholder', 'Search for a drug or orderset (e.g. "Aspirin")')}
           onChange={handleSearchTermChange}
           ref={searchInputRef}
+          value={searchTerm}
         />
       </ResponsiveWrapper>
       <OrderBasketSearchResults
-        searchInputRef={searchInputRef}
-        searchTerm={searchTerm}
-        onSearchTermClear={resetSearchTerm}
+        searchTerm={debouncedSearchTerm}
         onSearchResultClicked={onSearchResultClicked}
+        focusAndClearSearchInput={focusAndClearSearchInput}
       />
     </div>
   );

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useState } from 'react';
-import debounce from 'lodash-es/debounce';
 import { useTranslation } from 'react-i18next';
 import { Layer, Search } from '@carbon/react';
 import { useLayoutType } from '@openmrs/esm-framework';

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef,useState } from 'react';
 import debounce from 'lodash-es/debounce';
 import { useTranslation } from 'react-i18next';
 import { Layer, Search } from '@carbon/react';
@@ -15,6 +15,7 @@ export default function OrderBasketSearch({ onSearchResultClicked }: OrderBasket
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const [searchTerm, setSearchTerm] = useState('');
+  const searchInputRef = useRef(null);
 
   const handleSearchTermChange = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
     const input = event?.target?.value?.trim();
@@ -38,9 +39,11 @@ export default function OrderBasketSearch({ onSearchResultClicked }: OrderBasket
           placeholder={t('searchFieldPlaceholder', 'Search for a drug or orderset (e.g. "Aspirin")')}
           labelText={t('searchFieldPlaceholder', 'Search for a drug or orderset (e.g. "Aspirin")')}
           onChange={handleSearchTermChange}
+          ref={searchInputRef}
         />
       </ResponsiveWrapper>
       <OrderBasketSearchResults
+        searchInputRef={searchInputRef}
         searchTerm={searchTerm}
         onSearchTermClear={resetSearchTerm}
         onSearchResultClicked={onSearchResultClicked}

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.resource.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.resource.tsx
@@ -1,5 +1,5 @@
 import { FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import useSWRImmutable from 'swr/immutable';
 import type { Drug, DrugOrderTemplate, OrderTemplate, OrderBasketItem } from '@openmrs/esm-patient-common-lib';
 
@@ -16,6 +16,22 @@ export interface DrugSearchResult {
     display: string;
     uuid: string;
   };
+}
+
+export function useDebounce(value: string, delay = 300) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
 }
 
 export function useDrugSearch(query: string): {

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { Button, ClickableTile, Tile, SkeletonText, ButtonSkeleton } from '@carbon/react';
 import { ShoppingCart } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { RefObject, useEffect, useMemo, useState } from 'react';
 import { Button, ClickableTile, Tile, SkeletonText, ButtonSkeleton } from '@carbon/react';
 import { ShoppingCart } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
@@ -12,9 +12,11 @@ export interface OrderBasketSearchResultsProps {
   searchTerm: string;
   onSearchTermClear: () => void;
   onSearchResultClicked: (searchResult: OrderBasketItem, directlyAddToBasket: boolean) => void;
+  searchInputRef: RefObject<HTMLInputElement>;
 }
 
 export default function OrderBasketSearchResults({
+  searchInputRef,
   searchTerm,
   onSearchTermClear,
   onSearchResultClicked,
@@ -22,7 +24,17 @@ export default function OrderBasketSearchResults({
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const { drugs, isLoading, error } = useDrugSearch(searchTerm);
-
+const [isSearchIputCleared, setIsSearchInputCleared] = useState(false);
+  function handleClick() {
+    setIsSearchInputCleared(true);
+    searchInputRef.current.value = '';
+  }
+  useEffect(() => {
+    if (isSearchIputCleared && searchInputRef.current) {
+      searchInputRef.current.focus();
+      setIsSearchInputCleared(false);
+    }
+  }, [isSearchIputCleared, searchInputRef]);
   if (!searchTerm) {
     return null;
   }
@@ -80,7 +92,7 @@ export default function OrderBasketSearchResults({
             </h4>
             <p className={styles.bodyShort01}>
               <span>{t('tryTo', 'Try to')}</span>{' '}
-              <span className={styles.link} role="link" tabIndex={0} onClick={onSearchTermClear}>
+              <span className={styles.link} role="link" tabIndex={0} onClick={handleClick}>
                 {t('searchAgain', 'search again')}
               </span>{' '}
               <span>{t('usingADifferentTerm', 'using a different term')}</span>

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
@@ -10,31 +10,19 @@ import styles from './order-basket-search-results.scss';
 
 export interface OrderBasketSearchResultsProps {
   searchTerm: string;
-  onSearchTermClear: () => void;
   onSearchResultClicked: (searchResult: OrderBasketItem, directlyAddToBasket: boolean) => void;
-  searchInputRef: RefObject<HTMLInputElement>;
+  focusAndClearSearchInput: () => void;
 }
 
 export default function OrderBasketSearchResults({
-  searchInputRef,
   searchTerm,
-  onSearchTermClear,
   onSearchResultClicked,
+  focusAndClearSearchInput,
 }: OrderBasketSearchResultsProps) {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const { drugs, isLoading, error } = useDrugSearch(searchTerm);
-const [isSearchIputCleared, setIsSearchInputCleared] = useState(false);
-  function handleClick() {
-    setIsSearchInputCleared(true);
-    searchInputRef.current.value = '';
-  }
-  useEffect(() => {
-    if (isSearchIputCleared && searchInputRef.current) {
-      searchInputRef.current.focus();
-      setIsSearchInputCleared(false);
-    }
-  }, [isSearchIputCleared, searchInputRef]);
+
   if (!searchTerm) {
     return null;
   }
@@ -72,7 +60,7 @@ const [isSearchIputCleared, setIsSearchInputCleared] = useState(false);
                 plural: drugs?.length === 0 || drugs?.length > 1 ? 's' : '',
               })}
             </span>
-            <Button kind="ghost" onClick={onSearchTermClear} size={isTablet ? 'md' : 'sm'}>
+            <Button kind="ghost" onClick={focusAndClearSearchInput} size={isTablet ? 'md' : 'sm'}>
               {t('clearSearchResults', 'Clear Results')}
             </Button>
           </div>
@@ -92,7 +80,7 @@ const [isSearchIputCleared, setIsSearchInputCleared] = useState(false);
             </h4>
             <p className={styles.bodyShort01}>
               <span>{t('tryTo', 'Try to')}</span>{' '}
-              <span className={styles.link} role="link" tabIndex={0} onClick={handleClick}>
+              <span className={styles.link} role="link" tabIndex={0} onClick={focusAndClearSearchInput}>
                 {t('searchAgain', 'search again')}
               </span>{' '}
               <span>{t('usingADifferentTerm', 'using a different term')}</span>


### PR DESCRIPTION
fix)O3-2158:Clear order basket search input and trap focus when search gets reset. i Declare a ref in the Drug Search component that tracks the Search input using the useRef hook and passed it down in Drug Search Result component and Update the logic in it to to accept the ref as a prop. Create a boolean state variable in the OrderBasketSearchResults component that tracks whether the search input was cleared and set to false and create function onClick handler's logic so that it sets the value of the state variable i created above to true. and i added useEffect hook in OrderBasketSearchResults component that traps focus to the Search input if the boolean state variable is true. After trapping focus, it set the state variable back to false.


https://github.com/openmrs/openmrs-esm-patient-chart/assets/110772072/a3b63172-a453-4af6-8161-bfdb19edb750


https://issues.openmrs.org/browse/O3-2158

