### PR TITLE
(chore) ESLint: Add consistent-type-imports and no-console rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,15 @@
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/ban-types": "off",
+    // Use `import type` instead of `import` for type imports https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "fixStyle": "inline-type-imports"
+      }
+    ],
     "prefer-const": "off",
+    "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-unsafe-optional-chaining": "off",
     "no-explicit-any": "off",
     "no-extra-boolean-cast": "off",

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { InlineLoading } from '@carbon/react';
 import { OHRIForm } from '@openmrs/openmrs-form-engine-lib';
-import { Visit } from '@openmrs/esm-framework';
+import { type Visit } from '@openmrs/esm-framework';
 import useFormSchema from '../hooks/useFormSchema';
 import FormError from './form-error.component';
 import styles from './form-renderer.scss';

--- a/packages/esm-form-engine-app/src/hooks/useFormSchema.tsx
+++ b/packages/esm-form-engine-app/src/hooks/useFormSchema.tsx
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 
 import { openmrsFetch } from '@openmrs/esm-framework';
-import { OHRIFormSchema } from '@openmrs/openmrs-form-engine-lib';
+import { type OHRIFormSchema } from '@openmrs/openmrs-form-engine-lib';
 
 /**
  * Custom hook to fetch form schema based on its form UUID.

--- a/packages/esm-form-engine-app/src/types/index.ts
+++ b/packages/esm-form-engine-app/src/types/index.ts
@@ -1,5 +1,5 @@
-import { OpenmrsFormResource } from '@openmrs/openmrs-form-engine-lib';
-import { OpenmrsResource } from '@openmrs/esm-framework';
+import { type OpenmrsFormResource } from '@openmrs/openmrs-form-engine-lib';
+import { type OpenmrsResource } from '@openmrs/esm-framework';
 
 export interface Form {
   uuid: string;

--- a/packages/esm-form-entry-app/.eslintrc.json
+++ b/packages/esm-form-entry-app/.eslintrc.json
@@ -1,0 +1,27 @@
+{
+  "root": true,
+  "ignorePatterns": [
+    "projects/**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts"
+      ],
+      "extends": [
+        "plugin:@angular-eslint/recommended",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.html"
+      ],
+      "extends": [
+        "plugin:@angular-eslint/template/recommended"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/esm-form-entry-app/angular.json
+++ b/packages/esm-form-entry-app/angular.json
@@ -1,28 +1,31 @@
 {
-	"$schema": "../../node_modules/@angular/cli/lib/config/schema.json",
-	"cli": {
+  "$schema": "../../node_modules/@angular/cli/lib/config/schema.json",
+  "cli": {
     "analytics": false,
     "cache": {
       "enabled": false
-    }
-	},
-	"version": 1,
-	"newProjectRoot": "projects",
-	"projects": {
-		"openmrs-esm-form-entry-app": {
-			"projectType": "application",
-			"schematics": {
-				"@schematics/angular:component": {
-					"style": "scss"
-				}
-			},
-			"root": "",
-			"sourceRoot": "src",
-			"prefix": "formentry",
-			"architect": {
-				"build": {
-					"builder": "ngx-build-plus:browser",
-					"options": {
+    },
+    "schematicCollections": [
+      "@angular-eslint/schematics"
+    ]
+  },
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "openmrs-esm-form-entry-app": {
+      "projectType": "application",
+      "schematics": {
+        "@schematics/angular:component": {
+          "style": "scss"
+        }
+      },
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "formentry",
+      "architect": {
+        "build": {
+          "builder": "ngx-build-plus:browser",
+          "options": {
             "allowedCommonJsDependencies": [
               "core-js",
               "dompurify",
@@ -33,108 +36,117 @@
               "rgbcolor",
               "zone.js"
             ],
-						"preserveSymlinks": true,
-						"outputPath": "dist",
-						"index": "",
-						"main": "src/index.ts",
-						"tsConfig": "tsconfig.app.json",
-						"aot": true,
-						"assets": [
-							"src/assets"
-						],
-						"styles": [
-							"src/styles.css"
-						],
-						"scripts": [],
-						"extraWebpackConfig": "webpack.config.js",
-						"commonChunk": false
-					},
-					"configurations": {
-						"production": {
-							"fileReplacements": [
-								{
-									"replace": "src/environments/environment.ts",
-									"with": "src/environments/environment.prod.ts"
-								}
-							],
-							"optimization": {
-								"scripts": true,
-								"styles": false
-							},
-							"outputHashing": "all",
-							"sourceMap": false,
-							"namedChunks": false,
-							"aot": true,
-							"extractLicenses": true,
-							"vendorChunk": false,
-							"buildOptimizer": true,
-							"budgets": [
-								{
-									"type": "initial",
-									"maximumWarning": "2mb",
-									"maximumError": "5mb"
-								},
-								{
-									"type": "anyComponentStyle",
-									"maximumWarning": "30kb",
-									"maximumError": "60kb"
-								}
-							],
-							"extraWebpackConfig": "webpack.prod.config.js"
-						}
-					}
-				},
-				"serve": {
-					"builder": "ngx-build-plus:dev-server",
-					"options": {
+            "preserveSymlinks": true,
+            "outputPath": "dist",
+            "index": "",
+            "main": "src/index.ts",
+            "tsConfig": "tsconfig.app.json",
+            "aot": true,
+            "assets": [
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.css"
+            ],
+            "scripts": [],
+            "extraWebpackConfig": "webpack.config.js",
+            "commonChunk": false
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
+              "optimization": {
+                "scripts": true,
+                "styles": false
+              },
+              "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "30kb",
+                  "maximumError": "60kb"
+                }
+              ],
+              "extraWebpackConfig": "webpack.prod.config.js"
+            }
+          }
+        },
+        "serve": {
+          "builder": "ngx-build-plus:dev-server",
+          "options": {
             "publicHost": "http://localhost:4200",
-						"browserTarget": "openmrs-esm-form-entry-app:build",
-						"extraWebpackConfig": "webpack.config.js"
-					},
-					"configurations": {
-						"production": {
-							"browserTarget": "openmrs-esm-form-entry-app:build:production",
-							"extraWebpackConfig": "webpack.prod.config.js"
-						}
-					}
-				},
-				"extract-i18n": {
-					"builder": "ngx-build-plus:extract-i18n",
-					"options": {
-						"browserTarget": "openmrs-esm-form-entry-app:build",
-						"extraWebpackConfig": "webpack.config.js"
-					}
-				},
-				"test": {
-					"builder": "@angular-devkit/build-angular:karma",
-					"options": {
-						"main": "src/test.ts",
-						"polyfills": "src/polyfills.ts",
-						"tsConfig": "tsconfig.spec.json",
-						"karmaConfig": "karma.conf.js",
-						"assets": [
-							"src/favicon.ico",
-							"src/assets"
-						],
-						"styles": [
-							"src/styles.css"
-						],
-						"scripts": []
-					}
-				},
-				"e2e": {
-					"builder": "@angular-devkit/build-angular:protractor",
-					"options": {
-						"protractorConfig": "e2e/protractor.conf.js",
-						"devServerTarget": "openmrs-esm-form-entry-app:serve"
-					},
-					"configurations": {
-						"production": {
-							"devServerTarget": "openmrs-esm-form-entry-app:serve:production"
-						}
-					}
-				}
-			}
-		}
+            "browserTarget": "openmrs-esm-form-entry-app:build",
+            "extraWebpackConfig": "webpack.config.js"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "openmrs-esm-form-entry-app:build:production",
+              "extraWebpackConfig": "webpack.prod.config.js"
+            }
+          }
+        },
+        "extract-i18n": {
+          "builder": "ngx-build-plus:extract-i18n",
+          "options": {
+            "browserTarget": "openmrs-esm-form-entry-app:build",
+            "extraWebpackConfig": "webpack.config.js"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.css"
+            ],
+            "scripts": []
+          }
+        },
+        "e2e": {
+          "builder": "@angular-devkit/build-angular:protractor",
+          "options": {
+            "protractorConfig": "e2e/protractor.conf.js",
+            "devServerTarget": "openmrs-esm-form-entry-app:serve"
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "openmrs-esm-form-entry-app:serve:production"
+            }
+          }
+        },
+        "lint": {
+          "builder": "@angular-eslint/builder:lint",
+          "options": {
+            "lintFilePatterns": [
+              "src/**/*.ts",
+              "src/**/*.html"
+            ]
+          }
+        }
+      }
+    }
   }
 }

--- a/packages/esm-form-entry-app/package.json
+++ b/packages/esm-form-entry-app/package.json
@@ -11,7 +11,7 @@
     "serve": "ng serve --port 4200 --live-reload true",
     "debug": "yarn run serve",
     "build": "ng build --configuration production",
-    "lint": "cross-env eslint src --ext ts --fix --max-warnings=0"
+    "lint": "ng lint"
   },
   "openmrs:develop": {
     "command": "yarn run serve",
@@ -71,6 +71,11 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^15.2.10",
+    "@angular-eslint/builder": "15.2.1",
+    "@angular-eslint/eslint-plugin": "15.2.1",
+    "@angular-eslint/eslint-plugin-template": "15.2.1",
+    "@angular-eslint/schematics": "15.2.1",
+    "@angular-eslint/template-parser": "15.2.1",
     "@angular/cli": "^15.2.10",
     "@angular/compiler-cli": "^15.2.10",
     "@angular/language-service": "^15.2.10",
@@ -79,8 +84,11 @@
     "@types/jasmine": "~3.6.11",
     "@types/jasminewd2": "~2.0.3",
     "@types/webpack-env": "^1.18.2",
+    "@typescript-eslint/eslint-plugin": "5.48.2",
+    "@typescript-eslint/parser": "5.48.2",
     "codelyzer": "^6.0.2",
     "copy-webpack-plugin": "^11.0.0",
+    "eslint": "^8.33.0",
     "jasmine-core": "~5.1.1",
     "jasmine-spec-reporter": "~7.0.0",
     "karma": "~6.4.2",

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -2,7 +2,7 @@ import { NgZone, Component, HostListener, OnDestroy, OnInit } from '@angular/cor
 import { registerLocaleData } from '@angular/common';
 import { Form } from '@openmrs/ngx-formentry';
 import { Observable, forkJoin, from, throwError, of, Subscription } from 'rxjs';
-import { catchError, concatAll, map, mergeMap, switchMap, take } from 'rxjs/operators';
+import { catchError, concatAll, map, mergeMap, take } from 'rxjs/operators';
 import { OpenmrsEsmApiService } from '../openmrs-api/openmrs-esm-api.service';
 import { FormSchemaService } from '../form-schema/form-schema.service';
 import { FormSubmissionService } from '../form-submission/form-submission.service';

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
@@ -5,7 +5,7 @@ import { ChartLineSmooth, Table } from '@carbon/react/icons';
 import { CardHeader, EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { useConfig } from '@openmrs/esm-framework';
 import { useObs } from '../resources/useObs';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 import ObsGraph from '../obs-graph/obs-graph.component';
 import ObsTable from '../obs-table/obs-table.component';
 import styles from './obs-switchable.scss';

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
 import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import { mockWeightAndViralLoadResult } from '../__mocks__/generic-widgets.mock';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 import ObsSwitchable from './obs-switchable.component';
 
 const mockedUseConfig = useConfig as jest.Mock;

--- a/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
+++ b/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 import { openmrsFetch, fhirBaseUrl, useConfig } from '@openmrs/esm-framework';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 
 export interface UseObsResult {
   data: Array<ObsResult>;

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form-tab.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form-tab.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { RadioButtonGroup, RadioButton } from '@carbon/react';
-import { OpenMRSResource } from '../../types';
+import { type OpenMRSResource } from '../../types';
 import styles from './allergy-form-tab.scss';
 
 interface AllergyFormTabProps {

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
@@ -22,12 +22,12 @@ import {
 } from '@carbon/react';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm, Controller, Control, UseFormSetValue } from 'react-hook-form';
-import { ExtensionSlot, FetchResponse, showSnackbar, useConfig, useLayoutType } from '@openmrs/esm-framework';
-import { DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
+import { useForm, Controller, type Control, type UseFormSetValue } from 'react-hook-form';
+import { ExtensionSlot, type FetchResponse, showSnackbar, useConfig, useLayoutType } from '@openmrs/esm-framework';
+import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import {
   type AllergensAndAllergicReactions,
-  NewAllergy,
+  type NewAllergy,
   saveAllergy,
   useAllergensAndAllergicReactions,
 } from './allergy-form.resource';

--- a/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
+++ b/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
@@ -2,7 +2,7 @@ import useSWR from 'swr';
 import { map } from 'rxjs/operators';
 import capitalize from 'lodash-es/capitalize';
 import { fhirBaseUrl, openmrsFetch, openmrsObservableFetch } from '@openmrs/esm-framework';
-import { FHIRAllergy, FHIRAllergyResponse } from '../types';
+import { type FHIRAllergy, type FHIRAllergyResponse } from '../types';
 
 export type Allergy = {
   id: string;

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-form/appointments-form.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-form/appointments-form.component.tsx
@@ -31,7 +31,7 @@ import {
   saveRecurringAppointments,
   useAppointments,
   useAppointmentService,
-} from './../appointments.resource';
+} from '../appointments.resource';
 import type { Appointment, AppointmentPayload, RecurringPattern } from '../../types';
 import { dateFormat, datePickerFormat, datePickerPlaceHolder, weekDays } from '../../constants';
 import styles from './appointments-form.scss';

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-table.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-table.component.tsx
@@ -6,7 +6,7 @@ dayjs.extend(utc);
 import { useTranslation } from 'react-i18next';
 import {
   DataTable,
-  DataTableHeader,
+  type DataTableHeader,
   Table,
   TableCell,
   TableContainer,
@@ -17,7 +17,7 @@ import {
 } from '@carbon/react';
 import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import { formatDatetime, parseDate, useLayoutType, usePagination } from '@openmrs/esm-framework';
-import { Appointment } from '../types';
+import { type Appointment } from '../types';
 import { AppointmentsActionMenu } from './appointments-action-menu.component';
 import styles from './appointments-table.scss';
 

--- a/packages/esm-patient-appointments-app/src/appointments/appointments.resource.ts
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments.resource.ts
@@ -2,10 +2,10 @@ import dayjs from 'dayjs';
 import useSWR from 'swr';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import {
-  AppointmentPayload,
-  AppointmentService,
-  AppointmentsFetchResponse,
-  RecurringAppointmentsPayload,
+  type AppointmentPayload,
+  type AppointmentService,
+  type AppointmentsFetchResponse,
+  type RecurringAppointmentsPayload,
 } from '../types';
 import isToday from 'dayjs/plugin/isToday';
 dayjs.extend(isToday);

--- a/packages/esm-patient-attachments-app/src/attachments.resource.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments.resource.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
-import { AttachmentResponse, UploadedFile } from './attachments-types';
+import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type AttachmentResponse, type UploadedFile } from './attachments-types';
 
 export const attachmentUrl = '/ws/rest/v1/attachment';
 

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-grid-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-grid-overview.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { SkeletonPlaceholder } from '@carbon/react';
-import { Attachment } from '../attachments-types';
+import { type Attachment } from '../attachments-types';
 import AttachmentThumbnail from './attachment-thumbnail.component';
 import styles from './attachments-grid-overview.scss';
 

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
@@ -5,7 +5,7 @@ import { showModal, showSnackbar, useLayoutType, UserHasAccess } from '@openmrs/
 import { CardHeader, EmptyState } from '@openmrs/esm-patient-common-lib';
 import { createAttachment, deleteAttachmentPermanently, useAttachments } from '../attachments.resource';
 import { createGalleryEntry } from '../utils';
-import { UploadedFile, Attachment } from '../attachments-types';
+import { type UploadedFile, type Attachment } from '../attachments-types';
 import AttachmentsGridOverview from './attachments-grid-overview.component';
 import AttachmentsTableOverview from './attachments-table-overview.component';
 import AttachmentPreview from './image-preview.component';

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-table-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-table-overview.component.tsx
@@ -14,7 +14,7 @@ import {
 import { useLayoutType } from '@openmrs/esm-framework';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Attachment } from '../attachments-types';
+import { type Attachment } from '../attachments-types';
 import styles from './attachments-table-overview.scss';
 
 interface AttachmentsTableOverviewProps {

--- a/packages/esm-patient-attachments-app/src/attachments/delete-attachment-confirmation-modal.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/delete-attachment-confirmation-modal.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ModalHeader, ModalBody, ModalFooter } from '@carbon/react';
-import { Attachment } from '../attachments-types';
+import { type Attachment } from '../attachments-types';
 import styles from './delete-attachment-confirmation-modal.scss';
 
 interface DeleteAttachmentConfirmationProps {

--- a/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, OverflowMenu, OverflowMenuItem } from '@carbon/react';
 import { Close } from '@carbon/react/icons';
 import { useLayoutType } from '@openmrs/esm-framework';
-import { Attachment } from '../attachments-types';
+import { type Attachment } from '../attachments-types';
 import styles from './image-preview.scss';
 
 interface AttachmentPreviewProps {

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader-context.resources.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader-context.resources.tsx
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { CameraMediaUploaderContextType } from './camera-media-uploader-types';
+import { type CameraMediaUploaderContextType } from './camera-media-uploader-types';
 
 const CameraMediaUploaderContext = createContext<CameraMediaUploaderContextType>({});
 

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader-types.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader-types.tsx
@@ -1,5 +1,5 @@
-import { UploadedFile } from '../attachments-types';
-import { FetchResponse } from '@openmrs/esm-framework';
+import { type UploadedFile } from '../attachments-types';
+import { type FetchResponse } from '@openmrs/esm-framework';
 
 export interface CameraMediaUploaderContextType {
   multipleFiles?: boolean;

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader.component.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef, useContext } from 'react';
-import { UploadedFile } from '../attachments-types';
-import { FetchResponse, showSnackbar } from '@openmrs/esm-framework';
+import { type UploadedFile } from '../attachments-types';
+import { type FetchResponse, showSnackbar } from '@openmrs/esm-framework';
 import CameraMediaUploaderContext from './camera-media-uploader-context.resources';
 import { useTranslation } from 'react-i18next';
 import CameraComponent from './camera.component';

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/camera.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/camera.component.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect, useContext, MutableRefObject } from 'react';
+import React, { useRef, useCallback, useEffect, useContext, type MutableRefObject } from 'react';
 import Camera from 'react-html5-camera-photo';
 import CameraMediaUploaderContext from './camera-media-uploader-context.resources';
 import 'react-html5-camera-photo/build/css/index.css';

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
@@ -1,9 +1,9 @@
-import React, { SyntheticEvent, useCallback, useEffect, useState, useContext } from 'react';
+import React, { type SyntheticEvent, useCallback, useEffect, useState, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, TextArea, TextInput, ModalHeader, ModalBody, ModalFooter } from '@carbon/react';
 import { UserHasAccess } from '@openmrs/esm-framework';
 import styles from './file-review.scss';
-import { UploadedFile } from '../attachments-types';
+import { type UploadedFile } from '../attachments-types';
 import CameraMediaUploaderContext from './camera-media-uploader-context.resources';
 import { DocumentPdf, DocumentUnknown } from '@carbon/react/icons';
 

--- a/packages/esm-patient-attachments-app/src/utils.ts
+++ b/packages/esm-patient-attachments-app/src/utils.ts
@@ -1,4 +1,4 @@
-import { AttachmentResponse, Attachment } from './attachments-types';
+import { type AttachmentResponse, type Attachment } from './attachments-types';
 import { attachmentUrl } from './attachments.resource';
 import { formatDate } from '@openmrs/esm-framework';
 

--- a/packages/esm-patient-banner-app/src/banner-tags/visit-tag.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/visit-tag.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tag, Toggletip, ToggletipButton, ToggletipContent } from '@carbon/react';
-import { Visit, formatDatetime, parseDate } from '@openmrs/esm-framework';
+import { type Visit, formatDatetime, parseDate } from '@openmrs/esm-framework';
 import { useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
 import styles from './visit-tag.scss';
 

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { type MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Button, Tag } from '@carbon/react';

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { InlineLoading } from '@carbon/react';
 import { ConfigurableLink, parseDate, useConfig } from '@openmrs/esm-framework';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 import { useRelationships } from './relationships.resource';
 import { usePatientContactAttributes } from '../hooks/usePatientAttributes';
 import { usePatientListsForPatient } from '../hooks/usePatientListsForPatient';

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { openmrsFetch } from '@openmrs/esm-framework';
-import { mockPatient, renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import { usePatientAttributes, usePatientContactAttributes } from '../hooks/usePatientAttributes';
 import { usePatientListsForPatient } from '../hooks/usePatientListsForPatient';
 import ContactDetails from './contact-details.component';
@@ -90,12 +90,12 @@ const mockCohorts = [
 ];
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
-jest.mock('../hooks/usePatientAttributes.tsx', () => ({
+jest.mock('../hooks/usePatientAttributes', () => ({
   usePatientAttributes: jest.fn(),
   usePatientContactAttributes: jest.fn(),
 }));
 
-jest.mock('../hooks/usePatientListsForPatient.tsx', () => ({
+jest.mock('../hooks/usePatientListsForPatient', () => ({
   usePatientListsForPatient: jest.fn(),
 }));
 

--- a/packages/esm-patient-banner-app/src/contact-details/relationships.resource.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/relationships.resource.tsx
@@ -1,6 +1,6 @@
-import { FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
 import useSWR from 'swr';
+import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
 
 const customRepresentation =
   'custom:(display,uuid,personA:(uuid,age,display),personB:(uuid,age,display),relationshipType:(uuid,display,description,aIsToB,bIsToA))';

--- a/packages/esm-patient-banner-app/src/hooks/usePatientAttributes.ts
+++ b/packages/esm-patient-banner-app/src/hooks/usePatientAttributes.ts
@@ -1,7 +1,7 @@
 import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
 import useSWRImmutable from 'swr/immutable';
-import { ConfigObject } from '../config-schema';
-import { Patient } from '../types';
+import { type ConfigObject } from '../config-schema';
+import { type Patient } from '../types';
 
 const customRepresentation =
   'custom:(uuid,display,identifiers:(identifier,uuid,preferred,location:(uuid,name),identifierType:(uuid,name,format,formatDescription,validator)),person:(uuid,display,gender,birthdate,dead,age,deathDate,birthdateEstimated,causeOfDeath,preferredName:(uuid,preferred,givenName,middleName,familyName),attributes,preferredAddress:(uuid,preferred,address1,address2,cityVillage,longitude,stateProvince,latitude,country,postalCode,countyDistrict,address3,address4,address5,address6,address7)))';

--- a/packages/esm-patient-banner-app/src/hooks/usePatientListsForPatient.tsx
+++ b/packages/esm-patient-banner-app/src/hooks/usePatientListsForPatient.tsx
@@ -1,7 +1,7 @@
-import { FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
-import useSWR from 'swr';
-import { CohortMemberResponse } from '../types';
 import { useMemo } from 'react';
+import useSWR from 'swr';
+import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type CohortMemberResponse } from '../types';
 
 export function usePatientListsForPatient(patientUuid: string) {
   const customRepresentation = 'custom:(uuid,patient:ref,cohort:(uuid,name,startDate,endDate))';

--- a/packages/esm-patient-banner-app/src/types/index.ts
+++ b/packages/esm-patient-banner-app/src/types/index.ts
@@ -1,4 +1,4 @@
-import { OpenmrsResource } from '@openmrs/esm-framework';
+import { type OpenmrsResource } from '@openmrs/esm-framework';
 
 export interface Location {
   uuid: string;

--- a/packages/esm-patient-chart-app/src/deceased/deceased-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/deceased/deceased-form.component.tsx
@@ -13,7 +13,7 @@ import {
   DataTableSkeleton,
 } from '@carbon/react';
 import { WarningFilled } from '@carbon/react/icons';
-import { DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
+import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import { ExtensionSlot, useLayoutType, showSnackbar, showModal } from '@openmrs/esm-framework';
 import { markPatientDeceased, usePatientDeathConcepts, usePatientDeceased } from './deceased.resource';
 import BaseConceptAnswer from './base-concept-answer.component';

--- a/packages/esm-patient-chart-app/src/offline.ts
+++ b/packages/esm-patient-chart-app/src/offline.ts
@@ -1,5 +1,5 @@
 import { messageOmrsServiceWorker, saveVisit, setupOfflineSync, usePatient } from '@openmrs/esm-framework';
-import { OfflineVisit, visitSyncType } from '@openmrs/esm-patient-common-lib';
+import { type OfflineVisit, visitSyncType } from '@openmrs/esm-patient-common-lib';
 
 export function setupCacheableRoutes() {
   messageOmrsServiceWorker({

--- a/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Tag } from '@carbon/react';
 import { formatDate, useConfig } from '@openmrs/esm-framework';
-import { ChartConfig } from '../config-schema';
+import { type ChartConfig } from '../config-schema';
 import { useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
 
 interface VisitAttributeTagsProps {

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useMemo } from 'react';
 import { Navigate } from 'react-router-dom';
-import { ConfigObject, useExtensionStore } from '@openmrs/esm-framework';
+import { type ConfigObject, useExtensionStore } from '@openmrs/esm-framework';
 import { useNavGroups } from '@openmrs/esm-patient-common-lib';
-import { DashboardView, DashboardConfig, LayoutMode } from './dashboard-view.component';
+import { DashboardView, type DashboardConfig, type LayoutMode } from './dashboard-view.component';
 import { basePath } from '../../constants';
 
 function makePath(target: DashboardConfig, params: Record<string, string> = {}) {

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
@@ -1,8 +1,8 @@
-import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useMatch } from 'react-router-dom';
 import {
   Extension,
-  ExtensionData,
+  type ExtensionData,
   ExtensionSlot,
   getExtensionNameFromId,
   useExtensionSlotMeta,

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
@@ -11,7 +11,7 @@ import {
 import { useParams } from 'react-router-dom';
 import { changeWorkspaceContext, useWorkspaces } from '@openmrs/esm-patient-common-lib';
 import { spaBasePath } from '../constants';
-import { LayoutMode } from './chart-review/dashboard-view.component';
+import { type LayoutMode } from './chart-review/dashboard-view.component';
 import ActionMenu from './action-menu/action-menu.component';
 import ChartReview from '../patient-chart/chart-review/chart-review.component';
 import Loader from '../loader/loader.component';

--- a/packages/esm-patient-chart-app/src/side-nav/side-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/side-nav/side-menu.component.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { SideNavProps } from '@carbon/react';
+import { type SideNavProps } from '@carbon/react';
 import { LeftNavMenu, useLayoutType } from '@openmrs/esm-framework';
-import { isDesktop } from '../utils';
 
 interface SideMenuPanelProps extends SideNavProps {}
 

--- a/packages/esm-patient-chart-app/src/utils.ts
+++ b/packages/esm-patient-chart-app/src/utils.ts
@@ -1,4 +1,4 @@
-import { isDesktop as checkIfIsDesktop, LayoutType } from '@openmrs/esm-framework';
+import { isDesktop as checkIfIsDesktop, type LayoutType } from '@openmrs/esm-framework';
 
 export function isDesktop(layout: LayoutType) {
   return checkIfIsDesktop(layout);

--- a/packages/esm-patient-chart-app/src/visit-header/retrospective-visit-label.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/retrospective-visit-label.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Toggletip, ToggletipButton, ToggletipContent, Tag } from '@carbon/react';
-import { Visit, formatDatetime, parseDate } from '@openmrs/esm-framework';
+import { type Visit, formatDatetime, parseDate } from '@openmrs/esm-framework';
 import styles from './retrospective-visit-label.scss';
 
 interface RetrospectiveVisitLabelProps {

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -16,7 +16,7 @@ import {
   interpolateUrl,
 } from '@openmrs/esm-framework';
 import { launchPatientWorkspace, useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
-import { MappedQueuePriority, useVisitQueueEntry } from '../visit/queue-entry/queue.resource';
+import { type MappedQueuePriority, useVisitQueueEntry } from '../visit/queue-entry/queue.resource';
 import { EditQueueEntry } from '../visit/queue-entry/edit-queue-entry.component';
 import VisitHeaderSideMenu from './visit-header-side-menu.component';
 import styles from './visit-header.scss';

--- a/packages/esm-patient-chart-app/src/visit/hooks/useDefaultLocation.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useDefaultLocation.tsx
@@ -1,6 +1,6 @@
-import { FetchResponse, openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, useConfig } from '@openmrs/esm-framework';
 import useSWRImmutable from 'swr/immutable';
-import { ChartConfig } from '../../config-schema';
+import { type ChartConfig } from '../../config-schema';
 
 export const useDefaultLoginLocation = () => {
   const config = useConfig() as ChartConfig;

--- a/packages/esm-patient-chart-app/src/visit/hooks/useDeleteVisit.hook.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useDeleteVisit.hook.tsx
@@ -1,4 +1,4 @@
-import { Visit, showActionableNotification, showSnackbar, useVisit } from '@openmrs/esm-framework';
+import { type Visit, showActionableNotification, showSnackbar, useVisit } from '@openmrs/esm-framework';
 import { deleteVisit, restoreVisit, useVisits } from '../visits-widget/visit.resource';
 import { useTranslation } from 'react-i18next';
 import { useState } from 'react';

--- a/packages/esm-patient-chart-app/src/visit/hooks/useLocations.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useLocations.tsx
@@ -1,4 +1,4 @@
-import { FetchResponse, Location, openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, type Location, openmrsFetch } from '@openmrs/esm-framework';
 import { useEffect } from 'react';
 import useSWR from 'swr';
 

--- a/packages/esm-patient-chart-app/src/visit/hooks/useOfflineVisitType.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useOfflineVisitType.tsx
@@ -1,5 +1,5 @@
-import { VisitType, useConfig } from '@openmrs/esm-framework';
-import { ChartConfig } from '../../config-schema';
+import { type VisitType, useConfig } from '@openmrs/esm-framework';
+import { type ChartConfig } from '../../config-schema';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/packages/esm-patient-chart-app/src/visit/hooks/useRecommendedVisitTypes.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useRecommendedVisitTypes.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import useSWR from 'swr';
 import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
-import { ChartConfig } from '../../config-schema';
+import { type ChartConfig } from '../../config-schema';
 
 interface EnrollmentVisitType {
   dataDependencies: Array<string>;

--- a/packages/esm-patient-chart-app/src/visit/hooks/useUpcomingAppointments.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useUpcomingAppointments.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { openmrsFetch, OpenmrsResource } from '@openmrs/esm-framework';
+import { openmrsFetch, type OpenmrsResource } from '@openmrs/esm-framework';
 
 export interface AppointmentPayload {
   patientUuid: string;

--- a/packages/esm-patient-chart-app/src/visit/hooks/useVisitAttributeType.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useVisitAttributeType.tsx
@@ -1,4 +1,4 @@
-import { FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
 import { useEffect, useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
 

--- a/packages/esm-patient-chart-app/src/visit/past-visit-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/past-visit-overview.component.tsx
@@ -10,12 +10,12 @@ import {
   TableRow,
   TableHeader,
   TableCell,
-  DataTableHeader,
+  type DataTableHeader,
 } from '@carbon/react';
 import { Edit } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
 import { setCurrentVisit } from '@openmrs/esm-framework';
-import { DefaultWorkspaceProps, ErrorState } from '@openmrs/esm-patient-common-lib';
+import { type DefaultWorkspaceProps, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { usePastVisits } from './visits-widget/visit.resource';
 import styles from './past-visit-overview.scss';
 

--- a/packages/esm-patient-chart-app/src/visit/queue-entry/edit-queue-entry.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/queue-entry/edit-queue-entry.component.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { showModal, useLayoutType } from '@openmrs/esm-framework';
 import styles from './edit-queue-entry.scss';
-import { MappedVisitQueueEntry } from './queue.resource';
+import { type MappedVisitQueueEntry } from './queue.resource';
 import { Edit } from '@carbon/react/icons';
 import { Button } from '@carbon/react';
 

--- a/packages/esm-patient-chart-app/src/visit/queue-entry/queue.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/queue-entry/queue.resource.tsx
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { fhirBaseUrl, openmrsFetch, Visit } from '@openmrs/esm-framework';
+import { fhirBaseUrl, openmrsFetch, type Visit } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
 export type QueuePriority = 'Emergency' | 'Not Urgent' | 'Priority' | 'Urgent';
 export type MappedQueuePriority = Omit<QueuePriority, 'Urgent'>;

--- a/packages/esm-patient-chart-app/src/visit/visit-action-items/delete-visit-action-item.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-action-items/delete-visit-action-item.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from '@carbon/react';
-import { UserHasAccess, Visit, showModal, useLayoutType } from '@openmrs/esm-framework';
+import { UserHasAccess, type Visit, showModal, useLayoutType } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { TrashCan } from '@carbon/react/icons';
 

--- a/packages/esm-patient-chart-app/src/visit/visit-action-items/edit-visit-details.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-action-items/edit-visit-details.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from '@carbon/react';
-import { UserHasAccess, Visit, useLayoutType } from '@openmrs/esm-framework';
+import { UserHasAccess, type Visit, useLayoutType } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { Edit } from '@carbon/react/icons';

--- a/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.component.tsx
@@ -6,8 +6,8 @@ import debounce from 'lodash-es/debounce';
 import isEmpty from 'lodash-es/isEmpty';
 import { Layer, RadioButtonGroup, RadioButton, Search, StructuredListSkeleton } from '@carbon/react';
 import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
-import { useLayoutType, usePagination, VisitType } from '@openmrs/esm-framework';
-import { VisitFormData } from './visit-form.resource';
+import { useLayoutType, usePagination, type VisitType } from '@openmrs/esm-framework';
+import { type VisitFormData } from './visit-form.resource';
 import styles from './visit-type-overview.scss';
 
 interface BaseVisitTypeProps {

--- a/packages/esm-patient-chart-app/src/visit/visit-form/location-selection.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/location-selection.component.tsx
@@ -4,11 +4,11 @@ import isEmpty from 'lodash/isEmpty';
 import { ComboBox } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import { useFormContext, Controller } from 'react-hook-form';
-import { Location, OpenmrsResource, useConfig, useSession } from '@openmrs/esm-framework';
+import { type Location, type OpenmrsResource, useConfig, useSession } from '@openmrs/esm-framework';
 import { useDefaultLoginLocation } from '../hooks/useDefaultLocation';
 import { useLocations } from '../hooks/useLocations';
-import { VisitFormData } from './visit-form.resource';
-import { ChartConfig } from '../../config-schema';
+import { type VisitFormData } from './visit-form.resource';
+import { type ChartConfig } from '../../config-schema';
 import styles from './visit-form.scss';
 
 const LocationSelector = () => {

--- a/packages/esm-patient-chart-app/src/visit/visit-form/recommended-visit-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/recommended-visit-type.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StructuredListSkeleton } from '@carbon/react';
-import { PatientProgram } from '@openmrs/esm-patient-common-lib';
+import { type PatientProgram } from '@openmrs/esm-patient-common-lib';
 import { useRecommendedVisitTypes } from '../hooks/useRecommendedVisitTypes';
 import BaseVisitType from './base-visit-type.component';
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
@@ -1,6 +1,6 @@
 import { useConfig } from '@openmrs/esm-framework';
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { ChartConfig } from '../../config-schema';
+import { type ChartConfig } from '../../config-schema';
 import { useConceptAnswersForVisitAttributeType, useVisitAttributeType } from '../hooks/useVisitAttributeType';
 import {
   TextInput,
@@ -16,9 +16,9 @@ import {
 } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import styles from './visit-attribute-type.scss';
-import { Controller, ControllerRenderProps, useFormContext } from 'react-hook-form';
+import { Controller, type ControllerRenderProps, useFormContext } from 'react-hook-form';
 import dayjs from 'dayjs';
-import { VisitFormData } from './visit-form.resource';
+import { type VisitFormData } from './visit-form.resource';
 
 interface VisitAttributes {
   [uuid: string]: string;

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import styles from './visit-form.scss';
 import { Controller, useFormContext } from 'react-hook-form';
-import { VisitFormData } from './visit-form.resource';
+import { type VisitFormData } from './visit-form.resource';
 import { DatePicker, DatePickerInput, Layer, SelectItem, TimePicker, TimePickerSelect } from '@carbon/react';
 import classNames from 'classnames';
 import { useLayoutType } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
-import { amPm } from '@openmrs/esm-patient-common-lib';
+import { type amPm } from '@openmrs/esm-patient-common-lib';
 
 interface VisitDateTimeFieldProps {
   visitDatetimeLabel: string;

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -23,35 +23,35 @@ import {
   showSnackbar,
   useSession,
   ExtensionSlot,
-  NewVisitPayload,
+  type NewVisitPayload,
   toOmrsIsoString,
   toDateObjectStrict,
   useLayoutType,
   useVisitTypes,
   useConfig,
   useVisit,
-  Visit,
+  type Visit,
   updateVisit,
   useConnectivity,
 } from '@openmrs/esm-framework';
 import {
   convertTime12to24,
   createOfflineVisitForPatient,
-  DefaultWorkspaceProps,
+  type DefaultWorkspaceProps,
   time12HourFormatRegex,
   useActivePatientEnrollment,
 } from '@openmrs/esm-patient-common-lib';
 import { MemoizedRecommendedVisitType } from './recommended-visit-type.component';
-import { ChartConfig } from '../../config-schema';
+import { type ChartConfig } from '../../config-schema';
 import { saveQueueEntry } from '../hooks/useServiceQueue';
-import { AppointmentPayload, saveAppointment } from '../hooks/useUpcomingAppointments';
+import { type AppointmentPayload, saveAppointment } from '../hooks/useUpcomingAppointments';
 import { useLocations } from '../hooks/useLocations';
 import { useVisitQueueEntry } from '../queue-entry/queue.resource';
 import BaseVisitType from './base-visit-type.component';
 import LocationSelector from './location-selection.component';
 import VisitAttributeTypeFields from './visit-attribute-type.component';
 import styles from './visit-form.scss';
-import { VisitFormData } from './visit-form.resource';
+import { type VisitFormData } from './visit-form.resource';
 import VisitDateTimeField from './visit-date-time.component';
 import { useVisits } from '../visits-widget/visit.resource';
 import { useOfflineVisitType } from '../hooks/useOfflineVisitType';

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.resource.ts
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.resource.ts
@@ -1,4 +1,4 @@
-import { amPm } from '@openmrs/esm-patient-common-lib';
+import { type amPm } from '@openmrs/esm-patient-common-lib';
 
 export type VisitFormData = {
   visitStartDate: Date;

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
@@ -5,13 +5,13 @@ import {
   useVisit,
   openmrsFetch,
   showSnackbar,
-  FetchResponse,
+  type FetchResponse,
   showActionableNotification,
 } from '@openmrs/esm-framework';
 import { mockCurrentVisit } from '../../__mocks__/visits.mock';
 import { mockPatient } from '../../../../../tools/test-helpers';
 import { mockVisitQueueEntries } from '../../__mocks__/visitQueueEntry.mock';
-import { MappedVisitQueueEntry, useVisitQueueEntry } from '../queue-entry/queue.resource';
+import { type MappedVisitQueueEntry, useVisitQueueEntry } from '../queue-entry/queue.resource';
 import { removeQueuedPatient } from '../hooks/useServiceQueue';
 import CancelVisitDialog from './cancel-visit-dialog.component';
 

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/delete-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/delete-visit-dialog.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, ModalHeader, ModalBody, ModalFooter, InlineLoading } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { Visit, formatDatetime } from '@openmrs/esm-framework';
+import { type Visit, formatDatetime } from '@openmrs/esm-framework';
 import styles from './start-visit-dialog.scss';
 import { useDeleteVisit } from '../hooks/useDeleteVisit.hook';
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SkeletonText } from '@carbon/react';
 import { useConfig } from '@openmrs/esm-framework';
-import { Observation } from '../visit.resource';
+import { type Observation } from '../visit.resource';
 import styles from './styles.scss';
 
 interface EncounterObservationsProps {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import {
   DataTable,
-  DataTableHeader,
+  type DataTableHeader,
   Table,
   TableBody,
   TableCell,

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/tests-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/tests-summary.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ExtensionSlot } from '@openmrs/esm-framework';
-import { ExternalOverviewProps } from '@openmrs/esm-patient-common-lib';
-import { Encounter } from '../visit.resource';
+import { type ExternalOverviewProps } from '@openmrs/esm-patient-common-lib';
+import { type Encounter } from '../visit.resource';
 
 const TestsSummary = ({ patientUuid, encounters }: { patientUuid: string; encounters: Array<Encounter> }) => {
   const filter = React.useMemo<ExternalOverviewProps['filter']>(() => {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -5,7 +5,7 @@ import isEmpty from 'lodash-es/isEmpty';
 import {
   Button,
   DataTable,
-  DataTableHeader,
+  type DataTableHeader,
   Dropdown,
   Layer,
   OverflowMenu,
@@ -42,7 +42,7 @@ import {
 import { launchPatientWorkspace, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import type { HtmlFormEntryForm } from '@openmrs/esm-patient-forms-app/src/config-schema';
 import { deleteEncounter } from './visits-table.resource';
-import { MappedEncounter } from '../../visit.resource';
+import { type MappedEncounter } from '../../visit.resource';
 import EncounterObservations from '../../encounter-observations';
 import styles from './visits-table.scss';
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { openmrsFetch, OpenmrsResource, Privilege, Visit } from '@openmrs/esm-framework';
+import { openmrsFetch, type OpenmrsResource, type Privilege, type Visit } from '@openmrs/esm-framework';
 
 export function useVisits(patientUuid: string) {
   const customRepresentation =

--- a/packages/esm-patient-chart-app/src/workspace/workspace-renderer.component.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-renderer.component.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import classNames from 'classnames';
 import { useLayoutType } from '@openmrs/esm-framework';
-import { OpenWorkspace, useWorkspaces } from '@openmrs/esm-patient-common-lib';
-import { mountRootParcel, ParcelConfig } from 'single-spa';
+import { type OpenWorkspace, useWorkspaces } from '@openmrs/esm-patient-common-lib';
+import { mountRootParcel, type ParcelConfig } from 'single-spa';
 import Parcel from 'single-spa-react/parcel';
 import Loader from '../loader/loader.component';
 import styles from './workspace-window.scss';

--- a/packages/esm-patient-common-lib/src/dashboards/createDashboardLink.tsx
+++ b/packages/esm-patient-common-lib/src/dashboards/createDashboardLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { DashboardLinkConfig } from '../types';
+import { type DashboardLinkConfig } from '../types';
 import { DashboardExtension } from './DashboardExtension';
 
 export const createDashboardLink = (db: DashboardLinkConfig) => {

--- a/packages/esm-patient-common-lib/src/offline/visit.ts
+++ b/packages/esm-patient-common-lib/src/offline/visit.ts
@@ -1,12 +1,12 @@
 import {
   getSynchronizationItems,
-  NewVisitPayload,
-  QueueItemDescriptor,
+  type NewVisitPayload,
+  type QueueItemDescriptor,
   queueSynchronizationItem,
   useConnectivity,
   useSession,
   useVisit,
-  Visit,
+  type Visit,
 } from '@openmrs/esm-framework';
 import { useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';

--- a/packages/esm-patient-common-lib/src/orders/postOrders.ts
+++ b/packages/esm-patient-common-lib/src/orders/postOrders.ts
@@ -1,7 +1,7 @@
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { getPatientUuidFromUrl } from '../get-patient-uuid-from-url';
-import { OrderBasketStore, orderBasketStore } from './store';
-import { OrderBasketItem, OrderPost } from './types';
+import { type OrderBasketStore, orderBasketStore } from './store';
+import { type OrderBasketItem, type OrderPost } from './types';
 
 export async function postOrders(encounterUuid: string, abortController: AbortController) {
   const patientUuid = getPatientUuidFromUrl();

--- a/packages/esm-patient-common-lib/src/orders/types.ts
+++ b/packages/esm-patient-common-lib/src/orders/types.ts
@@ -1,4 +1,4 @@
-import { OpenmrsResource } from '@openmrs/esm-framework';
+import { type OpenmrsResource } from '@openmrs/esm-framework';
 
 export interface OrderBasketItem {
   action: 'NEW' | 'REVISE' | 'DISCONTINUE' | 'RENEW' | undefined;

--- a/packages/esm-patient-common-lib/src/orders/useOrderBasket.test.tsx
+++ b/packages/esm-patient-common-lib/src/orders/useOrderBasket.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { useOrderBasket } from './useOrderBasket';
-import { OrderBasketItem, PostDataPrepFunction } from './types';
+import { type OrderBasketItem, type PostDataPrepFunction } from './types';
 import { _resetOrderBasketStore } from './store';
 
 jest.mock('../get-patient-uuid-from-url', () => ({

--- a/packages/esm-patient-common-lib/src/orders/useOrderBasket.ts
+++ b/packages/esm-patient-common-lib/src/orders/useOrderBasket.ts
@@ -2,7 +2,7 @@ import { useStoreWithActions } from '@openmrs/esm-framework';
 import type { OrderBasketItem, PostDataPrepFunction } from './types';
 import { getPatientUuidFromUrl } from '../get-patient-uuid-from-url';
 import { useEffect } from 'react';
-import { OrderBasketStore, orderBasketStore } from './store';
+import { type OrderBasketStore, orderBasketStore } from './store';
 
 const orderBasketStoreActions = {
   setOrderBasketItems(

--- a/packages/esm-patient-common-lib/src/programs/usePatientProgramEnrollment.tsx
+++ b/packages/esm-patient-common-lib/src/programs/usePatientProgramEnrollment.tsx
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
-import { PatientProgram } from '../types';
+import { type PatientProgram } from '../types';
 import uniqBy from 'lodash-es/uniqBy';
 const customRepresentation = `custom:(uuid,display,program,dateEnrolled,dateCompleted,location:(uuid,display))`;
 

--- a/packages/esm-patient-common-lib/src/types/index.ts
+++ b/packages/esm-patient-common-lib/src/types/index.ts
@@ -1,4 +1,4 @@
-import { OpenmrsResource } from '@openmrs/esm-framework';
+import { type OpenmrsResource } from '@openmrs/esm-framework';
 
 export * from './test-results';
 export * from './workspace';

--- a/packages/esm-patient-common-lib/src/useSystemVisitSetting.ts
+++ b/packages/esm-patient-common-lib/src/useSystemVisitSetting.ts
@@ -1,5 +1,5 @@
 import useSWRImmutable from 'swr/immutable';
-import { FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
 
 export function useSystemVisitSetting() {

--- a/packages/esm-patient-common-lib/src/workspaces/useWorkspaces.tsx
+++ b/packages/esm-patient-common-lib/src/workspaces/useWorkspaces.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { getWorkspaceStore, OpenWorkspace, WorkspaceWindowState } from '@openmrs/esm-patient-common-lib';
-import { Prompt, WorkspaceStoreState, updateWorkspaceWindowState } from './workspaces';
+import { getWorkspaceStore, type OpenWorkspace, type WorkspaceWindowState } from '@openmrs/esm-patient-common-lib';
+import { type Prompt, type WorkspaceStoreState, updateWorkspaceWindowState } from './workspaces';
 
 export interface WorkspacesInfo {
   active: boolean;

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
@@ -1,8 +1,8 @@
-import { ExtensionRegistration, getGlobalStore, navigate, translateFrom } from '@openmrs/esm-framework';
+import { type ExtensionRegistration, getGlobalStore, navigate, translateFrom } from '@openmrs/esm-framework';
 // FIXME We should not rely on internals here
 import { getExtensionRegistration } from '@openmrs/esm-framework/src/internal';
 import _i18n from 'i18next';
-import { WorkspaceWindowState } from '../types/workspace';
+import { type WorkspaceWindowState } from '../types/workspace';
 
 export interface Prompt {
   title: string;

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-action-menu.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-action-menu.component.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Layer, OverflowMenu, OverflowMenuItem } from '@carbon/react';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { showModal, useLayoutType } from '@openmrs/esm-framework';
-import { Condition } from './conditions.resource';
+import { type Condition } from './conditions.resource';
 import styles from './conditions-action-menu.scss';
 
 interface conditionsActionMenuProps {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
@@ -5,7 +5,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Button, ButtonSet, Form, InlineLoading, InlineNotification } from '@carbon/react';
 import { useLayoutType } from '@openmrs/esm-framework';
-import { ConditionDataTableRow, useConditions } from './conditions.resource';
+import { type ConditionDataTableRow, useConditions } from './conditions.resource';
 import ConditionsWidget from './conditions-widget.component';
 import styles from './conditions-form.scss';
 

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, useCallback, useEffect, useRef, useState } from 'react';
+import React, { type Dispatch, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
 import 'dayjs/plugin/utc';
@@ -19,15 +19,15 @@ import { WarningFilled } from '@carbon/react/icons';
 import { useFormContext, Controller } from 'react-hook-form';
 import { showToast, useLayoutType, useSession } from '@openmrs/esm-framework';
 import {
-  CodedCondition,
-  ConditionDataTableRow,
+  type CodedCondition,
+  type ConditionDataTableRow,
   createCondition,
-  FormFields,
+  type FormFields,
   updateCondition,
   useConditions,
   useConditionsSearch,
 } from './conditions.resource';
-import { ConditionFormData } from './conditions-form.component';
+import { type ConditionFormData } from './conditions-form.component';
 import styles from './conditions-form.scss';
 
 interface ConditionsWidgetProps {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions.resource.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions.resource.tsx
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 import { fhirBaseUrl, openmrsFetch, useConfig } from '@openmrs/esm-framework';
-import { FHIRCondition, FHIRConditionResponse } from '../types';
+import { type FHIRCondition, type FHIRConditionResponse } from '../types';
 
 export type Condition = {
   clinicalStatus: string;

--- a/packages/esm-patient-flags-app/src/flags/flags-list.component.tsx
+++ b/packages/esm-patient-flags-app/src/flags/flags-list.component.tsx
@@ -4,7 +4,7 @@ import isEmpty from 'lodash-es/isEmpty';
 import orderBy from 'lodash-es/orderBy';
 import { useTranslation } from 'react-i18next';
 import { Button, ButtonSet, Dropdown, Form, InlineLoading, Layer, Search, Tile, Toggle, Stack } from '@carbon/react';
-import { DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
+import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import { useLayoutType, showSnackbar, parseDate, formatDate } from '@openmrs/esm-framework';
 import { usePatientFlags, enablePatientFlag, disablePatientFlag } from './hooks/usePatientFlags';
 import { getFlagType } from './utils';

--- a/packages/esm-patient-flags-app/src/flags/hooks/usePatientFlags.tsx
+++ b/packages/esm-patient-flags-app/src/flags/hooks/usePatientFlags.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import useSWR from 'swr';
-import { openmrsFetch, FetchResponse } from '@openmrs/esm-framework';
+import { openmrsFetch, type FetchResponse } from '@openmrs/esm-framework';
 
 interface FlagFetchResponse {
   uuid: string;

--- a/packages/esm-patient-forms-app/src/form-entry-interop.ts
+++ b/packages/esm-patient-forms-app/src/form-entry-interop.ts
@@ -1,5 +1,5 @@
-import { navigate, Visit } from '@openmrs/esm-framework';
-import { HtmlFormEntryForm } from './config-schema';
+import { navigate, type Visit } from '@openmrs/esm-framework';
+import { type HtmlFormEntryForm } from './config-schema';
 import isEmpty from 'lodash-es/isEmpty';
 import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
 

--- a/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ExtensionSlot, usePatient } from '@openmrs/esm-framework';
-import { DefaultWorkspaceProps, FormEntryProps, useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
+import {
+  type DefaultWorkspaceProps,
+  type FormEntryProps,
+  useVisitOrOfflineVisit,
+} from '@openmrs/esm-patient-common-lib';
 
 interface FormEntryComponentProps extends DefaultWorkspaceProps {
   mutateForm: () => void;

--- a/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
@@ -5,8 +5,8 @@ import debounce from 'lodash-es/debounce';
 import first from 'lodash-es/first';
 import {
   DataTable,
-  DataTableHeader,
-  DataTableRow,
+  type DataTableHeader,
+  type DataTableRow,
   Layer,
   Table,
   TableBody,
@@ -23,8 +23,8 @@ import {
 import { Edit } from '@carbon/react/icons';
 import { EmptyDataIllustration, PatientChartPagination, useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
 import { formatDatetime, useConfig, useLayoutType, usePagination } from '@openmrs/esm-framework';
-import { ConfigObject } from '../config-schema';
-import { CompletedFormInfo } from '../types';
+import { type ConfigObject } from '../config-schema';
+import { type CompletedFormInfo } from '../types';
 import { launchFormEntryOrHtmlForms } from '../form-entry-interop';
 import styles from './form-view.scss';
 

--- a/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithSwr } from '../../../../tools/test-helpers';
-import FormsList, { FormsListProps } from './forms-list.component';
+import FormsList, { type FormsListProps } from './forms-list.component';
 
 jest.mock('lodash-es/debounce', () => jest.fn((fn) => fn));
 

--- a/packages/esm-patient-forms-app/src/hooks/use-forms.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-forms.ts
@@ -7,7 +7,7 @@ import {
   userHasAccess,
   useSession,
 } from '@openmrs/esm-framework';
-import { ListResponse, Form, EncounterWithFormRef, CompletedFormInfo } from '../types';
+import { type ListResponse, type Form, type EncounterWithFormRef, type CompletedFormInfo } from '../types';
 import { customEncounterRepresentation, formEncounterUrl, formEncounterUrlPoc } from '../constants';
 import { type ConfigObject } from '../config-schema';
 import { isValidOfflineFormEncounter } from '../offline-forms/offline-form-helpers';

--- a/packages/esm-patient-forms-app/src/hooks/use-program-config.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-program-config.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { openmrsFetch, OpenmrsResource, Visit } from '@openmrs/esm-framework';
+import { openmrsFetch, type OpenmrsResource, Visit } from '@openmrs/esm-framework';
 
 interface ProgramConfigObj {
   name: string;

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-form-helpers.ts
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-form-helpers.ts
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 import { getDynamicOfflineDataEntries } from '@openmrs/esm-framework';
-import { Form, FormEncounterResource } from '../types';
-import { HtmlFormEntryForm } from '../config-schema';
+import { type Form, type FormEncounterResource } from '../types';
+import { type HtmlFormEntryForm } from '../config-schema';
 
 /**
  * Returns whether the given form encounter is valid for offline mode and can be cached.

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-forms-overview-card.component.tsx
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-forms-overview-card.component.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Layer, Tile, SkeletonText } from '@carbon/react';
 import { ArrowRight } from '@carbon/react/icons';

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-forms.component.tsx
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-forms.component.tsx
@@ -2,9 +2,9 @@ import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DataTable,
-  DataTableCustomRenderProps,
-  DataTableHeader,
-  DataTableRow,
+  type DataTableCustomRenderProps,
+  type DataTableHeader,
+  type DataTableRow,
   Layer,
   Search,
   SkeletonPlaceholder,
@@ -28,7 +28,7 @@ import {
   useSession,
 } from '@openmrs/esm-framework';
 import { useDynamicFormDataEntries } from './offline-form-helpers';
-import { Form } from '../types';
+import { type Form } from '../types';
 import { useValidOfflineFormEncounters } from './use-offline-form-encounters';
 import styles from './offline-forms.styles.scss';
 import { EmptyState } from '@openmrs/esm-patient-common-lib';

--- a/packages/esm-patient-forms-app/src/offline-forms/use-offline-form-encounters.ts
+++ b/packages/esm-patient-forms-app/src/offline-forms/use-offline-form-encounters.ts
@@ -1,7 +1,7 @@
 import { useFormEncounters } from '../hooks/use-forms';
 import { isValidOfflineFormEncounter } from './offline-form-helpers';
 import { useConfig } from '@openmrs/esm-framework';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 
 /**
  * Returns an `SWRResult` of those form encounters that work with offline mode.

--- a/packages/esm-patient-forms-app/src/offline.ts
+++ b/packages/esm-patient-forms-app/src/offline.ts
@@ -5,11 +5,11 @@ import {
   openmrsFetch,
   setupDynamicOfflineDataHandler,
   setupOfflineSync,
-  SyncProcessOptions,
-  Visit,
+  type SyncProcessOptions,
+  type Visit,
 } from '@openmrs/esm-framework';
 import { launchFormEntry } from './form-entry-interop';
-import { Form } from './types';
+import { type Form } from './types';
 import { isFormJsonSchema } from './offline-forms/offline-form-helpers';
 import { formEncounterUrl, formEncounterUrlPoc } from './constants';
 import escapeRegExp from 'lodash-es/escapeRegExp';

--- a/packages/esm-patient-immunizations-app/src/config-schema.ts
+++ b/packages/esm-patient-immunizations-app/src/config-schema.ts
@@ -1,5 +1,5 @@
 import immunizationWidgetSchema from './immunizations/immunization-widget-config-schema';
-import { ImmunizationWidgetConfigObject } from './immunizations/immunization-domain';
+import { type ImmunizationWidgetConfigObject } from './immunizations/immunization-domain';
 
 export const configSchema = {
   immunizationsConfig: immunizationWidgetSchema,

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunization-mapper.ts
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunization-mapper.ts
@@ -6,14 +6,14 @@ import isUndefined from 'lodash-es/isUndefined';
 import map from 'lodash-es/map';
 import orderBy from 'lodash-es/orderBy';
 import {
-  Code,
-  FHIRImmunizationBundle,
-  FHIRImmunizationBundleEntry,
-  FHIRImmunizationResource,
-  ImmunizationData,
-  ImmunizationDoseData,
-  ImmunizationFormData,
-  Reference,
+  type Code,
+  type FHIRImmunizationBundle,
+  type FHIRImmunizationBundleEntry,
+  type FHIRImmunizationResource,
+  type ImmunizationData,
+  type ImmunizationDoseData,
+  type ImmunizationFormData,
+  type Reference,
 } from './immunization-domain';
 
 const mapToImmunizationDose = (immunizationBundleEntry: FHIRImmunizationBundleEntry): ImmunizationDoseData => {

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
@@ -30,7 +30,7 @@ import {
 import { useConfig, usePagination } from '@openmrs/esm-framework';
 import { useImmunizations, useImmunizationsConceptSet } from './immunizations.resource';
 import { findConfiguredSequences, findExistingDoses, latestFirst } from './utils';
-import { ExistingDoses, Sequence } from '../types';
+import { type ExistingDoses, type Sequence } from '../types';
 import { immunizationFormSub } from './immunization-utils';
 import SequenceTable from './immunizations-sequence-table';
 import styles from './immunizations-detailed-summary.scss';

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
@@ -1,11 +1,11 @@
-import React, { SyntheticEvent, useEffect, useState } from 'react';
+import React, { type SyntheticEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ButtonSet, DatePicker, DatePickerInput, Form, Select, SelectItem, TextInput } from '@carbon/react';
 import { showNotification, showToast, useSession, useVisit, useLayoutType } from '@openmrs/esm-framework';
-import { DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
+import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import { savePatientImmunization } from './immunizations.resource';
 import { mapToFHIRImmunizationResource } from './immunization-mapper';
-import { ImmunizationFormData, ImmunizationSequence } from './immunization-domain';
+import { type ImmunizationFormData, type ImmunizationSequence } from './immunization-domain';
 import { immunizationFormSub } from './immunization-utils';
 import styles from './immunizations-form.scss';
 

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-sequence-table.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-sequence-table.tsx
@@ -4,7 +4,7 @@ import isEmpty from 'lodash-es/isEmpty';
 import { Button, DataTable, Table, TableHead, TableRow, TableHeader, TableBody, TableCell } from '@carbon/react';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import ImmunizationsForm from './immunizations-form.component';
-import { ExistingDoses, Immunization } from '../types';
+import { type ExistingDoses, type Immunization } from '../types';
 
 interface SequenceTableProps {
   immunizations: Immunization;

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations.resource.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations.resource.tsx
@@ -2,7 +2,7 @@ import useSWR from 'swr';
 import { openmrsFetch, fhirBaseUrl, useConfig } from '@openmrs/esm-framework';
 import includes from 'lodash-es/includes';
 import split from 'lodash-es/split';
-import { FHIRImmunizationBundle, FHIRImmunizationResource, OpenmrsConcept } from './immunization-domain';
+import { type FHIRImmunizationBundle, type FHIRImmunizationResource, type OpenmrsConcept } from './immunization-domain';
 import { mapFromFHIRImmunizationBundle } from './immunization-mapper';
 
 function getImmunizationsConceptSetByUuid(

--- a/packages/esm-patient-immunizations-app/src/immunizations/utils.ts
+++ b/packages/esm-patient-immunizations-app/src/immunizations/utils.ts
@@ -1,7 +1,7 @@
 import map from 'lodash-es/map';
 import find from 'lodash-es/find';
-import { ExistingDoses, Immunization } from '../types';
-import { ImmunizationSequenceDefinition, OpenmrsConcept, ImmunizationData } from './immunization-domain';
+import { type ExistingDoses, type Immunization } from '../types';
+import { type ImmunizationSequenceDefinition, type OpenmrsConcept, type ImmunizationData } from './immunization-domain';
 
 export const findConfiguredSequences = (
   configuredSequences: Array<ImmunizationSequenceDefinition>,

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
@@ -3,9 +3,9 @@ import { render, renderHook, screen, within } from '@testing-library/react';
 import AddLabOrderWorkspace from './add-lab-order.workspace';
 import userEvent from '@testing-library/user-event';
 import { _resetOrderBasketStore, orderBasketStore } from '@openmrs/esm-patient-common-lib/src/orders/store';
-import { LabOrderBasketItem } from '../api';
+import { type LabOrderBasketItem } from '../api';
 import { age, useConfig, useLayoutType, usePatient, useSession } from '@openmrs/esm-framework';
-import { PostDataPrepFunction, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import { type PostDataPrepFunction, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { createEmptyLabOrder } from './lab-order';
 
 jest.setTimeout(10000);

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
@@ -5,8 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
 import { ArrowLeft } from '@carbon/react/icons';
 import { age, formatDate, parseDate, useLayoutType, usePatient } from '@openmrs/esm-framework';
-import { DefaultWorkspaceProps, launchPatientWorkspace, OrderBasketItem } from '@openmrs/esm-patient-common-lib';
-import { LabOrderBasketItem } from '../api';
+import {
+  type DefaultWorkspaceProps,
+  launchPatientWorkspace,
+  type OrderBasketItem,
+} from '@openmrs/esm-patient-common-lib';
+import { type LabOrderBasketItem } from '../api';
 import { TestTypeSearch } from './test-type-search';
 import { LabOrderForm } from './lab-order-form.component';
 import styles from './add-lab-order.scss';

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, ButtonSet, Column, ComboBox, Form, Layer, Grid, InlineNotification, TextInput } from '@carbon/react';
 import { launchPatientWorkspace, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { useLayoutType, useSession } from '@openmrs/esm-framework';
-import { LabOrderBasketItem, careSettingUuid, prepLabOrderPostData } from '../api';
+import { type LabOrderBasketItem, careSettingUuid, prepLabOrderPostData } from '../api';
 import { priorityOptions } from './lab-order';
 import { type TestType, useTestTypes } from './useTestTypes';
 import styles from './lab-order-form.scss';

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order.ts
@@ -1,5 +1,5 @@
-import { LabOrderBasketItem } from '../api';
-import { TestType } from './useTestTypes';
+import { type LabOrderBasketItem } from '../api';
+import { type TestType } from './useTestTypes';
 
 // See the Urgency enum in https://github.com/openmrs/openmrs-core/blob/492dcd35b85d48730bd19da48f6db146cc882c22/api/src/main/java/org/openmrs/Order.java
 export const priorityOptions = [

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
@@ -5,7 +5,7 @@ import { Button, ButtonSkeleton, Layer, Search, SkeletonText, Tile } from '@carb
 import { ArrowRight, ShoppingCartArrowDown, ShoppingCartArrowUp } from '@carbon/react/icons';
 import { useDebounce, useLayoutType, useSession } from '@openmrs/esm-framework';
 import { closeWorkspace, launchPatientWorkspace, useOrderBasket } from '@openmrs/esm-patient-common-lib';
-import { LabOrderBasketItem, prepLabOrderPostData } from '../api';
+import { type LabOrderBasketItem, prepLabOrderPostData } from '../api';
 import { type TestType, useTestTypes } from './useTestTypes';
 import { createEmptyLabOrder } from './lab-order';
 import styles from './test-type-search.scss';

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
 import fuzzy from 'fuzzy';
-import { FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
-import { Concept } from '../../types';
+import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type Concept } from '../../types';
 
 export interface TestType {
   label: string;

--- a/packages/esm-patient-labs-app/src/lab-orders/api.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/api.ts
@@ -1,8 +1,8 @@
 import useSWR, { mutate } from 'swr';
-import { FetchResponse, openmrsFetch, useConfig } from '@openmrs/esm-framework';
-import { ConfigObject } from '../config-schema';
+import { type FetchResponse, openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { type ConfigObject } from '../config-schema';
 import { useCallback, useMemo } from 'react';
-import { OrderBasketItem, OrderPost, PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';
+import { type OrderBasketItem, type OrderPost, type PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';
 
 export const careSettingUuid = '6f0c9a92-6f24-11e3-af88-005056821db0';
 /**

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.extension.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.extension.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, Tile } from '@carbon/react';
 import { Add, ChevronDown, ChevronUp } from '@carbon/react/icons';
 import { useLayoutType } from '@openmrs/esm-framework';
-import { launchPatientWorkspace, OrderBasketItem, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import { launchPatientWorkspace, type OrderBasketItem, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { LabOrderBasketItemTile } from './lab-order-basket-item-tile.component';
 import { prepLabOrderPostData } from '../api';
 import LabIcon from './lab-icon.component';

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.test.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { screen, render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LabOrderBasketPanel from './lab-order-basket-panel.extension';
-import { OrderBasketItem } from '@openmrs/esm-patient-common-lib';
-import { LabOrderBasketItem } from '../api';
+import { type OrderBasketItem } from '@openmrs/esm-patient-common-lib';
+import { type LabOrderBasketItem } from '../api';
 
 const mockUseOrderBasket = jest.fn();
 

--- a/packages/esm-patient-labs-app/src/test-results/filter/filter-context.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/filter/filter-context.tsx
@@ -2,7 +2,13 @@ import React, { createContext, useReducer, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import isObject from 'lodash/isObject';
 import { parseTime } from '../panel-timeline/helpers';
-import { TreeNode, FilterContextProps, ReducerState, ReducerActionType, TimelineData } from './filter-types';
+import {
+  type TreeNode,
+  type FilterContextProps,
+  type ReducerState,
+  ReducerActionType,
+  type TimelineData,
+} from './filter-types';
 import reducer from './filter-reducer';
 
 const initialState: ReducerState = {

--- a/packages/esm-patient-labs-app/src/test-results/filter/filter-reducer.ts
+++ b/packages/esm-patient-labs-app/src/test-results/filter/filter-reducer.ts
@@ -1,4 +1,11 @@
-import { ReducerAction, ReducerState, ReducerActionType, TreeParents, TreeNode, LowestNode } from './filter-types';
+import {
+  type ReducerAction,
+  type ReducerState,
+  ReducerActionType,
+  type TreeParents,
+  type TreeNode,
+  type LowestNode,
+} from './filter-types';
 
 export const getName = (prefix, name) => {
   return prefix ? `${prefix}-${name}` : name;

--- a/packages/esm-patient-labs-app/src/test-results/filter/filter-set.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/filter/filter-set.tsx
@@ -7,7 +7,7 @@ import type { FilterNodeProps, FilterLeafProps } from './filter-types';
 import { FilterEmptyState } from '../ui-elements/resetFiltersEmptyState';
 import FilterContext from './filter-context';
 import styles from './filter-set.styles.scss';
-import { ConfigObject } from '../../config-schema';
+import { type ConfigObject } from '../../config-schema';
 
 const isIndeterminate = (kids, checkboxes) => {
   return kids && !kids?.every((kid) => checkboxes[kid]) && !kids?.every((kid) => !checkboxes[kid]);

--- a/packages/esm-patient-labs-app/src/test-results/filter/filter-types.ts
+++ b/packages/esm-patient-labs-app/src/test-results/filter/filter-types.ts
@@ -1,4 +1,4 @@
-import { OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
+import { type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 interface Observation {
   display: string;
   flatName: string;

--- a/packages/esm-patient-labs-app/src/test-results/grouped-timeline/grouped-timeline-types.ts
+++ b/packages/esm-patient-labs-app/src/test-results/grouped-timeline/grouped-timeline-types.ts
@@ -1,5 +1,5 @@
 import type { OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
-import { TreeNode } from '../filter/filter-types';
+import { type TreeNode } from '../filter/filter-types';
 
 export interface PanelNameCornerProps {
   showShadow: boolean;

--- a/packages/esm-patient-labs-app/src/test-results/loadPatientTestData/helpers.ts
+++ b/packages/esm-patient-labs-app/src/test-results/loadPatientTestData/helpers.ts
@@ -1,10 +1,10 @@
 import {
-  PatientData,
-  ObsRecord,
-  ConceptUuid,
-  ConceptRecord,
-  ObsMetaInfo,
-  OBSERVATION_INTERPRETATION,
+  type PatientData,
+  type ObsRecord,
+  type ConceptUuid,
+  type ConceptRecord,
+  type ObsMetaInfo,
+  type OBSERVATION_INTERPRETATION,
 } from '@openmrs/esm-patient-common-lib';
 
 const PAGE_SIZE = 300;

--- a/packages/esm-patient-labs-app/src/test-results/loadPatientTestData/loadPatientData.ts
+++ b/packages/esm-patient-labs-app/src/test-results/loadPatientTestData/loadPatientData.ts
@@ -6,7 +6,13 @@ import {
   extractMetaInformation,
   addUserDataToCache,
 } from './helpers';
-import { PatientData, ObsRecord, ConceptUuid, ObsUuid, ObsMetaInfo } from '@openmrs/esm-patient-common-lib';
+import {
+  type PatientData,
+  type ObsRecord,
+  type ConceptUuid,
+  type ObsUuid,
+  type ObsMetaInfo,
+} from '@openmrs/esm-patient-common-lib';
 import uniq from 'lodash-es/uniq';
 
 function parseSingleObsData(

--- a/packages/esm-patient-labs-app/src/test-results/loadPatientTestData/usePatientResultsData.ts
+++ b/packages/esm-patient-labs-app/src/test-results/loadPatientTestData/usePatientResultsData.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PatientData } from '@openmrs/esm-patient-common-lib';
+import { type PatientData } from '@openmrs/esm-patient-common-lib';
 import loadPatientData from './loadPatientData';
 
 type LoadingState = {

--- a/packages/esm-patient-labs-app/src/test-results/overview/common-datatable.component.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/overview/common-datatable.component.tsx
@@ -11,8 +11,8 @@ import {
   TableBody,
 } from '@carbon/react';
 import { useLayoutType } from '@openmrs/esm-framework';
-import { OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
-import { OverviewPanelData } from './useOverviewData';
+import { type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
+import { type OverviewPanelData } from './useOverviewData';
 import styles from './common-datatable.scss';
 
 interface CommonDataTableProps {

--- a/packages/esm-patient-labs-app/src/test-results/overview/common-overview.component.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/overview/common-overview.component.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 import { Button, TableToolbarContent, TableToolbar, Toggletip, ToggletipButton, ToggletipContent } from '@carbon/react';
 import { ChartLine, Information, Table } from '@carbon/react/icons';
 import { EmptyState } from '@openmrs/esm-patient-common-lib';
-import { OverviewPanelEntry } from './useOverviewData';
+import { type OverviewPanelEntry } from './useOverviewData';
 import { useTranslation } from 'react-i18next';
 import { formatDatetime, navigate } from '@openmrs/esm-framework';
 import CommonDataTable from './common-datatable.component';

--- a/packages/esm-patient-labs-app/src/test-results/overview/external-overview.extension.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/overview/external-overview.extension.tsx
@@ -4,8 +4,13 @@ import { useTranslation } from 'react-i18next';
 import { Button, DataTableSkeleton } from '@carbon/react';
 import { ArrowRight } from '@carbon/react/icons';
 import { navigate } from '@openmrs/esm-framework';
-import { EmptyState, ExternalOverviewProps, PanelFilterProps, PatientData } from '@openmrs/esm-patient-common-lib';
-import { parseSingleEntry, OverviewPanelEntry } from './useOverviewData';
+import {
+  EmptyState,
+  type ExternalOverviewProps,
+  type PanelFilterProps,
+  type PatientData,
+} from '@openmrs/esm-patient-common-lib';
+import { parseSingleEntry, type OverviewPanelEntry } from './useOverviewData';
 import usePatientResultsData from '../loadPatientTestData/usePatientResultsData';
 import CommonOverview from './common-overview.component';
 import styles from './external-overview.scss';

--- a/packages/esm-patient-labs-app/src/test-results/overview/useOverviewData.ts
+++ b/packages/esm-patient-labs-app/src/test-results/overview/useOverviewData.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { ObsRecord, OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
+import { type ObsRecord, type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import usePatientResultsData from '../loadPatientTestData/usePatientResultsData';
 
 export interface OverviewPanelData {

--- a/packages/esm-patient-labs-app/src/test-results/panel-timeline/helpers.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/panel-timeline/helpers.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { ConfigurableLink, formatDate, formatTime, parseDate } from '@openmrs/esm-framework';
-import { OBSERVATION_INTERPRETATION, getPatientUuidFromUrl } from '@openmrs/esm-patient-common-lib';
-import { ParsedTimeType } from '../filter/filter-types';
+import { type OBSERVATION_INTERPRETATION, getPatientUuidFromUrl } from '@openmrs/esm-patient-common-lib';
+import { type ParsedTimeType } from '../filter/filter-types';
 import { testResultsBasePath } from '../helpers';
 import type { ObsRecord } from '../../types';
 import styles from './timeline.scss';

--- a/packages/esm-patient-labs-app/src/test-results/panel-timeline/index.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/panel-timeline/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { parseTime } from './helpers';
-import { ObsRecord } from '../../types';
+import { type ObsRecord } from '../../types';
 import Timeline from './timeline.component';
 
 interface PanelTimelineComponentProps {

--- a/packages/esm-patient-labs-app/src/test-results/panel-timeline/timeline.component.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/panel-timeline/timeline.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { PaddingContainer, TimeSlots, Grid, RowStartCell, GridItems, ShadowBox } from './helpers';
 import { EmptyState } from '@openmrs/esm-patient-common-lib';
-import { ParsedTimeType } from '../filter/filter-types';
+import { type ParsedTimeType } from '../filter/filter-types';
 import type { ObsRecord } from '../../types';
 import useScrollIndicator from './useScroll';
 import styles from './timeline.scss';

--- a/packages/esm-patient-labs-app/src/test-results/panel-timeline/types.ts
+++ b/packages/esm-patient-labs-app/src/test-results/panel-timeline/types.ts
@@ -1,5 +1,5 @@
-import { ParsedTimeType } from '../filter/filter-types';
-import { ObsRecord } from '../../types';
+import { type ParsedTimeType } from '../filter/filter-types';
+import { type ObsRecord } from '../../types';
 
 export interface TimelineData {
   parsedTimes: ParsedTimeType;

--- a/packages/esm-patient-labs-app/src/test-results/panel-view/helper.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/panel-view/helper.tsx
@@ -1,6 +1,6 @@
 import styles from './result-panel.scss';
-import { Concept, ConceptMeta, FHIRObservationResource, observationInterpretation } from '../../types';
-import { OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
+import { type Concept, type ConceptMeta, type FHIRObservationResource, observationInterpretation } from '../../types';
+import { type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 
 export const getConceptUuid = (obs: FHIRObservationResource) => obs?.code.coding[0].code;
 

--- a/packages/esm-patient-labs-app/src/test-results/panel-view/usePanelData.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/panel-view/usePanelData.tsx
@@ -1,8 +1,14 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { FetchResponse, openmrsFetch, usePatient } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, usePatient } from '@openmrs/esm-framework';
 import useSWRInfinite from 'swr/infinite';
 import { extractMetaInformation, getConceptUuid } from './helper';
-import { Concept, ConceptMeta, FHIRObservationResource, FhirResponse, ObsRecord } from '../../types';
+import {
+  type Concept,
+  type ConceptMeta,
+  type FHIRObservationResource,
+  type FhirResponse,
+  type ObsRecord,
+} from '../../types';
 
 export function useObservations() {
   const { patientUuid } = usePatient();

--- a/packages/esm-patient-labs-app/src/test-results/trendline/trendline-resource.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/trendline/trendline-resource.tsx
@@ -2,8 +2,8 @@ import useSWR from 'swr';
 import { OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import { assessValue } from '../loadPatientTestData/helpers';
 import { useMemo } from 'react';
-import { FetchResponse, openmrsFetch, showNotification } from '@openmrs/esm-framework';
-import { TreeNode } from '../filter/filter-types';
+import { type FetchResponse, openmrsFetch, showNotification } from '@openmrs/esm-framework';
+import { type TreeNode } from '../filter/filter-types';
 
 function computeTrendlineData(treeNode: TreeNode): Array<TreeNode> {
   const tests: Array<TreeNode> = [];

--- a/packages/esm-patient-labs-app/src/test-results/trendline/trendline.component.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/trendline/trendline.component.tsx
@@ -4,7 +4,7 @@ import { Button, InlineLoading, SkeletonText } from '@carbon/react';
 import { ArrowLeft } from '@carbon/react/icons';
 import { LineChart } from '@carbon/charts-react';
 import { formatDate, formatTime, parseDate, ConfigurableLink } from '@openmrs/esm-framework';
-import { EmptyState, OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
+import { EmptyState, type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import { useObstreeData } from './trendline-resource';
 import { testResultsBasePath } from '../helpers';
 import CommonDataTable from '../overview/common-datatable.component';

--- a/packages/esm-patient-labs-app/src/types.ts
+++ b/packages/esm-patient-labs-app/src/types.ts
@@ -1,4 +1,4 @@
-import { OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
+import { type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 
 export interface FhirResponse<T> {
   total: number;

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
@@ -9,7 +9,7 @@ import {
   mockDrugOrderTemplateApiData,
   mockPatientDrugOrdersApiData,
 } from '../__mocks__/medication.mock';
-import { PostDataPrepFunction, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import { type PostDataPrepFunction, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { useSession } from '@openmrs/esm-framework';
 import { _resetOrderBasketStore } from '@openmrs/esm-patient-common-lib/src/orders/store';
 

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import DrugSearch from './drug-search/drug-search.component';
-import { DefaultWorkspaceProps, launchPatientWorkspace, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import { type DefaultWorkspaceProps, launchPatientWorkspace, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { DrugOrderForm } from './drug-order-form.component';
 import { useSession } from '@openmrs/esm-framework';
 import { careSettingUuid, prepMedicationOrderPostData } from '../api/api';

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -27,7 +27,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Controller, useController, useForm } from 'react-hook-form';
 import { age, formatDate, parseDate, useConfig, useLayoutType, usePatient } from '@openmrs/esm-framework';
 import { useOrderConfig } from '../api/order-config';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 import type {
   DosingUnit,
   DrugOrderBasketItem,

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.resource.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.resource.tsx
@@ -1,8 +1,8 @@
-import { FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
+import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
 import type { Drug } from '@openmrs/esm-patient-common-lib';
-import { DrugOrderBasketItem, DrugOrderTemplate, OrderTemplate } from '../../types';
+import { type DrugOrderBasketItem, type DrugOrderTemplate, type OrderTemplate } from '../../types';
 
 export interface DrugSearchResult {
   uuid: string;

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/helpers.ts
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/helpers.ts
@@ -1,4 +1,4 @@
-import { DrugOrderBasketItem } from '../../types';
+import { type DrugOrderBasketItem } from '../../types';
 
 type DrugsOrOrders = Pick<DrugOrderBasketItem, 'action' | 'commonMedicationName'>;
 

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
@@ -5,7 +5,7 @@ import { ArrowRight, ShoppingCartArrowUp, ShoppingCartArrowDown } from '@carbon/
 import { useTranslation } from 'react-i18next';
 import { closeWorkspace, launchPatientWorkspace, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { useConfig, useLayoutType, usePatient, UserHasAccess } from '@openmrs/esm-framework';
-import { ConfigObject } from '../../config-schema';
+import { type ConfigObject } from '../../config-schema';
 import { prepMedicationOrderPostData, usePatientOrders } from '../../api/api';
 import { ordersEqual } from './helpers';
 import {

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -1,9 +1,9 @@
 import useSWR, { mutate } from 'swr';
-import { FetchResponse, openmrsFetch, toOmrsIsoString, useConfig } from '@openmrs/esm-framework';
-import { ConfigObject } from '../config-schema';
+import { type FetchResponse, openmrsFetch, toOmrsIsoString, useConfig } from '@openmrs/esm-framework';
+import { type ConfigObject } from '../config-schema';
 import { useCallback, useMemo } from 'react';
-import { OrderPost, PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';
-import { DrugOrderBasketItem } from '../types';
+import { type OrderPost, type PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';
+import { type DrugOrderBasketItem } from '../types';
 
 export const careSettingUuid = '6f0c9a92-6f24-11e3-af88-005056821db0';
 

--- a/packages/esm-patient-medications-app/src/api/order-config.ts
+++ b/packages/esm-patient-medications-app/src/api/order-config.ts
@@ -1,7 +1,13 @@
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
-import { DosingUnit, DurationUnit, MedicationFrequency, MedicationRoute, QuantityUnit } from '../types';
+import {
+  type DosingUnit,
+  type DurationUnit,
+  type MedicationFrequency,
+  type MedicationRoute,
+  type QuantityUnit,
+} from '../types';
 
 export interface CommonConfigProps {
   uuid: string;

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -16,15 +16,15 @@ import {
   TableHeader,
   TableRow,
 } from '@carbon/react';
-import { CardHeader, Order, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, type Order, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { Add, User, Printer } from '@carbon/react/icons';
 import { age, formatDate, useConfig, useLayoutType, usePatient } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { useLaunchWorkspaceRequiringVisit } from '@openmrs/esm-patient-common-lib/src/useLaunchWorkspaceRequiringVisit';
 import styles from './medications-details-table.scss';
-import { AddDrugOrderWorkspaceAdditionalProps } from '../add-drug-order/add-drug-order.workspace';
-import { DrugOrderBasketItem } from '../types';
-import { ConfigObject } from '../config-schema';
+import { type AddDrugOrderWorkspaceAdditionalProps } from '../add-drug-order/add-drug-order.workspace';
+import { type DrugOrderBasketItem } from '../types';
+import { type ConfigObject } from '../config-schema';
 import { useReactToPrint } from 'react-to-print';
 import PrintComponent from '../print/print.component';
 

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.test.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.test.tsx
@@ -5,7 +5,7 @@ import { getByTextWithMarkup } from '../../../../tools/test-helpers';
 import { mockDrugSearchResultApiData, mockPatientDrugOrdersApiData, patientUuid } from '../__mocks__/medication.mock';
 import DrugOrderBasketPanel from './drug-order-basket-panel.extension';
 import { getTemplateOrderBasketItem } from '../add-drug-order/drug-search/drug-search.resource';
-import { DrugOrderBasketItem } from '../types';
+import { type DrugOrderBasketItem } from '../types';
 
 const mockUseOrderBasket = jest.fn();
 

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.component.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.component.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, ClickableTile, Tile } from '@carbon/react';
 import { TrashCan, Warning } from '@carbon/react/icons';
 import { useLayoutType } from '@openmrs/esm-framework';
-import { DrugOrderBasketItem } from '../types';
+import { type DrugOrderBasketItem } from '../types';
 import styles from './order-basket-item-tile.scss';
 
 export interface OrderBasketItemTileProps {

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -2,11 +2,11 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DataTableSkeleton } from '@carbon/react';
 import { parseDate } from '@openmrs/esm-framework';
-import { EmptyState, ErrorState, Order } from '@openmrs/esm-patient-common-lib';
+import { EmptyState, ErrorState, type Order } from '@openmrs/esm-patient-common-lib';
 import { usePatientOrders } from '../api/api';
 import { useLaunchWorkspaceRequiringVisit } from '@openmrs/esm-patient-common-lib/src/useLaunchWorkspaceRequiringVisit';
 import MedicationsDetailsTable from '../components/medications-details-table.component';
-import { AddDrugOrderWorkspaceAdditionalProps } from '../add-drug-order/add-drug-order.workspace';
+import { type AddDrugOrderWorkspaceAdditionalProps } from '../add-drug-order/add-drug-order.workspace';
 
 export interface MedicationsSummaryProps {
   patientUuid: string;

--- a/packages/esm-patient-medications-app/src/types.ts
+++ b/packages/esm-patient-medications-app/src/types.ts
@@ -1,4 +1,4 @@
-import { Drug, OrderBasketItem } from '@openmrs/esm-patient-common-lib';
+import { type Drug, type OrderBasketItem } from '@openmrs/esm-patient-common-lib';
 
 export interface DrugOrderBasketItem extends OrderBasketItem {
   drug: Drug;

--- a/packages/esm-patient-notes-app/src/config-schema.ts
+++ b/packages/esm-patient-notes-app/src/config-schema.ts
@@ -1,4 +1,4 @@
-import notesConfigSchema, { VisitNoteConfigObject } from './notes/visit-note-config-schema';
+import notesConfigSchema, { type VisitNoteConfigObject } from './notes/visit-note-config-schema';
 
 export const configSchema = {
   visitNoteConfig: notesConfigSchema,

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -1,10 +1,10 @@
-import React, { SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { type SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import debounce from 'lodash-es/debounce';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm, Controller, Control, FormState } from 'react-hook-form';
+import { useForm, Controller, type Control } from 'react-hook-form';
 import {
   Button,
   ButtonSet,
@@ -32,7 +32,7 @@ import {
   useLayoutType,
   useSession,
 } from '@openmrs/esm-framework';
-import { DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
+import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import type { ConfigObject } from '../config-schema';
 import type { Concept, Diagnosis, DiagnosisPayload, VisitNotePayload } from '../types';
 import {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
@@ -2,12 +2,12 @@ import useSWR from 'swr';
 import { map } from 'rxjs/operators';
 import { openmrsFetch, openmrsObservableFetch, useConfig } from '@openmrs/esm-framework';
 import {
-  EncountersFetchResponse,
-  RESTPatientNote,
-  PatientNote,
-  VisitNotePayload,
-  DiagnosisPayload,
-  Concept,
+  type EncountersFetchResponse,
+  type RESTPatientNote,
+  type PatientNote,
+  type VisitNotePayload,
+  type DiagnosisPayload,
+  type Concept,
 } from '../types';
 
 interface UseVisitNotes {

--- a/packages/esm-patient-orders-app/src/api/api.ts
+++ b/packages/esm-patient-orders-app/src/api/api.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
-import { FetchResponse, openmrsFetch, OpenmrsResource, parseDate, Visit } from '@openmrs/esm-framework';
-import { OrderPost, useVisitOrOfflineVisit, useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
+import { type FetchResponse, openmrsFetch, type OpenmrsResource, parseDate, type Visit } from '@openmrs/esm-framework';
+import { type OrderPost, useVisitOrOfflineVisit, useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
 
 /**
  * Returns a function which refreshes the patient orders cache. Uses SWR's mutate function.

--- a/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.test.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen, render, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useLayoutType, usePatient } from '@openmrs/esm-framework';
-import { OrderBasketItem, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import { type OrderBasketItem, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { mockPatient } from '../../../../tools/test-helpers';
 import { orderBasketStore } from '@openmrs/esm-patient-common-lib/src/orders/store';
 import OrderBasketActionButton from './order-basket-action-button.extension';

--- a/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
@@ -7,10 +7,10 @@ import {
   postOrders,
   useOrderBasket,
   useVisitOrOfflineVisit,
-  OrderBasketItem,
-  DefaultWorkspaceProps,
+  type OrderBasketItem,
+  type DefaultWorkspaceProps,
 } from '@openmrs/esm-patient-common-lib';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 import { createEmptyEncounter, useOrderEncounter, useMutatePatientOrders } from '../api/api';
 import styles from './order-basket.scss';
 

--- a/packages/esm-patient-orders-app/src/types/order.ts
+++ b/packages/esm-patient-orders-app/src/types/order.ts
@@ -1,4 +1,4 @@
-import { Order } from '@openmrs/esm-patient-common-lib';
+import { type Order } from '@openmrs/esm-patient-common-lib';
 
 export interface PatientMedicationFetchResponse {
   results: Array<Order>;

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import {
   Button,
   DataTable,
-  DataTableHeader,
+  type DataTableHeader,
   DataTableSkeleton,
   InlineLoading,
   InlineNotification,
@@ -21,7 +21,7 @@ import {
   formatDate,
   formatDatetime,
   useConfig,
-  ConfigObject,
+  type ConfigObject,
   useLayoutType,
   isDesktop as desktopLayout,
 } from '@openmrs/esm-framework';

--- a/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
@@ -29,7 +29,7 @@ import {
   useLayoutType,
   parseDate,
 } from '@openmrs/esm-framework';
-import { DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
+import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import {
   createProgramEnrollment,
   useAvailablePrograms,

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
@@ -24,7 +24,7 @@ import {
   PatientChartPagination,
 } from '@openmrs/esm-patient-common-lib';
 import {
-  ConfigObject,
+  type ConfigObject,
   formatDate,
   formatDatetime,
   useConfig,
@@ -33,7 +33,7 @@ import {
   isDesktop as desktopLayout,
 } from '@openmrs/esm-framework';
 import { usePrograms } from './programs.resource';
-import { ConfigurableProgram } from '../types';
+import { type ConfigurableProgram } from '../types';
 import styles from './programs-overview.scss';
 
 interface ProgramsOverviewProps {

--- a/packages/esm-patient-programs-app/src/programs/programs.resource.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs.resource.tsx
@@ -1,12 +1,11 @@
-import useSWR, { mutate } from 'swr';
+import useSWR from 'swr';
 import { map as rxjsMap } from 'rxjs/operators';
-import { openmrsFetch, openmrsObservableFetch, useConfig } from '@openmrs/esm-framework';
-import { ConfigurableProgram, PatientProgram, Program, ProgramsFetchResponse } from '../types';
+import { openmrsFetch, openmrsObservableFetch } from '@openmrs/esm-framework';
+import { type PatientProgram, type Program, type ProgramsFetchResponse } from '../types';
 import uniqBy from 'lodash-es/uniqBy';
 import filter from 'lodash-es/filter';
 import includes from 'lodash-es/includes';
 import map from 'lodash-es/map';
-import { ConfigObject } from '../config-schema';
 
 export const customRepresentation = `custom:(uuid,display,program,dateEnrolled,dateCompleted,location:(uuid,display))`;
 

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-base.component.tsx
@@ -11,7 +11,7 @@ import {
   withUnit,
   useVisitOrOfflineVisit,
 } from '@openmrs/esm-patient-common-lib';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 import { launchVitalsAndBiometricsForm } from '../utils';
 import { useVitalsAndBiometrics } from '../common';
 import BiometricsChart from './biometrics-chart.component';

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Tab, Tabs, TabList } from '@carbon/react';
 import { LineChart } from '@carbon/charts-react';
 import { formatDate, parseDate } from '@openmrs/esm-framework';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 import { type PatientVitals } from '../common';
 import styles from './biometrics-chart.scss';
 

--- a/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   DataTable,
-  DataTableRow,
+  type DataTableRow,
   Table,
   TableCell,
   TableContainer,

--- a/packages/esm-patient-vitals-app/src/common/data.resource.ts
+++ b/packages/esm-patient-vitals-app/src/common/data.resource.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { type FHIRResource, type FetchResponse, fhirBaseUrl, openmrsFetch, useConfig } from '@openmrs/esm-framework';
-import { type ObsRecord, useVitalsConceptMetadata, ConceptMetadata } from '@openmrs/esm-patient-common-lib';
+import { type ObsRecord, useVitalsConceptMetadata, type ConceptMetadata } from '@openmrs/esm-patient-common-lib';
 import { type KeyedMutator } from 'swr';
 import useSWRInfinite from 'swr/infinite';
 import { type ConfigObject } from '../config-schema';

--- a/packages/esm-patient-vitals-app/src/utils.ts
+++ b/packages/esm-patient-vitals-app/src/utils.ts
@@ -1,4 +1,4 @@
-import { Visit } from '@openmrs/esm-framework';
+import { type Visit } from '@openmrs/esm-framework';
 import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
 import { type ConfigObject } from './config-schema';
 import { patientVitalsBiometricsFormWorkspace } from './constants';

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
@@ -8,7 +8,7 @@ import { Button, InlineLoading, Tag } from '@carbon/react';
 import { ArrowRight, Time } from '@carbon/react/icons';
 import { ConfigurableLink, formatDate, parseDate, useConfig } from '@openmrs/esm-framework';
 import { useVisitOrOfflineVisit, useVitalsConceptMetadata, useWorkspaces } from '@openmrs/esm-patient-common-lib';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 import { launchVitalsAndBiometricsForm as launchForm } from '../utils';
 import VitalsHeaderItem from './vitals-header-item.component';
 import styles from './vitals-header.scss';

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -26,7 +26,7 @@ import {
   usePatient,
   useVisit,
 } from '@openmrs/esm-framework';
-import { DefaultWorkspaceProps, useVitalsConceptMetadata } from '@openmrs/esm-patient-common-lib';
+import { type DefaultWorkspaceProps, useVitalsConceptMetadata } from '@openmrs/esm-patient-common-lib';
 import type { ConfigObject } from '../config-schema';
 import {
   calculateBodyMassIndex,

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { FetchResponse, showNotification, showToast } from '@openmrs/esm-framework';
+import { type FetchResponse, showNotification, showToast } from '@openmrs/esm-framework';
 import { mockConceptMetadata, mockVitalsConfig, mockVitalsSignsConcept } from '../__mocks__/vitals.mock';
 import { mockPatient } from '../../../../tools/test-helpers';
 import { saveVitalsAndBiometrics } from '../common';

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
@@ -1,5 +1,5 @@
 import isNumber from 'lodash/isNumber';
-import { ConceptMetadata } from '@openmrs/esm-patient-common-lib';
+import { type ConceptMetadata } from '@openmrs/esm-patient-common-lib';
 
 export function calculateBodyMassIndex(weight: number, height: number): number {
   if (!weight || !height) return;

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -6,7 +6,7 @@ import { Warning } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
 import { useLayoutType } from '@openmrs/esm-framework';
 import { generatePlaceholder } from '../common';
-import { VitalsBiometricsFormData } from './vitals-biometrics-form.component';
+import { type VitalsBiometricsFormData } from './vitals-biometrics-form.component';
 import styles from './vitals-biometrics-input.scss';
 
 type fieldId =

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import orderBy from 'lodash-es/orderBy';
 import {
   DataTable,
-  DataTableHeader,
-  DataTableRow,
+  type DataTableHeader,
+  type DataTableRow,
   Table,
   TableCell,
   TableContainer,

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
@@ -5,7 +5,7 @@ import { Tab, Tabs, TabList } from '@carbon/react';
 import { LineChart } from '@carbon/charts-react';
 import { formatDate, parseDate } from '@openmrs/esm-framework';
 import { withUnit } from '@openmrs/esm-patient-common-lib';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 import { type PatientVitals } from '../common';
 import styles from './vitals-chart.scss';
 

--- a/packages/esm-patient-vitals-app/src/weight-tile/weight-tile.component.tsx
+++ b/packages/esm-patient-vitals-app/src/weight-tile/weight-tile.component.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { InlineLoading } from '@carbon/react';
 import { useConfig } from '@openmrs/esm-framework';
 import { useVitalsConceptMetadata } from '@openmrs/esm-patient-common-lib';
-import { ConfigObject } from '../config-schema';
+import { type ConfigObject } from '../config-schema';
 import styles from './weight-tile.scss';
 import { useVitalsAndBiometrics } from '../common';
 

--- a/tools/test-helpers.tsx
+++ b/tools/test-helpers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SWRConfig } from 'swr';
-import { type RenderOptions, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 
 // This component wraps whatever component is passed to it with an SWRConfig context which provides a global configuration for all SWR hooks.
 const swrWrapper = ({ children }: { children: React.ReactNode }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,6 +373,94 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@angular-eslint/builder@npm:15.2.1":
+  version: 15.2.1
+  resolution: "@angular-eslint/builder@npm:15.2.1"
+  peerDependencies:
+    eslint: ^7.20.0 || ^8.0.0
+    typescript: "*"
+  checksum: 919f46d705d8cab644b04c00d8968cc5f482cefe4e016d9c1c2b5dd0643d3dc31fb4746030eef6b95cf221ae9c100f96fbcf233c008c57c623613d4607f2e3cb
+  languageName: node
+  linkType: hard
+
+"@angular-eslint/bundled-angular-compiler@npm:15.2.1":
+  version: 15.2.1
+  resolution: "@angular-eslint/bundled-angular-compiler@npm:15.2.1"
+  checksum: 1b5438a9898dfdf6415cc3e0eeb9bd850e3f43c863c93ff8534877a7b82caeb12389bcbd23e5c3b1a1ffa86b459d6b07039e3180ef19c7cb47bc8bfda4023158
+  languageName: node
+  linkType: hard
+
+"@angular-eslint/eslint-plugin-template@npm:15.2.1":
+  version: 15.2.1
+  resolution: "@angular-eslint/eslint-plugin-template@npm:15.2.1"
+  dependencies:
+    "@angular-eslint/bundled-angular-compiler": 15.2.1
+    "@angular-eslint/utils": 15.2.1
+    "@typescript-eslint/type-utils": 5.48.2
+    "@typescript-eslint/utils": 5.48.2
+    aria-query: 5.1.3
+    axobject-query: 3.1.1
+  peerDependencies:
+    eslint: ^7.20.0 || ^8.0.0
+    typescript: "*"
+  checksum: baa235ad4096d939f4a6464ac0ba7790667ab1bea5b751e003721d937dc819d1e0ab7a405d846a1b9609f0f9ffab9191a5c30cf804e0e0331c1d2f5f0db444e2
+  languageName: node
+  linkType: hard
+
+"@angular-eslint/eslint-plugin@npm:15.2.1":
+  version: 15.2.1
+  resolution: "@angular-eslint/eslint-plugin@npm:15.2.1"
+  dependencies:
+    "@angular-eslint/utils": 15.2.1
+    "@typescript-eslint/utils": 5.48.2
+  peerDependencies:
+    eslint: ^7.20.0 || ^8.0.0
+    typescript: "*"
+  checksum: cd145691f980e3e21b0f0dd278297877d51580b8877191c08a87182e091e56bd492c22a894f3d9fd820804c5a3e1481cb8e537669cbd78d95f5a59cb206bfeee
+  languageName: node
+  linkType: hard
+
+"@angular-eslint/schematics@npm:15.2.1":
+  version: 15.2.1
+  resolution: "@angular-eslint/schematics@npm:15.2.1"
+  dependencies:
+    "@angular-eslint/eslint-plugin": 15.2.1
+    "@angular-eslint/eslint-plugin-template": 15.2.1
+    ignore: 5.2.4
+    strip-json-comments: 3.1.1
+    tmp: 0.2.1
+  peerDependencies:
+    "@angular/cli": ">= 15.0.0 < 16.0.0"
+  checksum: f78f1d294ba29393f1178846abd0a394e12292f155e221ccf83337454eb0787b3394c6a149c664dad8d061d85c5a02bde64754803ee5c3c69560884c6fdabaa4
+  languageName: node
+  linkType: hard
+
+"@angular-eslint/template-parser@npm:15.2.1":
+  version: 15.2.1
+  resolution: "@angular-eslint/template-parser@npm:15.2.1"
+  dependencies:
+    "@angular-eslint/bundled-angular-compiler": 15.2.1
+    eslint-scope: ^7.0.0
+  peerDependencies:
+    eslint: ^7.20.0 || ^8.0.0
+    typescript: "*"
+  checksum: 48123f0c55576172f4f34e4a35258ddb8c7a7e2a503320a77990ab95d367afa2e157b6644e15dd7fd7b431fc46800afc6de412e420c57715868e1b4c0e5b8449
+  languageName: node
+  linkType: hard
+
+"@angular-eslint/utils@npm:15.2.1":
+  version: 15.2.1
+  resolution: "@angular-eslint/utils@npm:15.2.1"
+  dependencies:
+    "@angular-eslint/bundled-angular-compiler": 15.2.1
+    "@typescript-eslint/utils": 5.48.2
+  peerDependencies:
+    eslint: ^7.20.0 || ^8.0.0
+    typescript: "*"
+  checksum: 82c55b8e2eec054e1d8443c5658508d741cb708d8c4f39458d8994b4b7b43b573a3df8d06ff26dcd1414040579eaba6d15232f3bee3601b906c0c40f6e793a63
+  languageName: node
+  linkType: hard
+
 "@angular-extensions/elements@npm:^15.3.0":
   version: 15.3.0
   resolution: "@angular-extensions/elements@npm:15.3.0"
@@ -3182,10 +3270,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/eslintrc@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@eslint/eslintrc@npm:2.1.3"
+  dependencies:
+    ajv: ^6.12.4
+    debug: ^4.3.2
+    espree: ^9.6.0
+    globals: ^13.19.0
+    ignore: ^5.2.0
+    import-fresh: ^3.2.1
+    js-yaml: ^4.1.0
+    minimatch: ^3.1.2
+    strip-json-comments: ^3.1.1
+  checksum: 5c6c3878192fe0ddffa9aff08b4e2f3bcc8f1c10d6449b7295a5f58b662019896deabfc19890455ffd7e60a5bd28d25d0eaefb2f78b2d230aae3879af92b89e5
+  languageName: node
+  linkType: hard
+
 "@eslint/js@npm:8.50.0":
   version: 8.50.0
   resolution: "@eslint/js@npm:8.50.0"
   checksum: 302478f2acaaa7228729ec6a04f56641590185e1d8cd1c836a6db8a6b8009f80a57349341be9fbb9aa1721a7a569d1be3ffc598a33300d22816f11832095386c
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:8.54.0":
+  version: 8.54.0
+  resolution: "@eslint/js@npm:8.54.0"
+  checksum: 6d88a6f711ef0133566b5340e3178a178fbb297585766460f195d0a9db85688f1e5cf8559fd5748aeb3131e2096c66595b323d8edab22df015acda68f1ebde92
   languageName: node
   linkType: hard
 
@@ -3272,6 +3384,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@humanwhocodes/config-array@npm:^0.11.13":
+  version: 0.11.13
+  resolution: "@humanwhocodes/config-array@npm:0.11.13"
+  dependencies:
+    "@humanwhocodes/object-schema": ^2.0.1
+    debug: ^4.1.1
+    minimatch: ^3.0.5
+  checksum: f8ea57b0d7ed7f2d64cd3944654976829d9da91c04d9c860e18804729a33f7681f78166ef4c761850b8c324d362f7d53f14c5c44907a6b38b32c703ff85e4805
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/module-importer@npm:^1.0.1":
   version: 1.0.1
   resolution: "@humanwhocodes/module-importer@npm:1.0.1"
@@ -3283,6 +3406,13 @@ __metadata:
   version: 1.2.1
   resolution: "@humanwhocodes/object-schema@npm:1.2.1"
   checksum: a824a1ec31591231e4bad5787641f59e9633827d0a2eaae131a288d33c9ef0290bd16fda8da6f7c0fcb014147865d12118df10db57f27f41e20da92369fcb3f1
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/object-schema@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@humanwhocodes/object-schema@npm:2.0.1"
+  checksum: 24929487b1ed48795d2f08346a0116cc5ee4634848bce64161fb947109352c562310fd159fc64dda0e8b853307f5794605191a9547f7341158559ca3c8262a45
   languageName: node
   linkType: hard
 
@@ -4791,6 +4921,11 @@ __metadata:
   resolution: "@openmrs/esm-form-entry-app@workspace:packages/esm-form-entry-app"
   dependencies:
     "@angular-devkit/build-angular": ^15.2.10
+    "@angular-eslint/builder": 15.2.1
+    "@angular-eslint/eslint-plugin": 15.2.1
+    "@angular-eslint/eslint-plugin-template": 15.2.1
+    "@angular-eslint/schematics": 15.2.1
+    "@angular-eslint/template-parser": 15.2.1
     "@angular-extensions/elements": ^15.3.0
     "@angular/animations": ^15.2.10
     "@angular/cdk": ^15.2.9
@@ -4814,8 +4949,11 @@ __metadata:
     "@types/jasmine": ~3.6.11
     "@types/jasminewd2": ~2.0.3
     "@types/webpack-env": ^1.18.2
+    "@typescript-eslint/eslint-plugin": 5.48.2
+    "@typescript-eslint/parser": 5.48.2
     codelyzer: ^6.0.2
     copy-webpack-plugin: ^11.0.0
+    eslint: ^8.33.0
     jasmine-core: ~5.1.1
     jasmine-spec-reporter: ~7.0.0
     jspdf: ^2.5.1
@@ -7447,6 +7585,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7.3.12":
+  version: 7.5.6
+  resolution: "@types/semver@npm:7.5.6"
+  checksum: 563a0120ec0efcc326567db2ed920d5d98346f3638b6324ea6b50222b96f02a8add3c51a916b6897b51523aad8ac227d21d3dcf8913559f1bfc6c15b14d23037
+  languageName: node
+  linkType: hard
+
 "@types/semver@npm:^7.5.0":
   version: 7.5.3
   resolution: "@types/semver@npm:7.5.3"
@@ -7565,6 +7710,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/eslint-plugin@npm:5.48.2":
+  version: 5.48.2
+  resolution: "@typescript-eslint/eslint-plugin@npm:5.48.2"
+  dependencies:
+    "@typescript-eslint/scope-manager": 5.48.2
+    "@typescript-eslint/type-utils": 5.48.2
+    "@typescript-eslint/utils": 5.48.2
+    debug: ^4.3.4
+    ignore: ^5.2.0
+    natural-compare-lite: ^1.4.0
+    regexpp: ^3.2.0
+    semver: ^7.3.7
+    tsutils: ^3.21.0
+  peerDependencies:
+    "@typescript-eslint/parser": ^5.0.0
+    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 78a9d0550f0b4aa026efef939ef93a36d84464f4f74c7f7e9e99bcc385eb9dd4e6755f9046775dfd74906933df3c2f6ac8c02ddee5df2f6f69d54c4f85f6eeed
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/eslint-plugin@npm:^6.7.3":
   version: 6.7.3
   resolution: "@typescript-eslint/eslint-plugin@npm:6.7.3"
@@ -7590,6 +7758,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/parser@npm:5.48.2":
+  version: 5.48.2
+  resolution: "@typescript-eslint/parser@npm:5.48.2"
+  dependencies:
+    "@typescript-eslint/scope-manager": 5.48.2
+    "@typescript-eslint/types": 5.48.2
+    "@typescript-eslint/typescript-estree": 5.48.2
+    debug: ^4.3.4
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 0ca1494dfde0019c647afc8d48e751856c0c9e302627cc63e59cb221d4350d2e260f99e57660e4ab27ded873c1c677e43e2dba973a0656c6522205b9b52e0290
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/parser@npm:^6.7.3":
   version: 6.7.3
   resolution: "@typescript-eslint/parser@npm:6.7.3"
@@ -7608,6 +7793,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:5.48.2":
+  version: 5.48.2
+  resolution: "@typescript-eslint/scope-manager@npm:5.48.2"
+  dependencies:
+    "@typescript-eslint/types": 5.48.2
+    "@typescript-eslint/visitor-keys": 5.48.2
+  checksum: d18a9016b734b58eb7664701a1f8933704167cd7a96c10b8d3d224301b9e194674fdde4d288079d6800452d4524b38c83f7e8dc76cea15793d2358aa7026fdde
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:6.7.3":
   version: 6.7.3
   resolution: "@typescript-eslint/scope-manager@npm:6.7.3"
@@ -7615,6 +7810,23 @@ __metadata:
     "@typescript-eslint/types": 6.7.3
     "@typescript-eslint/visitor-keys": 6.7.3
   checksum: 08215444b7c70af5c45e185ba3c31c550a0a671ab464a67058cbee680c94aa9d1a062958976d8b09f7bcabf2f63114cdc7be2e4e32e2dfdcb2d7cc79961b7b32
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:5.48.2":
+  version: 5.48.2
+  resolution: "@typescript-eslint/type-utils@npm:5.48.2"
+  dependencies:
+    "@typescript-eslint/typescript-estree": 5.48.2
+    "@typescript-eslint/utils": 5.48.2
+    debug: ^4.3.4
+    tsutils: ^3.21.0
+  peerDependencies:
+    eslint: "*"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: ad60a3557ebdb6e42ceab4627ca79c0101723ab65b2db63f9b36f9ee4df13687c3be6ecc243f0a3e84ed96d30331997c46421e7a4bc8ed58367e98d2a92b8339
   languageName: node
   linkType: hard
 
@@ -7635,10 +7847,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:5.48.2":
+  version: 5.48.2
+  resolution: "@typescript-eslint/types@npm:5.48.2"
+  checksum: 9c5e860a0102badf5116985cfa0a1be5b1d7453c3fd84861c4e82d9b73b881304f52ea8455740f5b4af8491dabe5e8d2dfdeb5e333a509118b1fd7e718496147
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/types@npm:6.7.3":
   version: 6.7.3
   resolution: "@typescript-eslint/types@npm:6.7.3"
   checksum: 4adb6177ec710e7438610fee553839a7abecc498dbb36d0170786bab66c5e5415cd720ac06419fd905458ad88c39b661603af5f013adc299137ccb4c51c4c879
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:5.48.2":
+  version: 5.48.2
+  resolution: "@typescript-eslint/typescript-estree@npm:5.48.2"
+  dependencies:
+    "@typescript-eslint/types": 5.48.2
+    "@typescript-eslint/visitor-keys": 5.48.2
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.3.7
+    tsutils: ^3.21.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 3ae06c597249220bcc138857d37ab2c14204d7db42e943e1a4fe6c56b6912ea271e3ab19f15f458390c54f82ac47785481546b644ff3c111cbb37398cf29949a
   languageName: node
   linkType: hard
 
@@ -7660,6 +7897,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:5.48.2":
+  version: 5.48.2
+  resolution: "@typescript-eslint/utils@npm:5.48.2"
+  dependencies:
+    "@types/json-schema": ^7.0.9
+    "@types/semver": ^7.3.12
+    "@typescript-eslint/scope-manager": 5.48.2
+    "@typescript-eslint/types": 5.48.2
+    "@typescript-eslint/typescript-estree": 5.48.2
+    eslint-scope: ^5.1.1
+    eslint-utils: ^3.0.0
+    semver: ^7.3.7
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: d363dbf577acc5817427ac0e1290df685b027de6b03bbc150fa252e6435a2e88e254ec4c1db03773cbcae14875d1529e447861e015bf19055bd2b02de766f722
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:6.7.3":
   version: 6.7.3
   resolution: "@typescript-eslint/utils@npm:6.7.3"
@@ -7677,6 +7932,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/visitor-keys@npm:5.48.2":
+  version: 5.48.2
+  resolution: "@typescript-eslint/visitor-keys@npm:5.48.2"
+  dependencies:
+    "@typescript-eslint/types": 5.48.2
+    eslint-visitor-keys: ^3.3.0
+  checksum: 4d83d1e4b39ad76fe865b0580dbfcad6d6f9e936de3d40c1c13d552d40e394eab390a7f9d1172ba59ce457853b93ed0ec253642e6d07cd6cf4fa0b5ec006f0c4
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:6.7.3":
   version: 6.7.3
   resolution: "@typescript-eslint/visitor-keys@npm:6.7.3"
@@ -7684,6 +7949,13 @@ __metadata:
     "@typescript-eslint/types": 6.7.3
     eslint-visitor-keys: ^3.4.1
   checksum: cef64173a919107f420703e204d97d0afef0d9bd7a67570df5bdb39ac9464211c5a7b3af735d8f41e8004b443ab83e88b1d6fb951886aed4d3fe9d4778667199
+  languageName: node
+  linkType: hard
+
+"@ungap/structured-clone@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@ungap/structured-clone@npm:1.2.0"
+  checksum: 4f656b7b4672f2ce6e272f2427d8b0824ed11546a601d8d5412b9d7704e83db38a8d9f402ecdf2b9063fc164af842ad0ec4a55819f621ed7e7ea4d1efcc74524
   languageName: node
   linkType: hard
 
@@ -8806,6 +9078,15 @@ __metadata:
   dependencies:
     ast-types-flow: 0.0.7
   checksum: 0d3c64a8277711fe543624e0d114d661a2b3b451dd796116dc963893ac77f8dd7df42fdf5bbf37a1234adfa6f2196ee3bd0096407e133bce547c2a725f4288ee
+  languageName: node
+  linkType: hard
+
+"axobject-query@npm:3.1.1":
+  version: 3.1.1
+  resolution: "axobject-query@npm:3.1.1"
+  dependencies:
+    deep-equal: ^2.0.5
+  checksum: c12a5da10dc7bab75e1cda9b6a3b5fcf10eba426ddf1a17b71ef65a434ed707ede7d1c4f013ba1609e970bc8c0cddac01365080d376204314e9b294719acd8a5
   languageName: node
   linkType: hard
 
@@ -13192,7 +13473,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:5.1.1":
+"eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
   dependencies:
@@ -13202,7 +13483,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^7.2.2":
+"eslint-scope@npm:^7.0.0, eslint-scope@npm:^7.2.2":
   version: 7.2.2
   resolution: "eslint-scope@npm:7.2.2"
   dependencies:
@@ -13212,10 +13493,76 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-utils@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "eslint-utils@npm:3.0.0"
+  dependencies:
+    eslint-visitor-keys: ^2.0.0
+  peerDependencies:
+    eslint: ">=5"
+  checksum: 0668fe02f5adab2e5a367eee5089f4c39033af20499df88fe4e6aba2015c20720404d8c3d6349b6f716b08fdf91b9da4e5d5481f265049278099c4c836ccb619
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "eslint-visitor-keys@npm:2.1.0"
+  checksum: e3081d7dd2611a35f0388bbdc2f5da60b3a3c5b8b6e928daffff7391146b434d691577aa95064c8b7faad0b8a680266bcda0a42439c18c717b80e6718d7e267d
+  languageName: node
+  linkType: hard
+
 "eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
   version: 3.4.3
   resolution: "eslint-visitor-keys@npm:3.4.3"
   checksum: 36e9ef87fca698b6fd7ca5ca35d7b2b6eeaaf106572e2f7fd31c12d3bfdaccdb587bba6d3621067e5aece31c8c3a348b93922ab8f7b2cbc6aaab5e1d89040c60
+  languageName: node
+  linkType: hard
+
+"eslint@npm:^8.33.0":
+  version: 8.54.0
+  resolution: "eslint@npm:8.54.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.2.0
+    "@eslint-community/regexpp": ^4.6.1
+    "@eslint/eslintrc": ^2.1.3
+    "@eslint/js": 8.54.0
+    "@humanwhocodes/config-array": ^0.11.13
+    "@humanwhocodes/module-importer": ^1.0.1
+    "@nodelib/fs.walk": ^1.2.8
+    "@ungap/structured-clone": ^1.2.0
+    ajv: ^6.12.4
+    chalk: ^4.0.0
+    cross-spawn: ^7.0.2
+    debug: ^4.3.2
+    doctrine: ^3.0.0
+    escape-string-regexp: ^4.0.0
+    eslint-scope: ^7.2.2
+    eslint-visitor-keys: ^3.4.3
+    espree: ^9.6.1
+    esquery: ^1.4.2
+    esutils: ^2.0.2
+    fast-deep-equal: ^3.1.3
+    file-entry-cache: ^6.0.1
+    find-up: ^5.0.0
+    glob-parent: ^6.0.2
+    globals: ^13.19.0
+    graphemer: ^1.4.0
+    ignore: ^5.2.0
+    imurmurhash: ^0.1.4
+    is-glob: ^4.0.0
+    is-path-inside: ^3.0.3
+    js-yaml: ^4.1.0
+    json-stable-stringify-without-jsonify: ^1.0.1
+    levn: ^0.4.1
+    lodash.merge: ^4.6.2
+    minimatch: ^3.1.2
+    natural-compare: ^1.4.0
+    optionator: ^0.9.3
+    strip-ansi: ^6.0.1
+    text-table: ^0.2.0
+  bin:
+    eslint: bin/eslint.js
+  checksum: 7e876e9da2a18a017271cf3733d05a3dfbbe469272d75753408c6ea5b1646c71c6bb18cb91e10ca930144c32c1ce3701e222f1ae6784a3975a69f8f8aa68e49f
   languageName: node
   linkType: hard
 
@@ -15356,7 +15703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.0.4, ignore@npm:^5.2.0, ignore@npm:^5.2.4":
+"ignore@npm:5.2.4, ignore@npm:^5.0.4, ignore@npm:^5.2.0, ignore@npm:^5.2.4":
   version: 5.2.4
   resolution: "ignore@npm:5.2.4"
   checksum: 3d4c309c6006e2621659311783eaea7ebcd41fe4ca1d78c91c473157ad6666a57a2df790fe0d07a12300d9aac2888204d7be8d59f9aaf665b1c7fcdb432517ef
@@ -19132,6 +19479,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"natural-compare-lite@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "natural-compare-lite@npm:1.4.0"
+  checksum: 5222ac3986a2b78dd6069ac62cbb52a7bf8ffc90d972ab76dfe7b01892485d229530ed20d0c62e79a6b363a663b273db3bde195a1358ce9e5f779d4453887225
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -22102,6 +22456,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regexpp@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "regexpp@npm:3.2.0"
+  checksum: a78dc5c7158ad9ddcfe01aa9144f46e192ddbfa7b263895a70a5c6c73edd9ce85faf7c0430e59ac38839e1734e275b9c3de5c57ee3ab6edc0e0b1bdebefccef8
+  languageName: node
+  linkType: hard
+
 "regexpu-core@npm:^5.3.1":
   version: 5.3.2
   resolution: "regexpu-core@npm:5.3.2"
@@ -23935,7 +24296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-json-comments@npm:^3.1.1":
+"strip-json-comments@npm:3.1.1, strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
@@ -24423,21 +24784,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tmp@npm:0.2.1, tmp@npm:^0.2.1, tmp@npm:~0.2.1":
+  version: 0.2.1
+  resolution: "tmp@npm:0.2.1"
+  dependencies:
+    rimraf: ^3.0.0
+  checksum: 8b1214654182575124498c87ca986ac53dc76ff36e8f0e0b67139a8d221eaecfdec108c0e6ec54d76f49f1f72ab9325500b246f562b926f85bcdfca8bf35df9e
+  languageName: node
+  linkType: hard
+
 "tmp@npm:^0.0.33":
   version: 0.0.33
   resolution: "tmp@npm:0.0.33"
   dependencies:
     os-tmpdir: ~1.0.2
   checksum: 902d7aceb74453ea02abbf58c203f4a8fc1cead89b60b31e354f74ed5b3fb09ea817f94fb310f884a5d16987dd9fa5a735412a7c2dd088dd3d415aa819ae3a28
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.2.1, tmp@npm:~0.2.1":
-  version: 0.2.1
-  resolution: "tmp@npm:0.2.1"
-  dependencies:
-    rimraf: ^3.0.0
-  checksum: 8b1214654182575124498c87ca986ac53dc76ff36e8f0e0b67139a8d221eaecfdec108c0e6ec54d76f49f1f72ab9325500b246f562b926f85bcdfca8bf35df9e
   languageName: node
   linkType: hard
 
@@ -24675,10 +25036,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.10.0, tslib@npm:^1.9.0":
+"tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
+  languageName: node
+  linkType: hard
+
+"tsutils@npm:^3.21.0":
+  version: 3.21.0
+  resolution: "tsutils@npm:3.21.0"
+  dependencies:
+    tslib: ^1.8.1
+  peerDependencies:
+    typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+  checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Adds two ESLint rules:

- `consistent-type-imports` - requires that type annotations be marked with the `type` keyword in imports. Read more about the rationale for this [here](https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how).
- `no-console` - lint errors out if `console.log`s are found in the code. 

Also amends the ESLint configuration in the form-entry Angular app so it uses `ng lint` with a minimal @angular/eslint configuration instead.

## Screenshots
*None*

## Related Issue
*None*

## Other
*None*
