### PR TITLE
(fix) O3-2362: Opening a form from forms-dashboard shows a confirmation modal

### DIFF
--- a/packages/esm-patient-forms-app/src/routes.json
+++ b/packages/esm-patient-forms-app/src/routes.json
@@ -38,9 +38,7 @@
           "key": "clinicalForm",
           "default": "Clinical form"
         },
-        "type": "clinical-form",
-        "canMaximize": true,
-        "canHide": true,
+        "type": "forms-dashboard",
         "width": "wider"
       }
     }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR includes the fix for the issue introduced by #1335 . 
The forms-dashboard has the workspace type = clinical-forms. Hence opening a form with the same workspace type shows a modal showing a form is already open. 

The forms-dasboard's workspace now has type = `forms-dashboard`

## Screenshots
https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/562c0ccb-e361-4054-862c-bef920b3e379

## Related Issue
https://issues.openmrs.org/browse/O3-2362

## Other
The forms dashboard is not a clinical form, and hence it shouldn't be allowed to hide. The workspace's prop `canHide` is now removed from the setup
