### PR TITLE
(fix) Fix the dose input combobox width in the drug order form

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -24,7 +24,7 @@ import { Add, ArrowLeft, Subtract } from '@carbon/react/icons';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Controller, useController, useForm } from 'react-hook-form';
-import { age, formatDate, isDesktop, parseDate, useConfig, useLayoutType, usePatient } from '@openmrs/esm-framework';
+import { age, formatDate, parseDate, useConfig, useLayoutType, usePatient } from '@openmrs/esm-framework';
 import { useOrderConfig } from '../api/order-config';
 import { ConfigObject } from '../config-schema';
 import {
@@ -342,7 +342,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel }: Drug
           ) : (
             <>
               <Grid className={styles.gridRow}>
-                <Column lg={8} md={2} sm={4} className={styles.linkedInput}>
+                <Column lg={8} md={4} sm={4} className={styles.linkedInput}>
                   <InputWrapper>
                     <div className={styles.numberInput}>
                       <ControlledFieldInput
@@ -359,7 +359,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel }: Drug
                     </div>
                   </InputWrapper>
                 </Column>
-                <Column lg={8} md={2} sm={4}>
+                <Column lg={8} md={4} sm={4}>
                   <InputWrapper>
                     <ControlledFieldInput
                       control={control}

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -21,21 +21,21 @@ import {
   Toggle,
 } from '@carbon/react';
 import { Add, ArrowLeft, Subtract } from '@carbon/react/icons';
-import { age, formatDate, parseDate, useConfig, useLayoutType, usePatient } from '@openmrs/esm-framework';
-import { useOrderConfig } from '../api/order-config';
-import { ConfigObject } from '../config-schema';
-import styles from './drug-order-form.scss';
-import { Controller, useController, useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useController, useForm } from 'react-hook-form';
+import { age, formatDate, isDesktop, parseDate, useConfig, useLayoutType, usePatient } from '@openmrs/esm-framework';
+import { useOrderConfig } from '../api/order-config';
+import { ConfigObject } from '../config-schema';
 import {
-  DosingUnit,
-  DrugOrderBasketItem,
-  DurationUnit,
-  MedicationFrequency,
-  MedicationRoute,
-  QuantityUnit,
+  type DosingUnit,
+  type DrugOrderBasketItem,
+  type DurationUnit,
+  type MedicationFrequency,
+  type MedicationRoute,
+  type QuantityUnit,
 } from '../types';
+import styles from './drug-order-form.scss';
 
 export interface DrugOrderFormProps {
   initialOrderBasketItem: DrugOrderBasketItem;
@@ -342,7 +342,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel }: Drug
           ) : (
             <>
               <Grid className={styles.gridRow}>
-                <Column lg={4} md={2} sm={4} className={styles.linkedInput}>
+                <Column lg={8} md={2} sm={4} className={styles.linkedInput}>
                   <InputWrapper>
                     <div className={styles.numberInput}>
                       <ControlledFieldInput
@@ -359,7 +359,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel }: Drug
                     </div>
                   </InputWrapper>
                 </Column>
-                <Column lg={4} md={2} sm={4}>
+                <Column lg={8} md={2} sm={4}>
                   <InputWrapper>
                     <ControlledFieldInput
                       control={control}
@@ -374,6 +374,8 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel }: Drug
                     />
                   </InputWrapper>
                 </Column>
+              </Grid>
+              <Grid className={styles.gridRow}>
                 <Column lg={8} md={4} sm={4}>
                   <InputWrapper>
                     <ControlledFieldInput
@@ -389,9 +391,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel }: Drug
                     />
                   </InputWrapper>
                 </Column>
-              </Grid>
-              <Grid className={styles.gridRow}>
-                <Column lg={16} md={4} sm={4}>
+                <Column lg={8} md={4} sm={4}>
                   <InputWrapper>
                     <ControlledFieldInput
                       control={control}
@@ -731,7 +731,7 @@ const ControlledFieldInput = ({ name, control, type, ...restProps }) => {
           onChange={({ selectedItem }) => onChange(selectedItem)}
           onBlur={onBlur}
           ref={ref}
-          className={`${fieldState?.error?.message && styles.fieldError} ${styles.combobox}`}
+          className={fieldState?.error?.message && styles.fieldError}
           {...restProps}
         />
       );

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -731,7 +731,7 @@ const ControlledFieldInput = ({ name, control, type, ...restProps }) => {
           onChange={({ selectedItem }) => onChange(selectedItem)}
           onBlur={onBlur}
           ref={ref}
-          className={fieldState?.error?.message && styles.fieldError}
+          className={`${fieldState?.error?.message && styles.fieldError} ${styles.combobox}`}
           {...restProps}
         />
       );

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
@@ -150,6 +150,7 @@
 .gridRow {
   padding: 0px;
   margin-left: calc(spacing.$spacing-03 * -1);
+  align-items: baseline;
 
   :global(.cds--number) {
     display: inline-block;
@@ -235,8 +236,3 @@
   color: colors.$red-60;
 }
 
-.combobox {
-  :global(.cds--list-box--expanded .cds--list-box__menu) {
-    width: fit-content;
-  }
-}

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
@@ -1,18 +1,16 @@
-@use '@carbon/styles/scss/type';
-@use '@carbon/styles/scss/spacing';
-@use '@carbon/styles/scss/colors';
-@import '~@openmrs/esm-styleguide/src/vars';
-@import "../root";
+@use '@carbon/colors';
+@use '@carbon/layout';
+@use '@carbon/type';
 
 .orderForm {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: spacing.$spacing-03 0 0 spacing.$spacing-05;
-  height: calc(100vh - spacing.$spacing-12);
+  padding: layout.$spacing-03 0 0 layout.$spacing-05;
+  height: calc(100vh - layout.$spacing-12);
 
   input[data-invalid]:focus {
-    outline: 2px solid  #da1e28;
+    outline: 2px solid  colors.$red-60;
      outline-offset: -2px;
   }
 
@@ -21,15 +19,15 @@
   }
 
   :global(.cds--css-grid-column) {
-    margin: 0 spacing.$spacing-03 !important;
+    margin: 0 layout.$spacing-03 !important;
   }
 
   :global(.cds--subgrid) {
-    margin: 0 calc(spacing.$spacing-03 * -1) !important;
+    margin: 0 calc(layout.$spacing-03 * -1) !important;
   }
 
   :global(.cds--number--nosteppers.cds--number input[type=number]) {
-    padding-right: spacing.$spacing-05;
+    padding-right: layout.$spacing-05;
   }
 
   :global(.cds--list-box) {
@@ -43,23 +41,23 @@
 
 .medicationInfo {
   border: 0;
-  padding: spacing.$spacing-05;
-  margin-left: calc(spacing.$spacing-05 * -1);
+  padding: layout.$spacing-05;
+  margin-left: calc(layout.$spacing-05 * -1);
   box-sizing: border-box;
 }
 
 .inlineNotification {
   width: 100%;
   max-width: unset;
-  margin-top: calc(spacing.$spacing-03 * -1);
-  margin-left: calc(spacing.$spacing-05 * -1);
+  margin-top: calc(layout.$spacing-03 * -1);
+  margin-left: calc(layout.$spacing-05 * -1);
 }
 
 .stickyMedicationInfo {
   position: fixed;
-  background-color: #0072c3;
-  color: #ffffff;
-  top: spacing.$spacing-12;
+  background-color: colors.$cyan-60;
+  color: colors.$white-0;
+  top: layout.$spacing-12;
   z-index: 1;
   display: flex;
   align-items: center;
@@ -71,15 +69,15 @@
 }
 
 .patientHeader {
-  padding: spacing.$spacing-03 spacing.$spacing-05 spacing.$spacing-06;
-  background-color: $ui-01;
+  padding: layout.$spacing-03 layout.$spacing-05 layout.$spacing-06;
+  background-color: colors.$gray-10;
 
   span:first-of-type {
-    margin-right: spacing.$spacing-03;
+    margin-right: layout.$spacing-03;
   }
 
   .text02 {
-    color: $text-02;
+    color: colors.$gray-70;
   }
 }
 
@@ -89,12 +87,12 @@
 }
 
 .formSection {
-  margin-bottom: spacing.$spacing-06;
+  margin-bottom: layout.$spacing-06;
 }
 
 .sectionHeader {
   @include type.type-style("heading-01");
-  margin-bottom: spacing.$spacing-05;
+  margin-bottom: layout.$spacing-05;
 }
 
 .pullColumnContentRight > div {
@@ -122,7 +120,7 @@
 .numberInput {
   :global(.cds--number__input-wrapper) input {
   min-width: unset !important;
-  padding-right: spacing.$spacing-05;
+  padding-right: layout.$spacing-05;
   }
 }
 
@@ -130,14 +128,14 @@
   align-items: center;
   display: flex;
   justify-content: flex-start;
-  margin: spacing.$spacing-03 0;
+  margin: layout.$spacing-03 0;
 
   button {
     display: flex;
    padding-left: 0 !important;
     svg {
       order: 1;
-      margin-right: spacing.$spacing-03;
+      margin-right: layout.$spacing-03;
       margin-left: 0 !important;
     }
 
@@ -149,20 +147,20 @@
 
 .gridRow {
   padding: 0px;
-  margin-left: calc(spacing.$spacing-03 * -1);
-  align-items: baseline;
+  margin-left: calc(layout.$spacing-03 * -1);
+}
 
-  :global(.cds--number) {
-    display: inline-block;
-  }
+/* Desktop */
+:global(.omrs-breakpoint-lt-desktop) .gridRow {
+  align-items: baseline;
 }
 
 .field {
-  margin-bottom: spacing.$spacing-05;
+  margin-bottom: layout.$spacing-05;
 }
 
 .buttonSet {
-  margin-left: calc(spacing.$spacing-05 * -1);
+  margin-left: calc(layout.$spacing-05 * -1);
 
   :global(.cds--btn) {
     width: 50%;
@@ -183,10 +181,9 @@
 
 .linkedInput::after {
   content: "";
-  border: 1px solid $text-03;
-  width: spacing.$spacing-05;
-  margin-right: calc(spacing.$spacing-05 * -1);
-  margin-top: spacing.$spacing-05;
+  border: 1px solid colors.$gray-40;
+  width: layout.$spacing-05;
+  margin-right: calc(layout.$spacing-05 * -1);
 }
 
 .customNumberInput {
@@ -195,7 +192,7 @@
   align-items: flex-end;
 
   :global(.cds--btn) {
-    background-color: #393939;
+    background-color: colors.$gray-80;
   }
 
   .customInput {
@@ -208,17 +205,17 @@
 /* Tablet */
 :global(.omrs-breakpoint-lt-desktop) {
   .orderForm {
-    height: calc(100vh - 10rem);
+    height: 100%;
     background-color: #ededed;
   }
 
   .stickyMedicationInfo {
-    top: spacing.$spacing-09;
+    top: layout.$spacing-09;
   }
 
   .buttonSet {
-    padding: spacing.$spacing-06 spacing.$spacing-05;
-    background-color: $ui-02;
+    padding: layout.$spacing-06 layout.$spacing-05;
+    background-color: colors.$white-0;
   }
 }
 

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
@@ -234,3 +234,9 @@
 .errorLabel {
   color: colors.$red-60;
 }
+
+.combobox {
+  :global(.cds--list-box--expanded .cds--list-box__menu) {
+    width: fit-content;
+  }
+}

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search.scss
@@ -2,6 +2,7 @@
 
 .searchPopupContainer {
   position: relative;
+  height: 100vh;
 }
 
 .searchPopup {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue with the drug order form where the dose input combobox does not fit the width of its content. In it, I've applied a style override where I set the value of the `width` property of the list box element to `fit-content` so that it fits the width of its content.

## Screenshots

> Before

<img width="468" alt="CleanShot 2023-09-07 at 11 37 18@2x" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/31e789df-26c7-41b4-8cb1-62e866abb55b">


> After

<img width="468" alt="CleanShot 2023-09-07 at 11 47 34@2x" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/7db7e073-477a-40b0-82e5-67d0b51d87d7">

## Related issue

https://openmrs.slack.com/archives/CKS32D55G/p1694105267198369 