### PR TITLE
(feat) Remove redundant translation configuration settings

### DIFF
--- a/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useConfig, usePatient, useVisit } from '@openmrs/esm-framework';
+import { usePatient, useVisit } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 
 interface StartVisitOverflowMenuItemProps {
@@ -12,7 +12,6 @@ const StartVisitOverflowMenuItem: React.FC<StartVisitOverflowMenuItemProps> = ({
   const { currentVisit } = useVisit(patientUuid);
   const { patient } = usePatient(patientUuid);
   const handleClick = useCallback(() => launchPatientWorkspace('start-visit-workspace-form'), []);
-  const { startVisitLabel } = useConfig();
 
   const isDeceased = Boolean(patient?.deceasedDateTime);
 
@@ -29,9 +28,7 @@ const StartVisitOverflowMenuItem: React.FC<StartVisitOverflowMenuItemProps> = ({
             maxWidth: '100vw',
           }}
         >
-          <span className="cds--overflow-menu-options__option-content">
-            {!startVisitLabel ? <>{t('startVisit', 'Start visit')}</> : startVisitLabel}
-          </span>
+          <span className="cds--overflow-menu-options__option-content">{t('startVisit', 'Start visit')}</span>
         </button>
       </li>
     )

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
@@ -2,15 +2,10 @@ import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
 import { launchPatientChartWithWorkspaceOpen } from '@openmrs/esm-patient-common-lib';
-import { navigate, useConfig } from '@openmrs/esm-framework';
-
-interface StartVisitButtonProps {
-  patientUuid: string;
-}
+import { navigate } from '@openmrs/esm-framework';
 
 const StartVisitButton = ({ patientUuid }) => {
   const { t } = useTranslation();
-  const { startVisitLabel } = useConfig();
 
   const handleStartVisit = useCallback(() => {
     launchPatientChartWithWorkspaceOpen({
@@ -24,7 +19,7 @@ const StartVisitButton = ({ patientUuid }) => {
 
   return (
     <Button kind="primary" onClick={handleStartVisit}>
-      {!startVisitLabel ? <>{t('startVisit', 'Start visit')}</> : startVisitLabel}
+      {t('startVisit', 'Start visit')}
     </Button>
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes some redundant translation configuration from the `Start Visit` component that affects how the button label gets translated in the UI. For such scenarios, translation configuration should leverage the [translation overrides](https://o3-docs.openmrs.org/docs/configureO3YourWay/translation-in-o3#translation-overrides-specific-to-an-individual-o3-module) mechanism instead.

## Related Issue
*None*

## Other
*None*