### PR TITLE
(fix) 03-2588: Tweak workspace alert badge UI

### DIFF
--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.component.tsx
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.component.tsx
@@ -42,7 +42,8 @@ export const SiderailNavButton: React.FC<SiderailNavButtonProps> = ({
       >
         <div className={styles.elementContainer}>
           {getIcon({ size: 16 })}
-          <span className={styles.countTag}>{formOpenInTheBackground ? '!' : tagContent}</span>
+          {formOpenInTheBackground ? <span className={styles.interruptedTag}>!</span> : null}
+          {!formOpenInTheBackground ? <span className={styles.countTag}>{tagContent}</span> : null}
         </div>
 
         <span>{label}</span>
@@ -56,13 +57,15 @@ export const SiderailNavButton: React.FC<SiderailNavButtonProps> = ({
       className={classNames(styles.container, {
         [styles.active]: isWorkspaceActive,
       })}
+      enterDelayMs={1000}
       kind="ghost"
       label={label}
       onClick={handler}
     >
       <div className={styles.elementContainer}>
         {getIcon({ size: 20 })}
-        <span className={styles.countTag}>{formOpenInTheBackground ? '!' : tagContent}</span>
+        {formOpenInTheBackground ? <span className={styles.interruptedTag}>!</span> : null}
+        {!formOpenInTheBackground ? <span className={styles.countTag}>{tagContent}</span> : null}
       </div>
     </IconButton>
   );

--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.component.tsx
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.component.tsx
@@ -30,6 +30,20 @@ export const SiderailNavButton: React.FC<SiderailNavButtonProps> = ({
   const isWorkspaceActive = workspaceWindowState !== 'hidden' && workspaceIndex === 0;
   const formOpenInTheBackground = workspaceIndex > 0 || (workspaceIndex === 0 && workspaceWindowState === 'hidden');
 
+  function Tags({ isTablet }: { isTablet: boolean }) {
+    return (
+      <>
+        {getIcon({ size: isTablet ? 16 : 20 })}
+
+        {formOpenInTheBackground ? (
+          <span className={styles.interruptedTag}>!</span>
+        ) : (
+          <span className={styles.countTag}>{tagContent}</span>
+        )}
+      </>
+    );
+  }
+
   if (layout === 'tablet') {
     return (
       <Button
@@ -40,11 +54,9 @@ export const SiderailNavButton: React.FC<SiderailNavButtonProps> = ({
         role="button"
         tabIndex={0}
       >
-        <div className={styles.elementContainer}>
-          {getIcon({ size: 16 })}
-          {formOpenInTheBackground ? <span className={styles.interruptedTag}>!</span> : null}
-          {!formOpenInTheBackground ? <span className={styles.countTag}>{tagContent}</span> : null}
-        </div>
+        <span className={styles.elementContainer}>
+          <Tags isTablet />
+        </span>
 
         <span>{label}</span>
       </Button>
@@ -57,15 +69,13 @@ export const SiderailNavButton: React.FC<SiderailNavButtonProps> = ({
       className={classNames(styles.container, {
         [styles.active]: isWorkspaceActive,
       })}
-      enterDelayMs={1000}
+      enterDelayMs={300}
       kind="ghost"
       label={label}
       onClick={handler}
     >
       <div className={styles.elementContainer}>
-        {getIcon({ size: 20 })}
-        {formOpenInTheBackground ? <span className={styles.interruptedTag}>!</span> : null}
-        {!formOpenInTheBackground ? <span className={styles.countTag}>{tagContent}</span> : null}
+        <Tags isTablet={false} />
       </div>
     </IconButton>
   );

--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
@@ -38,25 +38,18 @@
     text-align: center;
     color: $ui-01;
     background-color: $danger;
-    padding: 0 3px 0 4px;
+    padding: 0 4px;
     border-radius: 50%;
     top: -10px;
     right: -10px;
-  } 
+  }
 
   .interruptedTag {
-    position: absolute;
+    @extend .countTag;
     font-size: 10px;
-    text-align: center;
-    color: $ui-01;
-    background-color: $danger;
     padding: 0 5px;
     width: 14px;
     height: 14px;
-    border-radius: 50%;
-    top: -10px;
-    right: -10px;
-    font-size: 9px;
   }
 }
 

--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
@@ -42,6 +42,21 @@
     border-radius: 50%;
     top: -10px;
     right: -10px;
+  } 
+
+  .interruptedTag {
+    position: absolute;
+    font-size: 10px;
+    text-align: center;
+    color: $ui-01;
+    background-color: $danger;
+    padding: 0 5px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    top: -10px;
+    right: -10px;
+    font-size: 9px;
   }
 }
 
@@ -85,5 +100,3 @@
     }
   }
 }
-
-


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I added a new  **class styles.interruptedTag** that is conditional rendered. If formOpenInTheBackground is true, it renders a <span> element with the class styles.interruptedTag containing an exclamation mark (With the shape of the icon being circular). If formOpenInTheBackground is false, it renders null, meaning nothing is displayed. 

## Screenshots
**Appearance on desktop**

![Screenshot 2023-11-23 at 5 53 10 PM](https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/b1b4dc28-0326-491f-87a0-1e7f7686199b)

**Appearance on tablet**

![Screenshot 2023-11-23 at 5 53 44 PM](https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/600b78f0-8029-4eab-b84c-e01276eeba14)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
