### PR TITLE
(fix) Tweak appearance of flagged vital signs

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -20,7 +20,9 @@ interface PaginatedVitalsProps {
   pageSize: number;
   pageUrl: string;
   urlLabel: string;
+  // @ts-ignore
   tableRows: Array<typeof DataTableRow>;
+  // @ts-ignore
   tableHeaders: Array<typeof DataTableHeader>;
   isPrinting?: boolean;
 }

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import orderBy from 'lodash-es/orderBy';
 import {
   DataTable,
+  DataTableHeader,
+  DataTableRow,
   Table,
   TableCell,
   TableContainer,
@@ -13,12 +15,13 @@ import {
 import { useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import styles from './paginated-vitals.scss';
+
 interface PaginatedVitalsProps {
   pageSize: number;
   pageUrl: string;
   urlLabel: string;
-  tableRows: Array<Record<string, string>>;
-  tableHeaders: Array<Record<string, string | boolean>>;
+  tableRows: Array<typeof DataTableRow>;
+  tableHeaders: Array<typeof DataTableHeader>;
   isPrinting?: boolean;
 }
 
@@ -31,6 +34,7 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
   isPrinting,
 }) => {
   const isTablet = useLayoutType() === 'tablet';
+
   const StyledTableCell = ({ interpretation, children }: { interpretation: string; children: React.ReactNode }) => {
     switch (interpretation) {
       case 'critically_high':
@@ -62,40 +66,20 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
       ? orderBy(tableRows, [key], ['desc'])
       : orderBy(tableRows, [key], ['asc']);
 
-  function customSortRow(vitalA, vitalB, { sortDirection, sortStates, ...props }) {
-    const { key } = props;
-    setSortParams({ key, order: sortDirection });
-  }
-
   const { results: paginatedVitals, goTo, currentPage } = usePagination(sortedData, pageSize);
 
   const rows = isPrinting ? sortedData : paginatedVitals;
 
   return (
     <div>
-      <DataTable
-        rows={rows}
-        sortRow={customSortRow}
-        headers={tableHeaders}
-        isSortable
-        size={isTablet ? 'lg' : 'sm'}
-        useZebraStyles
-      >
-        {({ rows, headers, getHeaderProps, getTableProps }) => (
+      <DataTable rows={rows} headers={tableHeaders} size={isTablet ? 'lg' : 'sm'} useZebraStyles>
+        {({ rows, headers, getTableProps }) => (
           <TableContainer>
             <Table {...getTableProps()}>
               <TableHead>
                 <TableRow>
                   {headers.map((header) => (
-                    <TableHeader
-                      className={`${styles.productiveHeading01} ${styles.text02}`}
-                      {...getHeaderProps({
-                        header,
-                        isSortable: header.isSortable,
-                      })}
-                    >
-                      {header.header?.content ?? header.header}
-                    </TableHeader>
+                    <TableHeader>{header.header?.content ?? header.header}</TableHeader>
                   ))}
                 </TableRow>
               </TableHead>

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
@@ -4,56 +4,55 @@
 
 td {
   white-space: nowrap;
+}
 
-  &.criticallyLow, &.criticallyHigh, &.low, &.high {
-    td:nth-child(2) {
-      @include type.type-style("heading-compact-01");
-    }
+.criticallyLow, .criticallyHigh, .low, .high {
+  td:nth-child(2) {
+    @include type.type-style("heading-compact-01");
   }
+}
 
-  &.criticallyLow, &.criticallyHigh {
-    outline: 2px solid colors.$red-60;
-    outline-offset: -1px;
+.criticallyLow, .criticallyHigh {
+  border: 2px solid colors.$red-60 !important;
+}
+
+.low, .high {
+  border: 1.5px solid colors.$black-100 !important;
+}
+
+.criticallyLow {
+  td:nth-child(2)::after {
+    content: " ↓↓";
   }
+}
 
-  &.low, &.high {
-    outline: 1px solid colors.$black-100;
+.criticallyHigh {
+  td:nth-child(2)::after {
+    content: " ↑↑";
   }
+}
 
-  &.criticallyLow {
-    td:nth-child(2)::after {
-      content: " ↓↓";
-    }
+.low {
+  td:nth-child(2)::after {
+    content: " ↓";
   }
+}
 
-  &.criticallyHigh {
-    td:nth-child(2)::after {
-      content: " ↑↑";
-    }
+.high {
+  td:nth-child(2)::after {
+    content: " ↑";
   }
+}
 
-  &.low {
-    td:nth-child(2)::after {
-      content: " ↓";
-    }
+.off-scale-low {
+  td:nth-child(2)::after {
+    content: " ↓↓↓";
   }
+}
 
-  &.high {
-    td:nth-child(2)::after {
-      content: " ↑";
-    }
-  }
-
-  &.off-scale-low {
-    td:nth-child(2)::after {
-      content: " ↓↓↓";
-    }
-  }
-
-  &.off-scale-high {
-    td:nth-child(2)::after {
-      content: " ↑↑↑";
-    }
+.off-scale-high {
+  td:nth-child(2)::after {
+    content: " ↑↑↑";
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

I've made a few styling tweaks to the appearance of flagged vital signs in the vitals overview table. It's not 100%, but things look better than what's currently implemented (see screenshots below). I've also removed column sorting logic from the Datatable.

## Screenshots

> Before

![CleanShot 2023-10-20 at 10  43 02@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/9f7c3f9d-eb3a-40ba-9d36-c0b6a65b8a47)

> After

![CleanShot 2023-10-20 at 10  43 19@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/3d93c2d1-2f8e-41f2-b78d-7eb6bf6779c6)

> Before

![CleanShot 2023-10-20 at 10  43 51@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/02ea3f1a-05c1-4fc1-af4f-72e323ec4b33)

> After

![CleanShot 2023-10-20 at 10  44 04@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/31cfda2f-bab0-427c-94a1-6c70a304e89d)

> Before

![CleanShot 2023-10-20 at 10  47 22@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/653c57bb-ed59-4f1a-899f-f4a68e0859c6)

> After

![CleanShot 2023-10-20 at 10  47 34@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/d6237f6b-4802-4dc4-a021-387f407a78ea)

## Related Issue
*None*

## Other
*None*
