### PR TITLE
O3 2425 Fix issue: Drug orders 'Immediately add to basket' button should not close workspace window

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
@@ -43,7 +43,7 @@ export default function AddDrugOrderWorkspace({ order: initialOrder, closeWorksp
       setOrders([...orders, searchResult]);
       setCurrentOrder(searchResult);
     },
-    [setOrders, orders, closeWorkspace, activeOrders.data, t],
+    [setOrders, orders, activeOrders.data, t],
   );
 
   const saveDrugOrder = useCallback(

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
@@ -28,7 +28,7 @@ export default function AddDrugOrderWorkspace({ order: initialOrder, closeWorksp
   }, [closeWorkspace, currentOrder, orders, setOrders]);
 
   const chooseDrug = useCallback(
-    (searchResult: DrugOrderBasketItem, directlyAddToBasket: boolean) => {
+    (searchResult: DrugOrderBasketItem) => {
       if (activeOrders.data?.find((existing) => existing.drug?.concept.uuid === searchResult.drug?.concept.uuid)) {
         showToast({
           kind: 'warning',
@@ -41,11 +41,7 @@ export default function AddDrugOrderWorkspace({ order: initialOrder, closeWorksp
         return;
       }
       setOrders([...orders, searchResult]);
-      if (directlyAddToBasket) {
-        closeWorkspace();
-      } else {
-        setCurrentOrder(searchResult);
-      }
+      setCurrentOrder(searchResult);
     },
     [setOrders, orders, closeWorkspace, activeOrders.data, t],
   );

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
@@ -8,7 +8,7 @@ import { useDebounce } from './drug-search.resource';
 import { DrugOrderBasketItem } from '../../types';
 
 export interface OrderBasketSearchProps {
-  onSearchResultClicked: (searchResult: DrugOrderBasketItem, directlyAddToBasket: boolean) => void;
+  onSearchResultClicked: (searchResult: DrugOrderBasketItem) => void;
 }
 
 export default function OrderBasketSearch({ onSearchResultClicked }: OrderBasketSearchProps) {

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
@@ -10,7 +10,7 @@ import { DrugOrderBasketItem } from '../../types';
 
 export interface OrderBasketSearchResultsProps {
   searchTerm: string;
-  onSearchResultClicked: (searchResult: DrugOrderBasketItem, directlyAddToBasket: boolean) => void;
+  onSearchResultClicked: (searchResult: DrugOrderBasketItem) => void;
   focusAndClearSearchInput: () => void;
 }
 
@@ -95,7 +95,7 @@ export default function OrderBasketSearchResults({
 
 interface DrugSearchResultItemProps {
   drug: DrugSearchResult;
-  onSearchResultClicked: (searchResult: DrugOrderBasketItem, directlyAddToBasket: boolean) => void;
+  onSearchResultClicked: (searchResult: DrugOrderBasketItem) => void;
 }
 
 const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({ drug, onSearchResultClicked }) => {
@@ -122,7 +122,7 @@ const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({ drug, onSea
           key={templates?.length ? templates[indx]?.uuid : drug?.uuid}
           role="listitem"
           className={isTablet ? `${styles.tabletSearchResultTile}` : `${styles.desktopSearchResultTile}`}
-          onClick={() => onSearchResultClicked(orderItem, false)}
+          onClick={() => onSearchResultClicked(orderItem)}
         >
           <div className={styles.searchResultTile}>
             <div className={`${styles.searchResultTileContent} ${styles.text02}`}>
@@ -156,7 +156,7 @@ const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({ drug, onSea
               hasIconOnly={true}
               renderIcon={(props) => <ShoppingCart size={16} {...props} />}
               iconDescription={t('directlyAddToBasket', 'Immediately add to basket')}
-              onClick={() => onSearchResultClicked(orderItem, true)}
+              onClick={() => onSearchResultClicked(orderItem)}
               tooltipPosition="left"
               tooltipAlignment="end"
             />

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.test.tsx
@@ -68,7 +68,6 @@ describe('OrderBasketSearchResults', () => {
         undefined,
         mockDrugOrderTemplateApiData[mockDrugSearchResultApiData[0].uuid][0],
       ),
-      false,
     );
   });
 });


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This pull request is addressing an issue where,  clicking on the "Immediately add to basket" button in the drug search section results in closing the workspace window entirely. 

## Screenshots
[<!-- Required if you are making UI changes. -->](https://github.com/openmrs/openmrs-esm-patient-chart/assets/29108523/bc08f844-42fb-488d-9866-c932407aee59)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-2425

## Other
<!-- Anything not covered above -->
