### PR TITLE
(chore) O3-2405: Retrieve Logs in E2E gh action for Improved Issue Tracking

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,8 +56,22 @@ jobs:
 
       - name: Upload report
         uses: actions/upload-artifact@v3
-        if: always()
+        if: "!cancelled()"
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+      - name: Capture Server Logs
+        if: "!cancelled()"
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './logs'
+
+      - name: Upload Logs as Artifact
+        uses: actions/upload-artifact@v2
+        if: "!cancelled()"
+        with:
+          name: server-logs
+          path: './logs'
+          retention-days: 2


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This pull request introduces a significant enhancement to our testing and issue tracking process by capturing backend logs in GitHub Actions during our E2E tests for patient conditions and programs. As noted, we have been experiencing intermittent failures in these tests due to 503 errors from the backend, which are difficult to reproduce locally. This enhancement will enable us to gather essential diagnostic information, aiding in the identification of the root cause and facilitating quicker issue resolution.

### Why is this Change Important?

- Enables us to gather backend logs in the context of failing E2E tests.
- Provides critical information for diagnosing and resolving [intermittent 503 errors](https://issues.openmrs.org/browse/O3-2405). 
- Allows us to track upcoming issues related to backend errors more effectively.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-2405

