### PR TITLE
(fix) O3-1676 & O3-1677: Workspace implementation improved as per design

### DIFF
--- a/packages/esm-form-engine-app/src/index.ts
+++ b/packages/esm-form-engine-app/src/index.ts
@@ -17,6 +17,7 @@ export function startupApp() {
     name: 'patient-form-entry-workspace',
     title: 'Clinical Form',
     load: getAsyncLifecycle(() => import('./form-renderer/form-renderer.component'), options),
+    variant: 'clinical-form',
   });
 }
 

--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.component.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.component.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { ExtensionSlot, useBodyScrollLock, useLayoutType, usePatient } from '@openmrs/esm-framework';
 import { useWorkspaces, useWorkspaceWindowSize } from '@openmrs/esm-patient-common-lib';
 import { Button, Header, HeaderGlobalBar, HeaderName } from '@carbon/react';
-import { ArrowRight, DownToBottom, Maximize, Minimize } from '@carbon/react/icons';
+import { ArrowRight, DownToBottom, Maximize, Minimize, Close } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
 import { patientChartWorkspaceHeaderSlot } from '../constants';
 import { isDesktop } from '../utils';
@@ -55,10 +55,14 @@ const WorkspaceWindow: React.FC<ContextWorkspaceParams> = () => {
   }, [workspaces, patientUuid]);
 
   const workspaceTitle = workspaces[0]?.additionalProps?.['workspaceTitle'] ?? workspaces[0]?.title ?? '';
+  const workspaceVariant = workspaces[0]?.variant;
+  const closeWorkspace = workspaces[0]?.closeWorkspace ?? (() => {});
 
   return (
     <aside
-      className={`${styles.container} ${maximized ? `${styles.maximized}` : undefined} ${
+      className={`${styles.container} ${
+        workspaceVariant === 'clinical-form' ? styles.clinicalForm : styles.independent
+      } ${maximized ? `${styles.maximized}` : undefined} ${
         isWorkspaceWindowOpen
           ? `${styles.show}`
           : `${styles.hide}
@@ -74,32 +78,46 @@ const WorkspaceWindow: React.FC<ContextWorkspaceParams> = () => {
           <ExtensionSlot name={patientChartWorkspaceHeaderSlot} />
           {isDesktop(layout) && (
             <>
-              <Button
-                iconDescription={maximized ? t('minimize', 'Minimize') : t('maximize', 'Maximize')}
-                hasIconOnly
-                kind="ghost"
-                onClick={toggleWindowState}
-                renderIcon={(props) =>
-                  maximized ? <Minimize size={16} {...props} /> : <Maximize size={16} {...props} />
-                }
-                tooltipPosition="bottom"
-              />
-              <Button
-                iconDescription={t('hide', 'Hide')}
-                hasIconOnly
-                kind="ghost"
-                onClick={() => updateWindowSize('hidden')}
-                renderIcon={(props) => <ArrowRight size={16} {...props} />}
-                tooltipPosition="bottom"
-                tooltipAlignment="end"
-              />
+              {workspaceVariant === 'clinical-form' && (
+                <Button
+                  iconDescription={maximized ? t('minimize', 'Minimize') : t('maximize', 'Maximize')}
+                  hasIconOnly
+                  kind="ghost"
+                  onClick={toggleWindowState}
+                  renderIcon={(props) =>
+                    maximized ? <Minimize size={16} {...props} /> : <Maximize size={16} {...props} />
+                  }
+                  tooltipPosition="bottom"
+                />
+              )}
+              {workspaceVariant !== 'independent' ? (
+                <Button
+                  iconDescription={t('hide', 'Hide')}
+                  hasIconOnly
+                  kind="ghost"
+                  onClick={() => updateWindowSize('hidden')}
+                  renderIcon={(props) => <ArrowRight size={16} {...props} />}
+                  tooltipPosition="bottom"
+                  tooltipAlignment="end"
+                />
+              ) : (
+                <Button
+                  iconDescription={t('close', 'Close')}
+                  hasIconOnly
+                  kind="ghost"
+                  onClick={() => closeWorkspace()}
+                  renderIcon={(props) => <Close size={16} {...props} />}
+                  tooltipPosition="bottom"
+                  tooltipAlignment="end"
+                />
+              )}
             </>
           )}
           {layout === 'tablet' && (
             <Button
               iconDescription={t('close', 'Close')}
               hasIconOnly
-              onClick={() => workspaces[0]?.closeWorkspace()}
+              onClick={() => {}}
               renderIcon={(props) => <DownToBottom size={16} {...props} />}
               tooltipPosition="bottom"
               tooltipAlignment="end"

--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
@@ -4,6 +4,8 @@
 @import "../root.scss";
 
 .header {
+  box-sizing: content-box;
+  border-bottom: 1px solid $text-03;
   background-color: $ui-03;
   top: 3rem;
   z-index: 100;
@@ -45,9 +47,6 @@
   width: calc(100% - 3rem);
 }
 
-.dynamicWidth {
-  width: 32.5rem;
-}
 
 /* Desktop */
 :global(.omrs-breakpoint-gt-tablet) {
@@ -61,26 +60,32 @@
   }
 
   .container {
-    margin-right: 2.825rem;
-    width: 32.5rem;
+    margin-right: 3rem;
     height: 100vh;
   }
 
-  .headerGlobalBar {
-    &>button {
-      min-height: spacing.$spacing-08;
-      background-color: $ui-02;
-      border-color: $color-gray-30;
-      border-style: solid;
-      border-width: 0 1px 0 0;
+  .clinicalForm {
+    width: 32.25rem;
+    .dynamicWidth {
+      width: 32.25rem;
     }
   }
-}
 
-/* Small desktop */
-:global(.omrs-breakpoint-lt-large-desktop){
-  .dynamicWidth {
-    width: 32.5rem;
+  .independent {
+    width: 26.25rem;
+    .dynamicWidth {
+      width: 26.25rem;
+    }
+  }
+
+  .headerGlobalBar {
+    button {
+      background-color: $ui-02;
+      border-right: 1px solid $ui-03;
+    }
+    button:last-child {
+      border-right: none;
+    }
   }
 }
 
@@ -128,7 +133,7 @@
 html[dir='rtl'] {
   :global(.omrs-breakpoint-gt-tablet) {
     .container {
-      margin-left: 2.825rem;
+      margin-left: 3rem;
       margin-right: unset;
     }
   }

--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
@@ -46,7 +46,7 @@
 }
 
 .dynamicWidth {
-  width: calc(50% - 9.625rem);
+  width: 32.5rem;
 }
 
 /* Desktop */
@@ -62,7 +62,7 @@
 
   .container {
     margin-right: 2.825rem;
-    flex: 1;
+    width: 32.5rem;
     height: 100vh;
   }
 
@@ -80,7 +80,7 @@
 /* Small desktop */
 :global(.omrs-breakpoint-lt-large-desktop){
   .dynamicWidth {
-    width: calc(50% - 1.625rem);
+    width: 32.5rem;
   }
 }
 

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
@@ -34,6 +34,7 @@ export interface WorkspaceRegistration {
   load(): Promise<any>;
   /** Only one of each "type" of workspace is allowed to be open at a time. The default is "form" */
   type?: string;
+  variant?: 'independent' | 'clinical-form' | 'siderail';
   preferredWindowSize?: WorkspaceWindowState;
 }
 
@@ -48,6 +49,7 @@ export function registerWorkspace(workspace: WorkspaceRegistration) {
     ...workspace,
     preferredWindowSize: workspace.preferredWindowSize ?? 'normal',
     type: workspace.type ?? 'form',
+    variant: workspace.variant ?? 'independent',
   };
 }
 
@@ -69,6 +71,7 @@ function getWorkspaceRegistration(name: string): WorkspaceRegistration {
         preferredWindowSize: workspaceExtension.meta?.screenSize ?? 'normal',
         load: workspaceExtension.load,
         type: workspaceExtension.meta?.type ?? 'form',
+        variant: workspaceExtension.meta?.variant ?? 'independent',
       };
     } else {
       throw new Error(`No workspace named '${name}' has been registered.`);

--- a/packages/esm-patient-forms-app/src/index.ts
+++ b/packages/esm-patient-forms-app/src/index.ts
@@ -39,6 +39,7 @@ export function startupApp() {
     name: 'patient-form-entry-workspace',
     title: 'Clinical Form',
     load: getAsyncLifecycle(() => import('./forms/form-entry.component'), options),
+    variant: 'clinical-form',
   });
 }
 

--- a/packages/esm-patient-forms-app/src/routes.json
+++ b/packages/esm-patient-forms-app/src/routes.json
@@ -38,7 +38,8 @@
           "key": "clinicalForm",
           "default": "Clinical form"
         },
-        "type": "order"
+        "type": "order",
+        "variant": "clinical-form"
       }
     }
   ]

--- a/packages/esm-patient-notes-app/src/routes.json
+++ b/packages/esm-patient-notes-app/src/routes.json
@@ -27,7 +27,8 @@
           "key": "visitNote",
           "default": "Visit Note"
         },
-        "type": "visit-note"
+        "type": "visit-note",
+        "variant": "siderail"
       }
     }
   ]

--- a/packages/esm-patient-orders-app/src/index.ts
+++ b/packages/esm-patient-orders-app/src/index.ts
@@ -20,6 +20,7 @@ registerWorkspace({
   title: 'Order Basket',
   load: getAsyncLifecycle(() => import('./order-basket/order-basket.workspace'), options),
   type: 'order',
+  variant: 'siderail',
 });
 
 export const orderBasketActionMenu = getAsyncLifecycle(


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR brings the following changes to the workspaces:
### Workspace Variants
The registered workspaces can be registered with a variant keyword, which can be of 3 types:
#### Independent workspace (variant = "independent")
This variant denotes to the set of workspaces which are not collapsible and has a `X` button on the top right corner.
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/6006d7f2-c2fb-48df-bde4-4758b7b39405)

![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/21b06bfd-b866-431b-9839-3c7becdeb370)

#### Siderail workspace (variant = "siderail")
These workspaces are allowed to callapse and marked as active on the corresponding action button on the side rail.
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/49a13dc5-290c-4aaf-86f5-f4b8beaf9708)

![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/a55f15b5-59f6-4a1c-8fbb-73c6323ace12)


#### Clinical forms (variant = "clinical-form")
These workspaces are also allowed to collapse, but also can be maximised to full width and have a total width of 520px, as compared to the above 2 variants, which are 420px in width.
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/7cfa2b6e-836b-4bc6-b9cf-5b1b12714f83)
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/9e77df4e-5dd1-4cf3-8880-627e5fb76c84)

### Workspace width
The workspaces are now confined to 420px/ 520px, depending on the variant. The workspace width will remain fixed as the desktop size changes.

Reference: https://zeroheight.com/23a080e38/p/483a22-workspace


## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/c08bc38c-5204-42af-ab6a-0a1487bcf01a



## Related Issue
https://issues.openmrs.org/browse/O3-1676
https://issues.openmrs.org/browse/O3-1677

## Other
<!-- Anything not covered above -->
