### PR TITLE
Allow edit O2 form in visits widget

### DIFF
--- a/packages/esm-patient-chart-app/src/form-entry-interop.ts
+++ b/packages/esm-patient-chart-app/src/form-entry-interop.ts
@@ -1,0 +1,61 @@
+import { navigate } from '@openmrs/esm-framework';
+import type { HtmlFormEntryForm } from '@openmrs/esm-patient-forms-app/src/config-schema';
+import type { MappedEncounter } from './visit/visits-widget/visit.resource';
+import isEmpty from 'lodash-es/isEmpty';
+import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
+
+export function launchFormEntryOrHtmlForms(
+  encounter: MappedEncounter | undefined,
+  patient: string,
+  htmlFormEntryForms: Array<HtmlFormEntryForm>,
+  mutateForms?: () => void,
+) {
+  if (encounter) {
+    const htmlForm = htmlFormEntryForms.find((form) => form.formUuid === encounter?.form?.uuid);
+    if (isEmpty(htmlForm)) {
+      launchFormEntry(
+        encounter?.form?.uuid,
+        patient,
+        encounter.id,
+        encounter.form.display,
+        encounter.visitUuid,
+        encounter.visitTypeUuid,
+        mutateForms,
+      );
+    } else {
+      if (encounter?.id) {
+        navigate({
+          to: `\${openmrsBase}/htmlformentryui/htmlform/editHtmlFormWithStandardUi.page?patientId=${patient}&visitId=${encounter.visitUuid}&encounterId=${encounter?.id}&definitionUiResource=${htmlForm.formUiResource}&returnUrl=${window.location.href}`,
+        });
+      } else {
+        navigate({
+          to: `\${openmrsBase}/htmlformentryui/htmlform/${htmlForm.formUiPage}.page?patientId=${patient}&visitId=${encounter.visitUuid}&definitionUiResource=${htmlForm.formUiResource}&returnUrl=${window.location.href}`,
+        });
+      }
+    }
+  } else {
+    launchStartVisitPrompt();
+  }
+}
+
+export function launchFormEntry(
+  formUuid: string,
+  patientUuid: string,
+  encounterUuid?: string,
+  formName?: string,
+  visitUuid?: string,
+  visitTypeUuid?: string,
+  mutateForm?: () => void,
+) {
+  launchPatientWorkspace('patient-form-entry-workspace', {
+    workspaceTitle: formName,
+    mutateForm,
+    formInfo: {
+      encounterUuid,
+      formUuid,
+      patientUuid,
+      visitTypeUuid: visitTypeUuid,
+      visitUuid: visitUuid,
+    },
+  });
+}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -30,7 +30,6 @@ import {
   formatDatetime,
   getConfig,
   isDesktop,
-  navigate,
   parseDate,
   showModal,
   showToast,
@@ -39,10 +38,11 @@ import {
   useSession,
   userHasAccess,
 } from '@openmrs/esm-framework';
-import { launchPatientWorkspace, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
+import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import type { HtmlFormEntryForm } from '@openmrs/esm-patient-forms-app/src/config-schema';
 import { deleteEncounter } from './visits-table.resource';
 import { MappedEncounter } from '../../visit.resource';
+import { launchFormEntryOrHtmlForms } from '../../../../form-entry-interop';
 import EncounterObservations from '../../encounter-observations';
 import styles from './visits-table.scss';
 
@@ -121,28 +121,6 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
       key: 'provider',
     },
   );
-
-  const launchWorkspace = (
-    formUuid: string,
-    visitUuid?: string,
-    encounterUuid?: string,
-    formName?: string,
-    visitTypeUuid?: string,
-    visitStartDatetime?: string,
-    visitStopDatetime?: string,
-  ) => {
-    const htmlForm = htmlFormEntryFormsConfig?.find((form) => form.formUuid === formUuid);
-    if (isEmpty(htmlForm)) {
-      launchPatientWorkspace('patient-form-entry-workspace', {
-        workspaceTitle: formName,
-        formInfo: { visitUuid, visitTypeUuid, visitStartDatetime, visitStopDatetime, formUuid, encounterUuid },
-      });
-    } else {
-      navigate({
-        to: `\${openmrsBase}/htmlformentryui/htmlform/${htmlForm.formUiPage}.page?patientId=${patientUuid}&visitId=${visitUuid}&encounterId=${encounterUuid}&definitionUiResource=${htmlForm.formUiResource}&returnUrl=${window.location.href}`,
-      });
-    }
-  };
 
   const tableRows = useMemo(() => {
     return paginatedVisits?.map((encounter) => ({
@@ -291,14 +269,10 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
                                       itemText={t('editThisEncounter', 'Edit this encounter')}
                                       size={desktopLayout ? 'sm' : 'lg'}
                                       onClick={() => {
-                                        launchWorkspace(
-                                          selectedVisit?.form?.uuid,
-                                          selectedVisit?.visitUuid,
-                                          selectedVisit?.id,
-                                          selectedVisit?.form?.display,
-                                          selectedVisit?.visitTypeUuid,
-                                          selectedVisit?.visitStartDatetime,
-                                          selectedVisit?.visitStopDatetime,
+                                        launchFormEntryOrHtmlForms(
+                                          selectedVisit,
+                                          patientUuid,
+                                          htmlFormEntryFormsConfig,
                                         );
                                       }}
                                     />
@@ -328,15 +302,7 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
                                   <Button
                                     kind="ghost"
                                     onClick={() => {
-                                      launchWorkspace(
-                                        selectedVisit.form.uuid,
-                                        selectedVisit.visitUuid,
-                                        selectedVisit.id,
-                                        selectedVisit.form.display,
-                                        selectedVisit.visitTypeUuid,
-                                        selectedVisit?.visitStartDatetime,
-                                        selectedVisit?.visitStopDatetime,
-                                      );
+                                      launchFormEntryOrHtmlForms(selectedVisit, patientUuid, htmlFormEntryFormsConfig);
                                     }}
                                     renderIcon={(props) => <Edit size={16} {...props} />}
                                   >


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This pull request addresses an issue where clicking "Edit this Encounter" always opened a new form instead of allowing users to edit the existing O2 form within the visits widget. The modification ensures a more intuitive and efficient workflow by enabling the direct editing of O2 forms.


## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/94977371/d9a9e7ca-f419-4e8d-9708-61f40c41c67f)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Thanks,
CC: @ibacher 
