### PR TITLE
(fix) O3-2485: Updated the config key for the visit location field in the start visit form

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -139,7 +139,7 @@ export interface ChartConfig {
     alt: string;
     name: string;
   };
-  viewOnlyVisitLocationField: boolean;
+  disableChangingVisitLocation: boolean;
 }
 
 export const configSchema = {

--- a/packages/esm-patient-chart-app/src/visit/visit-form/location-selection.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/location-selection.component.tsx
@@ -18,7 +18,7 @@ const LocationSelector = () => {
   const { locations, isLoading: isLoadingLocations, error } = useLocations(searchTerm);
   const { defaultFacility, isLoading: loadingDefaultFacility } = useDefaultLoginLocation();
   const config = useConfig() as ChartConfig;
-  const viewOnlyVisitLocationField = config?.viewOnlyVisitLocationField;
+  const disableChangingVisitLocation = config?.disableChangingVisitLocation;
   const locationsToShow: Array<OpenmrsResource> =
     !loadingDefaultFacility && !isEmpty(defaultFacility)
       ? [defaultFacility]
@@ -38,7 +38,7 @@ const LocationSelector = () => {
     <section data-testid="combo">
       <div className={styles.sectionTitle}>{t('visitLocation', 'Visit Location')}</div>
       <div className={`${styles.selectContainer} ${styles.sectionField}`}>
-        {!viewOnlyVisitLocationField ? (
+        {!disableChangingVisitLocation ? (
           <Controller
             name="visitLocation"
             control={control}
@@ -54,7 +54,7 @@ const LocationSelector = () => {
                 onBlur={onBlur}
                 itemToString={(loc: Location) => loc?.display}
                 onInputChange={(loc) => handleSearch(loc)}
-                readOnly={viewOnlyVisitLocationField}
+                readOnly={disableChangingVisitLocation}
               />
             )}
           />


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR is a follow up to #1403, with the updated config prop was updated in the other parts of the app too.

## Screenshots

![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/96221830-dcfb-4a8b-b8c5-71ef2553e030)

![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/8f69faff-8236-47ce-91e0-a99331d36afe)

Design was confirmed with Ciaran in the slack thread [here](https://openmrs.slack.com/archives/CKS32D55G/p1697034450164649?thread_ts=1696590390.484279&cid=CKS32D55G)

## Related Issue
https://issues.openmrs.org/browse/O3-2485

## Other
<!-- Anything not covered above -->
