### PR TITLE
(fix) O3-2527: User not having provider account throwing error when searching for drug orders

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
@@ -40,7 +40,7 @@ export default function AddDrugOrderWorkspace({ order: initialOrder, closeWorksp
   const saveDrugOrder = useCallback(
     (finalizedOrder: DrugOrderBasketItem) => {
       finalizedOrder.careSetting = careSettingUuid;
-      finalizedOrder.orderer = session.currentProvider.uuid;
+      finalizedOrder.orderer = session?.currentProvider?.uuid;
       const newOrders = [...orders];
       const existingOrder = orders.find((order) => ordersEqual(order, finalizedOrder));
       newOrders[orders.indexOf(existingOrder)] = finalizedOrder;
@@ -48,7 +48,7 @@ export default function AddDrugOrderWorkspace({ order: initialOrder, closeWorksp
       closeWorkspace();
       launchPatientWorkspace('order-basket');
     },
-    [orders, setOrders, closeWorkspace, session.currentProvider.uuid],
+    [orders, setOrders, closeWorkspace, session?.currentProvider?.uuid],
   );
 
   if (!currentOrder) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
The drug search requires the user to have a provider account and throws an error if the user doesn't have one. 

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-2527

## Other
<!-- Anything not covered above -->
