### PR TITLE
(feat) O3-2423: Lab order flow should have test type search page

### DIFF
--- a/packages/esm-form-entry-app/package.json
+++ b/packages/esm-form-entry-app/package.json
@@ -89,7 +89,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "^2.1.0",
     "ngx-build-plus": "^14.0.0",
-    "openmrs": "^5.1.0",
+    "openmrs": "next",
     "protractor": "~7.0.0",
     "rxjs": "~6.6.7",
     "style-loader": "2.x",

--- a/packages/esm-patient-common-lib/src/orders/types.ts
+++ b/packages/esm-patient-common-lib/src/orders/types.ts
@@ -58,6 +58,7 @@ export interface Order {
   brandName?: string;
   careSetting: OpenmrsResource;
   commentToFulfiller: string;
+  concept: OpenmrsResource;
   dateActivated: string;
   dateStopped?: string | null;
   dispenseAsWritten: boolean;

--- a/packages/esm-patient-labs-app/package.json
+++ b/packages/esm-patient-labs-app/package.json
@@ -42,6 +42,7 @@
     "@carbon/react": "^1.12.0",
     "@openmrs/esm-patient-common-lib": "^5.1.0",
     "d3": "^7.6.1",
+    "fuzzy": "^0.1.3",
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.scss
@@ -3,51 +3,6 @@
 @import '~@openmrs/esm-styleguide/src/vars';
 @import "../../root";
 
-.container {
-  height: var(--desktop-workspace-window-height);
-  display: flex;
-  flex-direction: column;
-}
-
-.orderForm {
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: spacing.$spacing-03 0 0 spacing.$spacing-05;
-
-  :global(.cds--css-grid) {
-    max-width: unset;
-  }
-
-  :global(.cds--css-grid-column) {
-    margin: 0 spacing.$spacing-03 !important;
-  }
-
-  :global(.cds--subgrid) {
-    margin: 0 calc(spacing.$spacing-03 * -1) !important;
-  }
-
-  :global(.cds--number--nosteppers.cds--number input[type=number]) {
-    padding-right: spacing.$spacing-05;
-  }
-
-  :global(.cds--list-box) {
-    border: none;
-  }
-
-  :global(.cds--number__control-btn) {
-    border: 0;
-  }
-}
-
-.inlineNotification {
-  width: 100%;
-  max-width: unset;
-  margin-top: calc(spacing.$spacing-03 * -1);
-  margin-left: calc(spacing.$spacing-05 * -1);
-}
-
 .patientHeader {
   padding: spacing.$spacing-03 spacing.$spacing-05 spacing.$spacing-06;
   background-color: $ui-01;
@@ -58,42 +13,6 @@
   
   .text02 {
     color: $text-02;
-  }
-}
-
-.orderFormHeading {
-  @include type.type-style("heading-03");
-  margin-bottom: 0;
-}
-
-.formSection {
-  margin-bottom: spacing.$spacing-06;
-}
-
-.sectionHeader {
-  @include type.type-style("heading-01");
-  margin-bottom: spacing.$spacing-05;
-}
-
-.pullColumnContentRight > div {
-  float: right;
-}
-
-.fullWidthDatePickerContainer {
-  :global .cds--date-picker {
-    width: 100%;
-
-    :global .cds--date-picker-container {
-      width: 100%;
-
-      :global .cds--date-picker-input__wrapper {
-        width: 100%;
-
-        :global .cds--date-picker__input {
-          width: 100%;
-        }
-      }
-    }
   }
 }
 
@@ -117,6 +36,7 @@
     }
   }
 }
+<<<<<<< HEAD
 
 .gridRow {
   padding: 0px;
@@ -176,3 +96,5 @@
   }
 
 }
+=======
+>>>>>>> b48d5508 (First pass at creating test type search page. Need to fix the test type resource and create the page for an empty search box.)

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.scss
@@ -3,6 +3,12 @@
 @import '~@openmrs/esm-styleguide/src/vars';
 @import "../../root";
 
+.container {
+  position: relative;
+  min-height: var(--desktop-workspace-window-height);
+  background-color: white;
+}
+
 .patientHeader {
   padding: spacing.$spacing-03 spacing.$spacing-05 spacing.$spacing-06;
   background-color: $ui-01;
@@ -20,7 +26,7 @@
   align-items: center;
   display: flex;
   justify-content: flex-start;
-  margin: spacing.$spacing-03 0;
+  padding: spacing.$spacing-03 0;
 
   button {
     display: flex;
@@ -36,65 +42,3 @@
     }
   }
 }
-<<<<<<< HEAD
-
-.gridRow {
-  padding: 0px;
-  margin-left: calc(spacing.$spacing-03 * -1);
-
-  :global(.cds--number) {
-    display: inline-block;
-  }
-}
-
-.field {
-  margin-bottom: spacing.$spacing-05;
-}
-
-.buttonSet {
-  margin-left: calc(spacing.$spacing-05 * -1);
-
-  :global(.cds--btn) {
-    width: 50%;
-    max-width: unset;
-  }
-}
-
-.linkedInput {
-  display: flex;
-  align-items: center;
-
-  :global(.cds--layer-one), 
-  :global(.cds--layer-two), 
-  :global(.cds--layer) {
-    flex: 1;
-  }
-}
-
-.linkedInput::after {
-  content: "";
-  border: 1px solid $text-03;
-  width: spacing.$spacing-05;
-  margin-right: calc(spacing.$spacing-05 * -1);
-  margin-top: spacing.$spacing-05;
-}
-
-/* Tablet */
-:global(.omrs-breakpoint-lt-desktop) {
-
-  .container {
-    height: var(--tablet-workspace-window-height);
-  }
-
-  .orderForm {
-    background-color: #ededed;
-  }
-
-  .buttonSet {
-    padding: spacing.$spacing-06 spacing.$spacing-05;
-    background-color: $ui-02;
-  }
-
-}
-=======
->>>>>>> b48d5508 (First pass at creating test type search page. Need to fix the test type resource and create the page for an empty search box.)

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.scss
@@ -7,6 +7,8 @@
   position: relative;
   min-height: var(--desktop-workspace-window-height);
   background-color: white;
+  display: flex;
+  flex-direction: column;
 }
 
 .patientHeader {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.scss
@@ -14,25 +14,23 @@
 .patientHeader {
   padding: spacing.$spacing-03 spacing.$spacing-05 spacing.$spacing-06;
   background-color: $ui-01;
-  
+
   span:first-of-type {
     margin-right: spacing.$spacing-03;
   }
-  
+
   .text02 {
     color: $text-02;
   }
 }
 
 .backButton {
-  align-items: center;
-  display: flex;
-  justify-content: flex-start;
-  padding: spacing.$spacing-03 0;
+  padding: spacing.$spacing-03;
 
   button {
     display: flex;
-   padding-left: 0 !important;
+    padding-left: 0 !important;
+
     svg {
       order: 1;
       margin-right: spacing.$spacing-03;

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
@@ -61,6 +61,6 @@ export default function AddLabOrderWorkspace({ order: initialOrder, closeWorkspa
       ) : (
         <LabOrderForm initialOrder={currentLabOrder} closeWorkspace={closeWorkspace} />
       )}
-    </>
+    </div>
   );
 }

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
@@ -1,31 +1,14 @@
 import React, { useCallback, useState } from 'react';
 import capitalize from 'lodash-es/capitalize';
 import { useTranslation } from 'react-i18next';
-import { Button, ButtonSet, Column, ComboBox, Form, Layer, Grid, TextInput, InlineNotification } from '@carbon/react';
+import { Button } from '@carbon/react';
 import { ArrowLeft } from '@carbon/react/icons';
 import { age, formatDate, parseDate, useLayoutType, usePatient, useSession } from '@openmrs/esm-framework';
-import {
-  DefaultWorkspaceProps,
-  launchPatientWorkspace,
-  OrderBasketItem,
-  useOrderBasket,
-} from '@openmrs/esm-patient-common-lib';
-import { LabOrderBasketItem, careSettingUuid, prepLabOrderPostData } from '../api';
+import { DefaultWorkspaceProps, launchPatientWorkspace, OrderBasketItem } from '@openmrs/esm-patient-common-lib';
+import { LabOrderBasketItem } from '../api';
 import styles from './add-lab-order.scss';
-import { TestType, useTestTypes } from './useTestTypes';
-
-// See the Urgency enum in https://github.com/openmrs/openmrs-core/blob/492dcd35b85d48730bd19da48f6db146cc882c22/api/src/main/java/org/openmrs/Order.java
-const priorityOptions = [
-  { value: 'ROUTINE', label: 'Routine' },
-  { value: 'STAT', label: 'Stat' },
-];
-// TODO add priority option `{ value: "ON_SCHEDULED_DATE", label: "On scheduled date" }` once the form supports a date.
-
-const emptyLabOrder: LabOrderBasketItem = {
-  action: 'NEW',
-  urgency: priorityOptions[0].value,
-  display: null,
-};
+import { TestTypeSearch } from './test-type-search';
+import { LabOrderForm } from './lab-order-form';
 
 export interface AddLabOrderWorkspaceAdditionalProps {
   order: OrderBasketItem;
@@ -36,11 +19,10 @@ export interface AddLabOrderWorkspace extends DefaultWorkspaceProps, AddLabOrder
 // Design: https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/62c6bf3e8e5a4119570c1bae
 export default function AddLabOrderWorkspace({ order: initialOrder, closeWorkspace }: AddLabOrderWorkspace) {
   const { t } = useTranslation();
-  const session = useSession();
+
   const { patient, isLoading: isLoadingPatient } = usePatient();
-  const { orders, setOrders } = useOrderBasket('labs', prepLabOrderPostData);
-  const [inProgressLabOrder, setInProgressLabOrder] = useState((initialOrder ?? emptyLabOrder) as LabOrderBasketItem);
-  const { testTypes, isLoading: isLoadingTestTypes, error: errorLoadingTestTypes } = useTestTypes();
+  const [currentLabOrder, setCurrentLabOrder] = useState(initialOrder as LabOrderBasketItem);
+
   const isTablet = useLayoutType() === 'tablet';
 
   const patientName = `${patient?.name?.[0]?.given?.join(' ')} ${patient?.name?.[0].family}`;
@@ -49,22 +31,6 @@ export default function AddLabOrderWorkspace({ order: initialOrder, closeWorkspa
     closeWorkspace();
     launchPatientWorkspace('order-basket');
   }, [closeWorkspace]);
-
-  const handleFormSubmission = useCallback(
-    (e: Event) => {
-      e.preventDefault();
-      inProgressLabOrder.careSetting = careSettingUuid;
-      inProgressLabOrder.orderer = session.currentProvider.uuid;
-      const newOrders = [...orders];
-      const existingOrder = orders.find((order) => ordersEqual(order, inProgressLabOrder));
-      const orderIndex = existingOrder ? orders.indexOf(existingOrder) : orders.length;
-      newOrders[orderIndex] = inProgressLabOrder;
-      setOrders(newOrders);
-      closeWorkspace();
-      launchPatientWorkspace('order-basket');
-    },
-    [orders, setOrders, closeWorkspace, session.currentProvider.uuid, inProgressLabOrder],
-  );
 
   return (
     <div className={styles.container}>
@@ -90,131 +56,11 @@ export default function AddLabOrderWorkspace({ order: initialOrder, closeWorkspa
           </Button>
         </div>
       )}
-      {errorLoadingTestTypes && (
-        <InlineNotification
-          kind="error"
-          lowContrast
-          className={styles.inlineNotification}
-          title={t('errorLoadingTestTypes', 'Error occured when loading test types')}
-          subtitle={t('tryReopeningTheForm', 'Please try launching the form again')}
-        />
+      {!currentLabOrder ? (
+        <TestTypeSearch openLabForm={setCurrentLabOrder} />
+      ) : (
+        <LabOrderForm initialOrder={currentLabOrder} closeWorkspace={closeWorkspace} />
       )}
-      <Form className={styles.orderForm} onSubmit={handleFormSubmission} id="drugOrderForm">
-        <div>
-          <Grid className={styles.gridRow}>
-            <Column lg={8} md={8} sm={4}>
-              <InputWrapper>
-                <ComboBox
-                  size="lg"
-                  id="testTypeInput"
-                  titleText={t('testType', 'Test type')}
-                  selectedItem={testTypes.find((t) => t.conceptUuid == inProgressLabOrder?.testType?.conceptUuid)}
-                  items={testTypes}
-                  itemToString={(item: TestType) => item?.label}
-                  placeholder={
-                    isLoadingTestTypes ? `${t('loading', 'Loading')}...` : t('testTypePlaceholder', 'Select one')
-                  }
-                  required
-                  disabled={isLoadingTestTypes}
-                  onChange={({ selectedItem }: { selectedItem: TestType }) => {
-                    setInProgressLabOrder({
-                      ...inProgressLabOrder,
-                      display: selectedItem?.label,
-                      testType: selectedItem,
-                    });
-                  }}
-                />
-              </InputWrapper>
-            </Column>
-          </Grid>
-          <Grid className={styles.gridRow}>
-            <Column lg={8} md={8} sm={4}>
-              <InputWrapper>
-                <TextInput
-                  id="labReferenceNumberInput"
-                  size="lg"
-                  labelText={t('labReferenceNumber', 'Lab reference number')}
-                  maxLength={150}
-                  value={inProgressLabOrder.labReferenceNumber}
-                  onChange={(e) =>
-                    setInProgressLabOrder({
-                      ...inProgressLabOrder,
-                      labReferenceNumber: e.target.value,
-                    })
-                  }
-                />
-              </InputWrapper>
-            </Column>
-          </Grid>
-          <Grid className={styles.gridRow}>
-            <Column lg={8} md={8} sm={4}>
-              <InputWrapper>
-                <ComboBox
-                  size="lg"
-                  id="priorityInput"
-                  titleText={t('priority', 'Priority')}
-                  selectedItem={priorityOptions.find((p) => p.value == inProgressLabOrder?.urgency)}
-                  items={priorityOptions}
-                  itemToString={(item) => item?.label}
-                  onChange={({ selectedItem }) =>
-                    setInProgressLabOrder({
-                      ...inProgressLabOrder,
-                      urgency: selectedItem?.value ?? priorityOptions[0],
-                    })
-                  }
-                />
-              </InputWrapper>
-            </Column>
-          </Grid>
-          <Grid className={styles.gridRow}>
-            <Column lg={16} md={8} sm={4}>
-              <InputWrapper>
-                <TextInput
-                  id="additionalInstructionsInput"
-                  size="lg"
-                  labelText={t('additionalInstructions', 'Additional instructions')}
-                  // placeholder={t('indicationPlaceholder', 'e.g. "Hypertension"')}
-                  value={inProgressLabOrder.instructions}
-                  onChange={(e) =>
-                    setInProgressLabOrder({
-                      ...inProgressLabOrder,
-                      instructions: e.target.value,
-                    })
-                  }
-                  maxLength={150}
-                />
-              </InputWrapper>
-            </Column>
-          </Grid>
-        </div>
-        <ButtonSet className={`${styles.buttonSet} ${isTablet ? styles.tabletButtonSet : styles.desktopButtonSet}`}>
-          <Button className={styles.button} kind="secondary" onClick={cancelOrder} size="xl">
-            {t('discard', 'Discard')}
-          </Button>
-          <Button
-            className={styles.button}
-            kind="primary"
-            type="submit"
-            size="xl"
-            disabled={!inProgressLabOrder.testType}
-          >
-            {t('saveOrder', 'Save order')}
-          </Button>
-        </ButtonSet>
-      </Form>
-    </div>
+    </>
   );
-}
-
-function InputWrapper({ children }) {
-  const isTablet = useLayoutType() === 'tablet';
-  return (
-    <Layer level={isTablet ? 1 : 0}>
-      <div className={styles.field}>{children}</div>
-    </Layer>
-  );
-}
-
-function ordersEqual(order1: LabOrderBasketItem, order2: LabOrderBasketItem) {
-  return order1.testType.conceptUuid === order2.testType.conceptUuid;
 }

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
@@ -11,12 +11,12 @@ import { TestTypeSearch } from './test-type-search';
 import { LabOrderForm } from './lab-order-form';
 
 export interface AddLabOrderWorkspaceAdditionalProps {
-  order: OrderBasketItem;
+  order?: OrderBasketItem;
 }
 
 export interface AddLabOrderWorkspace extends DefaultWorkspaceProps, AddLabOrderWorkspaceAdditionalProps {}
 
-// Design: https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/62c6bf3e8e5a4119570c1bae
+// Design: https://app.zeplin.io/project/60d5947dd636aebbd63dce4c/screen/640b06c440ee3f7af8747620
 export default function AddLabOrderWorkspace({ order: initialOrder, closeWorkspace }: AddLabOrderWorkspace) {
   const { t } = useTranslation();
 

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.scss
@@ -1,0 +1,72 @@
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/spacing';
+@import '~@openmrs/esm-styleguide/src/vars';
+@import "../../root";
+
+.orderForm {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: spacing.$spacing-03 0 0 spacing.$spacing-05;
+  height: calc(100vh - 9rem);
+
+  :global(.cds--css-grid) {
+    max-width: unset;
+  }
+
+  :global(.cds--css-grid-column) {
+    margin: 0 spacing.$spacing-03 !important;
+  }
+
+  :global(.cds--subgrid) {
+    margin: 0 calc(spacing.$spacing-03 * -1) !important;
+  }
+
+  :global(.cds--number--nosteppers.cds--number input[type=number]) {
+    padding-right: spacing.$spacing-05;
+  }
+
+  :global(.cds--list-box) {
+    border: none;
+  }
+
+  :global(.cds--number__control-btn) {
+    border: 0;
+  }
+}
+
+.gridRow {
+  padding: 0px;
+  margin-left: calc(spacing.$spacing-03 * -1);
+
+  :global(.cds--number) {
+    display: inline-block;
+  }
+}
+
+.field {
+  margin-bottom: spacing.$spacing-05;
+}
+
+.buttonSet {
+  margin-left: calc(spacing.$spacing-05 * -1);
+
+  :global(.cds--btn) {
+    width: 50%;
+    max-width: unset;
+  }
+}
+
+/* Tablet */
+:global(.omrs-breakpoint-lt-desktop) {
+  .orderForm {
+    height: calc(100vh - 10rem);
+    background-color: #ededed;
+  }
+
+  .buttonSet {
+    padding: spacing.$spacing-06 spacing.$spacing-05;
+    background-color: $ui-02;
+  }
+
+}

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.scss
@@ -4,11 +4,11 @@
 @import "../../root";
 
 .orderForm {
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   padding: spacing.$spacing-03 0 0 spacing.$spacing-05;
-  height: calc(100vh - 9rem);
 
   :global(.cds--css-grid) {
     max-width: unset;

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useState } from 'react';
 import { launchPatientWorkspace, useOrderBasket } from '@openmrs/esm-patient-common-lib';
-import { Button, ButtonSet, Column, ComboBox, Form, Layer, Grid, TextInput } from '@carbon/react';
+import { Button, ButtonSet, Column, ComboBox, Form, Layer, Grid, InlineNotification, TextInput } from '@carbon/react';
 import { LabOrderBasketItem, careSettingUuid, prepLabOrderPostData } from '../api';
 import { useLayoutType, useSession } from '@openmrs/esm-framework';
 import styles from './lab-order-form.scss';
 import { useTranslation } from 'react-i18next';
 import { priorityOptions } from './lab-order';
+import { TestType, useTestTypes } from './useTestTypes';
 
 export interface LabOrderFormProps {
   initialOrder: LabOrderBasketItem;
@@ -14,13 +15,14 @@ export interface LabOrderFormProps {
 
 // Designs:
 //   https://app.zeplin.io/project/60d5947dd636aebbd63dce4c/screen/640b06c440ee3f7af8747620
-//   https://app.zeplin.io/project/60d5947dd636aebbd63dce4c/screen/640b06cfab89e77b9b6b2a61
+//   https://app.zeplin.io/project/60d5947dd636aebbd63dce4c/screen/640b06d286e0aa7b0316db4a
 export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps) {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const session = useSession();
   const { orders, setOrders } = useOrderBasket<LabOrderBasketItem>('labs', prepLabOrderPostData);
   const [inProgressLabOrder, setInProgressLabOrder] = useState(initialOrder as LabOrderBasketItem);
+  const { testTypes, isLoading: isLoadingTestTypes, error: errorLoadingTestTypes } = useTestTypes();
 
   const handleFormSubmission = useCallback(
     (e: Event) => {
@@ -47,83 +49,120 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
   }, [closeWorkspace, inProgressLabOrder.testType.conceptUuid, orders, setOrders]);
 
   return (
-    <Form className={styles.orderForm} onSubmit={handleFormSubmission} id="drugOrderForm">
-      <div>
-        <Grid className={styles.gridRow}>
-          <Column lg={8} md={8} sm={4}>
-            <InputWrapper>
-              <TextInput
-                id="labReferenceNumberInput"
-                size="lg"
-                labelText={t('labReferenceNumber', 'Lab reference number')}
-                maxLength={150}
-                value={inProgressLabOrder.labReferenceNumber}
-                onChange={(e) =>
-                  setInProgressLabOrder({
-                    ...inProgressLabOrder,
-                    labReferenceNumber: e.target.value,
-                  })
-                }
-              />
-            </InputWrapper>
-          </Column>
-        </Grid>
-        <Grid className={styles.gridRow}>
-          <Column lg={8} md={8} sm={4}>
-            <InputWrapper>
-              <ComboBox
-                size="lg"
-                id="priorityInput"
-                titleText={t('priority', 'Priority')}
-                selectedItem={priorityOptions.find((p) => p.value == inProgressLabOrder?.urgency)}
-                items={priorityOptions}
-                itemToString={(item) => item?.label}
-                onChange={({ selectedItem }) =>
-                  setInProgressLabOrder({
-                    ...inProgressLabOrder,
-                    urgency: selectedItem?.value ?? priorityOptions[0],
-                  })
-                }
-              />
-            </InputWrapper>
-          </Column>
-        </Grid>
-        <Grid className={styles.gridRow}>
-          <Column lg={16} md={8} sm={4}>
-            <InputWrapper>
-              <TextInput
-                id="additionalInstructionsInput"
-                size="lg"
-                labelText={t('additionalInstructions', 'Additional instructions')}
-                // placeholder={t('indicationPlaceholder', 'e.g. "Hypertension"')}
-                value={inProgressLabOrder.instructions}
-                onChange={(e) =>
-                  setInProgressLabOrder({
-                    ...inProgressLabOrder,
-                    instructions: e.target.value,
-                  })
-                }
-                maxLength={150}
-              />
-            </InputWrapper>
-          </Column>
-        </Grid>
-      </div>
-      <ButtonSet className={`${styles.buttonSet} ${isTablet ? styles.tabletButtonSet : styles.desktopButtonSet}`}>
-        <Button className={styles.button} kind="secondary" onClick={cancelOrder} size="xl">
-          {t('discard', 'Discard')}
-        </Button>
-        <Button
-          className={styles.button}
-          kind="primary"
-          type="submit"
-          size="xl"
-          disabled={!inProgressLabOrder.testType}
-        >
-          {t('saveOrder', 'Save order')}
-        </Button>
-      </ButtonSet>
-    </Form>
+    <>
+      {errorLoadingTestTypes && (
+        <InlineNotification
+          kind="error"
+          lowContrast
+          className={styles.inlineNotification}
+          title={t('errorLoadingTestTypes', 'Error occured when loading test types')}
+          subtitle={t('tryReopeningTheForm', 'Please try launching the form again')}
+        />
+      )}
+      <Form className={styles.orderForm} onSubmit={handleFormSubmission} id="drugOrderForm">
+        <div>
+          <Grid className={styles.gridRow}>
+            <Column lg={16} md={8} sm={4}>
+              <InputWrapper>
+                <ComboBox
+                  size="lg"
+                  id="testTypeInput"
+                  titleText={t('testType', 'Test type')}
+                  selectedItem={testTypes.find((t) => t.conceptUuid == inProgressLabOrder?.testType?.conceptUuid)}
+                  items={testTypes}
+                  itemToString={(item: TestType) => item?.label}
+                  placeholder={
+                    isLoadingTestTypes ? `${t('loading', 'Loading')}...` : t('testTypePlaceholder', 'Select one')
+                  }
+                  required
+                  disabled={isLoadingTestTypes}
+                  onChange={({ selectedItem }: { selectedItem: TestType }) => {
+                    setInProgressLabOrder({
+                      ...inProgressLabOrder,
+                      display: selectedItem?.label,
+                      testType: selectedItem,
+                    });
+                  }}
+                />
+              </InputWrapper>
+            </Column>
+          </Grid>
+          <Grid className={styles.gridRow}>
+            <Column lg={16} md={8} sm={4}>
+              <InputWrapper>
+                <TextInput
+                  id="labReferenceNumberInput"
+                  size="lg"
+                  labelText={t('labReferenceNumber', 'Lab reference number')}
+                  maxLength={150}
+                  value={inProgressLabOrder.labReferenceNumber}
+                  onChange={(e) =>
+                    setInProgressLabOrder({
+                      ...inProgressLabOrder,
+                      labReferenceNumber: e.target.value,
+                    })
+                  }
+                />
+              </InputWrapper>
+            </Column>
+          </Grid>
+          <Grid className={styles.gridRow}>
+            <Column lg={8} md={8} sm={4}>
+              <InputWrapper>
+                <ComboBox
+                  size="lg"
+                  id="priorityInput"
+                  titleText={t('priority', 'Priority')}
+                  selectedItem={priorityOptions.find((p) => p.value == inProgressLabOrder?.urgency)}
+                  items={priorityOptions}
+                  itemToString={(item) => item?.label}
+                  onChange={({ selectedItem }) =>
+                    setInProgressLabOrder({
+                      ...inProgressLabOrder,
+                      urgency: selectedItem?.value ?? priorityOptions[0],
+                    })
+                  }
+                />
+              </InputWrapper>
+            </Column>
+          </Grid>
+          <Grid className={styles.gridRow}>
+            <Column lg={16} md={8} sm={4}>
+              <InputWrapper>
+                <TextInput
+                  id="additionalInstructionsInput"
+                  size="lg"
+                  labelText={t('additionalInstructions', 'Additional instructions')}
+                  // placeholder={t('indicationPlaceholder', 'e.g. "Hypertension"')}
+                  value={inProgressLabOrder.instructions}
+                  onChange={(e) =>
+                    setInProgressLabOrder({
+                      ...inProgressLabOrder,
+                      instructions: e.target.value,
+                    })
+                  }
+                  maxLength={150}
+                />
+              </InputWrapper>
+            </Column>
+          </Grid>
+        </div>
+        <ButtonSet className={`${styles.buttonSet} ${isTablet ? styles.tabletButtonSet : styles.desktopButtonSet}`}>
+          <Button className={styles.button} kind="secondary" onClick={cancelOrder} size="xl">
+            {t('discard', 'Discard')}
+          </Button>
+          <Button
+            className={styles.button}
+            kind="primary"
+            type="submit"
+            size="xl"
+            disabled={!inProgressLabOrder.testType}
+          >
+            {t('saveOrder', 'Save order')}
+          </Button>
+        </ButtonSet>
+      </Form>
+    </>
   );
 }
 

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.tsx
@@ -1,0 +1,137 @@
+import React, { useCallback, useState } from 'react';
+import { launchPatientWorkspace, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import { Button, ButtonSet, Column, ComboBox, Form, Layer, Grid, TextInput } from '@carbon/react';
+import { LabOrderBasketItem, careSettingUuid, prepLabOrderPostData } from '../api';
+import { useLayoutType, useSession } from '@openmrs/esm-framework';
+import styles from './lab-order-form.scss';
+import { useTranslation } from 'react-i18next';
+import { priorityOptions } from './lab-order';
+
+export interface LabOrderFormProps {
+  initialOrder: LabOrderBasketItem;
+  closeWorkspace: () => void;
+}
+
+// Designs:
+//   https://app.zeplin.io/project/60d5947dd636aebbd63dce4c/screen/640b06c440ee3f7af8747620
+//   https://app.zeplin.io/project/60d5947dd636aebbd63dce4c/screen/640b06cfab89e77b9b6b2a61
+export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps) {
+  const { t } = useTranslation();
+  const isTablet = useLayoutType() === 'tablet';
+  const session = useSession();
+  const { orders, setOrders } = useOrderBasket<LabOrderBasketItem>('labs', prepLabOrderPostData);
+  const [inProgressLabOrder, setInProgressLabOrder] = useState(initialOrder as LabOrderBasketItem);
+
+  const handleFormSubmission = useCallback(
+    (e: Event) => {
+      e.preventDefault();
+      inProgressLabOrder.careSetting = careSettingUuid;
+      inProgressLabOrder.orderer = session.currentProvider.uuid;
+      const newOrders = [...orders];
+      const existingOrder = orders.find(
+        (order) => order.testType.conceptUuid == inProgressLabOrder.testType.conceptUuid,
+      );
+      const orderIndex = existingOrder ? orders.indexOf(existingOrder) : orders.length;
+      newOrders[orderIndex] = inProgressLabOrder;
+      setOrders(newOrders);
+      closeWorkspace();
+      launchPatientWorkspace('order-basket');
+    },
+    [orders, setOrders, closeWorkspace, session.currentProvider.uuid, inProgressLabOrder],
+  );
+
+  const cancelOrder = useCallback(() => {
+    setOrders(orders.filter((order) => order.testType.conceptUuid !== inProgressLabOrder.testType.conceptUuid));
+    closeWorkspace();
+    launchPatientWorkspace('order-basket');
+  }, [closeWorkspace, inProgressLabOrder.testType.conceptUuid, orders, setOrders]);
+
+  return (
+    <Form className={styles.orderForm} onSubmit={handleFormSubmission} id="drugOrderForm">
+      <div>
+        <Grid className={styles.gridRow}>
+          <Column lg={8} md={8} sm={4}>
+            <InputWrapper>
+              <TextInput
+                id="labReferenceNumberInput"
+                size="lg"
+                labelText={t('labReferenceNumber', 'Lab reference number')}
+                maxLength={150}
+                value={inProgressLabOrder.labReferenceNumber}
+                onChange={(e) =>
+                  setInProgressLabOrder({
+                    ...inProgressLabOrder,
+                    labReferenceNumber: e.target.value,
+                  })
+                }
+              />
+            </InputWrapper>
+          </Column>
+        </Grid>
+        <Grid className={styles.gridRow}>
+          <Column lg={8} md={8} sm={4}>
+            <InputWrapper>
+              <ComboBox
+                size="lg"
+                id="priorityInput"
+                titleText={t('priority', 'Priority')}
+                selectedItem={priorityOptions.find((p) => p.value == inProgressLabOrder?.urgency)}
+                items={priorityOptions}
+                itemToString={(item) => item?.label}
+                onChange={({ selectedItem }) =>
+                  setInProgressLabOrder({
+                    ...inProgressLabOrder,
+                    urgency: selectedItem?.value ?? priorityOptions[0],
+                  })
+                }
+              />
+            </InputWrapper>
+          </Column>
+        </Grid>
+        <Grid className={styles.gridRow}>
+          <Column lg={16} md={8} sm={4}>
+            <InputWrapper>
+              <TextInput
+                id="additionalInstructionsInput"
+                size="lg"
+                labelText={t('additionalInstructions', 'Additional instructions')}
+                // placeholder={t('indicationPlaceholder', 'e.g. "Hypertension"')}
+                value={inProgressLabOrder.instructions}
+                onChange={(e) =>
+                  setInProgressLabOrder({
+                    ...inProgressLabOrder,
+                    instructions: e.target.value,
+                  })
+                }
+                maxLength={150}
+              />
+            </InputWrapper>
+          </Column>
+        </Grid>
+      </div>
+      <ButtonSet className={`${styles.buttonSet} ${isTablet ? styles.tabletButtonSet : styles.desktopButtonSet}`}>
+        <Button className={styles.button} kind="secondary" onClick={cancelOrder} size="xl">
+          {t('discard', 'Discard')}
+        </Button>
+        <Button
+          className={styles.button}
+          kind="primary"
+          type="submit"
+          size="xl"
+          disabled={!inProgressLabOrder.testType}
+        >
+          {t('saveOrder', 'Save order')}
+        </Button>
+      </ButtonSet>
+    </Form>
+  );
+}
+
+function InputWrapper({ children }) {
+  const isTablet = useLayoutType() === 'tablet';
+  return (
+    <Layer level={isTablet ? 1 : 0}>
+      <div className={styles.field}>{children}</div>
+    </Layer>
+  );
+}

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order.ts
@@ -1,0 +1,19 @@
+import { LabOrderBasketItem } from '../api';
+import { TestType } from './useTestTypes';
+
+// See the Urgency enum in https://github.com/openmrs/openmrs-core/blob/492dcd35b85d48730bd19da48f6db146cc882c22/api/src/main/java/org/openmrs/Order.java
+export const priorityOptions = [
+  { value: 'ROUTINE', label: 'Routine' },
+  { value: 'STAT', label: 'Stat' },
+];
+// TODO add priority option `{ value: "ON_SCHEDULED_DATE", label: "On scheduled date" }` once the form supports a date.
+
+export function createEmptyLabOrder(testType: TestType, orderer: string): LabOrderBasketItem {
+  return {
+    action: 'NEW',
+    urgency: priorityOptions[0].value,
+    display: testType.label,
+    testType,
+    orderer,
+  };
+}

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.scss
@@ -1,0 +1,116 @@
+@use '@carbon/styles/scss/spacing';
+@use '@carbon/styles/scss/type';
+@import "../../root";
+
+/** For TestTypeSearchResults */
+
+.container {
+  margin: spacing.$spacing-03 spacing.$spacing-05 spacing.$spacing-03;
+}
+
+.divider {
+  border: 0;
+  border-top: 1px solid $color-gray-30;
+  width: 66%;
+}
+
+.desktopDivider {
+  margin: spacing.$spacing-07 auto spacing.$spacing-05;
+}
+
+.tabletDivider {
+  margin: spacing.$spacing-08 auto spacing.$spacing-06;
+}
+
+.searchResultsCount {
+  @include type.type-style('body-compact-01');
+  color: $text-02;
+}
+
+.orderBasketSearchResultsHeader {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: spacing.$spacing-03;
+  align-items: center;
+}
+
+/** For TestTypeSearchResultItem */
+
+.searchResultTile {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border: 1px solid $grey-2;
+  &:not(:last-of-type) {
+    margin-bottom: spacing.$spacing-03;
+  }
+}
+
+.tabletSearchResultTile {
+  margin-top: 5px;
+  background-color: $ui-02;
+}
+
+.searchResultTileContent {
+  padding: spacing.$spacing-03 spacing.$spacing-05;
+}
+
+.searchResultActions {
+  border-top: 1px solid $grey-2;
+  padding: 0 spacing.$spacing-05;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.searchResultSkeletonWrapper {
+  margin: spacing.$spacing-03 1rem spacing.$spacing-03;
+  
+  :global(.cds--skeleton__text) {
+    margin: 0;
+  }
+
+  .searchResultCntSkeleton {
+    margin-right: spacing.$spacing-07;
+  }
+
+  .skeletonTile {
+    display: flex;
+    align-items: center;
+  }
+}
+
+.emptyState {
+  margin: spacing.$spacing-05;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: spacing.$spacing-07;
+  border: 1px solid $ui-03;
+  text-align: center;
+  background-color: $ui-01;
+}
+
+:global(.omrs-breakpoint-lt-small-desktop) .emptyState {
+  background-color: $ui-02;
+}
+
+.link {
+  color: $interactive-01;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.resultsContainer {
+  max-height: 27.5rem;
+  overflow-y: scroll;
+}
+
+.resultsContainer::-webkit-scrollbar {
+  width: spacing.$spacing-03;
+}
+
+.resultsContainer::-webkit-scrollbar-thumb {
+  background: $ui-04;
+  border-radius: spacing.$spacing-02;
+}

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.scss
@@ -2,10 +2,12 @@
 @use '@carbon/styles/scss/type';
 @import "../../root";
 
+/** For TestTypeSearch */
+
 /** For TestTypeSearchResults */
 
 .container {
-  margin: spacing.$spacing-03 spacing.$spacing-05 spacing.$spacing-03;
+  margin: spacing.$spacing-03 spacing.$spacing-05;
 }
 
 .divider {
@@ -102,7 +104,6 @@
 }
 
 .resultsContainer {
-  max-height: 27.5rem;
   overflow-y: scroll;
 }
 

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.scss
@@ -2,8 +2,6 @@
 @use '@carbon/styles/scss/type';
 @import "../../root";
 
-/** For TestTypeSearch */
-
 /** For TestTypeSearchResults */
 
 .container {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
@@ -1,0 +1,237 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button, ButtonSkeleton, Layer, Search, SkeletonText, Tile } from '@carbon/react';
+import { ArrowRight, ShoppingCartArrowDown, ShoppingCartArrowUp } from '@carbon/react/icons';
+import { useDebounce, useLayoutType, useSession } from '@openmrs/esm-framework';
+import { useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import { LabOrderBasketItem, prepLabOrderPostData } from '../api';
+import styles from './test-type-search.scss';
+import { TestType, useTestTypes } from './useTestTypes';
+import { createEmptyLabOrder } from './lab-order';
+
+export interface TestTypeSearchProps {
+  openLabForm: (searchResult: LabOrderBasketItem) => void;
+}
+
+export function TestTypeSearch({ openLabForm }: TestTypeSearchProps) {
+  const { t } = useTranslation();
+  const isTablet = useLayoutType() === 'tablet';
+  const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm);
+  const searchInputRef = useRef(null);
+
+  const focusAndClearSearchInput = () => {
+    setSearchTerm('');
+    searchInputRef.current?.focus();
+  };
+
+  const handleSearchTermChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value ?? '');
+  };
+
+  return (
+    <div className={styles.searchPopupContainer}>
+      <ResponsiveWrapper isTablet={isTablet}>
+        <Search
+          size="lg"
+          placeholder={t('searchFieldPlaceholder', 'Search for a test type')}
+          labelText={t('searchFieldPlaceholder', 'Search for a test type')}
+          onChange={handleSearchTermChange}
+          ref={searchInputRef}
+          value={searchTerm}
+        />
+      </ResponsiveWrapper>
+      <TestTypeSearchResults
+        searchTerm={debouncedSearchTerm}
+        openOrderForm={openLabForm}
+        focusAndClearSearchInput={focusAndClearSearchInput}
+      />
+    </div>
+  );
+}
+
+function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
+  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
+}
+
+interface TestTypeSearchResultsProps {
+  searchTerm: string;
+  openOrderForm: (searchResult: LabOrderBasketItem) => void;
+  focusAndClearSearchInput: () => void;
+}
+
+function TestTypeSearchResults({ searchTerm, openOrderForm, focusAndClearSearchInput }: TestTypeSearchResultsProps) {
+  const { t } = useTranslation();
+  const isTablet = useLayoutType() === 'tablet';
+  const { testTypes, isLoading, error } = useTestTypes();
+
+  if (!searchTerm) {
+    return null;
+  }
+
+  if (isLoading) {
+    return <TestTypeSearchSkeleton />;
+  }
+
+  if (error) {
+    return (
+      <Tile className={styles.emptyState}>
+        <div>
+          <h4 className={styles.productiveHeading01}>
+            {t('errorFetchingTestTypes', 'Error fetching results for "{searchTerm}"', {
+              searchTerm,
+            })}
+          </h4>
+          <p className={styles.bodyShort01}>
+            <span>{t('trySearchingAgain', 'Please try searching again')}</span>
+          </p>
+        </div>
+      </Tile>
+    );
+  }
+
+  return (
+    <>
+      {testTypes?.length ? (
+        <div className={styles.container}>
+          <div className={styles.orderBasketSearchResultsHeader}>
+            <span className={styles.searchResultsCount}>
+              {t('searchResultsMatchesForTerm', '{count} result{plural} for "{searchTerm}"', {
+                count: testTypes?.length,
+                searchTerm,
+                plural: testTypes?.length === 0 || testTypes?.length > 1 ? 's' : '',
+              })}
+            </span>
+            <Button kind="ghost" onClick={focusAndClearSearchInput} size={isTablet ? 'md' : 'sm'}>
+              {t('clearSearchResults', 'Clear Results')}
+            </Button>
+          </div>
+          <div className={styles.resultsContainer}>
+            {testTypes.map((testType) => (
+              <TestTypeSearchResultItem key={testType.conceptUuid} testType={testType} openOrderForm={openOrderForm} />
+            ))}
+          </div>
+        </div>
+      ) : (
+        <Tile className={styles.emptyState}>
+          <div>
+            <h4 className={styles.productiveHeading01}>
+              {t('noResultsForTestTypeSearch', 'No results to display for "{searchTerm}"', {
+                searchTerm,
+              })}
+            </h4>
+            <p className={styles.bodyShort01}>
+              <span>{t('tryTo', 'Try to')}</span>{' '}
+              <span className={styles.link} role="link" tabIndex={0} onClick={focusAndClearSearchInput}>
+                {t('searchAgain', 'search again')}
+              </span>{' '}
+              <span>{t('usingADifferentTerm', 'using a different term')}</span>
+            </p>
+          </div>
+        </Tile>
+      )}
+      <hr className={`${styles.divider} ${isTablet ? `${styles.tabletDivider}` : `${styles.desktopDivider}`}`} />
+    </>
+  );
+}
+
+interface TestTypeSearchResultItemProps {
+  testType: TestType;
+  openOrderForm: (searchResult: LabOrderBasketItem) => void;
+}
+
+const TestTypeSearchResultItem: React.FC<TestTypeSearchResultItemProps> = ({ testType, openOrderForm }) => {
+  const isTablet = useLayoutType() === 'tablet';
+  const session = useSession();
+  const { orders, setOrders } = useOrderBasket<LabOrderBasketItem>('labs', prepLabOrderPostData);
+  const testTypeAlreadyInBasket = useMemo(
+    () => orders?.some((order) => order.testType.conceptUuid === testType.conceptUuid),
+    [orders, testType],
+  );
+
+  const createLabOrder = useCallback(
+    (testType: TestType) => {
+      return createEmptyLabOrder(testType, session.currentProvider.uuid);
+    },
+    [session.currentProvider.uuid],
+  );
+
+  const { t } = useTranslation();
+
+  const addToBasket = useCallback(() => {
+    const labOrder = createLabOrder(testType);
+    setOrders([...orders, labOrder]);
+  }, [orders, setOrders, createLabOrder, testType]);
+
+  const removeFromBasket = useCallback(() => {
+    setOrders(orders.filter((order) => order.testType.conceptUuid != testType.conceptUuid));
+  }, [orders, setOrders, testType.conceptUuid]);
+
+  return (
+    <Tile
+      key={testType.conceptUuid}
+      role="listitem"
+      className={`${styles.searchResultTile} ${isTablet && styles.tabletSearchResultTile}`}
+    >
+      <div className={`${styles.searchResultTileContent} ${styles.text02}`}>
+        <p>
+          <span className={styles.productiveHeading01}>{testType.label}</span>{' '}
+        </p>
+      </div>
+      <div className={styles.searchResultActions}>
+        {testTypeAlreadyInBasket ? (
+          <Button
+            kind="danger--ghost"
+            renderIcon={(props) => <ShoppingCartArrowUp size={16} {...props} />}
+            onClick={() => removeFromBasket()}
+          >
+            {t('removeFromBasket', 'Remove from basket')}
+          </Button>
+        ) : (
+          <Button
+            kind="ghost"
+            renderIcon={(props) => <ShoppingCartArrowDown size={16} {...props} />}
+            onClick={() => addToBasket()}
+          >
+            {t('directlyAddToBasket', 'Add to basket')}
+          </Button>
+        )}
+        <Button
+          kind="ghost"
+          renderIcon={(props) => <ArrowRight size={16} {...props} />}
+          onClick={() => openOrderForm(createLabOrder(testType))}
+        >
+          {t('goToDrugOrderForm', 'Order form')}
+        </Button>
+      </div>
+    </Tile>
+  );
+};
+
+const TestTypeSearchSkeleton = () => {
+  const isTablet = useLayoutType() === 'tablet';
+  const tileClassName = `${isTablet ? `${styles.tabletSearchResultTile}` : `${styles.desktopSearchResultTile}`} ${
+    styles.skeletonTile
+  }`;
+  return (
+    <div className={styles.searchResultSkeletonWrapper}>
+      <div className={styles.orderBasketSearchResultsHeader}>
+        <SkeletonText className={styles.searchResultCntSkeleton} />
+        <ButtonSkeleton size={isTablet ? 'md' : 'sm'} />
+      </div>
+      <Tile className={tileClassName}>
+        <SkeletonText />
+      </Tile>
+      <Tile className={tileClassName}>
+        <SkeletonText />
+      </Tile>
+      <Tile className={tileClassName}>
+        <SkeletonText />
+      </Tile>
+      <Tile className={tileClassName}>
+        <SkeletonText />
+      </Tile>
+      <hr className={`${styles.divider} ${isTablet ? `${styles.tabletDivider}` : `${styles.desktopDivider}`}`} />
+    </div>
+  );
+};

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, ButtonSkeleton, Layer, Search, SkeletonText, Tile } from '@carbon/react';
 import { ArrowRight, ShoppingCartArrowDown, ShoppingCartArrowUp } from '@carbon/react/icons';
 import { useDebounce, useLayoutType, useSession } from '@openmrs/esm-framework';
-import { useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import { closeWorkspace, launchPatientWorkspace, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { LabOrderBasketItem, prepLabOrderPostData } from '../api';
 import styles from './test-type-search.scss';
 import { TestType, useTestTypes } from './useTestTypes';
@@ -159,6 +159,8 @@ const TestTypeSearchResultItem: React.FC<TestTypeSearchResultItemProps> = ({ tes
   const addToBasket = useCallback(() => {
     const labOrder = createLabOrder(testType);
     setOrders([...orders, labOrder]);
+    closeWorkspace('add-lab-order', true);
+    launchPatientWorkspace('order-basket');
   }, [orders, setOrders, createLabOrder, testType]);
 
   const removeFromBasket = useCallback(() => {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
@@ -30,7 +30,7 @@ export function TestTypeSearch({ openLabForm }: TestTypeSearchProps) {
   };
 
   return (
-    <div className={styles.searchPopupContainer}>
+    <>
       <ResponsiveWrapper isTablet={isTablet}>
         <Search
           size="lg"
@@ -46,7 +46,7 @@ export function TestTypeSearch({ openLabForm }: TestTypeSearchProps) {
         openOrderForm={openLabForm}
         focusAndClearSearchInput={focusAndClearSearchInput}
       />
-    </div>
+    </>
   );
 }
 

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
@@ -63,11 +63,7 @@ interface TestTypeSearchResultsProps {
 function TestTypeSearchResults({ searchTerm, openOrderForm, focusAndClearSearchInput }: TestTypeSearchResultsProps) {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
-  const { testTypes, isLoading, error } = useTestTypes();
-
-  if (!searchTerm) {
-    return null;
-  }
+  const { testTypes, isLoading, error } = useTestTypes(searchTerm);
 
   if (isLoading) {
     return <TestTypeSearchSkeleton />;
@@ -94,18 +90,20 @@ function TestTypeSearchResults({ searchTerm, openOrderForm, focusAndClearSearchI
     <>
       {testTypes?.length ? (
         <div className={styles.container}>
-          <div className={styles.orderBasketSearchResultsHeader}>
-            <span className={styles.searchResultsCount}>
-              {t('searchResultsMatchesForTerm', '{count} result{plural} for "{searchTerm}"', {
-                count: testTypes?.length,
-                searchTerm,
-                plural: testTypes?.length === 0 || testTypes?.length > 1 ? 's' : '',
-              })}
-            </span>
-            <Button kind="ghost" onClick={focusAndClearSearchInput} size={isTablet ? 'md' : 'sm'}>
-              {t('clearSearchResults', 'Clear Results')}
-            </Button>
-          </div>
+          {searchTerm && (
+            <div className={styles.orderBasketSearchResultsHeader}>
+              <span className={styles.searchResultsCount}>
+                {t('searchResultsMatchesForTerm', '{count} result{plural} for "{searchTerm}"', {
+                  count: testTypes?.length,
+                  searchTerm,
+                  plural: testTypes?.length === 0 || testTypes?.length > 1 ? 's' : '',
+                })}
+              </span>
+              <Button kind="ghost" onClick={focusAndClearSearchInput} size={isTablet ? 'md' : 'sm'}>
+                {t('clearSearchResults', 'Clear Results')}
+              </Button>
+            </div>
+          )}
           <div className={styles.resultsContainer}>
             {testTypes.map((testType) => (
               <TestTypeSearchResultItem key={testType.conceptUuid} testType={testType} openOrderForm={openOrderForm} />

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
@@ -1,7 +1,8 @@
-import useSWRImmutable from 'swr/immutable';
-import { Concept } from '../../types';
-import { FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
+import useSWRImmutable from 'swr/immutable';
+import fuzzy from 'fuzzy';
+import { FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { Concept } from '../../types';
 
 export interface TestType {
   label: string;
@@ -14,7 +15,7 @@ export interface UseTestType {
   error: Error;
 }
 
-export function useTestTypes(): UseTestType {
+export function useTestTypes(searchTerm: string = ''): UseTestType {
   const { data, error, isLoading } = useSWRImmutable<FetchResponse<{ results: Array<Concept> }>>(
     () => `/ws/rest/v1/concept?class=Test`,
     openmrsFetch,
@@ -33,8 +34,14 @@ export function useTestTypes(): UseTestType {
     }));
   }, [data]);
 
+  const filteredTestTypes = useMemo(() => {
+    return searchTerm
+      ? fuzzy.filter(searchTerm, testTypes, { extract: (testType) => testType.label }).map((result) => result.original)
+      : testTypes;
+  }, [testTypes, searchTerm]);
+
   return {
-    testTypes: testTypes,
+    testTypes: filteredTestTypes,
     isLoading: isLoading,
     error: error,
   };

--- a/packages/esm-patient-labs-app/src/lab-orders/api.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/api.ts
@@ -57,7 +57,7 @@ export function prepLabOrderPostData(order: LabOrderBasketItem, patientUuid: str
     action: 'NEW',
     patient: patientUuid,
     type: 'testorder',
-    careSetting: order.careSetting,
+    careSetting: careSettingUuid,
     orderer: order.orderer,
     encounter: encounterUuid,
     concept: order.testType.conceptUuid,

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-icon.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-icon.component.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import style from './lab-icon.scss';
 
-export function LabIcon() {
+interface LabIconProps {
+  isTablet: boolean;
+}
+
+export default function LabIcon({ isTablet }: LabIconProps) {
+  const size = isTablet ? 40 : 24;
   return (
     <div className={style.background}>
-      <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
           fillRule="evenodd"
           clipRule="evenodd"

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-icon.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-icon.scss
@@ -1,7 +1,3 @@
 .background {
-  width: 40px;
-  height: 40px;
-  margin: 1px 8px 7px 0;
-  padding: 4px;
   background-color: #e8daff;
 }

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.extension.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.extension.tsx
@@ -4,10 +4,10 @@ import { Button, Tile } from '@carbon/react';
 import { Add, ChevronDown, ChevronUp } from '@carbon/react/icons';
 import { useLayoutType } from '@openmrs/esm-framework';
 import { launchPatientWorkspace, OrderBasketItem, useOrderBasket } from '@openmrs/esm-patient-common-lib';
-import styles from './lab-order-basket-panel.scss';
 import { LabOrderBasketItemTile } from './lab-order-basket-item-tile.component';
-import { LabIcon } from './lab-icon.component';
 import { prepLabOrderPostData } from '../api';
+import LabIcon from './lab-icon.component';
+import styles from './lab-order-basket-panel.scss';
 
 /**
  * Designs: https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/648c44d9d4052c613e7f23da
@@ -43,17 +43,18 @@ export default function LabOrderBasketPanelExtension() {
     <Tile className={`${isTablet ? styles.tabletTile : styles.desktopTile} ${!isExpanded && styles.collapsedTile}`}>
       <div className={styles.heading}>
         <div className={styles.title}>
-          <div className={styles.headingIcon}>
-            <LabIcon />
+          <div className={`${isTablet ? styles.tabletIcon : styles.desktopIcon}`}>
+            <LabIcon isTablet={isTablet} />
           </div>
           <h4>{`${t('labOrders', 'Lab orders')} (${orders.length})`}</h4>
         </div>
-        <div>
+        <div className={styles.buttonContainer}>
           <Button
             kind="ghost"
             renderIcon={(props) => <Add size={16} {...props} />}
             iconDescription="Add lab order"
             onClick={openNewLabForm}
+            size={isTablet ? 'lg' : 'sm'}
           >
             {t('add', 'Add')}
           </Button>

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.extension.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.extension.tsx
@@ -59,6 +59,7 @@ export default function LabOrderBasketPanelExtension() {
             {t('add', 'Add')}
           </Button>
           <Button
+            className={styles.chevron}
             hasIconOnly
             kind="ghost"
             renderIcon={(props) =>

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.scss
@@ -33,7 +33,7 @@
   justify-content: space-between;
   align-items: center;
   text-align: left;
-  text-transform: capitalize;
+
   h4 {
     @include type.type-style('heading-compact-02');
     color: $text-02;
@@ -42,13 +42,22 @@
 
 .desktopTile .heading {
   border-left: 4px solid #6929c4;
+
+  h4 {
+    @include type.type-style('heading-compact-02');
+    color: $text-02;
+  }
 }
 
 .tabletTile .heading {
   padding: spacing.$spacing-03;
-  border-top: 1px solid $grey-2;
-  border-right: 1px solid $grey-2;
-  border-left: 1px solid $grey-2;
+  border: 1px solid $grey-2;
+  border-bottom: none;
+
+  h4 {
+    @include type.type-style('heading-03');
+    color: $ui-05;
+  }
 }
 
 .title {
@@ -56,6 +65,15 @@
   align-items: center;
 }
 
-.headingIcon {
-   margin: 0.3rem 0.8rem 0 0.3rem;
+.desktopIcon {
+  margin: 0.25rem 0.5rem 0.25rem 0.25rem;
+}
+
+.tabletIcon {
+  margin: 1rem 0.5rem 1rem 1rem;
+}
+
+.buttonContainer {
+  display: flex;
+  align-items: baseline;
 }

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.scss
@@ -77,3 +77,9 @@
   display: flex;
   align-items: baseline;
 }
+
+.chevron {
+  svg {
+    fill: black;
+  }
+}

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
@@ -1,10 +1,9 @@
 import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Layer, Search } from '@carbon/react';
-import { useLayoutType } from '@openmrs/esm-framework';
+import { useDebounce, useLayoutType } from '@openmrs/esm-framework';
 import OrderBasketSearchResults from './order-basket-search-results.component';
 import styles from './order-basket-search.scss';
-import { useDebounce } from './drug-search.resource';
 import { DrugOrderBasketItem } from '../../types';
 
 export interface DrugSearchProps {

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.resource.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.resource.tsx
@@ -19,22 +19,6 @@ export interface DrugSearchResult {
   };
 }
 
-export function useDebounce(value: string, delay = 300) {
-  const [debouncedValue, setDebouncedValue] = useState(value);
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [value, delay]);
-
-  return debouncedValue;
-}
-
 export function useDrugSearch(query: string): {
   isLoading: boolean;
   drugs: Array<DrugSearchResult>;

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
@@ -122,7 +122,7 @@ const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({ drug, openO
   } = useDrugTemplate(drug?.uuid);
   const { t } = useTranslation();
   const config = useConfig() as ConfigObject;
-  const orderItems: Array<DrugOrderBasketItem> = useMemo(
+  const drugItemTemplateOptions: Array<DrugOrderBasketItem> = useMemo(
     () =>
       templates?.length
         ? templates.map((template) => getTemplateOrderBasketItem(drug, config?.daysDurationUnit, template))
@@ -148,7 +148,7 @@ const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({ drug, openO
 
   return (
     <>
-      {orderItems.map((orderItem, indx) => (
+      {drugItemTemplateOptions.map((orderItem, indx) => (
         <Tile
           key={templates?.length ? templates[indx]?.uuid : drug?.uuid}
           role="listitem"

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.scss
@@ -109,15 +109,11 @@
   cursor: pointer;
 }
 
-.resultsContainer {
-}
-
 .resultsContainer::-webkit-scrollbar {
   width: spacing.$spacing-03;
 }
 
 .resultsContainer::-webkit-scrollbar-thumb {
-  // background: $ui-04;
   border-radius: spacing.$spacing-02;
 }
 

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.scss
@@ -66,11 +66,6 @@
   justify-content: flex-end;
 }
 
-.addToBasketButton {
-  color: #000;
-  flex: 0 0 auto;
-}
-
 .errorLabel {
   @extend .label01;
   color: $danger;

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.extension.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.extension.tsx
@@ -5,10 +5,10 @@ import { Add, ChevronDown, ChevronUp } from '@carbon/react/icons';
 import { useLayoutType } from '@openmrs/esm-framework';
 import { launchPatientWorkspace, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { prepMedicationOrderPostData } from '../api/api';
-import styles from './drug-order-basket-panel.scss';
+import type { DrugOrderBasketItem } from '../types';
 import OrderBasketItemTile from './order-basket-item-tile.component';
 import RxIcon from './rx-icon.component';
-import { DrugOrderBasketItem } from '../types';
+import styles from './drug-order-basket-panel.scss';
 
 /**
  * Designs: https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/62c6bb9500e7671a618efa56
@@ -48,17 +48,18 @@ export default function DrugOrderBasketPanelExtension() {
     <Tile className={`${isTablet ? styles.tabletTile : styles.desktopTile} ${!isExpanded && styles.collapsedTile}`}>
       <div className={styles.heading}>
         <div className={styles.title}>
-          <div className={styles.headingIcon}>
-            <RxIcon />
+          <div className={`${isTablet ? styles.tabletIcon : styles.desktopIcon}`}>
+            <RxIcon isTablet={isTablet} />
           </div>
           <h4>{`${t('drugOrders', 'Drug orders')} (${orders.length})`}</h4>
         </div>
-        <div>
+        <div className={styles.buttonContainer}>
           <Button
             kind="ghost"
             renderIcon={(props) => <Add size={16} {...props} />}
             iconDescription="Add medication"
             onClick={openDrugSearch}
+            size={isTablet ? 'lg' : 'sm'}
           >
             {t('add', 'Add')}
           </Button>

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.extension.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.extension.tsx
@@ -64,6 +64,7 @@ export default function DrugOrderBasketPanelExtension() {
             {t('add', 'Add')}
           </Button>
           <Button
+            className={styles.chevron}
             hasIconOnly
             kind="ghost"
             renderIcon={(props) =>

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
@@ -33,22 +33,27 @@
   justify-content: space-between;
   align-items: center;
   text-align: left;
-  text-transform: capitalize;
+
+}
+
+.desktopTile .heading {
+  border-left: 4px solid #0072c3;
+
   h4 {
     @include type.type-style('heading-compact-02');
     color: $text-02;
   }
 }
 
-.desktopTile .heading {
-  border-left: 4px solid #0072c3;
-}
-
 .tabletTile .heading {
   padding: spacing.$spacing-03;
-  border-top: 1px solid $grey-2;
-  border-right: 1px solid $grey-2;
-  border-left: 1px solid $grey-2;
+  border: 1px solid $grey-2;
+  border-bottom: none;
+
+  h4 {
+    @include type.type-style('heading-03');
+    color: $ui-05;
+  }
 }
 
 .title {
@@ -56,6 +61,15 @@
   align-items: center;
 }
 
-.headingIcon {
-   margin: 0.3rem 0.8rem 0 0.3rem;
+.desktopIcon {
+  margin: 0.25rem 0.5rem 0.25rem 0.25rem;
+}
+
+.tabletIcon {
+  margin: 1rem 0.5rem 1rem 1rem;
+}
+
+.buttonContainer {
+  display: flex;
+  align-items: baseline;
 }

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
@@ -73,3 +73,9 @@
   display: flex;
   align-items: baseline;
 }
+
+.chevron {
+  svg {
+    fill: black;
+  }
+}

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/rx-icon.component.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/rx-icon.component.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import style from './rx-icon.scss';
 
-export default function RxIcon() {
+interface RxIconProps {
+  isTablet: boolean;
+}
+
+function RxIcon({ isTablet }: RxIconProps) {
+  const size = isTablet ? 40 : 24;
   return (
     <div className={style.background}>
-      <svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg">
+      <svg width={size} height={size} viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg">
         <path
           d="M5.667 25.701V2.334h9.32c3.83-.038 6.304 2.152 6.509 6.033.066 1.262-.235 3.03-.665 3.887-.43.857-1.55 2.654-4.031 3.128l1.582 3.044 2.94-3.706H24l-4.58 5.73 2.753 5.251H18.98l-1.495-2.927-2.267 2.927H12.48l3.961-5.055-2.515-5.002h-5.47v10.057h-2.79zm2.796-12.447h6.911c.804-.053 3.133-.053 3.133-4.732 0-3.077-1.87-3.721-3.55-3.712H8.464v8.444z"
           fill="#0072C3"
@@ -14,3 +19,5 @@ export default function RxIcon() {
     </div>
   );
 }
+
+export default RxIcon;

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/rx-icon.scss
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/rx-icon.scss
@@ -1,7 +1,3 @@
 .background {
-  width: 40px;
-  height: 40px;
-  margin: 1px 8px 7px 0;
-  padding: 7px 6.7px 6.3px 6.7px;
   background-color: #bae6ff;
 }

--- a/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
@@ -177,7 +177,7 @@ function showOrderFailureToast(t: TFunction) {
     critical: true,
     kind: 'error',
     title: t('error', 'Error'),
-    description: t('errorSavingMedicationOrder', 'There were errors saving some medication orders.'),
+    description: t('errorSavingOrder', 'There were errors saving some orders.'),
   });
 }
 

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -32,6 +32,10 @@ interface ProgramsDetailedSummaryProps {
   patientUuid: string;
 }
 
+interface ProgramEditButtonProps {
+  programEnrollmentId: string;
+}
+
 const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const displayText = t('programEnrollments', 'Program enrollments');
@@ -41,7 +45,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
   const isTablet = layout === 'tablet';
   const isDesktop = desktopLayout(layout);
 
-  const { enrollments, isLoading, isError, isValidating, availablePrograms, eligiblePrograms, configurablePrograms } =
+  const { enrollments, isLoading, isError, isValidating, availablePrograms, eligiblePrograms } =
     usePrograms(patientUuid);
 
   const tableHeaders: Array<typeof DataTableHeader> = React.useMemo(
@@ -151,10 +155,6 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
   }
   return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchProgramsForm} />;
 };
-
-interface ProgramEditButtonProps {
-  programEnrollmentId: string;
-}
 
 function ProgramEditButton({ programEnrollmentId }: ProgramEditButtonProps) {
   const isTablet = useLayoutType() === 'tablet';

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -20,7 +20,6 @@ import {
   formatDate,
   formatDatetime,
   useConfig,
-  usePagination,
   ConfigObject,
   useLayoutType,
   isDesktop as desktopLayout,
@@ -38,20 +37,12 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
   const displayText = t('programEnrollments', 'Program enrollments');
   const headerTitle = t('carePrograms', 'Care Programs');
   const config = useConfig() as ConfigObject;
-  const programsCount = 5;
-  const isConfigurable = config.customUrl ? true : false;
   const layout = useLayoutType();
   const isTablet = layout === 'tablet';
   const isDesktop = desktopLayout(layout);
 
   const { enrollments, isLoading, isError, isValidating, availablePrograms, eligiblePrograms, configurablePrograms } =
     usePrograms(patientUuid);
-
-  const {
-    results: paginatedEnrollments,
-    goTo,
-    currentPage,
-  } = usePagination(isConfigurable ? configurablePrograms : enrollments ?? [], programsCount);
 
   const tableHeaders: Array<typeof DataTableHeader> = React.useMemo(
     () => [

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
@@ -10,7 +10,6 @@ import ProgramsDetailedSummary from './programs-detailed-summary.component';
 jest.setTimeout(20000);
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
-const mockUsePagination = usePagination as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -18,11 +17,6 @@ jest.mock('@openmrs/esm-framework', () => {
   return {
     ...originalModule,
     openmrsFetch: jest.fn(),
-    usePagination: jest.fn().mockImplementation(() => ({
-      currentPage: 1,
-      goTo: () => {},
-      results: [],
-    })),
   };
 });
 
@@ -75,11 +69,6 @@ describe('ProgramsDetailedSummary ', () => {
     const user = userEvent.setup();
 
     mockOpenmrsFetch.mockReturnValueOnce({ data: { results: mockEnrolledProgramsResponse } });
-    mockUsePagination.mockImplementation(() => ({
-      currentPage: 1,
-      goTo: () => {},
-      results: mockEnrolledProgramsResponse.slice(0, 5),
-    }));
 
     renderProgramsOverview();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/react-spectrum-ui@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@adobe/react-spectrum-ui@npm:1.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 18ad87c76e2019f22fa9f18df22fc06cb99e27d46fc82ed6974a4cab1d04c6a223ded51fae95d0890069cb7c9a10add468e5e9c62b9b33ac9b5ab9de25ff12e5
+  languageName: node
+  linkType: hard
+
+"@adobe/react-spectrum-workflow@npm:2.3.4":
+  version: 2.3.4
+  resolution: "@adobe/react-spectrum-workflow@npm:2.3.4"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 1c008fec02f19160a6a0589f9647d29b9652322b087ba521ba7e890747a23c70268c2e58799977823a65a8c44d832162743e0ecb3b082614bc70ba59a6eac2fc
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:2.2.0, @ampproject/remapping@npm:^2.1.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -3698,6 +3718,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.22.15, @babel/runtime@npm:^7.8.7":
+  version: 7.23.2
+  resolution: "@babel/runtime@npm:7.23.2"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: 6c4df4839ec75ca10175f636d6362f91df8a3137f86b38f6cd3a4c90668a0fe8e9281d320958f4fbd43b394988958585a17c3aab2a4ea6bf7316b22916a371fb
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:7.18.10, @babel/template@npm:^7.18.10":
   version: 7.18.10
   resolution: "@babel/template@npm:7.18.10"
@@ -3849,6 +3878,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/charts@npm:^1.12.0":
+  version: 1.13.6
+  resolution: "@carbon/charts@npm:1.13.6"
+  dependencies:
+    "@carbon/colors": ^11.19.0
+    "@carbon/telemetry": ~0.1.0
+    "@carbon/utils-position": ^1.1.4
+    carbon-components: ^10.58.10
+    d3: ^7.8.5
+    d3-cloud: ^1.2.7
+    d3-sankey: ^0.12.3
+    date-fns: ^2.30.0
+    html-to-image: ^1.11.11
+    lodash-es: ^4.17.21
+    topojson-client: ^3.1.0
+    tslib: ^2.6.2
+  peerDependencies:
+    d3: ^7.0.0
+    d3-cloud: ^1.2.5
+    d3-sankey: ^0.12.3
+  peerDependenciesMeta:
+    d3-cloud:
+      optional: true
+    d3-sankey:
+      optional: true
+  checksum: 8aebcf793f3fdd0d60633f54bad3b252a93f55aeac245405544ef70cc071c209cab84745d116bb748f590ccafa534c739d77765b28e3987d3f6c737f154b8568
+  languageName: node
+  linkType: hard
+
 "@carbon/charts@npm:^1.5.2, @carbon/charts@npm:^1.6.1":
   version: 1.6.1
   resolution: "@carbon/charts@npm:1.6.1"
@@ -3868,29 +3926,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/charts@npm:^1.6.3":
-  version: 1.6.8
-  resolution: "@carbon/charts@npm:1.6.8"
-  dependencies:
-    "@carbon/styles": ^1.4.0
-    "@carbon/telemetry": 0.1.0
-    "@carbon/utils-position": 1.1.1
-    carbon-components: ^10.56.0
-    d3-cloud: 1.2.5
-    d3-sankey: 0.12.3
-    date-fns: 2.8.1
-    lodash-es: 4.17.21
-    resize-observer-polyfill: 1.5.0
-  peerDependencies:
-    d3: 7.x
-  checksum: 1c4b2e9ed2155a19d88ad9de0a9a9ac1394092cf4eb2776205f645ba2ad30972ca598673299ff02d284ac43a3f0416dc92623bc9812539df91875ed7d7f30dd9
-  languageName: node
-  linkType: hard
-
 "@carbon/colors@npm:^11.17.1":
   version: 11.17.1
   resolution: "@carbon/colors@npm:11.17.1"
   checksum: 500764927dfb2e50d69cd365951a8fbd2fe031747f8fbae771751bda1f833608264c4690301879cdc8517232c0dfc93f0c40609fa985e66a35e36c0296f47c47
+  languageName: node
+  linkType: hard
+
+"@carbon/colors@npm:^11.19.0":
+  version: 11.19.0
+  resolution: "@carbon/colors@npm:11.19.0"
+  checksum: ea0448e90e05768c615af71955e5fe4435583e3637d039912336ba8b123fbbd841078df98cb71e56ebb0a0be04c88fed3fe34408585bdf3a11cb6297b9ce14b5
   languageName: node
   linkType: hard
 
@@ -3908,6 +3954,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/feature-flags@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "@carbon/feature-flags@npm:0.16.0"
+  checksum: 1fb964311f240c65fd57ee5971234b0c7b665d660b89ac931d0acc3d140ae0bed1b04eb8fc629f675a307be9579d9c4de317987749878b5a48bb364cbffd85d1
+  languageName: node
+  linkType: hard
+
 "@carbon/feature-flags@npm:^0.9.0":
   version: 0.9.0
   resolution: "@carbon/feature-flags@npm:0.9.0"
@@ -3921,6 +3974,15 @@ __metadata:
   dependencies:
     "@carbon/layout": ^11.16.1
   checksum: 70475ec21a7614c1c1ceca691b2e59f7d54115c222027f485120f89606aa97710bbe88d51c1db0509cd4bc94acf3914e9d48ca7e78b11ade8ca6498889385987
+  languageName: node
+  linkType: hard
+
+"@carbon/grid@npm:^11.20.0":
+  version: 11.20.0
+  resolution: "@carbon/grid@npm:11.20.0"
+  dependencies:
+    "@carbon/layout": ^11.19.0
+  checksum: 1f23b7f174880eac0ec37af6088a725694ad1bc7104c9c39978f301c8900fa1f9932e41d72b030577c28e15136ab0a5f967dca2b843d297dd265040ba1fc104c
   languageName: node
   linkType: hard
 
@@ -3951,6 +4013,13 @@ __metadata:
   version: 10.42.1
   resolution: "@carbon/icon-helpers@npm:10.42.1"
   checksum: 98981041d7fb44258c227825eb704b0f25fc6f1cc84d500d5cf0feba71307f5c1e1734f37608c9bb9836b5c864bafc8c6aa9f422f99250f662f67ad2c87708f7
+  languageName: node
+  linkType: hard
+
+"@carbon/icon-helpers@npm:^10.44.0":
+  version: 10.44.0
+  resolution: "@carbon/icon-helpers@npm:10.44.0"
+  checksum: c61b711ef78ba5546514917571ccec01c0943a2dc53d34a90987985bd839de7c164ce7bf9890d21012e585c1a655f6a5a9ac88492af4345653f095f9ddebe54a
   languageName: node
   linkType: hard
 
@@ -3993,10 +4062,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/icons-react@npm:^11.28.0":
+  version: 11.28.0
+  resolution: "@carbon/icons-react@npm:11.28.0"
+  dependencies:
+    "@carbon/icon-helpers": ^10.44.0
+    "@carbon/telemetry": 0.1.0
+    prop-types: ^15.7.2
+  peerDependencies:
+    react: ">=16"
+  checksum: c52c63835b43feb3177c4a90161dfb5191a542be0dfe6a3196af96a675f58b75e6c82718413653a313829c04c06d68072a21be66f7d36e39566e61609debaabd
+  languageName: node
+  linkType: hard
+
 "@carbon/layout@npm:^11.16.1":
   version: 11.16.1
   resolution: "@carbon/layout@npm:11.16.1"
   checksum: 83660f70dbbdac09bd3fb9d94c3c9c53b84557fb88f011452db84939a898d28bd57030e6c233088b6a9f68dfec8f76bdc073945b922d4bfdc76e055787201a65
+  languageName: node
+  linkType: hard
+
+"@carbon/layout@npm:^11.19.0":
+  version: 11.19.0
+  resolution: "@carbon/layout@npm:11.19.0"
+  checksum: 9786a9d13fc81132c33a05019fae1d6ed786739a285e276f76857d30bba7b5a58cb093c700fb7c8b697d7a199459c398f842d6a42351d02c3d67e7961fadd901
   languageName: node
   linkType: hard
 
@@ -4011,6 +4100,13 @@ __metadata:
   version: 11.13.1
   resolution: "@carbon/motion@npm:11.13.1"
   checksum: 0aa6aa062be02225c5ca2c34d4a9667ef09dc4ce415d29308d43e458ab0fca73655274632a08d8b72e8274c523088c03e680ad8778be033e6eb92f58ee5b2735
+  languageName: node
+  linkType: hard
+
+"@carbon/motion@npm:^11.15.0":
+  version: 11.15.0
+  resolution: "@carbon/motion@npm:11.15.0"
+  checksum: 985a559324fb4cb6b1df50ead3d9c1ceefec338f075f5cca4a9d937888cb6b357207a20493807eed47627e41529de215e4b51e0e217eee12970c1b8da2ce1b90
   languageName: node
   linkType: hard
 
@@ -4087,6 +4183,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/react@npm:^1.37.0":
+  version: 1.40.0
+  resolution: "@carbon/react@npm:1.40.0"
+  dependencies:
+    "@babel/runtime": ^7.18.3
+    "@carbon/feature-flags": ^0.16.0
+    "@carbon/icons-react": ^11.28.0
+    "@carbon/layout": ^11.19.0
+    "@carbon/styles": ^1.40.0
+    "@carbon/telemetry": 0.1.0
+    classnames: 2.3.2
+    copy-to-clipboard: ^3.3.1
+    downshift: 8.2.1
+    flatpickr: 4.6.9
+    invariant: ^2.2.3
+    lodash.debounce: ^4.0.8
+    lodash.findlast: ^4.5.0
+    lodash.isequal: ^4.5.0
+    lodash.omit: ^4.5.0
+    lodash.throttle: ^4.1.1
+    prop-types: ^15.7.2
+    react-is: ^18.2.0
+    use-resize-observer: ^6.0.0
+    wicg-inert: ^3.1.1
+    window-or-global: ^1.0.1
+  peerDependencies:
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0
+    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0
+    sass: ^1.33.0
+  checksum: 84e24e649dbdcf8c56b3603f1e7bc7dbb0d9c38b700c35f5134d23c07580012ef94f147676b86232aec7fcb58cc2e98a618fe6afa0793f21d1206f677a756358
+  languageName: node
+  linkType: hard
+
 "@carbon/styles@npm:^1.17.0, @carbon/styles@npm:^1.4.0":
   version: 1.17.0
   resolution: "@carbon/styles@npm:1.17.0"
@@ -4126,6 +4255,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/styles@npm:^1.40.0":
+  version: 1.40.0
+  resolution: "@carbon/styles@npm:1.40.0"
+  dependencies:
+    "@carbon/colors": ^11.19.0
+    "@carbon/feature-flags": ^0.16.0
+    "@carbon/grid": ^11.20.0
+    "@carbon/layout": ^11.19.0
+    "@carbon/motion": ^11.15.0
+    "@carbon/themes": ^11.25.0
+    "@carbon/type": ^11.24.0
+    "@ibm/plex": 6.0.0-next.6
+  peerDependencies:
+    sass: ^1.33.0
+  peerDependenciesMeta:
+    sass:
+      optional: true
+  checksum: b1021d9ce683e9259473b35863d1a1b6f749b2c9596c5badd16f16db55e9ec9587ef44325dd47ad95ecf6ee895e051053c9ce7edc50fc49ecd9c4fbd464d18de
+  languageName: node
+  linkType: hard
+
 "@carbon/styles@npm:~1.14.0":
   version: 1.14.0
   resolution: "@carbon/styles@npm:1.14.0"
@@ -4144,7 +4294,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/telemetry@npm:0.1.0":
+"@carbon/telemetry@npm:0.1.0, @carbon/telemetry@npm:~0.1.0":
   version: 0.1.0
   resolution: "@carbon/telemetry@npm:0.1.0"
   bin:
@@ -4177,6 +4327,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/themes@npm:^11.25.0":
+  version: 11.25.0
+  resolution: "@carbon/themes@npm:11.25.0"
+  dependencies:
+    "@carbon/colors": ^11.19.0
+    "@carbon/layout": ^11.19.0
+    "@carbon/type": ^11.24.0
+    color: ^4.0.0
+  checksum: 85d774d8ded4f7c8b8faba87521d4544300db75cb03071c60910936bba728ca855ed98926347fa568e58bc85e40b535846bc8a449509b545c67cee3ae7e700b8
+  languageName: node
+  linkType: hard
+
 "@carbon/type@npm:^11.10.0, @carbon/type@npm:^11.11.0":
   version: 11.11.0
   resolution: "@carbon/type@npm:11.11.0"
@@ -4197,10 +4359,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/type@npm:^11.24.0":
+  version: 11.24.0
+  resolution: "@carbon/type@npm:11.24.0"
+  dependencies:
+    "@carbon/grid": ^11.20.0
+    "@carbon/layout": ^11.19.0
+  checksum: 98c6a49cbe4cbcf1fef959b356e1e87c5197f2b19f72e7255abb3131dcc77f1832e0920d16d09cab0ea67dcc72f90f47ec6969052bf8e82302f7faf00f733795
+  languageName: node
+  linkType: hard
+
 "@carbon/utils-position@npm:1.1.1":
   version: 1.1.1
   resolution: "@carbon/utils-position@npm:1.1.1"
   checksum: 4919f41e07c54068cea6dab9e5a649772d4c8c6c45ac9121592e726fe3efd7f21b7e8c1ce233832f35894c6e1d0c4012aaeb950f55ed196e15d8e5decd89b2f6
+  languageName: node
+  linkType: hard
+
+"@carbon/utils-position@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@carbon/utils-position@npm:1.1.4"
+  checksum: b62b469e7985689f3f2b4afece26a60b08511eebe74ccb585e6fee65daf5973992c58ded70176230e5c5fcccd2dbf7a65280abd7607a99739e2f4004fb69b1ec
   languageName: node
   linkType: hard
 
@@ -4741,6 +4920,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/ecma402-abstract@npm:1.17.2":
+  version: 1.17.2
+  resolution: "@formatjs/ecma402-abstract@npm:1.17.2"
+  dependencies:
+    "@formatjs/intl-localematcher": 0.4.2
+    tslib: ^2.4.0
+  checksum: 026382b1fb295cef4387b2f2a34dace107b12fb7607793093b26595b0d639a30e5f4539665730897eb77eefabee2bb35c156896c63925b0ec03b746751e3fb00
+  languageName: node
+  linkType: hard
+
+"@formatjs/fast-memoize@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@formatjs/fast-memoize@npm:2.2.0"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: 8697fe72a7ece252d600a7d08105f2a2f758e2dd96f54ac0a4c508b1205a559fc08835635e1f8e5ca9dcc3ee61ce1fca4a0e7047b402f29fc96051e293a280ff
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-messageformat-parser@npm:2.7.0":
+  version: 2.7.0
+  resolution: "@formatjs/icu-messageformat-parser@npm:2.7.0"
+  dependencies:
+    "@formatjs/ecma402-abstract": 1.17.2
+    "@formatjs/icu-skeleton-parser": 1.6.2
+    tslib: ^2.4.0
+  checksum: 5c289b0090a3549fdeb5ee4c382666cf085be77c8a10abcee879e12e064126ec803a48d7f564a3cb5baf4529ef5fde3a61b30f9c54481279f0fb2cf2e9be1e7e
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-skeleton-parser@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@formatjs/icu-skeleton-parser@npm:1.6.2"
+  dependencies:
+    "@formatjs/ecma402-abstract": 1.17.2
+    tslib: ^2.4.0
+  checksum: f51658d0b086579a2173b91beb692822f08db1180c81fa41e62bef4236a0de98f9d6e46087d77c5e46fa4286f77b4b52a2467f3d8b81a4cf8dd817edb138d68b
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-localematcher@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@formatjs/intl-localematcher@npm:0.4.2"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: df579d8c453a11eed1ec55604f8dda121d728fc5109ed885892347a126089caef95a0edf71f1f6db3134bb9e73787062995baf7746a2577e8ca2980dcd6590cb
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -4793,6 +5021,43 @@ __metadata:
   version: 6.0.0-next.6
   resolution: "@ibm/plex@npm:6.0.0-next.6"
   checksum: cb7bece0f8688cf92a3fa37ab47c5921f22a2eb5e40dd72a3d6bbcd715910b0d79f9d160e229514a0c78c70679676746a93f4791a57407fc6aa636105aa11891
+  languageName: node
+  linkType: hard
+
+"@internationalized/date@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "@internationalized/date@npm:3.5.0"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  checksum: 621298a1686bad64212b1f2a497492dcc9d657a3789ea62a1a5ee1cb37719fa7a54944d4bb318bf22f709eccfcb6627e6d1aad9825aaa67c2150973ccca8c15d
+  languageName: node
+  linkType: hard
+
+"@internationalized/message@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@internationalized/message@npm:3.1.1"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+    intl-messageformat: ^10.1.0
+  checksum: c8658847e80a2dd6f5a253bdc20ce45d304ffa2147248e6422d72714ac501edd0d4cce09e4baf7753cd393e4df7014df747425ff9658728cd1f892d71c3d591b
+  languageName: node
+  linkType: hard
+
+"@internationalized/number@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "@internationalized/number@npm:3.3.0"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  checksum: 76e5bd0e7713d8010be90b2d3427371a0ee97e34e6d81da2c10587986503be308ab8bfd8f590e1d88977800f5d79f9e2d91e7ac1d6d34006575216027125f302
+  languageName: node
+  linkType: hard
+
+"@internationalized/string@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@internationalized/string@npm:3.1.1"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  checksum: 686b4d443dbf6794b5f32e0c3a0ee9333a64bfe2a01aec705fb71f5721f5c9e8aa25b380bdae85e21be0dc72103843642363efcaed437ebad3e7169e478b91ae
   languageName: node
   linkType: hard
 
@@ -6238,9 +6503,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-api@npm:5.1.0"
+"@openmrs/esm-api@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-api@npm:5.2.1-pre.1069"
   dependencies:
     "@types/fhir": 0.0.31
     lodash-es: ^4.17.21
@@ -6248,31 +6513,17 @@ __metadata:
     "@openmrs/esm-config": 5.x
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: 1cc3301fccb3f607dd5e85bea8162486c9b56ca71552545201c9f87ab6442fcedb708b499864a5b8397904d7a6f8340fbad1d9fd329aee6c843d91057b680810
+  checksum: 0b331c3b73c8dd245453bca42589c223b04fc126b69b6cd30863384dbc018c8532eb621aff6d3efef53ad99e111e667ec8f0ef78f79ef025cb0c16ba080c84fb
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-api@npm:5.1.1-pre.944"
+"@openmrs/esm-app-shell@npm:5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-app-shell@npm:5.2.1-pre.1069"
   dependencies:
-    "@types/fhir": 0.0.31
-    lodash-es: ^4.17.21
-  peerDependencies:
-    "@openmrs/esm-config": 5.x
-    "@openmrs/esm-error-handling": 5.x
-    "@openmrs/esm-offline": 5.x
-  checksum: 1b20af1f3aaf5995904cd8f6ec7cd074aaa88bc4d9cf8db4ddea9c930cd5d92ff7a916e75812c1af7c9f08664762ca80fdf171096006ede12fddd79fbece4ba4
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-app-shell@npm:5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-app-shell@npm:5.1.0"
-  dependencies:
-    "@carbon/react": ^1.12.0
-    "@openmrs/esm-framework": 5.1.0
-    "@openmrs/esm-styleguide": 5.1.0
+    "@carbon/react": ^1.37.0
+    "@openmrs/esm-framework": 5.2.1-pre.1069
+    "@openmrs/esm-styleguide": 5.2.1-pre.1069
     dayjs: ^1.10.4
     dexie: ^3.0.3
     html-webpack-plugin: ^5.5.0
@@ -6286,8 +6537,10 @@ __metadata:
     react-i18next: ^11.7.0
     react-router-dom: ^6.3.0
     rxjs: ^6.5.3
+    semver: ^7.3.4
     single-spa: ^5.9.2
     swc-loader: ^0.2.3
+    swr: ^2.2.2
     systemjs: ^6.8.3
     webpack: ^5.88.0
     webpack-pwa-manifest: ^4.3.0
@@ -6296,131 +6549,55 @@ __metadata:
     workbox-strategies: ^6.1.5
     workbox-webpack-plugin: ^6.1.5
     workbox-window: ^6.1.5
-  checksum: bef732adcbb99bf4a7e9e11bfdcea5c9b5719bc8cc71093db3eeec81b9d4aaa6d3de503a5817c02bb10704a152fe337f15d5280fd07dd16da52f829774b877b9
+  checksum: 35dfc22a1f9072b697bb1a392aad4d9d1b58539bfd2ba683e4ccd2c2d64fe0399829958275d6652be923e6880bee4f644b393368b3890352df39abd5f0cb51ef
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-app-shell@npm:5.1.1-pre.944"
-  dependencies:
-    "@carbon/react": ^1.12.0
-    "@openmrs/esm-framework": 5.1.1-pre.944
-    "@openmrs/esm-styleguide": 5.1.1-pre.944
-    dayjs: ^1.10.4
-    dexie: ^3.0.3
-    html-webpack-plugin: ^5.5.0
-    i18next: ^19.6.0
-    i18next-browser-languagedetector: ^4.3.1
-    i18next-icu: ^1.4.2
-    import-map-overrides: ^3.0.0
-    lodash-es: 4.17.21
-    react: ^18.1.0
-    react-dom: ^18.1.0
-    react-i18next: ^11.7.0
-    react-router-dom: ^6.3.0
-    rxjs: ^6.5.3
-    single-spa: ^5.9.2
-    swc-loader: ^0.2.3
-    systemjs: ^6.8.3
-    webpack: ^5.88.0
-    webpack-pwa-manifest: ^4.3.0
-    workbox-core: ^6.1.5
-    workbox-routing: ^6.1.5
-    workbox-strategies: ^6.1.5
-    workbox-webpack-plugin: ^6.1.5
-    workbox-window: ^6.1.5
-  checksum: d8b45293e481d1efbf3d1620e82c68ba1860d95422b2c76aa24b9c7fd4d917a26960d036d3b23af380678d9fbf85b941a813109b304b62340603f4a07c8de1a6
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-breadcrumbs@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-breadcrumbs@npm:5.1.0"
+"@openmrs/esm-breadcrumbs@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-breadcrumbs@npm:5.2.1-pre.1069"
   dependencies:
     path-to-regexp: 6.1.0
   peerDependencies:
     "@openmrs/esm-state": 5.x
-  checksum: a7d2f26bdec1d010680daf5c7edaf88037cc5ff88df8af4b36c1b40e95d998c0409de9fc62faa2d4afe4d48cd104a037a7b0bab85cace08b6b8fc28a6e99a93f
+  checksum: 50551d33c52e27589896d019b7da167fba27f8bd69c8128a5643a69fee9cf957e897feb380b70135bf66a32f27a686cf709ed24c6a38943f6105c566b341c88d
   languageName: node
   linkType: hard
 
-"@openmrs/esm-breadcrumbs@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-breadcrumbs@npm:5.1.1-pre.944"
-  dependencies:
-    path-to-regexp: 6.1.0
-  peerDependencies:
-    "@openmrs/esm-state": 5.x
-  checksum: 625879a1ba96592fb70727e817fcc6141bf0f28f018e85b96c8956e5cef3313843c017f79d055fea9cccc1078285968cc31cf79702e5f6be19bd8cedc59a62be
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-config@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-config@npm:5.1.0"
+"@openmrs/esm-config@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-config@npm:5.2.1-pre.1069"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: f4b4693df9a9b891a0a38ea5d3e848ddc64091d1e66d8d76075af09ec330c56aa3de18909e694d83ef9d4f7216e819aeb3ffcd5356dd442a7905c280bdb7de5f
+  checksum: a33a690d4e005b20e943b4c9e6fac61e46008890b6230c9554130760e21387bc3c8456a37548b3da1da6936ecf7fcc34156599bafc0c36eaa05cd42b08cc96d5
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-config@npm:5.1.1-pre.944"
-  dependencies:
-    ramda: ^0.26.1
+"@openmrs/esm-dynamic-loading@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.2.1-pre.1069"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-    "@openmrs/esm-state": 5.x
-    single-spa: 5.x
-  checksum: 64042c73aafc7a55ddbf32adf1102d8ae1a94594dd73a312d1c8d2e8b2a4a30abc25e6b5fd8e8d0b1593cf7c66940f4a896e3e381d85b48f308a94e7792d8eb1
+  checksum: cbe4bd1d26bebc383f40bdc3f5db759edfc4e3018ccaab138bca0e57d61ad9e19c927c8bb9923e65384cc2d83156e254f7bf490fbdae5be81b09dd7dbd2f0928
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.1.0"
+"@openmrs/esm-error-handling@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-error-handling@npm:5.2.1-pre.1069"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: c483e63ac4dbaf1e8804743cb0fb2f4c7b6e35671c61213823f661c8a6e83ea73a6b04e6d80a42dee345d76c5fa2107caf33a3cd6830483b6f044c56ebc0a64c
+  checksum: 1aedb24c31fc69fffb05121517d9ba446df517e5f1451c33ee79845065cb5a96a70b8680e44e3b14d7cecdcf50ad00999a3aa9a2e570e7eb3121f26bf7aa94bc
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.1.1-pre.944"
-  peerDependencies:
-    "@openmrs/esm-globals": 5.x
-  checksum: 3cc71018c610226b6c93d1e0b352e6f220cb1dba3c9eda860befd1d812ed28e3d124138043e10a3b6338c2ffd105ad24f907dfe9e8e6c06e8dc30aafafed2ae9
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-error-handling@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-error-handling@npm:5.1.0"
-  peerDependencies:
-    "@openmrs/esm-globals": 5.x
-  checksum: 6c63b28fc89169948cd2c2a38b04da19b70fd2773bffb12b173f57a3dba68474fee057b1697a79ed9203cb5007f5398d01d9e2aa0f59a3be8710f78d590567f6
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-error-handling@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-error-handling@npm:5.1.1-pre.944"
-  peerDependencies:
-    "@openmrs/esm-globals": 5.x
-  checksum: 21ee08203b1efc2c0250b9887adca322fe2ea59cf4936555333247170c2c9677f6383db4f06d68c5237d03d5dfc1003cd54b7e1d3a20295465baeee85fd136a3
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-extensions@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-extensions@npm:5.1.0"
+"@openmrs/esm-extensions@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-extensions@npm:5.2.1-pre.1069"
   dependencies:
     lodash-es: ^4.17.21
   peerDependencies:
@@ -6429,48 +6606,20 @@ __metadata:
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 746f0a707bcdfa2f173d6b782dffe16038a01354d8aa90fc664ba08cfaee47b8b3d2620c725c0581350b409cdcf06c8cc87c8c30edbb8926e1ca0b89c254cdaf
+  checksum: aebf0d5b0f4d6f5f52c8116410b2cbe88d37a470bcd36dbe322016b25b3243b348af561380cb3dbaf3988ef7aa40a375246b14c52dde56749fa6d3d0545ae3bb
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-extensions@npm:5.1.1-pre.944"
-  dependencies:
-    lodash-es: ^4.17.21
-  peerDependencies:
-    "@openmrs/esm-api": 5.x
-    "@openmrs/esm-config": 5.x
-    "@openmrs/esm-feature-flags": 5.x
-    "@openmrs/esm-state": 5.x
-    single-spa: 5.x
-  checksum: 81c014df9c3a28474c552558809846033168b25ccebcbc413ea4f46d3445d067377f630e393bd76885195b283ac7be1ddf827cd37c7b430540ce3f1398cfc69e
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-feature-flags@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-feature-flags@npm:5.1.0"
+"@openmrs/esm-feature-flags@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-feature-flags@npm:5.2.1-pre.1069"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 25f472288a7ab98bda05a2b928c9ffcf074762b09931dad3fa0fa0b0cf02bc774f37a2ff9922c4c101245257fab2415d908053a90a47f2554044b478b88d2bbd
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-feature-flags@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-feature-flags@npm:5.1.1-pre.944"
-  dependencies:
-    ramda: ^0.26.1
-  peerDependencies:
-    "@openmrs/esm-globals": 5.x
-    "@openmrs/esm-state": 5.x
-    single-spa: 5.x
-  checksum: 8a6e189cee0e94a9c3193881b080d9538f7bba802b7f037667a92d69072f468976bd7521870228c875d98ff1315a133f618b90ff7afe4fa7858d6e3f497dd8e8
+  checksum: 3e758cd022e7074ef6ed2ca55213dbf5aff8b6e99d2733ead14a2d65514e1123200044df5ea1da6db7d134cf2143357066d9f3af6fa06a2e0c808d2f6e966e57
   languageName: node
   linkType: hard
 
@@ -6536,7 +6685,7 @@ __metadata:
     ngx-bootstrap: ^6.0.0
     ngx-build-plus: ^14.0.0
     ngx-webcam: ^0.3.2
-    openmrs: ^5.1.0
+    openmrs: next
     protractor: ~7.0.0
     reflect-metadata: ^0.1.13
     rxjs: ~6.6.7
@@ -6556,23 +6705,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-framework@npm:5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-framework@npm:5.1.0"
+"@openmrs/esm-framework@npm:5.2.1-pre.1069, @openmrs/esm-framework@npm:next":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-framework@npm:5.2.1-pre.1069"
   dependencies:
-    "@openmrs/esm-api": ^5.1.0
-    "@openmrs/esm-breadcrumbs": ^5.1.0
-    "@openmrs/esm-config": ^5.1.0
-    "@openmrs/esm-dynamic-loading": ^5.1.0
-    "@openmrs/esm-error-handling": ^5.1.0
-    "@openmrs/esm-extensions": ^5.1.0
-    "@openmrs/esm-feature-flags": ^5.1.0
-    "@openmrs/esm-globals": ^5.1.0
-    "@openmrs/esm-offline": ^5.1.0
-    "@openmrs/esm-react-utils": ^5.1.0
-    "@openmrs/esm-state": ^5.1.0
-    "@openmrs/esm-styleguide": ^5.1.0
-    "@openmrs/esm-utils": ^5.1.0
+    "@openmrs/esm-api": ^5.2.1-pre.1069
+    "@openmrs/esm-breadcrumbs": ^5.2.1-pre.1069
+    "@openmrs/esm-config": ^5.2.1-pre.1069
+    "@openmrs/esm-dynamic-loading": ^5.2.1-pre.1069
+    "@openmrs/esm-error-handling": ^5.2.1-pre.1069
+    "@openmrs/esm-extensions": ^5.2.1-pre.1069
+    "@openmrs/esm-feature-flags": ^5.2.1-pre.1069
+    "@openmrs/esm-globals": ^5.2.1-pre.1069
+    "@openmrs/esm-offline": ^5.2.1-pre.1069
+    "@openmrs/esm-react-utils": ^5.2.1-pre.1069
+    "@openmrs/esm-state": ^5.2.1-pre.1069
+    "@openmrs/esm-styleguide": ^5.2.1-pre.1069
+    "@openmrs/esm-utils": ^5.2.1-pre.1069
     dayjs: ^1.10.7
   peerDependencies:
     dayjs: 1.x
@@ -6582,37 +6731,8 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     single-spa: 5.x
-  checksum: b0ec338aa1963a494ff8415418c93d73ac0cf98d09ab016153493d951a6bb932642fa2aef3cff59c86f7419784bea140216f91443a2a4438402f5ba31348ee96
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-framework@npm:5.1.1-pre.944, @openmrs/esm-framework@npm:next":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-framework@npm:5.1.1-pre.944"
-  dependencies:
-    "@openmrs/esm-api": ^5.1.1-pre.944
-    "@openmrs/esm-breadcrumbs": ^5.1.1-pre.944
-    "@openmrs/esm-config": ^5.1.1-pre.944
-    "@openmrs/esm-dynamic-loading": ^5.1.1-pre.944
-    "@openmrs/esm-error-handling": ^5.1.1-pre.944
-    "@openmrs/esm-extensions": ^5.1.1-pre.944
-    "@openmrs/esm-feature-flags": ^5.1.1-pre.944
-    "@openmrs/esm-globals": ^5.1.1-pre.944
-    "@openmrs/esm-offline": ^5.1.1-pre.944
-    "@openmrs/esm-react-utils": ^5.1.1-pre.944
-    "@openmrs/esm-state": ^5.1.1-pre.944
-    "@openmrs/esm-styleguide": ^5.1.1-pre.944
-    "@openmrs/esm-utils": ^5.1.1-pre.944
-    dayjs: ^1.10.7
-  peerDependencies:
-    dayjs: 1.x
-    i18next: 19.x
-    react: 18.x
-    react-dom: 18.x
-    react-i18next: 11.x
-    rxjs: 6.x
-    single-spa: 5.x
-  checksum: d0e6b0407295894f70631eb0b474054f0a3ede32c393a2ca1aae68fc1ee86248f7c90bdc37e75db2386b94b2d9c75be46eceeab08c09407499bf9e1b68d7d99a
+    swr: 2.x
+  checksum: 1a77b8d82db6ba2b7c6c4bcd4eaebb58a5f6cce353487ba32926cdcbe588ca0480e7b6187c82ad77cfb7df727cdd4938bc949072c71a378b3fcc9db872423a64
   languageName: node
   linkType: hard
 
@@ -6636,27 +6756,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-globals@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-globals@npm:5.1.0"
+"@openmrs/esm-globals@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-globals@npm:5.2.1-pre.1069"
   peerDependencies:
     single-spa: 5.x
-  checksum: b55e70c6decdc33928eea9deeadac54bcc1e301f043a00153dac41dcd2eb99d73bb7a8af2d6210cb14d963ce2c5e92238014a57429647757bda94cb38eb9914b
+  checksum: 80ff526852317a3f659bf9eb480c742f068e40d42e42dfe4314fe465cee3a6f745b51f7b6f415459f538c98f73060153eac1e1e32674cef351b6f861708675b5
   languageName: node
   linkType: hard
 
-"@openmrs/esm-globals@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-globals@npm:5.1.1-pre.944"
-  peerDependencies:
-    single-spa: 5.x
-  checksum: bf87103c32ec6c3363a44289331da390ee0b4c70cf48a8040ae3322caa5c8b5f352ce1df5803c658822c7f1c449714f3c97a54a7e60c6ad493d93ba651778bac
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-offline@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-offline@npm:5.1.0"
+"@openmrs/esm-offline@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-offline@npm:5.2.1-pre.1069"
   dependencies:
     dexie: ^3.0.3
     lodash-es: ^4.17.21
@@ -6668,25 +6779,7 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
-  checksum: db4cd57f74cf2b741ad53e78ea6869ed58eb51fac6bd9ac2fadff1db6651860925115c38a9be975122351815bda8eec12367a1fc4f6654a62b3fe464a9197ac6
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-offline@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-offline@npm:5.1.1-pre.944"
-  dependencies:
-    dexie: ^3.0.3
-    lodash-es: ^4.17.21
-    uuid: ^9.0.0
-    workbox-window: ^6.1.5
-  peerDependencies:
-    "@openmrs/esm-api": 5.x
-    "@openmrs/esm-globals": 5.x
-    "@openmrs/esm-state": 5.x
-    "@openmrs/esm-styleguide": 5.x
-    rxjs: 6.x
-  checksum: b1ce05e8a23152bc53a21ca1f2d171b5f6296ee2656cde0e80ab43c7de45aaf7070b131c2e0eae0ed2cbcf00135a40849e328beb256c5bdf8ece0f8cba6766b9
+  checksum: 9a9f0bc12cb1fa3da9dee79c272c168aafe0ffbf8964645506e5c55a4aa9347fb29db66f76b310b9ef558b9d6b77fae1f3c6aa01bd3747d181abfbc2ee80d535
   languageName: node
   linkType: hard
 
@@ -7079,13 +7172,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-react-utils@npm:5.1.0"
+"@openmrs/esm-react-utils@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-react-utils@npm:5.2.1-pre.1069"
   dependencies:
     lodash-es: ^4.17.21
     single-spa-react: ~5.0.0
-    swr: ^2.0.1
   peerDependencies:
     "@openmrs/esm-api": 5.x
     "@openmrs/esm-config": 5.x
@@ -7097,75 +7189,32 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     react-i18next: 11.x
-  checksum: be9064ee814f8cfe7ba9a2e17a34f0194ff4dde372370b9afce8d3883c825f26d51b6bbabec31c788e2528ded08ab573cfe5fe4926e40f9f3f5d06da2a19e08e
+    swr: 2.x
+  checksum: 518873d5741c9cb19c12502e7fbae731a66382ee9ea7af845f1f04b1b88ccc736dcf598af6e1f1328ed74dc08f16244e498056343e49d16ffa7feb2d22747458
   languageName: node
   linkType: hard
 
-"@openmrs/esm-react-utils@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-react-utils@npm:5.1.1-pre.944"
-  dependencies:
-    lodash-es: ^4.17.21
-    single-spa-react: ~5.0.0
-    swr: ^2.0.1
-  peerDependencies:
-    "@openmrs/esm-api": 5.x
-    "@openmrs/esm-config": 5.x
-    "@openmrs/esm-error-handling": 5.x
-    "@openmrs/esm-extensions": 5.x
-    "@openmrs/esm-globals": 5.x
-    dayjs: 1.x
-    i18next: 19.x
-    react: 18.x
-    react-dom: 18.x
-    react-i18next: 11.x
-  checksum: 8e24c02619781437bbfd4c31b41e112df1601dc6d48a33a6b16c8a1f8bd79a7d2adc15d3b0b6eebd954bc2969e0d618fcb1382dcfb3b27266ceac5951c45d7ff
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-state@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-state@npm:5.1.0"
-  dependencies:
-    zustand: ^4.3.6
-  checksum: d196870dc6faeafd4a1753f42cf3f43b3b68c3e030bd243dad9adf72991520606b150a320ba4d61515efd9dc5caff3e8388c3f497dbc8b97de4f4f09f7ad74f0
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-state@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-state@npm:5.1.1-pre.944"
+"@openmrs/esm-state@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-state@npm:5.2.1-pre.1069"
   dependencies:
     zustand: ^4.3.6
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 5f8c86e586388f1b5a2bf7946c938437467c7cbc7d5a130ddc579828846d36f4a67eb0c2930e5a1972ae2ce2c7afb87fea1f5c8924f84e6218ca14de40fe6a2f
+  checksum: fe01bf5540b91f2f009984ac6532ef7a9cd1e48c169eef3741ba22fc65016750ab4b93ec845d5a6fd895913cd531267196dc3bf6cbb62dbc3d93ea7978d821b3
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.1.0, @openmrs/esm-styleguide@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-styleguide@npm:5.1.0"
+"@openmrs/esm-styleguide@npm:5.2.1-pre.1069, @openmrs/esm-styleguide@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-styleguide@npm:5.2.1-pre.1069"
   dependencies:
-    "@carbon/charts": ^1.6.3
-    "@carbon/react": ^1.12.0
-    d3: ^7.8.0
-    lodash-es: ^4.17.21
-  peerDependencies:
-    "@openmrs/esm-framework": 5.x
-    react: 18.x
-    react-dom: 18.x
-    rxjs: 6.x
-  checksum: 5c89fe1bd223a72384a4dc5b7e817ae747209b725773b2733b7ddd9333b2b6ef262bfbfaa66277851c0cdbb332f22dd48ecd7ca1d0e8b36cbfceed7fb3317a40
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-styleguide@npm:5.1.1-pre.944, @openmrs/esm-styleguide@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-styleguide@npm:5.1.1-pre.944"
-  dependencies:
-    "@carbon/charts": ^1.6.3
-    "@carbon/react": ^1.12.0
+    "@carbon/charts": ^1.12.0
+    "@carbon/react": ^1.37.0
+    "@internationalized/date": ^3.5.0
+    "@react-spectrum/datepicker": ^3.8.0
+    "@react-spectrum/provider": ^3.9.0
+    "@react-spectrum/theme-default": ^3.5.6
     d3: ^7.8.0
     lodash-es: ^4.17.21
   peerDependencies:
@@ -7175,33 +7224,20 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: 43d5a4e1b72d64ca247b4ba00cc70f5049b45efa4295cf77160e7cd2b47c618affbf6c845be7db16e36dab8e7468cb43deef8f72f59deececea258f9e34fe780
+  checksum: 6a99f4c2f5cba9a1dbe5bb01ec0522e14c4e2db6b2a29fde123231f907d4d7ffdfd151ff104b014c0c28dc7a83f48ec7a0794ea8a266baf774dc54148183c923
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/esm-utils@npm:5.1.0"
+"@openmrs/esm-utils@npm:^5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/esm-utils@npm:5.2.1-pre.1069"
   dependencies:
     semver: 7.3.2
   peerDependencies:
     dayjs: 1.x
     i18next: 19.x
     rxjs: 6.x
-  checksum: e6e6b5902b5ed48d7a57a9d27c829d2d67b68df5d57fba603878063a143c62a61457a7371d8adcdc35e1ffb188d2227babf5282f9caebe9b2f95fc9954a2e91e
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-utils@npm:^5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/esm-utils@npm:5.1.1-pre.944"
-  dependencies:
-    semver: 7.3.2
-  peerDependencies:
-    dayjs: 1.x
-    i18next: 19.x
-    rxjs: 6.x
-  checksum: 0e66ab87fa6d1fe962d7a595a95f66836de34f4b6bc59388a2d64be4dfa0f06d33bcfbd67d50fcddf55f32e8c481433c66f351b49d6cc0f42d3bed79ffc0a00a
+  checksum: 7f009ef77074f9a1a7d85b0ed0c4a5960e1b310b5a1cbe2d60cd85fa6089b313870a2716d8fd0e929ebdcf88bd01c8142f14ee981990de1425ed3c916df2be60
   languageName: node
   linkType: hard
 
@@ -7282,9 +7318,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.1.0":
-  version: 5.1.0
-  resolution: "@openmrs/webpack-config@npm:5.1.0"
+"@openmrs/webpack-config@npm:5.2.1-pre.1069":
+  version: 5.2.1-pre.1069
+  resolution: "@openmrs/webpack-config@npm:5.2.1-pre.1069"
   dependencies:
     "@swc/core": ^1.3.58
     babel-preset-minify: ^0.5.1
@@ -7293,7 +7329,7 @@ __metadata:
     css-loader: ^5.2.4
     fork-ts-checker-webpack-plugin: ^6.5.0
     lodash: ^4.17.21
-    sass: ^1.44.0
+    sass: ">=1.45.0 <1.65.0"
     sass-loader: ^12.3.0
     style-loader: ^3.3.1
     swc-loader: ^0.2.3
@@ -7302,31 +7338,7 @@ __metadata:
     webpack-stats-plugin: ^1.0.3
   peerDependencies:
     webpack: 5.x
-  checksum: cf750af7b6ec302be09af0c109acad5ff4b8f0daaca13da10ab707286f51572de5d8f3a29b9cce218894e73decd5e61185ea442cc71e3d7e452a57d693a7013e
-  languageName: node
-  linkType: hard
-
-"@openmrs/webpack-config@npm:5.1.1-pre.944":
-  version: 5.1.1-pre.944
-  resolution: "@openmrs/webpack-config@npm:5.1.1-pre.944"
-  dependencies:
-    "@swc/core": ^1.3.58
-    babel-preset-minify: ^0.5.1
-    clean-webpack-plugin: ^4.0.0
-    copy-webpack-plugin: ^11.0.0
-    css-loader: ^5.2.4
-    fork-ts-checker-webpack-plugin: ^6.5.0
-    lodash: ^4.17.21
-    sass: ^1.44.0
-    sass-loader: ^12.3.0
-    style-loader: ^3.3.1
-    swc-loader: ^0.2.3
-    webpack: ^5.88.0
-    webpack-bundle-analyzer: ^4.5.0
-    webpack-stats-plugin: ^1.0.3
-  peerDependencies:
-    webpack: 5.x
-  checksum: 27a28577a8db095359fe897edd510a84865f56f7d12ac26727158da5ab18ee62bd338401b4c695030df400b485361b9429e57aa877660e5a6f2e1e1541c94a62
+  checksum: 0ed2d7085c1daf4407d143a059dc9dab2c44a3aa5a8c8801ee1dd286e3bd45f1fe4427c2f1aa917afdc8c08c146f2a51a74cb99bcdd65fa59d279186ff116a75
   languageName: node
   linkType: hard
 
@@ -7404,6 +7416,858 @@ __metadata:
   version: 1.0.0-next.21
   resolution: "@polka/url@npm:1.0.0-next.21"
   checksum: c7654046d38984257dd639eab3dc770d1b0340916097b2fac03ce5d23506ada684e05574a69b255c32ea6a144a957c8cd84264159b545fca031c772289d88788
+  languageName: node
+  linkType: hard
+
+"@react-aria/button@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "@react-aria/button@npm:3.8.3"
+  dependencies:
+    "@react-aria/focus": ^3.14.2
+    "@react-aria/interactions": ^3.19.0
+    "@react-aria/utils": ^3.21.0
+    "@react-stately/toggle": ^3.6.3
+    "@react-types/button": ^3.9.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: f2a22ea78b2a49a7b89f079dfe2570e3167146c2a383b015f583468ed02f32df2c19127c3b8847efad868a9727275354fb9081acb907b1d98711bf4f198690b3
+  languageName: node
+  linkType: hard
+
+"@react-aria/calendar@npm:^3.5.1":
+  version: 3.5.1
+  resolution: "@react-aria/calendar@npm:3.5.1"
+  dependencies:
+    "@internationalized/date": ^3.5.0
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/interactions": ^3.19.0
+    "@react-aria/live-announcer": ^3.3.1
+    "@react-aria/utils": ^3.21.0
+    "@react-stately/calendar": ^3.4.1
+    "@react-types/button": ^3.9.0
+    "@react-types/calendar": ^3.4.1
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 987b99d04e0eb596af920535a0c2e0462b6f9bf62549c9ceef2753e99ea8abaf8232cc23ae2ed3476e7113754716463e9928e643e0e8ccca0d17ea6abb33fb70
+  languageName: node
+  linkType: hard
+
+"@react-aria/datepicker@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@react-aria/datepicker@npm:3.8.0"
+  dependencies:
+    "@internationalized/date": ^3.5.0
+    "@internationalized/number": ^3.3.0
+    "@internationalized/string": ^3.1.1
+    "@react-aria/focus": ^3.14.2
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/interactions": ^3.19.0
+    "@react-aria/label": ^3.7.1
+    "@react-aria/spinbutton": ^3.5.3
+    "@react-aria/utils": ^3.21.0
+    "@react-stately/datepicker": ^3.8.0
+    "@react-types/button": ^3.9.0
+    "@react-types/calendar": ^3.4.1
+    "@react-types/datepicker": ^3.6.1
+    "@react-types/dialog": ^3.5.6
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 45b66519553b56943528102eae4ea079aa71ceaf4c0f5c091e04de4c8074de6189e7781dd0b9eda402e366ec6fcfd118dedb81978dbd89b50e1d830e7413cd54
+  languageName: node
+  linkType: hard
+
+"@react-aria/dialog@npm:^3.5.6":
+  version: 3.5.6
+  resolution: "@react-aria/dialog@npm:3.5.6"
+  dependencies:
+    "@react-aria/focus": ^3.14.2
+    "@react-aria/overlays": ^3.18.0
+    "@react-aria/utils": ^3.21.0
+    "@react-stately/overlays": ^3.6.3
+    "@react-types/dialog": ^3.5.6
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 1c78f4210ee1e5ce05863ca56228bec981ccd3a9988d0f83dbfa9324503b91eb22e87b824dfc4db0bc78fffbb5af82c906f71009fa25dfd8231a75c1ff680caa
+  languageName: node
+  linkType: hard
+
+"@react-aria/focus@npm:^3.14.2":
+  version: 3.14.2
+  resolution: "@react-aria/focus@npm:3.14.2"
+  dependencies:
+    "@react-aria/interactions": ^3.19.0
+    "@react-aria/utils": ^3.21.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+    clsx: ^1.1.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 97fb0daa6b79bb5d59069fe6d7e35d7f34689937f51d54b00e78c522c407343e1bf554d52033d325c7ef2cd940e67cc4bf655a4709fe66338a89d9f6daf45430
+  languageName: node
+  linkType: hard
+
+"@react-aria/i18n@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "@react-aria/i18n@npm:3.8.3"
+  dependencies:
+    "@internationalized/date": ^3.5.0
+    "@internationalized/message": ^3.1.1
+    "@internationalized/number": ^3.3.0
+    "@internationalized/string": ^3.1.1
+    "@react-aria/ssr": ^3.8.0
+    "@react-aria/utils": ^3.21.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: a62bd829e69ebffea285d26a0806a50d5675288b8612d21da59a93d5cd31430fbd8b49e2a421e35e34a570fdeb97d842a591970740787f484b7891445ddf6307
+  languageName: node
+  linkType: hard
+
+"@react-aria/interactions@npm:^3.19.0":
+  version: 3.19.0
+  resolution: "@react-aria/interactions@npm:3.19.0"
+  dependencies:
+    "@react-aria/ssr": ^3.8.0
+    "@react-aria/utils": ^3.21.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: c71ca5d288760de31a0d0572cc4800dd8644eaaf5aaf430fda60edbcbafb8840c06ab6e5188b211001610adc2286a693b1bf21764b6dc332350dfcc586d93221
+  languageName: node
+  linkType: hard
+
+"@react-aria/label@npm:^3.7.1":
+  version: 3.7.1
+  resolution: "@react-aria/label@npm:3.7.1"
+  dependencies:
+    "@react-aria/utils": ^3.21.0
+    "@react-types/label": ^3.8.1
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: aad1a1a8943b38b5a47e728d020560b065385c7e661a1264040972b398cfc093432d4e090d8f3b14afbbc2ebdc679ffeda1c869e83ff3c7951f7a2a31dd001c1
+  languageName: node
+  linkType: hard
+
+"@react-aria/live-announcer@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@react-aria/live-announcer@npm:3.3.1"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  checksum: df4e161247c87038eabf3f623a3ce18ef486f6c8a3e136b9c91bf3585312f48759cbd5d8ba6d0236231ee3070343798b9865a15a07afd9dabebafc0249a1fda7
+  languageName: node
+  linkType: hard
+
+"@react-aria/overlays@npm:^3.18.0":
+  version: 3.18.0
+  resolution: "@react-aria/overlays@npm:3.18.0"
+  dependencies:
+    "@react-aria/focus": ^3.14.2
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/interactions": ^3.19.0
+    "@react-aria/ssr": ^3.8.0
+    "@react-aria/utils": ^3.21.0
+    "@react-aria/visually-hidden": ^3.8.5
+    "@react-stately/overlays": ^3.6.3
+    "@react-types/button": ^3.9.0
+    "@react-types/overlays": ^3.8.3
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: d549c69b60e90db2cc1d0b3e92583a0e6953cc03a7446621f042633383a29fd8764fd1220da69378e6f4d39c67a27c4dfb77118117b4367fc0b3931a30b9d73e
+  languageName: node
+  linkType: hard
+
+"@react-aria/progress@npm:^3.4.6":
+  version: 3.4.6
+  resolution: "@react-aria/progress@npm:3.4.6"
+  dependencies:
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/label": ^3.7.1
+    "@react-aria/utils": ^3.21.0
+    "@react-types/progress": ^3.5.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 16fd10a9ec274582270dc86e4ffb8c377ecc3c95d88dbe7d0c0b93b306a4963ab1332f56da6aa5b1e56aab6bbb99e696819c71869d51bb546098bbe80cc40e48
+  languageName: node
+  linkType: hard
+
+"@react-aria/separator@npm:^3.3.6":
+  version: 3.3.6
+  resolution: "@react-aria/separator@npm:3.3.6"
+  dependencies:
+    "@react-aria/utils": ^3.21.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: d00b5994bd2c0aba89bd0722cb1c2388a0dc7e90367ca08f79fabea33de004924d082522c77b608054caf8db1962faf71eb0f694057209070b30328324a0a9a0
+  languageName: node
+  linkType: hard
+
+"@react-aria/spinbutton@npm:^3.5.3":
+  version: 3.5.3
+  resolution: "@react-aria/spinbutton@npm:3.5.3"
+  dependencies:
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/live-announcer": ^3.3.1
+    "@react-aria/utils": ^3.21.0
+    "@react-types/button": ^3.9.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: fe598ac93ee88eee84e62d922124b4fb91bedf24440c65421abaf818c5cdc65ddc11e460524ca18e4aab75ef482b3bd1802376f02758678c6e4a74cf34064ebe
+  languageName: node
+  linkType: hard
+
+"@react-aria/ssr@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@react-aria/ssr@npm:3.8.0"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: bdcd16da76d9af75dab0c44907963d9367562bc3261c6871a8ee15754e92f929dcd886e5553e08d6193ddb174d78382c10fb7b9b8c7b0cf470bc18c2ed34b106
+  languageName: node
+  linkType: hard
+
+"@react-aria/utils@npm:^3.21.0":
+  version: 3.21.0
+  resolution: "@react-aria/utils@npm:3.21.0"
+  dependencies:
+    "@react-aria/ssr": ^3.8.0
+    "@react-stately/utils": ^3.8.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+    clsx: ^1.1.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 9239caa5dd28ef6ebe811c97573f871e22ddce3521d5b3339a158fce83ba5d2b3066cbb3641158e27bec356a32eccb1340ec9074dbdad31e105509a06f1261e1
+  languageName: node
+  linkType: hard
+
+"@react-aria/visually-hidden@npm:^3.8.5":
+  version: 3.8.5
+  resolution: "@react-aria/visually-hidden@npm:3.8.5"
+  dependencies:
+    "@react-aria/interactions": ^3.19.0
+    "@react-aria/utils": ^3.21.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+    clsx: ^1.1.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 7d222be922b8609273be3425e36e54239bed16b6d1ad1061720a7ebb34cede6158a22678a7169cb9788d2167bd4a7b4a4691cd8ed33831c8b476fd6a568105cf
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/button@npm:^3.14.0":
+  version: 3.14.0
+  resolution: "@react-spectrum/button@npm:3.14.0"
+  dependencies:
+    "@react-aria/button": ^3.8.3
+    "@react-aria/focus": ^3.14.2
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/interactions": ^3.19.0
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/progress": ^3.7.0
+    "@react-spectrum/text": ^3.4.6
+    "@react-spectrum/utils": ^3.11.0
+    "@react-stately/toggle": ^3.6.3
+    "@react-types/button": ^3.9.0
+    "@react-types/progress": ^3.5.0
+    "@react-types/shared": ^3.21.0
+    "@spectrum-icons/ui": ^3.6.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: cc4eba7b3648046f9958621e62f434a570b6603e5d7afdf5926b59b70485e917197ffa70d6e350b35deca854b30d38d9024a0188f1c57b5f99da5e88748886d4
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/buttongroup@npm:^3.6.6":
+  version: 3.6.6
+  resolution: "@react-spectrum/buttongroup@npm:3.6.6"
+  dependencies:
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/button": ^3.14.0
+    "@react-spectrum/text": ^3.4.6
+    "@react-spectrum/utils": ^3.11.0
+    "@react-types/buttongroup": ^3.3.5
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 319be068469dc83dc329d32afa066f88969641c3b48e01712d93237f6b2188b9c150701ad13bed08171e417fddde248f24dff5e0942b2e71f4a53897bd06230a
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/calendar@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "@react-spectrum/calendar@npm:3.4.1"
+  dependencies:
+    "@internationalized/date": ^3.5.0
+    "@react-aria/calendar": ^3.5.1
+    "@react-aria/focus": ^3.14.2
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/interactions": ^3.19.0
+    "@react-aria/utils": ^3.21.0
+    "@react-aria/visually-hidden": ^3.8.5
+    "@react-spectrum/button": ^3.14.0
+    "@react-spectrum/label": ^3.15.0
+    "@react-spectrum/utils": ^3.11.0
+    "@react-stately/calendar": ^3.4.1
+    "@react-types/button": ^3.9.0
+    "@react-types/calendar": ^3.4.1
+    "@react-types/shared": ^3.21.0
+    "@spectrum-icons/ui": ^3.6.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 1300dfee4eef7425cb732409739a099ed6950c1757f3aae4bb2b3faff7b9fb523e417839d0331f78f4a3d2da69f44a52de85568c349c1b6544626972ca4b38e9
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/datepicker@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@react-spectrum/datepicker@npm:3.8.0"
+  dependencies:
+    "@internationalized/date": ^3.5.0
+    "@internationalized/number": ^3.3.0
+    "@react-aria/datepicker": ^3.8.0
+    "@react-aria/focus": ^3.14.2
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/interactions": ^3.19.0
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/button": ^3.14.0
+    "@react-spectrum/calendar": ^3.4.1
+    "@react-spectrum/dialog": ^3.8.3
+    "@react-spectrum/label": ^3.15.0
+    "@react-spectrum/layout": ^3.5.6
+    "@react-spectrum/utils": ^3.11.0
+    "@react-spectrum/view": ^3.6.3
+    "@react-stately/datepicker": ^3.8.0
+    "@react-stately/utils": ^3.8.0
+    "@react-types/datepicker": ^3.6.1
+    "@react-types/shared": ^3.21.0
+    "@spectrum-icons/ui": ^3.6.0
+    "@spectrum-icons/workflow": ^4.2.5
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 551f84c0f9475c19805b82bd430014612f9d40724a0289c3cab4b62cab18533c6402fcf4e5a14fdd60ae767db5cf8292cdcac9dfde34561bf2fa9dfcf566d585
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/dialog@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "@react-spectrum/dialog@npm:3.8.3"
+  dependencies:
+    "@react-aria/dialog": ^3.5.6
+    "@react-aria/focus": ^3.14.2
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/interactions": ^3.19.0
+    "@react-aria/overlays": ^3.18.0
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/button": ^3.14.0
+    "@react-spectrum/buttongroup": ^3.6.6
+    "@react-spectrum/divider": ^3.5.6
+    "@react-spectrum/layout": ^3.5.6
+    "@react-spectrum/overlays": ^5.5.0
+    "@react-spectrum/text": ^3.4.6
+    "@react-spectrum/utils": ^3.11.0
+    "@react-spectrum/view": ^3.6.3
+    "@react-stately/overlays": ^3.6.3
+    "@react-stately/utils": ^3.8.0
+    "@react-types/button": ^3.9.0
+    "@react-types/dialog": ^3.5.6
+    "@react-types/shared": ^3.21.0
+    "@spectrum-icons/ui": ^3.6.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 8364ac6f2b2070c6436a22c83d11c61e5d79152ba5f0d5189c1ce00720a1fc5f5d76141b8e3cfc13e70bf284fa6ae28b0853ef61d5a1c7cbbd64a7a6eae3d85e
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/divider@npm:^3.5.6":
+  version: 3.5.6
+  resolution: "@react-spectrum/divider@npm:3.5.6"
+  dependencies:
+    "@react-aria/separator": ^3.3.6
+    "@react-spectrum/utils": ^3.11.0
+    "@react-types/divider": ^3.3.5
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 39e1048813f8acd03f2deaf9ec9faff0d144ed7f3acd7156d9f575c5e34a30633f50b15b9f7f6a93203fc984327bf7d44bce48d1fb66b88a7aa061c166c38912
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/form@npm:^3.6.6":
+  version: 3.6.6
+  resolution: "@react-spectrum/form@npm:3.6.6"
+  dependencies:
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/utils": ^3.11.0
+    "@react-types/form": ^3.5.4
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: f21f05a7ad5d11f7ed3f361ccd38e3d0ad5b67334381e33406eeb0f842a5c39877924a42720c06195ba2072e7c65ff8325d06faf9a3a31f8e45735a6504ea503
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/icon@npm:^3.7.6":
+  version: 3.7.6
+  resolution: "@react-spectrum/icon@npm:3.7.6"
+  dependencies:
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/utils": ^3.11.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 3c3fb5b86ef6f20e3a49de6a95ef3dded07ffd3edf80fb13fdcfb0e41153dd2752fbeb109af9dbdbc350e95e9a5cecafe82457c6ee08ed34325e43eb09dad5fd
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/label@npm:^3.15.0":
+  version: 3.15.0
+  resolution: "@react-spectrum/label@npm:3.15.0"
+  dependencies:
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/label": ^3.7.1
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/form": ^3.6.6
+    "@react-spectrum/layout": ^3.5.6
+    "@react-spectrum/utils": ^3.11.0
+    "@react-types/label": ^3.8.1
+    "@react-types/shared": ^3.21.0
+    "@spectrum-icons/ui": ^3.6.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: d350812c1ce98e562d229e788cd606f16038dc1c2b82be490b677f401ff2d12d2f7b2c4e88675d10fa069855d93774182e20c7990f4983d60a07dd489b5a5d54
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/layout@npm:^3.5.6":
+  version: 3.5.6
+  resolution: "@react-spectrum/layout@npm:3.5.6"
+  dependencies:
+    "@react-aria/ssr": ^3.8.0
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/utils": ^3.11.0
+    "@react-types/layout": ^3.3.11
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+    clsx: ^1.1.1
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 9c25cb0276519bfd061b1d45e806edd8693f8781662e40bfc9c8ac2f8d5f9ebd8184443a6bbd6ca8c00ec1addd1d3e85f2d5e4f790653b269420021e42b2c7b3
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/overlays@npm:^5.5.0":
+  version: 5.5.0
+  resolution: "@react-spectrum/overlays@npm:5.5.0"
+  dependencies:
+    "@react-aria/interactions": ^3.19.0
+    "@react-aria/overlays": ^3.18.0
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/utils": ^3.11.0
+    "@react-stately/overlays": ^3.6.3
+    "@react-types/overlays": ^3.8.3
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+    react-transition-group: ^4.4.5
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: d740623c9289bc172c0e1bb7f008b33c1a502579a8948131e0ef6f619894edb4bc9490d610e876c88c5929d639face1c07d47f60f4b9ef75d4a58f16b61abe7c
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/progress@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "@react-spectrum/progress@npm:3.7.0"
+  dependencies:
+    "@react-aria/progress": ^3.4.6
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/utils": ^3.11.0
+    "@react-types/progress": ^3.5.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 2d493086c89271f1292bb9f3770e2b024079c165c20cf60a025ce3989233bab15c1fa57722db7f840a0e72fe91763c2323d0bc4f17f75a84003b975f1d7538cc
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/provider@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "@react-spectrum/provider@npm:3.9.0"
+  dependencies:
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/overlays": ^3.18.0
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/utils": ^3.11.0
+    "@react-types/provider": ^3.7.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+    clsx: ^1.1.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 376b5bf7fe846239492c9f598472bd4592e7b47c4c5d3d5ad5a392ea5c848f7f61cbdbf0b4d3a5f442c97203bb4a0589e0ec6b8ba6da3e217115843973184e49
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/text@npm:^3.4.6":
+  version: 3.4.6
+  resolution: "@react-spectrum/text@npm:3.4.6"
+  dependencies:
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/utils": ^3.11.0
+    "@react-types/shared": ^3.21.0
+    "@react-types/text": ^3.3.5
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: e41abb2808435064aecad1a3627b867118af93e4bdc9e6b152f5b6e27dd70e6f548f1b1d1e331112d8efc8df3a6029b063921a57da24d923c9da583c11a53d87
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/theme-default@npm:^3.5.6":
+  version: 3.5.6
+  resolution: "@react-spectrum/theme-default@npm:3.5.6"
+  dependencies:
+    "@react-types/provider": ^3.7.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 31f9d53adf38c27452eb2a6eec752096dec96c54cc0e826ab123f4594968765e762afd0f60ba4bf5515fe5ef1b3ba3aecc893758213563f541ad7d728bc37b98
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/utils@npm:^3.11.0":
+  version: 3.11.0
+  resolution: "@react-spectrum/utils@npm:3.11.0"
+  dependencies:
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/ssr": ^3.8.0
+    "@react-aria/utils": ^3.21.0
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+    clsx: ^1.1.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 3b3db4254d29ff27570f965db6bf9f94c6279e338d89b4cb8b85dd4d883ad606d047374fef7f24fe63a68a139ab01b06be50087ea05eae74040783f37244a6cb
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/view@npm:^3.6.3":
+  version: 3.6.3
+  resolution: "@react-spectrum/view@npm:3.6.3"
+  dependencies:
+    "@react-aria/i18n": ^3.8.3
+    "@react-aria/utils": ^3.21.0
+    "@react-spectrum/utils": ^3.11.0
+    "@react-types/shared": ^3.21.0
+    "@react-types/view": ^3.4.5
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 8dec716fa70c50b2f8b2fa1e83ac2c60a7dad2fff34f95aa1d5549e07411a4548697053a2cf850c74c3f72c45f8bbcdc7fec6c3b7532f3ff8182a44ebe249767
+  languageName: node
+  linkType: hard
+
+"@react-stately/calendar@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "@react-stately/calendar@npm:3.4.1"
+  dependencies:
+    "@internationalized/date": ^3.5.0
+    "@react-stately/utils": ^3.8.0
+    "@react-types/calendar": ^3.4.1
+    "@react-types/datepicker": ^3.6.1
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 49d1fc4bf6cb06b2bda97e39211cf7de7f8983d0245e6a770718cb85a6d13682d0e4ab830fd3e53b09e3ac4925d818a08a26fc8733923fc108be9cb4044a5d45
+  languageName: node
+  linkType: hard
+
+"@react-stately/datepicker@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@react-stately/datepicker@npm:3.8.0"
+  dependencies:
+    "@internationalized/date": ^3.5.0
+    "@internationalized/string": ^3.1.1
+    "@react-stately/overlays": ^3.6.3
+    "@react-stately/utils": ^3.8.0
+    "@react-types/datepicker": ^3.6.1
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: a460260bb606a9da663b519a0921c3a9339502bf72d6bb8bbba0a4bdd406fa9416801a8adfc36a91163645219d0d4edb0d39b024735931b081128e646c07aa46
+  languageName: node
+  linkType: hard
+
+"@react-stately/overlays@npm:^3.6.3":
+  version: 3.6.3
+  resolution: "@react-stately/overlays@npm:3.6.3"
+  dependencies:
+    "@react-stately/utils": ^3.8.0
+    "@react-types/overlays": ^3.8.3
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: dca8e2dc2ab7150d365349a71b3851a81a33664de0b4048d96c20690ddb0cbfe83e454d8fde85a45d077aca9f993183088664f7aa079dc49641dacc38ec075a6
+  languageName: node
+  linkType: hard
+
+"@react-stately/toggle@npm:^3.6.3":
+  version: 3.6.3
+  resolution: "@react-stately/toggle@npm:3.6.3"
+  dependencies:
+    "@react-stately/utils": ^3.8.0
+    "@react-types/checkbox": ^3.5.2
+    "@react-types/shared": ^3.21.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 5c726c37876629ad958252a3a9bb319837676c288730192fa44bc705815eebc6ebcdc89351ff2b4be5f2148b51e7443156096eee25310a7fed69634ba821f84c
+  languageName: node
+  linkType: hard
+
+"@react-stately/utils@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@react-stately/utils@npm:3.8.0"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 908423686bbf9a6d5d364456f60314047466f338de93e3789db38c292c6b9e953b227b554d0d175b7a2a5da544bbd59cb39d2897e575fcb79c85274bab65d223
+  languageName: node
+  linkType: hard
+
+"@react-types/button@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "@react-types/button@npm:3.9.0"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 93bd08f894c2a5e0b53b680759326b3151773bf3594f3169ecff012cbfc376e6a0472506f8b2bbf43aa41e37e410d8054dfaee728da9db86287d06adb80c9809
+  languageName: node
+  linkType: hard
+
+"@react-types/buttongroup@npm:^3.3.5":
+  version: 3.3.5
+  resolution: "@react-types/buttongroup@npm:3.3.5"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 3466196215384f9682d74f12ac2eb5c99da5ec5ec68a8382e5990743fce58b79a56e2070e743387f08e731a50bac06a5dfd15156223e5f0a3770676aafe77c79
+  languageName: node
+  linkType: hard
+
+"@react-types/calendar@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "@react-types/calendar@npm:3.4.1"
+  dependencies:
+    "@internationalized/date": ^3.5.0
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 314a4c52b0b3034ee38bb06c38887f1fba6d437e42fa34d7b622c7e4dcacf078d3ce12feb9afb1f853e5f9ab1240ee93f498ce87d25a4bdad67746c5aeeca536
+  languageName: node
+  linkType: hard
+
+"@react-types/checkbox@npm:^3.5.2":
+  version: 3.5.2
+  resolution: "@react-types/checkbox@npm:3.5.2"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 56e764547ab7943fc5522150769b5b670b804ac308224fc2a76bed339acf9472703efc320859ac36684d6cb4b00f9f6c25385737a42c54e4791095e96aacd57d
+  languageName: node
+  linkType: hard
+
+"@react-types/datepicker@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "@react-types/datepicker@npm:3.6.1"
+  dependencies:
+    "@internationalized/date": ^3.5.0
+    "@react-types/calendar": ^3.4.1
+    "@react-types/overlays": ^3.8.3
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: b9a39fbe0fe21d6395b5387d50ba3b382d72e55f30fecf82b654938d8602404caa70ad1230fc2143e5d01f96179848b9d8cad5affa4f0e49fef0a4620741a9c0
+  languageName: node
+  linkType: hard
+
+"@react-types/dialog@npm:^3.5.6":
+  version: 3.5.6
+  resolution: "@react-types/dialog@npm:3.5.6"
+  dependencies:
+    "@react-types/overlays": ^3.8.3
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 4e6971bc93cce8fe9c0fb0995e6a924545701fb5a021b1eca904762247c8ab99fd8dc88eac05e6f6ae3b7b4864e9bd29891516fe2199d04e51152028973c5401
+  languageName: node
+  linkType: hard
+
+"@react-types/divider@npm:^3.3.5":
+  version: 3.3.5
+  resolution: "@react-types/divider@npm:3.3.5"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: a4897ddf314e732227e6ea5ea090fce954bf7e1f06f693d2e052ef798f9e6845cb5f8433bc34a727133c249b9f303cd043f89383da1f3242eb4534479e4f5f46
+  languageName: node
+  linkType: hard
+
+"@react-types/form@npm:^3.5.4":
+  version: 3.5.4
+  resolution: "@react-types/form@npm:3.5.4"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: b45f510fc82fdbdb58c4669def87ccc60169d3ff87c2842b96753e658760ce873413459fc726857202e9a31ffa50f49968af3a7f22a56ef57b9b4e6ea02080ac
+  languageName: node
+  linkType: hard
+
+"@react-types/label@npm:^3.8.1":
+  version: 3.8.1
+  resolution: "@react-types/label@npm:3.8.1"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 92b16f25b588e909c54870666790099b83324ecb08da1860aff34a58a6cbbb018a1af6ebba40bba2e078bb3fc6f836ec345ffaf8380d7bcc766711d9aeb1344c
+  languageName: node
+  linkType: hard
+
+"@react-types/layout@npm:^3.3.11":
+  version: 3.3.11
+  resolution: "@react-types/layout@npm:3.3.11"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 5a1d81bbf5fc68db9bfe62b968efc02165d54b081be208e183b14c3c5f7c221ed36616b3c736af1d09a3575598c341b7e0e592823368d852aa7cdf74d34f8fd8
+  languageName: node
+  linkType: hard
+
+"@react-types/overlays@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "@react-types/overlays@npm:3.8.3"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: e2b0a8170b2f0f6b53da91e3e55748b90951d7c0a03ff7150479e17dce4d32fbe58158786ce4037ac3fce733675e4f42049d5a2baad7e3d72601acd31c1fed46
+  languageName: node
+  linkType: hard
+
+"@react-types/progress@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "@react-types/progress@npm:3.5.0"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: a9649e8d22e2738bdc09c85bde5035bcea39e684fa0aa270951ad33e40f6400983943267d676aac503a15bbdda5c4a5e3f155965a425f617c841540bbbca4f52
+  languageName: node
+  linkType: hard
+
+"@react-types/provider@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "@react-types/provider@npm:3.7.0"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 648007639394cb637e804490ef115d2da3075307ce1a9935bb5fae9621c7862d3c0b0e3faa1cb3b51094b182dc668cf9a1c277bdb2653e3d764117216c4f33d1
+  languageName: node
+  linkType: hard
+
+"@react-types/shared@npm:^3.21.0":
+  version: 3.21.0
+  resolution: "@react-types/shared@npm:3.21.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 1decbd6765c345104225e9245eb865e154fa6b869f6f9ee298f4e0a988333b9d819fb05217eb6ce38c7f3d3f1b81e6aabf14c1ee378acbc2c21a162d1181ac12
+  languageName: node
+  linkType: hard
+
+"@react-types/text@npm:^3.3.5":
+  version: 3.3.5
+  resolution: "@react-types/text@npm:3.3.5"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 99066198c26771a09dd3b69114d15a16f5f0229b5d84a0734401ee66aaed1b1c5e574e164117bc7e19c877159ccf8c9e54b063158efc19699c7443ca27f1588e
+  languageName: node
+  linkType: hard
+
+"@react-types/view@npm:^3.4.5":
+  version: 3.4.5
+  resolution: "@react-types/view@npm:3.4.5"
+  dependencies:
+    "@react-types/shared": ^3.21.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 566ba9c2baa0d3bbadee915a5ebcf8fa18313f32a6af30363408f897592121b237d718709034c821dc0d9572a67f676a0e96c5c68f1d7f50212419f3dc202fa6
   languageName: node
   linkType: hard
 
@@ -7567,6 +8431,34 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^3.0.0
   checksum: 614d30cb4d5201550c940945d44c9e0b6d64a888ff2cd5b357f95ad6721070d6b8839cd10e15b76bf5e14af0bcc1d8f9ec00d49a46318f1f669a4bec1d7f3148
+  languageName: node
+  linkType: hard
+
+"@spectrum-icons/ui@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@spectrum-icons/ui@npm:3.6.0"
+  dependencies:
+    "@adobe/react-spectrum-ui": 1.2.0
+    "@react-spectrum/icon": ^3.7.6
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: aea89ff16078cab4b9142993b1cd9a1b695630cdaf6ad8933aed26a28f01d1e1269a3c88506c91b29b59ccc4f81de75f3f5336d38311809c2a82e0c788c5facc
+  languageName: node
+  linkType: hard
+
+"@spectrum-icons/workflow@npm:^4.2.5":
+  version: 4.2.5
+  resolution: "@spectrum-icons/workflow@npm:4.2.5"
+  dependencies:
+    "@adobe/react-spectrum-workflow": 2.3.4
+    "@react-spectrum/icon": ^3.7.6
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 26fcbd7b97e792111d1bb457a907e8b246fa69e2ebf3bbb664945a5f64df9b1af1a1b4b8a7a4bdcebeb3bda56b203fd873ff4e63b6ff9b72d420dedf2e31810c
   languageName: node
   linkType: hard
 
@@ -7840,6 +8732,15 @@ __metadata:
   version: 0.1.1
   resolution: "@swc/counter@npm:0.1.1"
   checksum: bb974babd493ba01c0d4a95ab610c3fc15fbf609c08cb0342798e485f57ecc0950abbf84e07124e63c5fe610b492d9a8dd03701d3b9ef7329d9e8bf3cc44980f
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:^0.5.0":
+  version: 0.5.3
+  resolution: "@swc/helpers@npm:0.5.3"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: 61c3f7ccd47fc70ad91437df88be6b458cdc11e311cb331288827d7c50befffc72aa18fe913ec2a9e70fbf44e4b818bed38bfd7c329d689e1ff3c198d084cd02
   languageName: node
   linkType: hard
 
@@ -11116,15 +12017,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"carbon-components@npm:^10.56.0":
-  version: 10.58.6
-  resolution: "carbon-components@npm:10.58.6"
+"carbon-components@npm:^10.58.10":
+  version: 10.58.11
+  resolution: "carbon-components@npm:10.58.11"
   dependencies:
     "@carbon/telemetry": 0.1.0
     flatpickr: 4.6.1
     lodash.debounce: ^4.0.8
     warning: ^3.0.0
-  checksum: 9af81c7974884fedb224a295ee41b0d98611888a3c0e7a1da9e60266faf225586502fb1594c232823152de0be36e1d45cb43cfdeec08d451141262cbdb49b701
+  checksum: d53969e39e496110a7136802a08cb1b1d68c859efe96fcbe62af1ea67cea0d2d552c9d8b58d7413199d21841a5e26bfb781bae2cae6595097681c5587e2e6d6d
   languageName: node
   linkType: hard
 
@@ -11491,6 +12392,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clsx@npm:^1.1.1":
+  version: 1.2.1
+  resolution: "clsx@npm:1.2.1"
+  checksum: 30befca8019b2eb7dbad38cff6266cf543091dae2825c856a62a8ccf2c3ab9c2907c4d12b288b73101196767f66812365400a227581484a05f968b0307cfaf12
+  languageName: node
+  linkType: hard
+
 "cmd-shim@npm:6.0.1":
   version: 6.0.1
   resolution: "cmd-shim@npm:6.0.1"
@@ -11660,17 +12568,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:2, commander@npm:^2.11.0, commander@npm:^2.19.0, commander@npm:^2.20.0":
+  version: 2.20.3
+  resolution: "commander@npm:2.20.3"
+  checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
+  languageName: node
+  linkType: hard
+
 "commander@npm:7, commander@npm:^7.0.0, commander@npm:^7.1.0, commander@npm:^7.2.0":
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
-  languageName: node
-  linkType: hard
-
-"commander@npm:^2.11.0, commander@npm:^2.19.0, commander@npm:^2.20.0":
-  version: 2.20.3
-  resolution: "commander@npm:2.20.3"
-  checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
   languageName: node
   linkType: hard
 
@@ -11747,6 +12655,13 @@ __metadata:
   version: 1.0.17
   resolution: "compute-scroll-into-view@npm:1.0.17"
   checksum: b20c05a10c37813c5a6e4bf053c00f65c88d23afed7a6bd7a2a69e05e2ffc2df3483ecfe407d36bf16b8cec8be21ae1966c9c523093a03117e567156cd79a51e
+  languageName: node
+  linkType: hard
+
+"compute-scroll-into-view@npm:^3.0.3":
+  version: 3.1.0
+  resolution: "compute-scroll-into-view@npm:3.1.0"
+  checksum: 224549d6dd1d40342230de5c6d69cac5c3ed5c2f6a4437310f959aadc8db1d20b03da44a6e0de14d9419c6f9130ce51ec99a91b11bde55d4640f10551c89c213
   languageName: node
   linkType: hard
 
@@ -12583,6 +13498,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-cloud@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "d3-cloud@npm:1.2.7"
+  dependencies:
+    d3-dispatch: ^1.0.3
+  checksum: 6217c46e32250daf1cfd71c2f5515a433b12bdb28affff55d27bf3249b8b12ebaab391d15ed973cbf0790758d8834d9870b9315790691dfcdc3e2b82a6f20631
+  languageName: node
+  linkType: hard
+
 "d3-color@npm:1 - 3, d3-color@npm:3":
   version: 3.1.0
   resolution: "d3-color@npm:3.1.0"
@@ -12747,7 +13671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-sankey@npm:0.12.3":
+"d3-sankey@npm:0.12.3, d3-sankey@npm:^0.12.3":
   version: 0.12.3
   resolution: "d3-sankey@npm:0.12.3"
   dependencies:
@@ -12931,6 +13855,44 @@ __metadata:
     d3-transition: 3
     d3-zoom: 3
   checksum: e7bf5918f2a97d0c0cc489d64348b323446aa824c32b65f0888846c26f80ed05dbee18a4b7c9a487b3e60d9d404e4672d169573fe63439e3e53abd5812bcd766
+  languageName: node
+  linkType: hard
+
+"d3@npm:^7.8.5":
+  version: 7.8.5
+  resolution: "d3@npm:7.8.5"
+  dependencies:
+    d3-array: 3
+    d3-axis: 3
+    d3-brush: 3
+    d3-chord: 3
+    d3-color: 3
+    d3-contour: 4
+    d3-delaunay: 6
+    d3-dispatch: 3
+    d3-drag: 3
+    d3-dsv: 3
+    d3-ease: 3
+    d3-fetch: 3
+    d3-force: 3
+    d3-format: 3
+    d3-geo: 3
+    d3-hierarchy: 3
+    d3-interpolate: 3
+    d3-path: 3
+    d3-polygon: 3
+    d3-quadtree: 3
+    d3-random: 3
+    d3-scale: 4
+    d3-scale-chromatic: 3
+    d3-selection: 3
+    d3-shape: 3
+    d3-time: 3
+    d3-time-format: 4
+    d3-timer: 3
+    d3-transition: 3
+    d3-zoom: 3
+  checksum: e407e79731f74d946a5eb8dec2f037b5a4ad33c294409b1d3531fdf7094de48adfe364974cb37e2396bdb81e23149d56d0ede716c004d6aebb52b3cc114cd15c
   languageName: node
   linkType: hard
 
@@ -13471,6 +14433,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dom-helpers@npm:^5.0.1":
+  version: 5.2.1
+  resolution: "dom-helpers@npm:5.2.1"
+  dependencies:
+    "@babel/runtime": ^7.8.7
+    csstype: ^3.0.2
+  checksum: 863ba9e086f7093df3376b43e74ce4422571d404fc9828bf2c56140963d5edf0e56160f9b2f3bb61b282c07f8fc8134f023c98fd684bddcb12daf7b0f14d951c
+  languageName: node
+  linkType: hard
+
 "dom-serialize@npm:^2.2.1":
   version: 2.2.1
   resolution: "dom-serialize@npm:2.2.1"
@@ -13621,6 +14593,21 @@ __metadata:
   peerDependencies:
     react: ">=0.14.9"
   checksum: fc8e731106cdaa9bfcd1d855d8b25dbaaa6fb22dfb51a3c32e51f460c199730a6ddfbd311891bbdc4bba642238d2239f1fb7642ce5d3f616f09fc68abd6a76f4
+  languageName: node
+  linkType: hard
+
+"downshift@npm:8.2.1":
+  version: 8.2.1
+  resolution: "downshift@npm:8.2.1"
+  dependencies:
+    "@babel/runtime": ^7.22.15
+    compute-scroll-into-view: ^3.0.3
+    prop-types: ^15.8.1
+    react-is: ^18.2.0
+    tslib: ^2.6.2
+  peerDependencies:
+    react: ">=16.12.0"
+  checksum: f6cf5e18d7958ea924bda0b13b46045cbd64a419e4e3079460e6edce8a25b0d99972b0ff607971016a09568cb46dfd53c924a2c86be8f4a5825ef2f2d703f0da
   languageName: node
   linkType: hard
 
@@ -16606,6 +17593,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-to-image@npm:^1.11.11":
+  version: 1.11.11
+  resolution: "html-to-image@npm:1.11.11"
+  checksum: b453beca72a697bf06fae4945e5460d1d9b1751e8569a0d721dda9485df1dde093938cc9bd9172b8df5fc23133a53a4d619777b3d22f7211cd8a67e3197ab4e8
+  languageName: node
+  linkType: hard
+
 "html-webpack-plugin@npm:^5.5.0":
   version: 5.5.0
   resolution: "html-webpack-plugin@npm:5.5.0"
@@ -17280,6 +18274,18 @@ __metadata:
   dependencies:
     intl-messageformat-parser: 1.4.0
   checksum: 5562de75dddae69546180403fec196ed6564d41cb82964de8e319bd9fa9edfe5aaa581bc40775815b65fbdab3db96b62bb0757c2a936ac025e705333e4bd82cd
+  languageName: node
+  linkType: hard
+
+"intl-messageformat@npm:^10.1.0":
+  version: 10.5.4
+  resolution: "intl-messageformat@npm:10.5.4"
+  dependencies:
+    "@formatjs/ecma402-abstract": 1.17.2
+    "@formatjs/fast-memoize": 2.2.0
+    "@formatjs/icu-messageformat-parser": 2.7.0
+    tslib: ^2.4.0
+  checksum: 1ac36b37134c435956762b5e9078314bb1d999992253c7ec884d135bf94eea160a3feede9d3c61c3b8a3016ca1553ba3fa3132bf95be4400c59ea95cb85a5ad6
   languageName: node
   linkType: hard
 
@@ -21763,50 +22769,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openmrs@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "openmrs@npm:5.1.0"
-  dependencies:
-    "@openmrs/esm-app-shell": 5.1.0
-    "@openmrs/webpack-config": 5.1.0
-    "@pnpm/npm-conf": ^2.1.0
-    "@swc/core": ^1.3.58
-    autoprefixer: ^10.4.2
-    axios: ^0.21.1
-    browserslist-config-openmrs: ^1.0.1
-    copy-webpack-plugin: ^11.0.0
-    cssnano: ^5.0.16
-    ejs: ^3.1.8
-    glob: ^7.1.3
-    html-webpack-plugin: ^5.5.0
-    inquirer: ^7.3.3
-    mini-css-extract-plugin: ^2.4.5
-    npm-registry-fetch: ^14.0.3
-    pacote: ^15.0.0
-    postcss: ^8.4.6
-    postcss-loader: ^6.2.1
-    rimraf: ^3.0.2
-    swc-loader: ^0.2.3
-    tar: ^6.0.5
-    typescript: ^4.6.4
-    webpack: ^5.88.0
-    webpack-cli: ^4.10.0
-    webpack-dev-server: ^4.10.1
-    webpack-pwa-manifest: ^4.3.0
-    workbox-webpack-plugin: ^6.4.1
-    yargs: ^17.6.2
-  bin:
-    openmrs: dist/cli.js
-  checksum: 7b0ae32defa57256c0f0d897ca5afe17f0b43c753dc7f6c727d6935a31bdfa6c8e6ef84053da7cc3f451f8541d48591e72192ca5adb8fe71539f57f2d99757ab
-  languageName: node
-  linkType: hard
-
 "openmrs@npm:next":
-  version: 5.1.1-pre.944
-  resolution: "openmrs@npm:5.1.1-pre.944"
+  version: 5.2.1-pre.1069
+  resolution: "openmrs@npm:5.2.1-pre.1069"
   dependencies:
-    "@openmrs/esm-app-shell": 5.1.1-pre.944
-    "@openmrs/webpack-config": 5.1.1-pre.944
+    "@openmrs/esm-app-shell": 5.2.1-pre.1069
+    "@openmrs/webpack-config": 5.2.1-pre.1069
     "@pnpm/npm-conf": ^2.1.0
     "@swc/core": ^1.3.58
     autoprefixer: ^10.4.2
@@ -21835,7 +22803,7 @@ __metadata:
     yargs: ^17.6.2
   bin:
     openmrs: dist/cli.js
-  checksum: f44fea00f954b0c2dbe7e75a8ca42393d8fcd546b96d156a1ca6a0654a84e4cb70923169cac45d5e0cfd9171fb3f556749cb7456bf64a2dd3633a38666a805ba
+  checksum: eb845aaf45640a501679752e2eb199047db4dcd75510769c3cede109cfede386bc02934642e2f203e9e48f9cdbf7b4539e0e966a128a18f1e351cc5c4a974f52
   languageName: node
   linkType: hard
 
@@ -24261,6 +25229,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-transition-group@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "react-transition-group@npm:4.4.5"
+  dependencies:
+    "@babel/runtime": ^7.5.5
+    dom-helpers: ^5.0.1
+    loose-envify: ^1.4.0
+    prop-types: ^15.6.2
+  peerDependencies:
+    react: ">=16.6.0"
+    react-dom: ">=16.6.0"
+  checksum: 75602840106aa9c6545149d6d7ae1502fb7b7abadcce70a6954c4b64a438ff1cd16fc77a0a1e5197cdd72da398f39eb929ea06f9005c45b132ed34e056ebdeb1
+  languageName: node
+  linkType: hard
+
 "react-waypoint@npm:^10.3.0":
   version: 10.3.0
   resolution: "react-waypoint@npm:10.3.0"
@@ -26649,18 +27632,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swr@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "swr@npm:2.0.1"
-  dependencies:
-    use-sync-external-store: ^1.2.0
-  peerDependencies:
-    react: ^16.11.0 || ^17.0.0 || ^18.0.0
-  checksum: 5466e46a80bccf722c212ea3f14668b4e7f047d958f3da7252fba3529e6b1773a1762aa4bbf43aec104cc50625dbd55380539eeef59fd5ad9ebca6ad0552f45d
-  languageName: node
-  linkType: hard
-
-"swr@npm:^2.2.4":
+"swr@npm:^2.2.2, swr@npm:^2.2.4":
   version: 2.2.4
   resolution: "swr@npm:2.2.4"
   dependencies:
@@ -27110,6 +28082,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"topojson-client@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "topojson-client@npm:3.1.0"
+  dependencies:
+    commander: 2
+  bin:
+    topo2geo: bin/topo2geo
+    topomerge: bin/topomerge
+    topoquantize: bin/topoquantize
+  checksum: 8c029a4f18324ace0b8b55dd90edbd40c9e3c6de18bafbb5da37ca20ebf20e26fbd4420891acb3c2c264e214185f7557871f5651a9eee517028663be98d836de
+  languageName: node
+  linkType: hard
+
 "toposort@npm:^2.0.2":
   version: 2.0.2
   resolution: "toposort@npm:2.0.2"
@@ -27288,7 +28273,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.3.1, tslib@npm:^2.5.0, tslib@npm:^2.6.0":
+"tslib@npm:^2.3.1, tslib@npm:^2.5.0, tslib@npm:^2.6.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad

--- a/yarn.lock
+++ b/yarn.lock
@@ -6970,6 +6970,7 @@ __metadata:
     "@carbon/react": ^1.12.0
     "@openmrs/esm-patient-common-lib": ^5.1.0
     d3: ^7.6.1
+    fuzzy: ^0.1.3
     lodash-es: ^4.17.21
     webpack: ^5.88.2
   peerDependencies:
@@ -15760,6 +15761,13 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: c3f1f5ba20f4e962efb71344ce0a40722163e85bee2101ce25f88214e78182d2d2476aa85ef37950c579eb6cf6ee811c17b3101bb84004bb75655f3e33f3fdb5
+  languageName: node
+  linkType: hard
+
+"fuzzy@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "fuzzy@npm:0.1.3"
+  checksum: acc09c6173e12d5dc8ae51857551ddbe834befa9ebc6be6d5581d09117265d704809d80407d220fd0652f347a9975a4d106854cacc8bd031487a0ede86982f84
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Partially implements the lab order search page in the lab order flow. https://app.zeplin.io/project/60d5947dd636aebbd63dce4c/screen/640b06cfab89e77b9b6b2a61

This does not include the correct UI for the "no search term" state, wherein a list of panels should be shown. That is ticket [O3-2439](https://issues.openmrs.org/browse/O3-2439).

There's not actually much new code here; mostly stuff moving around.

## Screenshots
https://github.com/openmrs/openmrs-esm-patient-chart/assets/1031876/0daec7b3-cc55-4523-aebb-a1581f034e9d


## Related Issue
https://issues.openmrs.org/browse/O3-2423
