### PR TITLE
(fix) Fix appearance of icon button dividers

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.scss
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.scss
@@ -13,13 +13,6 @@
   padding: spacing.$spacing-04 0 spacing.$spacing-04 spacing.$spacing-05;
 }
 
-.divider {
-  width: 1px;
-  height: 1rem;
-  color: $ui-03;
-  margin: 0rem 0.5rem;
-}
-
 .toggleButtons {
   width: fit-content;
   margin: 0 spacing.$spacing-03;

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.component.tsx
@@ -66,7 +66,7 @@ const AppointmentsBase: React.FC<AppointmentsBaseProps> = ({ patientUuid }) => {
               <Switch name={'today'} text={t('today', 'Today')} />
               <Switch name={'past'} text={t('past', 'Past')} />
             </ContentSwitcher>
-            <div className={styles.divider}></div>
+            <div className={styles.divider}>|</div>
             <Button
               kind="ghost"
               renderIcon={(props) => <Add size={16} {...props} />}

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.scss
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.scss
@@ -1,8 +1,9 @@
+@use '@carbon/colors';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @import '~@openmrs/esm-styleguide/src/vars';
 
-// TO DO Move this styles to style - guide 
+// TO DO Move this styles to style - guide
 // https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-styleguide/src/_vars.scss
 $color-blue-30 : #a6c8ff;
 $color-blue-10: #edf5ff;
@@ -43,7 +44,7 @@ $color-blue-10: #edf5ff;
   border-radius: 0px spacing.$spacing-02 spacing.$spacing-02 0px;
 }
 
-.contentSwitcherWrapper > div > button[aria-selected=true], 
+.contentSwitcherWrapper > div > button[aria-selected=true],
 .contentSwitcherWrapper > div > button[aria-selected=true]:first-child {
   background-color: $color-blue-10;
   color: $color-blue-60-2;
@@ -51,7 +52,7 @@ $color-blue-10: #edf5ff;
   border-right: 1px solid $color-blue-60-2;
 }
 
-.contentSwitcherWrapper > div > button[aria-selected=true], 
+.contentSwitcherWrapper > div > button[aria-selected=true],
 .contentSwitcherWrapper > div > button[aria-selected=true]:last-child {
   background-color: $color-blue-10;
   color: $color-blue-60-2;
@@ -64,9 +65,10 @@ $color-blue-10: #edf5ff;
 }
 
 .divider {
-  border-left: 1px solid $ui-03;
+  width: 1px;
   height: spacing.$spacing-05;
-  margin: 0 spacing.$spacing-05 0 spacing.$spacing-06;
+  color: colors.$gray-20;
+  margin: 0 spacing.$spacing-05;
 }
 
 .content {

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.scss
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.scss
@@ -17,13 +17,13 @@
       height: spacing.$spacing-05;
     }
   }
-
 }
 
 .divider {
-  border-left: 1px solid $ui-03;
+  width: 1px;
   height: spacing.$spacing-05;
-  margin: 0 spacing.$spacing-03 0 spacing.$spacing-05;
+  color: colors.$gray-20;
+  margin: 0 spacing.$spacing-05;
 }
 
 .validatingDataIcon {

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.scss
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.scss
@@ -1,3 +1,4 @@
+@use '@carbon/colors';
 @use '@carbon/styles/scss/spacing';
 @import "../root.scss";
 

--- a/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
+++ b/packages/esm-patient-biometrics-app/src/biometrics/biometrics-overview.scss
@@ -26,7 +26,7 @@
   width: 1px;
   height: spacing.$spacing-05;
   color: $ui-03;
-  margin: 0rem spacing.$spacing-03 0 spacing.$spacing-05;
+  margin: 0 spacing.$spacing-05;
 }
 
 .backgroundDataFetchingIndicator {

--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
@@ -13,7 +13,7 @@ export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
     <aside className={styles.sideRail}>
       <div className={styles.container}>
         <ExtensionSlot className={styles.chartExtensions} name={'action-menu-chart-items-slot'} />
-        {layout === 'small-desktop' || layout === 'large-desktop' ? <div className={styles.divider}></div> : null}
+        {layout === 'small-desktop' || layout === 'large-desktop' ? <div className={styles.divider}>|</div> : null}
         <ExtensionSlot className={styles.nonChartExtensions} name={'action-menu-non-chart-items-slot'} />
       </div>
     </aside>

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -114,7 +114,7 @@ function ConditionsDetailedSummary({ patient }) {
                 size={isTablet ? 'lg' : 'sm'}
               />
             </div>
-            <div className={styles.divider}></div>
+            <div className={styles.divider}>|</div>
             <Button
               kind="ghost"
               renderIcon={(props) => <Add size={16} {...props} />}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.scss
@@ -1,3 +1,4 @@
+@use '@carbon/colors';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @import "~@openmrs/esm-styleguide/src/vars";
@@ -7,9 +8,10 @@
 }
 
 .divider {
-  border-left: 1px solid $ui-03;
+  width: 1px;
   height: spacing.$spacing-05;
-  margin: 0 spacing.$spacing-03;
+  color: colors.$gray-20;
+  margin: 0 spacing.$spacing-05;
 }
 
 .rightMostFlexContainer {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
@@ -122,7 +122,7 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patientUuid }) 
                 size={isTablet ? 'lg' : 'sm'}
               />
             </div>
-            <div className={styles.divider}></div>
+            <div className={styles.divider}>|</div>
             <Button
               kind="ghost"
               renderIcon={(props) => <Add size={16} {...props} />}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.scss
@@ -1,3 +1,4 @@
+@use '@carbon/colors';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @import "~@openmrs/esm-styleguide/src/vars";
@@ -7,9 +8,10 @@
 }
 
 .divider {
-  border-left: 1px solid $ui-03;
+  width: 1px;
   height: spacing.$spacing-05;
-  margin: 0 spacing.$spacing-03;
+  color: colors.$gray-20;
+  margin: 0 spacing.$spacing-05;
 }
 
 .rightMostFlexContainer {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.scss
@@ -11,7 +11,7 @@
   width: 1px;
   height: spacing.$spacing-05;
   color: colors.$gray-20;
-  margin-left: spacing.$spacing-05;
+  margin: 0 spacing.$spacing-05;
 }
 
 .vitalsHeaderActionItems {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue with the spacing around dividers in the card header titles in various widgets in the patient chart. See the screenshots below for context. These regressions are likely owing to recent API changes in the Carbon `ContentSwitcher` and `Button` components, specifically changes related to the `LayoutConstraint` component wrapper.

## Screenshots

> Before

![CleanShot 2023-10-05 at 12  25 06@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/d0a53e78-3a11-442a-95ec-7e1d02904690)

> After

![CleanShot 2023-10-05 at 12  21 32@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/ff71e066-b10a-48fb-ba8d-1cd2a8e3b81d)

## Related Issue
*None*

## Other
*None*
