### PR TITLE
(feat) Add current visit summary component

### DIFF
--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -238,3 +238,11 @@ export const deleteEncounterModal = getAsyncLifecycle(
     moduleName,
   },
 );
+
+export const currentVisitSummary = getAsyncLifecycle(
+  () => import('./visit/visits-widget/current-visit-summary.component'),
+  {
+    featureName: 'current-visit-summary',
+    moduleName,
+  },
+);

--- a/packages/esm-patient-chart-app/src/routes.json
+++ b/packages/esm-patient-chart-app/src/routes.json
@@ -149,6 +149,13 @@
     {
       "name": "delete-encounter-modal",
       "component": "deleteEncounterModal"
+    },
+    {
+      "name": "current-visit-summary",
+      "component": "currentVisitSummary",
+      "meta": {
+        "columnSpan": 4
+      }
     }
   ],
   "pages": [

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.component.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import VisitSummary from './past-visits-components/visit-summary.component';
+import { ErrorState } from '@openmrs/esm-framework';
+import { useTranslation } from 'react-i18next';
+import { InlineLoading } from '@carbon/react';
+import { CardHeader, EmptyState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import styles from './current-visit-summary.scss';
+import { useVisits } from './visit.resource';
+
+interface CurrentVisitSummaryProps {
+  patientUuid: string;
+}
+
+const CurrentVisitSummary: React.FC<CurrentVisitSummaryProps> = ({ patientUuid }) => {
+  const { t } = useTranslation();
+  const { visits, isLoading, isValidating, isError } = useVisits(patientUuid);
+
+  const [currentVisit] = visits?.filter((visit) => visit.stopDatetime === null) ?? [];
+
+  if (isLoading) {
+    return (
+      <InlineLoading
+        status="active"
+        iconDescription={t('loading', 'Loading')}
+        description={t('loadingVisit', 'Loading current visit...')}
+      />
+    );
+  }
+
+  if (isError) {
+    return <ErrorState headerTitle={t('failedToLoadCurrentVisit', 'Failed loading current visit')} error={isError} />;
+  }
+
+  if (!Boolean(currentVisit)) {
+    return (
+      <EmptyState
+        headerTitle={t('currentVisit', 'currentVisit')}
+        displayText={t('noActiveVisitMessage', 'active visit')}
+        launchForm={() => launchPatientWorkspace('start-visit-workspace-form')}
+      />
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <CardHeader title={t('currentVisit', 'Current Visit')}>
+        <span>{isValidating ? <InlineLoading /> : null}</span>
+      </CardHeader>
+      <div className={styles.visitSummaryCard}>
+        <VisitSummary visit={currentVisit} patientUuid={patientUuid} />
+      </div>
+    </div>
+  );
+};
+
+export default CurrentVisitSummary;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.component.tsx
@@ -1,21 +1,18 @@
 import React from 'react';
-import VisitSummary from './past-visits-components/visit-summary.component';
-import { ErrorState } from '@openmrs/esm-framework';
+import { ErrorState, useVisit } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { InlineLoading } from '@carbon/react';
 import { CardHeader, EmptyState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import styles from './current-visit-summary.scss';
-import { useVisits } from './visit.resource';
 
+import VisitSummary from './past-visits-components/visit-summary.component';
+import styles from './current-visit-summary.scss';
 interface CurrentVisitSummaryProps {
   patientUuid: string;
 }
 
 const CurrentVisitSummary: React.FC<CurrentVisitSummaryProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
-  const { visits, isLoading, isValidating, isError } = useVisits(patientUuid);
-
-  const [currentVisit] = visits?.filter((visit) => visit.stopDatetime === null) ?? [];
+  const { isLoading, currentVisit, error, isValidating } = useVisit(patientUuid);
 
   if (isLoading) {
     return (
@@ -27,11 +24,11 @@ const CurrentVisitSummary: React.FC<CurrentVisitSummaryProps> = ({ patientUuid }
     );
   }
 
-  if (isError) {
-    return <ErrorState headerTitle={t('failedToLoadCurrentVisit', 'Failed loading current visit')} error={isError} />;
+  if (!!error) {
+    return <ErrorState headerTitle={t('failedToLoadCurrentVisit', 'Failed loading current visit')} error={error} />;
   }
 
-  if (!Boolean(currentVisit)) {
+  if (!currentVisit) {
     return (
       <EmptyState
         headerTitle={t('currentVisit', 'currentVisit')}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.scss
@@ -1,0 +1,11 @@
+@use '@carbon/styles/scss/spacing';
+@use '@carbon/styles/scss/colors';
+
+
+.container{
+    background-color: colors.$white-0;
+}
+
+.visitSummaryCard{
+    margin: 0 spacing.$spacing-05;
+}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/curret-visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/curret-visit-summary.test.tsx
@@ -1,37 +1,77 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import CurrentVisitSummary from './current-visit-summary.component';
-import { useVisits } from './visit.resource';
+import { useVisit, getConfig } from '@openmrs/esm-framework';
 
-const mockUseVisits = useVisits as jest.Mock;
-
-jest.mock('./visit.resource', () => ({
+const mockUseVisits = useVisit as jest.Mock;
+const mockGetConfig = getConfig as jest.Mock;
+jest.mock('@openmrs/esm-framework', () => ({
+  ...jest.requireActual('@openmrs/esm-framework/mock'),
   useVisits: jest.fn(),
+  getConfig: jest.fn(),
 }));
 
 describe('CurrentVisitSummary', () => {
-  it('should display loading state', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should display loading state', () => {
     mockUseVisits.mockReturnValueOnce({
-      visits: [],
+      currentVisit: null,
       isLoading: true,
       isValidating: false,
-      isError: null,
+      error: null,
     });
 
     render(<CurrentVisitSummary patientUuid="some-uuid" />);
     expect(screen.getByText('Loading current visit...')).toBeInTheDocument();
   });
 
-  it('should display empty state when there is no active visit', () => {
+  test('should display empty state when there is no active visit', () => {
     mockUseVisits.mockReturnValueOnce({
-      visits: [],
+      currentVisit: null,
       isLoading: false,
       isValidating: false,
-      isError: null,
+      error: null,
     });
 
     render(<CurrentVisitSummary patientUuid="some-uuid" />);
     expect(screen.getByText('currentVisit')).toBeInTheDocument();
     expect(screen.getByText('There are no active visit to display for this patient')).toBeInTheDocument();
+  });
+
+  test("should display visit summary when there's an active visit", async () => {
+    mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
+    mockUseVisits.mockReturnValueOnce({
+      currentVisit: {
+        uuid: 'some-uuid',
+        display: 'Visit 1',
+        startDatetime: '2021-03-23T10:00:00.000+0300',
+        stopDatetime: null,
+        location: {
+          uuid: 'some-uuid',
+          display: 'Location 1',
+        },
+        visitType: {
+          uuid: 'some-uuid',
+          display: 'Visit Type 1',
+        },
+        encounters: [],
+      },
+      isLoading: false,
+      isValidating: false,
+      error: null,
+    });
+
+    render(<CurrentVisitSummary patientUuid="some-uuid" />);
+    await waitFor(() => {
+      expect(screen.getByText('Current Visit')).toBeInTheDocument();
+      expect(screen.getByText('Diagnoses')).toBeInTheDocument();
+      const buttonNames = ['Notes', 'Tests', 'Medications', 'Encounters'];
+      buttonNames.forEach((buttonName) => {
+        expect(screen.getByText(buttonName)).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/curret-visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/curret-visit-summary.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CurrentVisitSummary from './current-visit-summary.component';
+import { useVisits } from './visit.resource';
+
+const mockUseVisits = useVisits as jest.Mock;
+
+jest.mock('./visit.resource', () => ({
+  useVisits: jest.fn(),
+}));
+
+describe('CurrentVisitSummary', () => {
+  it('should display loading state', () => {
+    mockUseVisits.mockReturnValueOnce({
+      visits: [],
+      isLoading: true,
+      isValidating: false,
+      isError: null,
+    });
+
+    render(<CurrentVisitSummary patientUuid="some-uuid" />);
+    expect(screen.getByText('Loading current visit...')).toBeInTheDocument();
+  });
+
+  it('should display empty state when there is no active visit', () => {
+    mockUseVisits.mockReturnValueOnce({
+      visits: [],
+      isLoading: false,
+      isValidating: false,
+      isError: null,
+    });
+
+    render(<CurrentVisitSummary patientUuid="some-uuid" />);
+    expect(screen.getByText('currentVisit')).toBeInTheDocument();
+    expect(screen.getByText('There are no active visit to display for this patient')).toBeInTheDocument();
+  });
+});

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -55,17 +55,19 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
     const notes: Array<Note> = [];
 
     // Iterating through every Encounter
-    visit?.encounters.forEach((enc: Encounter) => {
+    visit?.encounters?.forEach((enc: Encounter) => {
       // Orders of every encounter put in a single array.
-      medications.push(
-        ...enc.orders.map((order: Order) => ({
-          order,
-          provider: {
-            name: enc.encounterProviders.length ? enc.encounterProviders[0].provider.person.display : '',
-            role: enc.encounterProviders.length ? enc.encounterProviders[0].encounterRole.display : '',
-          },
-        })),
-      );
+      if (enc.hasOwnProperty('orders')) {
+        medications.push(
+          ...enc.orders.map((order: Order) => ({
+            order,
+            provider: {
+              name: enc.encounterProviders.length ? enc.encounterProviders[0].provider.person.display : '',
+              role: enc.encounterProviders.length ? enc.encounterProviders[0].encounterRole.display : '',
+            },
+          })),
+        );
+      }
 
       //Check if there is a diagnosis associated with this encounter
       if (enc.hasOwnProperty('diagnoses')) {
@@ -81,20 +83,22 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
       }
 
       // Check for Visit Diagnoses and Notes
-      enc.obs.forEach((obs: Observation) => {
-        if (config.notesConceptUuids?.includes(obs.concept.uuid)) {
-          // Putting all notes in a single array.
-          notes.push({
-            note: obs.value,
-            provider: {
-              name: enc.encounterProviders.length ? enc.encounterProviders[0].provider.person.display : '',
-              role: enc.encounterProviders.length ? enc.encounterProviders[0].encounterRole.display : '',
-            },
-            time: enc.encounterDatetime ? formatTime(parseDate(enc.encounterDatetime)) : '',
-            concept: obs.concept,
-          });
-        }
-      });
+      if (enc.hasOwnProperty('obs')) {
+        enc.obs.forEach((obs: Observation) => {
+          if (config.notesConceptUuids?.includes(obs.concept.uuid)) {
+            // Putting all notes in a single array.
+            notes.push({
+              note: obs.value,
+              provider: {
+                name: enc.encounterProviders.length ? enc.encounterProviders[0].provider.person.display : '',
+                role: enc.encounterProviders.length ? enc.encounterProviders[0].encounterRole.display : '',
+              },
+              time: enc.encounterDatetime ? formatTime(parseDate(enc.encounterDatetime)) : '',
+              concept: obs.concept,
+            });
+          }
+        });
+      }
     });
 
     return [diagnoses, notes, medications];


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR adds `current-visit-summary` component. The rationale for this is that for the current visit, users required to have a quick way of seeing the visit summary instead of navigating to `visit-summary` dashboard to see this information. 

## Screenshots
![Screenshot from 2023-09-21 19-49-45](https://github.com/openmrs/openmrs-esm-patient-chart/assets/28008754/b8db9d0d-2d3a-4911-b656-393dc9db9324)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

## ToDo
Update `esm-core` api to include encounter and orders
