### PR TITLE
(feat) O3-2437: Restore a left border to the workspace

### DIFF
--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
@@ -62,7 +62,9 @@
   .container {
     margin-right: 3rem;
     height: 100vh;
+    border-left: 10px solid #a8a8a8;
   }
+  
 
   .widerWorkspace {
     width: 32.25rem;

--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
@@ -60,11 +60,10 @@
   }
 
   .container {
+    border-left: 1px solid $text-03;
     margin-right: 3rem;
-    height: 100vh;
-    border-left: 1px solid #a8a8a8;
+    min-height: 100vh;
   }
-  
 
   .widerWorkspace {
     width: 32.25rem;

--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
@@ -62,7 +62,7 @@
   .container {
     margin-right: 3rem;
     height: 100vh;
-    border-left: 10px solid #a8a8a8;
+    border-left: 1px solid #a8a8a8;
   }
   
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. 
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work is validated by existing tests.

## Summary

In this PR, I've restored a left border of `1px solid #a8a8a8` to the workspace container to get it in line with the [design documentation](https://zeroheight.com/23a080e38/p/483a22-workspace).

## Screenshots

> With left border

<img width="1307" alt="CleanShot 2023-09-28 at 11 19 16@2x" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/56c1ce32-d8ac-40a0-b8b4-43838de67db3">

## Related Issue
https://issues.openmrs.org/browse/O3-2437

## Other
