### PR TITLE
(fix)O3-2485: Allow view only field for the visit location selector

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/location-selection.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/location-selection.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styles from './visit-form.scss';
 import { Location, OpenmrsResource, useLayoutType, useSession } from '@openmrs/esm-framework';
 import { ComboBox, InlineNotification } from '@carbon/react';
@@ -11,9 +11,8 @@ import { VisitFormData } from './visit-form.component';
 
 const LocationSelector = () => {
   const { t } = useTranslation();
-  const [searchTerm, setSearchTerm] = useState('');
   const selectedSessionLocation = useSession().sessionLocation;
-  const { locations, isLoading: isLoadingLocations, error } = useLocations(searchTerm);
+  const { locations } = useLocations('');
   const { defaultFacility, isLoading: loadingDefaultFacility } = useDefaultLoginLocation();
   const locationsToShow: Array<OpenmrsResource> =
     !loadingDefaultFacility && !isEmpty(defaultFacility)
@@ -26,10 +25,6 @@ const LocationSelector = () => {
 
   const { control } = useFormContext<VisitFormData>();
 
-  const handleSearch = (searchString) => {
-    setSearchTerm(searchString);
-  };
-
   return (
     <section data-testid="combo">
       <div className={styles.sectionTitle}>{t('visitLocation', 'Visit Location')}</div>
@@ -37,18 +32,15 @@ const LocationSelector = () => {
         <Controller
           name="visitLocation"
           control={control}
-          render={({ field: { onBlur, onChange, value } }) => (
+          render={({ field: { value } }) => (
             <ComboBox
               titleText={t('selectLocation', 'Select a location')}
               aria-label={t('selectLocation', 'Select a location')}
               id="location"
-              invalidText="Required"
               items={locationsToShow}
               selectedItem={value}
-              onChange={({ selectedItem }) => onChange(selectedItem)}
-              onBlur={onBlur}
               itemToString={(loc: Location) => loc?.display}
-              onInputChange={(loc) => handleSearch(loc)}
+              disabled={true}
             />
           )}
         />


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I changed the location display to view-only to prevent a user from changing it accidentally by removing the handleSearch function as it's not necessary if the ComboBox is read-only and set the disabled prop of the ComboBox to true, which makes it read-only and prevents user's interaction.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
