### PR TITLE
(feat) Update encounter date to pick visitStartDatetime

### DIFF
--- a/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
@@ -1,6 +1,6 @@
 import { DataSources, EncounterAdapter, Form, FormFactory, PatientIdentifierAdapter } from '@openmrs/ngx-formentry';
 import { Injectable } from '@angular/core';
-import * as moment from 'moment';
+import dayjs from 'dayjs';
 import { FormDataSourceService } from '../form-data-source/form-data-source.service';
 import { ConfigResourceService } from '../services/config-resource.service';
 import { MonthlyScheduleResourceService } from '../services/monthly-scheduled-resource.service';
@@ -243,9 +243,13 @@ export class FormCreationService {
 
   private setDefaultValues(form: Form, createFormParams: CreateFormParams) {
     const { session } = createFormParams;
-
+    let currentDate = dayjs().format();
+    const visitStartDatetime = dayjs(this.singleSpaPropsService.getProp('visitStartDatetime')).format();
+    // If the visit start date is before the current date, use the visit start date as the default date.
+    if (visitStartDatetime && dayjs(visitStartDatetime).isBefore(currentDate, 'date')) {
+      currentDate = visitStartDatetime;
+    }
     // Encounter date and time.
-    const currentDate = moment().format();
     const encounterDate = form.searchNodeByQuestionId('encDate');
     if (encounterDate.length > 0) {
       encounterDate[0].control.setValue(currentDate);


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR updates the default value of encounterDate on the form to default to `visitStartDatetime` if the `visitStartDatetime` is before `current Date`

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://thepalladiumgroup.atlassian.net/browse/KHP3-4256

## Other
<!-- Anything not covered above -->
