### PR TITLE
(feat) O3-2391: Ability to hide observations in encounters via config…

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -103,13 +103,13 @@ export const esmPatientChartSchema = {
       _description: 'The organization name displayed when image is absent',
     },
   },
-  hideFieldsByConceptUuid: {
+  hideObsByConceptUuid: {
     _type: Type.Array,
     _elements: {
       _type: Type.ConceptUuid,
     },
     _description:
-      'An array of concept UUIDs. When this array is not empty, any observations in the observations list view that match any of the UUIDs in this array will be hidden.',
+      'An array of concept UUIDs. If an observation has a concept UUID that matches any of the ones in this array, it will be hidden from the observations list in the Encounters summary table.',
     _default: [],
   },
 };

--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -103,6 +103,15 @@ export const esmPatientChartSchema = {
       _description: 'The organization name displayed when image is absent',
     },
   },
+  hideFieldsByConceptUuid: {
+    _type: Type.Array,
+    _elements: {
+      _type: Type.ConceptUuid,
+    },
+    _description:
+      'An array of concept UUIDs. When this array is not empty, any observations in the observations list view that match any of the UUIDs in this array will be hidden.',
+    _default: [],
+  },
 };
 
 export interface ChartConfig {

--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -103,7 +103,7 @@ export const esmPatientChartSchema = {
       _description: 'The organization name displayed when image is absent',
     },
   },
-  hideObsByConceptUuid: {
+  obsConceptUuidsToHide: {
     _type: Type.Array,
     _elements: {
       _type: Type.ConceptUuid,

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SkeletonText } from '@carbon/react';
 import { useConfig } from '@openmrs/esm-framework';
@@ -11,7 +11,7 @@ interface EncounterObservationsProps {
 
 const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observations }) => {
   const { t } = useTranslation();
-  const { hideFieldsByConceptUuid = [] } = useConfig();
+  const { hideObsByConceptUuid = [] } = useConfig();
 
   function getAnswerFromDisplay(display: string): string {
     const colonIndex = display.indexOf(':');
@@ -27,9 +27,9 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
   }
 
   if (observations) {
-    const filteredObservations = !!hideFieldsByConceptUuid.length
-      ? observations?.filter((it) => {
-          return !hideFieldsByConceptUuid.includes(it?.concept?.uuid);
+    const filteredObservations = !!hideObsByConceptUuid.length
+      ? observations?.filter((obs) => {
+          return !hideObsByConceptUuid.includes(obs?.concept?.uuid);
         })
       : observations;
     return (

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SkeletonText } from '@carbon/react';
+import { useConfig } from '@openmrs/esm-framework';
 import { Observation } from '../visit.resource';
 import styles from './styles.scss';
 
@@ -10,6 +11,7 @@ interface EncounterObservationsProps {
 
 const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observations }) => {
   const { t } = useTranslation();
+  const { hideFieldsByConceptUuid = [] } = useConfig();
 
   function getAnswerFromDisplay(display: string): string {
     const colonIndex = display.indexOf(':');
@@ -25,9 +27,14 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
   }
 
   if (observations) {
+    const filteredObservations = !!hideFieldsByConceptUuid.length
+      ? observations?.filter((it) => {
+          return !hideFieldsByConceptUuid.includes(it?.concept?.uuid);
+        })
+      : observations;
     return (
       <div className={styles.observation}>
-        {observations?.map((obs, index) => {
+        {filteredObservations?.map((obs, index) => {
           if (obs.groupMembers) {
             return (
               <React.Fragment key={index}>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
@@ -11,7 +11,7 @@ interface EncounterObservationsProps {
 
 const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observations }) => {
   const { t } = useTranslation();
-  const { hideObsByConceptUuid = [] } = useConfig();
+  const { obsConceptUuidsToHide = [] } = useConfig();
 
   function getAnswerFromDisplay(display: string): string {
     const colonIndex = display.indexOf(':');
@@ -27,9 +27,9 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
   }
 
   if (observations) {
-    const filteredObservations = !!hideObsByConceptUuid.length
+    const filteredObservations = !!obsConceptUuidsToHide.length
       ? observations?.filter((obs) => {
-          return !hideObsByConceptUuid.includes(obs?.concept?.uuid);
+          return !obsConceptUuidsToHide.includes(obs?.concept?.uuid);
         })
       : observations;
     return (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Sometimes it is necessary to hide something in the list of observations when viewing an encounter. For example, this could be lines about added attachments (see screenshot). It could also be other entities that do not need to be shown in the user interface.

## Screenshots
![264690566-5f5251fb-f3d4-4330-89ad-e76924cee741](https://github.com/openmrs/openmrs-esm-patient-chart/assets/17073192/3f451c02-ff88-42eb-aa38-0698a1412691)


## Related Issue
[https://issues.openmrs.org/browse/O3-2391](https://issues.openmrs.org/browse/O3-2391)
