### PR TITLE
(fix:forms-app) Don't fetch encounters if there is no patientUuid yet

### DIFF
--- a/packages/esm-patient-forms-app/src/hooks/use-forms.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-forms.ts
@@ -42,8 +42,10 @@ export function useEncountersWithFormRef(
   startDate: Date = dayjs(new Date()).startOf('day').subtract(500, 'day').toDate(),
   endDate: Date = dayjs(new Date()).endOf('day').toDate(),
 ) {
-  const url = `/ws/rest/v1/encounter?v=${customEncounterRepresentation}&patient=${patientUuid}&fromdate=${startDate.toISOString()}&todate=${endDate.toISOString()}`;
-  return useSWR(url, (url) => openmrsFetch<ListResponse<EncounterWithFormRef>>(url));
+  const url = patientUuid
+    ? `/ws/rest/v1/encounter?v=${customEncounterRepresentation}&patient=${patientUuid}&fromdate=${startDate.toISOString()}&todate=${endDate.toISOString()}`
+    : null;
+  return useSWR(url, openmrsFetch<ListResponse<EncounterWithFormRef>>);
 }
 
 // December 31, 1969; hopefully we don't have encounters before that


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Very small fix to not call the encounter endpoint from the form engine until a patientUuid is available.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
