### PR TITLE
(fix) Restore ability to optionally launch clinical form from vitals and biometrics widget 

### DIFF
--- a/packages/esm-patient-vitals-app/src/utils.ts
+++ b/packages/esm-patient-vitals-app/src/utils.ts
@@ -30,7 +30,7 @@ export function launchVitalsAndBiometricsForm(currentVisit: Visit, config: Confi
 
   if (config.vitals.useFormEngine) {
     const { formUuid, formName } = config.vitals;
-    launchFormEntry(formUuid, undefined, formName);
+    launchFormEntry(formUuid, '', formName);
   } else {
     launchPatientWorkspace(patientVitalsBiometricsFormWorkspace);
   }

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
@@ -141,6 +141,27 @@ describe('VitalsHeader: ', () => {
 
     expect(screen.queryByTitle(/abnormal value/i)).toBeInTheDocument();
   });
+
+  test('should launch Form Entry vitals and biometrics form', async () => {
+    const user = userEvent.setup();
+    const { useConfig } = require('@openmrs/esm-framework');
+    const updateVitalsConfigMock = {
+      ...mockVitalsConfig,
+      vitals: { ...mockVitalsConfig.vitals, useFormEngine: true, formName: 'Triage' },
+    };
+    useConfig.mockImplementation(() => updateVitalsConfigMock);
+
+    renderVitalsHeader();
+    await waitForLoadingToFinish();
+
+    const recordVitalsButton = screen.getByText(/Record vitals/i);
+
+    await waitFor(() => user.click(recordVitalsButton));
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('patient-form-entry-workspace', {
+      formInfo: { encounterUuid: '', formUuid: updateVitalsConfigMock.vitals.formUuid },
+      workspaceTitle: updateVitalsConfigMock.vitals.formName,
+    });
+  });
 });
 
 function renderVitalsHeader() {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes a regression from Breaking changes made while consolidating both Vitals and Biometrics to one package. Form entry expects empty string as single-spa prop to launch properly. This PR fixes that and adds a unit test to prevent future regression. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
