### PR TITLE
(fix) Redirect users back to previous page

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -148,9 +148,7 @@ const VisitHeader: React.FC = () => {
   const hasActiveVisit = !isLoading && !visitNotLoaded;
 
   const onClosePatientChart = useCallback(() => {
-    const originPage = localStorage.getItem('fromPage');
-    localStorage.removeItem('fromPage');
-    navigate({ to: `${window.spaBase}/${originPage || 'home'}` });
+    document.referrer === '' ? navigate({ to: `${window.spaBase}/home` }) : window.history.back();
   }, []);
 
   const openModal = useCallback((patientUuid) => {

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
@@ -21,6 +21,7 @@ const mockUseVisit = useVisit as jest.Mock;
 const mockUseLayoutType = useLayoutType as jest.Mock;
 const mockExtensionRegistry = {};
 const mockShowModal = showModal as jest.Mock;
+const mockNavigateBack = jest.fn();
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -51,6 +52,10 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
 });
 
 describe('Visit Header', () => {
+  beforeEach(() => {
+    window.history.back = mockNavigateBack;
+  });
+
   test('should display visit header and left nav bar hamburger icon', async () => {
     const user = userEvent.setup();
 
@@ -100,6 +105,12 @@ describe('Visit Header', () => {
     // Should close the visit-header
     await user.click(closeButton);
     expect(navigate).toHaveBeenCalledWith({ to: '/spa/home' });
+    expect(window.history.back).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, 'referrer', { value: 'some-uuid', configurable: true });
+    await user.click(closeButton);
+    expect(window.history.back).toHaveBeenCalled();
+    expect(mockNavigateBack).toHaveBeenCalled();
   });
 
   test('should display a truncated name when the patient name is very long', async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR adds ability to redirect user to the page they are from previously. If the user arrives to patient-chart through external link, the when closing the chart. The user is re-directed back to home.

## Screenshots
![Kapture 2023-08-31 at 20 36 04](https://github.com/openmrs/openmrs-esm-patient-chart/assets/28008754/fb9df77f-1957-43f5-8b70-404b75733537)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://thepalladiumgroup.atlassian.net/browse/KHP3-4068

## Other
<!-- Anything not covered above -->
