### PR TITLE
(fix) Hiding the workspace re-opens the workspace window.

### DIFF
--- a/packages/esm-patient-common-lib/src/workspaces/useWorkspaces.tsx
+++ b/packages/esm-patient-common-lib/src/workspaces/useWorkspaces.tsx
@@ -24,18 +24,6 @@ export function useWorkspaces(): WorkspacesInfo {
     getWorkspaceStore().subscribe(update);
   }, []);
 
-  // This hook is meant to be triggered only when workspace changes
-  // Accordingly the workspaceWindowState will be updated
-  useEffect(() => {
-    if (workspaces.length === 0) {
-      updateWorkspaceWindowState('hidden');
-    } else if (workspaceWindowState === 'hidden') {
-      updateWorkspaceWindowState('normal');
-    } else {
-      updateWorkspaceWindowState(workspaces[0].preferredWindowSize === 'maximized' ? 'maximized' : 'normal');
-    }
-  }, [workspaces, workspaceWindowState]);
-
   const memoisedResults = useMemo(
     () => ({
       active: workspaces.length > 0,

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
@@ -167,6 +167,11 @@ export function launchPatientWorkspace(name: string, additionalProps?: object) {
       });
     }
   }
+  if (store.getState().workspaceWindowState === 'hidden') {
+    updateWorkspaceWindowState(
+      store.getState().openWorkspaces[0].preferredWindowSize === 'maximized' ? 'maximized' : 'normal',
+    );
+  }
 }
 
 export function launchPatientChartWithWorkspaceOpen({


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
In addition to #1339, updating the workspace window state workflow was altered by me in wake of optimizing.
Before the handling was in the `useWorkspaces` hook and `workspace-window` component, which was meant to update the window state on the basis of workspaces.

Due to negligence, the useEffect written couldn't hide a workspace.

Solution: All the workspaces are opened by a single function `launchPatientWorkspace`, so it should be the only point of updating the workspace window state. Hence the workspace is hidden by `->` button and opened/ re-opened when calling the launchPatientWorkspace

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
