### PR TITLE
(fix)03-2586: Lab order search should have auto focus

### DIFF
--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
@@ -34,6 +34,7 @@ export function TestTypeSearch({ openLabForm }: TestTypeSearchProps) {
     <>
       <ResponsiveWrapper isTablet={isTablet}>
         <Search
+          autoFocus
           size="lg"
           placeholder={t('searchFieldPlaceholder', 'Search for a test type')}
           labelText={t('searchFieldPlaceholder', 'Search for a test type')}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I added `autoFocus `on Lab order search bar 

## Screenshots
**Before making changes**
![Screenshot 2023-11-21 at 3 54 41 PM](https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/df3d983c-21e9-4d85-8ddb-2e5994194713)

**After making changes**
![Screenshot 2023-11-21 at 3 51 04 PM](https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/69e0fc49-37ef-4920-b0c5-dd4608a9e12e)

## Related Issue
https://issues.openmrs.org/projects/O3/issues/O3-2586

## Other
<!-- Anything not covered above -->
