### PR TITLE
(fix)O3-2438: should not be visible until it is known whether there is an ongoing visit

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -133,7 +133,7 @@ function launchStartVisitForm() {
 const VisitHeader: React.FC = () => {
   const { t } = useTranslation();
   const { patient } = usePatient();
-  const { currentVisit, currentVisitIsRetrospective, isValidating } = useVisit(patient?.id);
+  const { currentVisit, currentVisitIsRetrospective, isLoading } = useVisit(patient?.id);
   const [isSideMenuExpanded, setIsSideMenuExpanded] = useState(false);
   const navMenuItems = useAssignedExtensions('patient-chart-dashboard-slot').map((extension) => extension.id);
   const { logo } = useConfig();
@@ -141,11 +141,7 @@ const VisitHeader: React.FC = () => {
 
   const showHamburger = useLayoutType() !== 'large-desktop' && navMenuItems.length > 0;
 
-  const isLoading = isValidating && currentVisit === null;
-  const visitNotLoaded = !isValidating && currentVisit === null;
   const toggleSideMenu = useCallback(() => setIsSideMenuExpanded((prevState) => !prevState), []);
-
-  const hasActiveVisit = !isLoading && !visitNotLoaded;
 
   const onClosePatientChart = useCallback(() => {
     document.referrer === '' ? navigate({ to: `${window.spaBase}/home` }) : window.history.back();
@@ -194,23 +190,15 @@ const VisitHeader: React.FC = () => {
         {systemVisitEnabled && (
           <>
             <ExtensionSlot name="visit-header-right-slot" />
-            {!hasActiveVisit && !isDeceased && (
+            {!isLoading && !currentVisit && !isDeceased && (
               <Button className={styles.startVisitButton} onClick={launchStartVisitForm} size="lg">
                 {t('startAVisit', 'Start a visit')}
               </Button>
             )}
-            {currentVisit !== null && (
-              <>
-                <HeaderGlobalAction
-                  className={styles.headerGlobalBarButton}
-                  aria-label={t('endVisit', 'End visit')}
-                  onClick={() => openModal(patient?.id)}
-                >
-                  <Button as="div" className={styles.startVisitButton}>
-                    {t('endVisit', 'End visit')}
-                  </Button>
-                </HeaderGlobalAction>
-              </>
+            {!isLoading && !!currentVisit && (
+              <Button onClick={() => openModal(patient?.id)} className={styles.startVisitButton}>
+                {t('endVisit', 'End visit')}
+              </Button>
             )}
           </>
         )}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The "Start a visit" button is conditionally rendered based on the hasActiveVisit variable, which is true when there is an ongoing visit and false when there isn't. The button will only be visible when there is no active visit and the patient is not deceased.


## Screenshots
**Before making changes**


https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/0c63f890-6179-45d1-8c3f-77f9473a783e


**After making the changes**

https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/896797ea-7215-4ba9-b59a-86673a81115d


## Related Issue
https://issues.openmrs.org/browse/O3-2438

## Other
<!-- Anything not covered above -->
