### PR TITLE
(chore) O3-2395: Enable Traces on E2E Tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,6 +18,7 @@ const config: PlaywrightTestConfig = {
     baseURL: `${process.env.E2E_BASE_URL}/spa/`,
     storageState: 'e2e/storageState.json',
     video: 'retain-on-failure',
+    trace: 'retain-on-failure'
   },
   projects: [
     {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, my PR title includes a conventional commit label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR addresses the following tasks from [O3-2395](https://issues.openmrs.org/browse/O3-2395):

1. Configured Playwright to enable traces on E2E tests.
2. Verified that traces are successfully generated and can be accessed.
3. Documented the process in the O3 dev docs [here](https://o3-docs.vercel.app/docs/frontend-modules/testing).

## Screenshots

<!-- Screenshots if applicable -->

## Related Issue

[O3-2395](https://issues.openmrs.org/browse/O3-2395)

## Other

- Updated Playwright configuration to enable traces with `trace: 'retain-on-failure'`.