### PR TITLE
(feat) Supporting O3-2510: Expose patient-common-lib on window

### DIFF
--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -7,12 +7,17 @@ import {
   registerFeatureFlag,
 } from '@openmrs/esm-framework';
 import { createDashboardLink } from '@openmrs/esm-patient-common-lib';
+import * as PatientCommonLib from '@openmrs/esm-patient-common-lib';
 import { esmPatientChartSchema } from './config-schema';
 import { moduleName, spaBasePath } from './constants';
 import { summaryDashboardMeta, encountersDashboardMeta } from './dashboard.meta';
 import { setupOfflineVisitsSync, setupCacheableRoutes } from './offline';
 import { genericDashboardConfigSchema } from './side-nav/generic-dashboard.component';
 import { genericNavGroupConfigSchema } from './side-nav/generic-nav-group.component';
+
+// This allows @openmrs/esm-patient-common-lib to be accessed by modules that are not
+// using webpack. This is used for ngx-formentry.
+window["_openmrs_esm_patient_common_lib"] = PatientCommonLib;
 
 export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Makes esm-patient-common-lib available on the window object. This will allow ngx-formentry to access it despite not being a webpack module.

## Related Issue
https://issues.openmrs.org/browse/O3-2510

## Other
Copilot called me out for doing a hack
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/1031876/596bfbde-d0d7-4879-8d82-2953bc908f50)
