### PR TITLE
(feat) The lab order form should have a reason for ordering field

### DIFF
--- a/packages/esm-patient-common-lib/src/orders/types.ts
+++ b/packages/esm-patient-common-lib/src/orders/types.ts
@@ -43,6 +43,7 @@ export interface OrderPost {
   previousOrder?: string;
   asNeededCondition?: string;
   orderReasonNonCoded?: string;
+  orderReason?: string;
   instructions?: string;
 }
 

--- a/packages/esm-patient-labs-app/src/config-schema.ts
+++ b/packages/esm-patient-labs-app/src/config-schema.ts
@@ -52,8 +52,8 @@ export const configSchema = {
       orderReasons: {
         _type: Type.Array,
         _elements: {
-          uuid: {
-            _type: Type.UUID,
+          concept: {
+            _type: Type.ConceptUuid,
             _description: 'Array of coded concepts that represent reasons for ordering a lab test',
           },
           label: {

--- a/packages/esm-patient-labs-app/src/config-schema.ts
+++ b/packages/esm-patient-labs-app/src/config-schema.ts
@@ -52,15 +52,8 @@ export const configSchema = {
       orderReasons: {
         _type: Type.Array,
         _elements: {
-          concept: {
-            _type: Type.ConceptUuid,
-            _description: 'Array of coded concepts that represent reasons for ordering a lab test',
-          },
-          label: {
-            _type: Type.String,
-            _default: null,
-            _description: 'The label for the reason for ordering concept',
-          },
+          _type: Type.ConceptUuid,
+          _description: 'Array of coded concepts that represent reasons for ordering a lab test',
         },
         _default: [],
         _description: 'Coded Lab test order reason options',
@@ -81,7 +74,7 @@ export interface LabTestReason {
 }
 export interface OrderReason {
   labTestUuid: string;
-  orderReasons: Array<LabTestReason>;
+  orderReasons: Array<string>;
 }
 export interface ConfigObject {
   concepts: Array<ObsTreeEntry>;

--- a/packages/esm-patient-labs-app/src/config-schema.ts
+++ b/packages/esm-patient-labs-app/src/config-schema.ts
@@ -41,11 +41,47 @@ export const configSchema = {
       _default: '52a447d3-a64a-11e3-9aeb-50e549534c5e',
     },
   },
+  labTests: {
+    _type: Type.Array,
+    _elements: {
+      labTestUuid: {
+        _type: Type.UUID,
+        _description: "UUID for the 'Lab' Test that require order reason",
+        _default: '',
+      },
+      labTestOrderReasons: {
+        _type: Type.Array,
+        _elements: {
+          uuid: {
+            _type: Type.UUID,
+            _description: 'Lab test concept UUID',
+          },
+          label: {
+            _type: Type.String,
+            _default: null,
+            _description: 'The label for order reason',
+          },
+        },
+        _default: [],
+        _description: 'Coded Lab test order reason options',
+      },
+    },
+    _default: [],
+    _description: 'Whether to allow for provision of order reason',
+  },
 };
 
 export interface ObsTreeEntry {
   conceptUuid: string;
   defaultOpen: boolean;
+}
+export interface LabTestReason {
+  uuid: string;
+  label?: string;
+}
+export interface OrderReason {
+  labTestUuid: string;
+  labTestOrderReasons: Array<LabTestReason>;
 }
 export interface ConfigObject {
   concepts: Array<ObsTreeEntry>;
@@ -53,4 +89,5 @@ export interface ConfigObject {
   orders: {
     labOrderTypeUuid: string;
   };
+  labTests: Array<OrderReason>;
 }

--- a/packages/esm-patient-labs-app/src/config-schema.ts
+++ b/packages/esm-patient-labs-app/src/config-schema.ts
@@ -41,25 +41,25 @@ export const configSchema = {
       _default: '52a447d3-a64a-11e3-9aeb-50e549534c5e',
     },
   },
-  labTests: {
+  labTestsWithOrderReasons: {
     _type: Type.Array,
     _elements: {
       labTestUuid: {
         _type: Type.UUID,
-        _description: "UUID for the 'Lab' Test that require order reason",
+        _description: 'UUID of the lab test that requires a reason for ordering',
         _default: '',
       },
-      labTestOrderReasons: {
+      orderReasons: {
         _type: Type.Array,
         _elements: {
           uuid: {
             _type: Type.UUID,
-            _description: 'Concept UUID representing the order reason',
+            _description: 'Array of coded concepts that represent reasons for ordering a lab test',
           },
           label: {
             _type: Type.String,
             _default: null,
-            _description: 'The label for order reason',
+            _description: 'The label for the reason for ordering concept',
           },
         },
         _default: [],
@@ -81,7 +81,7 @@ export interface LabTestReason {
 }
 export interface OrderReason {
   labTestUuid: string;
-  labTestOrderReasons: Array<LabTestReason>;
+  orderReasons: Array<LabTestReason>;
 }
 export interface ConfigObject {
   concepts: Array<ObsTreeEntry>;
@@ -89,5 +89,5 @@ export interface ConfigObject {
   orders: {
     labOrderTypeUuid: string;
   };
-  labTests: Array<OrderReason>;
+  labTestsWithOrderReasons: Array<OrderReason>;
 }

--- a/packages/esm-patient-labs-app/src/config-schema.ts
+++ b/packages/esm-patient-labs-app/src/config-schema.ts
@@ -54,7 +54,7 @@ export const configSchema = {
         _elements: {
           uuid: {
             _type: Type.UUID,
-            _description: 'Lab test concept UUID',
+            _description: 'Concept UUID representing the order reason',
           },
           label: {
             _type: Type.String,
@@ -67,7 +67,7 @@ export const configSchema = {
       },
     },
     _default: [],
-    _description: 'Whether to allow for provision of order reason',
+    _description: 'Whether to allow for provision of coded order reason',
   },
 };
 

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
@@ -45,6 +45,7 @@ const labOrderFormSchema = z.object({
       invalid_type_error: translateFrom(moduleName, 'addLabOrderLabReferenceRequired', 'Test type is required'),
     },
   ),
+  orderReason: z.string().optional(),
 });
 
 // Designs:
@@ -197,13 +198,21 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
             <Grid className={styles.gridRow}>
               <Column lg={16} md={8} sm={4}>
                 <InputWrapper>
-                  <ComboBox
-                    size="lg"
-                    id="orderReasonInput"
-                    titleText={t('orderReason', 'Order reason')}
-                    selectedItem={''}
-                    items={selectedLabTest.orderReasons}
-                    itemToString={(item) => item?.label}
+                  <Controller
+                    name="orderReason"
+                    control={control}
+                    render={({ field: { onChange, onBlur, value } }) => (
+                      <ComboBox
+                        size="lg"
+                        id="orderReasonInput"
+                        titleText={t('orderReason', 'Order reason')}
+                        selectedItem={''}
+                        itemToString={(item) => item?.label}
+                        items={selectedLabTest.orderReasons}
+                        onBlur={onBlur}
+                        onChange={({ selectedItem }) => onChange(selectedItem?.concept || '')}
+                      />
+                    )}
                   />
                 </InputWrapper>
               </Column>

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { launchPatientWorkspace, promptBeforeClosing, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { translateFrom, useLayoutType, useSession, useConfig } from '@openmrs/esm-framework';
-import { careSettingUuid, type LabOrderBasketItem, prepLabOrderPostData } from '../api';
+import { careSettingUuid, type LabOrderBasketItem, prepLabOrderPostData, useOrderReasons } from '../api';
 import {
   Button,
   ButtonSet,
@@ -73,9 +73,10 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
     },
   });
   const config = useConfig<ConfigObject>();
-  const orderReasons =
+  const orderReasonUuids =
     (config.labTestsWithOrderReasons?.find((c) => c.labTestUuid === defaultValues?.testType?.conceptUuid) || {})
       .orderReasons || [];
+  const { orderReasons } = useOrderReasons(orderReasonUuids);
 
   const handleFormSubmission = useCallback(
     (data: LabOrderBasketItem) => {
@@ -206,10 +207,10 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
                         id="orderReasonInput"
                         titleText={t('orderReason', 'Order reason')}
                         selectedItem={''}
-                        itemToString={(item) => item?.label}
+                        itemToString={(item) => item?.display}
                         items={orderReasons}
                         onBlur={onBlur}
-                        onChange={({ selectedItem }) => onChange(selectedItem?.concept || '')}
+                        onChange={({ selectedItem }) => onChange(selectedItem?.uuid || '')}
                       />
                     )}
                   />

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
@@ -72,7 +72,10 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
     },
   });
   const config = useConfig<ConfigObject>();
-  const selectedLabTest = config.labTests.find((p) => p.labTestUuid === defaultValues?.testType?.conceptUuid);
+  const selectedLabTest =
+    config && config.labTests
+      ? config.labTests.find((p) => p.labTestUuid === defaultValues?.testType?.conceptUuid)
+      : null;
 
   const handleFormSubmission = useCallback(
     (data: LabOrderBasketItem) => {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
@@ -73,8 +73,8 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
   });
   const config = useConfig<ConfigObject>();
   const selectedLabTest =
-    config && config.labTests
-      ? config.labTests.find((p) => p.labTestUuid === defaultValues?.testType?.conceptUuid)
+    config && config.labTestsWithOrderReasons
+      ? config.labTestsWithOrderReasons.find((p) => p.labTestUuid === defaultValues?.testType?.conceptUuid)
       : null;
 
   const handleFormSubmission = useCallback(
@@ -202,7 +202,7 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
                     id="orderReasonInput"
                     titleText={t('orderReason', 'Order reason')}
                     selectedItem={''}
-                    items={selectedLabTest.labTestOrderReasons}
+                    items={selectedLabTest.orderReasons}
                     itemToString={(item) => item?.label}
                   />
                 </InputWrapper>

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
@@ -73,10 +73,9 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
     },
   });
   const config = useConfig<ConfigObject>();
-  const selectedLabTest =
-    config && config.labTestsWithOrderReasons
-      ? config.labTestsWithOrderReasons.find((p) => p.labTestUuid === defaultValues?.testType?.conceptUuid)
-      : null;
+  const orderReasons =
+    (config.labTestsWithOrderReasons?.find((c) => c.labTestUuid === defaultValues?.testType?.conceptUuid) || {})
+      .orderReasons || [];
 
   const handleFormSubmission = useCallback(
     (data: LabOrderBasketItem) => {
@@ -194,7 +193,7 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
               </InputWrapper>
             </Column>
           </Grid>
-          {selectedLabTest && (
+          {orderReasons.length > 0 && (
             <Grid className={styles.gridRow}>
               <Column lg={16} md={8} sm={4}>
                 <InputWrapper>
@@ -208,7 +207,7 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
                         titleText={t('orderReason', 'Order reason')}
                         selectedItem={''}
                         itemToString={(item) => item?.label}
-                        items={selectedLabTest.orderReasons}
+                        items={orderReasons}
                         onBlur={onBlur}
                         onChange={({ selectedItem }) => onChange(selectedItem?.concept || '')}
                       />

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { launchPatientWorkspace, promptBeforeClosing, useOrderBasket } from '@openmrs/esm-patient-common-lib';
-import { translateFrom, useLayoutType, useSession } from '@openmrs/esm-framework';
+import { translateFrom, useLayoutType, useSession, useConfig } from '@openmrs/esm-framework';
 import { careSettingUuid, type LabOrderBasketItem, prepLabOrderPostData } from '../api';
 import {
   Button,
@@ -22,6 +22,7 @@ import { Controller, type FieldErrors, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { moduleName } from '@openmrs/esm-patient-chart-app/src/constants';
+import { type ConfigObject } from '../../config-schema';
 import styles from './lab-order-form.scss';
 
 export interface LabOrderFormProps {
@@ -70,6 +71,8 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
       ...initialOrder,
     },
   });
+  const config = useConfig<ConfigObject>();
+  const selectedLabTest = config.labTests.find((p) => p.labTestUuid === defaultValues?.testType?.conceptUuid);
 
   const handleFormSubmission = useCallback(
     (data: LabOrderBasketItem) => {
@@ -187,6 +190,22 @@ export function LabOrderForm({ initialOrder, closeWorkspace }: LabOrderFormProps
               </InputWrapper>
             </Column>
           </Grid>
+          {selectedLabTest && (
+            <Grid className={styles.gridRow}>
+              <Column lg={16} md={8} sm={4}>
+                <InputWrapper>
+                  <ComboBox
+                    size="lg"
+                    id="orderReasonInput"
+                    titleText={t('orderReason', 'Order reason')}
+                    selectedItem={''}
+                    items={selectedLabTest.labTestOrderReasons}
+                    itemToString={(item) => item?.label}
+                  />
+                </InputWrapper>
+              </Column>
+            </Grid>
+          )}
           <Grid className={styles.gridRow}>
             <Column lg={16} md={8} sm={4}>
               <InputWrapper>

--- a/packages/esm-patient-labs-app/src/lab-orders/api.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/api.ts
@@ -50,6 +50,7 @@ export interface LabOrderBasketItem extends OrderBasketItem {
   labReferenceNumber?: string;
   urgency?: string;
   instructions?: string;
+  orderReason?: string;
 }
 
 export function prepLabOrderPostData(order: LabOrderBasketItem, patientUuid: string, encounterUuid: string): OrderPost {
@@ -62,6 +63,7 @@ export function prepLabOrderPostData(order: LabOrderBasketItem, patientUuid: str
     encounter: encounterUuid,
     concept: order.testType.conceptUuid,
     instructions: order.instructions,
+    orderReason: order.orderReason,
   };
 }
 

--- a/packages/esm-patient-labs-app/src/lab-orders/api.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/api.ts
@@ -1,8 +1,9 @@
 import useSWR, { mutate } from 'swr';
-import { type FetchResponse, openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, useConfig, showSnackbar } from '@openmrs/esm-framework';
 import { type ConfigObject } from '../config-schema';
 import { useCallback, useMemo } from 'react';
 import { type OrderBasketItem, type OrderPost, type PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';
+import useSWRImmutable from 'swr/immutable';
 
 export const careSettingUuid = '6f0c9a92-6f24-11e3-af88-005056821db0';
 /**
@@ -42,6 +43,32 @@ export function usePatientLabOrders(patientUuid: string, status: 'ACTIVE' | 'any
   };
 }
 
+export function useOrderReasons(conceptUuids: Array<string>) {
+  const shouldFetch = conceptUuids && conceptUuids.length > 0;
+  const url = shouldFetch ? getConceptReferenceUrls(conceptUuids) : null;
+  const { data, error, isLoading } = useSWRImmutable<FetchResponse<ConceptResponse>, Error>(
+    shouldFetch ? `/ws/rest/v1/${url[0]}` : null,
+    openmrsFetch,
+  );
+
+  const ob = data?.data;
+  const orderReasons = ob
+    ? Object.entries(ob).map(([key, value]) => ({
+        uuid: value.uuid,
+        display: value.display,
+      }))
+    : [];
+
+  if (error) {
+    showSnackbar({
+      title: error.name,
+      subtitle: error.message,
+      kind: 'error',
+    });
+  }
+
+  return { orderReasons: orderReasons, isLoading };
+}
 export interface LabOrderBasketItem extends OrderBasketItem {
   testType?: {
     label: string;
@@ -66,9 +93,33 @@ export function prepLabOrderPostData(order: LabOrderBasketItem, patientUuid: str
     orderReason: order.orderReason,
   };
 }
+const chunkSize = 10;
+export function getConceptReferenceUrls(conceptUuids: Array<string>) {
+  const accumulator = [];
+  for (let i = 0; i < conceptUuids.length; i += chunkSize) {
+    accumulator.push(conceptUuids.slice(i, i + chunkSize));
+  }
+
+  return accumulator.map((partition) => `conceptreferences?references=${partition.join(',')}&v=custom:(uuid,display)`);
+}
 
 export type PostDataPrepLabOrderFunction = (
   order: LabOrderBasketItem,
   patientUuid: string,
   encounterUuid: string,
 ) => OrderPost;
+
+export interface ConceptAnswers {
+  display: string;
+  uuid: string;
+}
+export interface ConceptResponse {
+  uuid: string;
+  display: string;
+  datatype: {
+    uuid: string;
+    display: string;
+  };
+  answers: Array<ConceptAnswers>;
+  setMembers: Array<ConceptAnswers>;
+}

--- a/packages/esm-patient-labs-app/translations/en.json
+++ b/packages/esm-patient-labs-app/translations/en.json
@@ -24,6 +24,7 @@
   "onDate": "on",
   "orderActionNew": "New",
   "ordered": "Ordered",
+  "orderReason": "Order reason",
   "other": "Other",
   "panel": "Panel",
   "pleaseRequiredFields": "Please fill all required fields",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
![lab-order-reason](https://github.com/openmrs/openmrs-esm-patient-chart/assets/4432218/42c3e12e-6a55-47d2-9c0d-a40b163f8f3c)

## Related Issue

https://issues.openmrs.org/browse/O3-2361

## Other

Sample config schema

```ts
{
  "@openmrs/esm-patient-labs-app": {
    "labTestsWithOrderReasons": [
      {
        "labTestUuid": "854AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
        "orderReasons": [
          "161236AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
          "162080AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
          "160032AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
        ]
      }
    ]
  }
}
```