### PR TITLE
(Fix) Drug orders 'Immediately add to basket' button  closes the workspace window completely when clicked

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
@@ -43,6 +43,7 @@ export default function AddDrugOrderWorkspace({ order: initialOrder, closeWorksp
       setOrders([...orders, searchResult]);
       if (directlyAddToBasket) {
         closeWorkspace();
+        launchPatientWorkspace('order-basket');
       } else {
         setCurrentOrder(searchResult);
       }


### PR DESCRIPTION
…close workspace window

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This pull request is addressing an issue where, clicking on the "Immediately add to basket" button in the drug search section results in closing the workspace window entirely.

## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/openmrs/openmrs-esm-patient-chart/assets/29108523/7874ac8e-4eb9-47ee-9ad4-66543937a1fc


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-2425

## Other
<!-- Anything not covered above -->
