### PR TITLE
(fix)O3-2585: Added the active state for the new patient list icon in the side rail

### DIFF
--- a/packages/esm-patient-lists-app/src/action-button/patient-lists-action-button.extension.tsx
+++ b/packages/esm-patient-lists-app/src/action-button/patient-lists-action-button.extension.tsx
@@ -10,12 +10,12 @@ function PatientListsActionButton() {
 
   return (
     <SiderailNavButton
-      name="patient-lists-action-menu"
+      name={'patient-lists-action-menu'}
       getIcon={(props) => <Events {...props} />}
       label={t('patientLists', 'Patient lists')}
       iconDescription={t('patientLists', 'Patient lists')}
       handler={handleLaunchPatientListsWorkspace}
-      type="patient-lists"
+      type={'patient-list'}
     />
   );
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. 
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).

## Summary
Added the active state for the new patient list icon in the side rail

## Screenshots

# Before
![Screenshot from 2023-11-23 09-48-01](https://github.com/openmrs/openmrs-esm-patient-chart/assets/94807133/5fc95fa1-59b5-4d2d-85bf-cfcf59f4e8b0)


# After

![Screenshot from 2023-11-23 09-46-39](https://github.com/openmrs/openmrs-esm-patient-chart/assets/94807133/59a7ce15-d3d2-4c03-ad9f-8cfe585b1fce)
## Related Issue
https://issues.openmrs.org/browse/O3-2585