### PR TITLE
(test) Remove async waitFor from tests

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-error.test.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-error.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import FormError from './form-error.component';
@@ -30,7 +30,7 @@ describe('FormError', () => {
 
     const closeButton = screen.getByRole('button', { name: /close this panel/i });
 
-    await waitFor(() => user.click(closeButton));
+    await user.click(closeButton);
 
     expect(closeWorkspace).toHaveBeenCalled();
   });
@@ -43,7 +43,7 @@ describe('FormError', () => {
 
     const link = screen.getByRole('button', { name: /this list/i });
 
-    await waitFor(() => user.click(link));
+    await user.click(link);
 
     expect(closeWorkspace).toHaveBeenCalled();
     expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('clinical-forms-workspace');

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import FormRenderer from './form-renderer.component';
 import useFormSchema from '../hooks/useFormSchema';
 
@@ -43,7 +43,7 @@ describe('FormRenderer', () => {
     mockUseFormSchema.mockReturnValue({ schema: { id: 'test-schema' }, isLoading: false, error: null });
 
     render(<FormRenderer {...defaultProps} />);
-    await waitFor(() => expect(screen.getByText(/form engine lib/i)).toBeInTheDocument());
+    await expect(screen.getByText(/form engine lib/i)).toBeInTheDocument();
     expect(mockUseFormSchema).toHaveBeenCalledWith('test-form-uuid');
   });
 });

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
@@ -135,7 +135,7 @@ describe('Switchable obs viewer ', () => {
       name: /chart view/i,
     });
 
-    // await waitFor(() => user.click(chartViewButton));
+    // await user.click(chartViewButton);
 
     // expect(screen.queryByRole('table')).not.toBeInTheDocument();
     // expect(screen.getByRole('tab', { name: /viral load/i })).toHaveValue('');

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import { showSnackbar } from '@openmrs/esm-framework';
 import { mockAllergensAndAllergicReactions, mockAllergyResult } from '../../__mocks__/allergies.mock';
 import { mockPatient } from '../../../../../tools/test-helpers';
@@ -66,7 +66,7 @@ describe('AllergyForm ', () => {
 
     tabNames.map((tabName) => expect(screen.getByRole('tab', { name: tabName })).toBeInTheDocument());
 
-    await waitFor(() => user.click(screen.getByRole('tab', { name: /drug/i })));
+    await user.click(screen.getByRole('tab', { name: /drug/i }));
 
     expect(screen.getByRole('tab', { name: /drug/i })).toBeChecked;
     expect(screen.getByRole('radio', { name: /ace inhibitors/i })).toBeInTheDocument();
@@ -87,10 +87,10 @@ describe('AllergyForm ', () => {
 
     renderAllergyForm();
 
-    await waitFor(() => user.click(screen.getByRole('radio', { name: /ace inhibitors/i })));
-    await waitFor(() => user.click(screen.getByRole('checkbox', { name: /cough/i })));
-    await waitFor(() => user.click(screen.getByRole('radio', { name: /moderate/i })));
-    await waitFor(() => user.click(screen.getByRole('button', { name: /save and close/i })));
+    await user.click(screen.getByRole('radio', { name: /ace inhibitors/i }));
+    await user.click(screen.getByRole('checkbox', { name: /cough/i }));
+    await user.click(screen.getByRole('radio', { name: /moderate/i }));
+    await user.click(screen.getByRole('button', { name: /save and close/i }));
 
     expect(mockShowSnackbar).toHaveBeenCalledTimes(1);
     expect(mockShowSnackbar).toHaveBeenCalledWith({
@@ -114,8 +114,8 @@ describe('AllergyForm ', () => {
 
     renderAllergyForm();
 
-    await waitFor(() => user.click(screen.getByRole('radio', { name: /ace inhibitors/i })));
-    await waitFor(() => user.click(screen.getByRole('button', { name: /save and close/i })));
+    await user.click(screen.getByRole('radio', { name: /ace inhibitors/i }));
+    await user.click(screen.getByRole('button', { name: /save and close/i }));
 
     expect(mockShowSnackbar).toHaveBeenCalledTimes(1);
     expect(mockShowSnackbar).toHaveBeenCalledWith({

--- a/packages/esm-patient-appointments-app/src/__mocks__/location.mock.ts
+++ b/packages/esm-patient-appointments-app/src/__mocks__/location.mock.ts
@@ -10,9 +10,3 @@ export const mockLocations = [
     name: 'Inpatient Ward',
   },
 ];
-
-export const mockLocationsDataResponse = {
-  data: {
-    results: mockLocations,
-  },
-};

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.test.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
 import { mockAppointmentsData } from '../__mocks__/appointments.mock';
@@ -94,7 +94,7 @@ describe('AppointmensOverview', () => {
     expect(screen.getByTitle(/Empty data illustration/i)).toBeInTheDocument();
     expect(screen.getByText(/There are no upcoming appointments to display for this patient/i)).toBeInTheDocument();
 
-    await waitFor(() => user.click(pastAppointmentsTab));
+    await user.click(pastAppointmentsTab);
     expect(screen.getByRole('table')).toBeInTheDocument();
 
     const expectedColumnHeaders = [/date/, /location/, /service/];

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-form/appointments-form.test.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-form/appointments-form.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockLocations, mockLocationsDataResponse } from '../../__mocks__/location.mock';
+import { mockLocations } from '../../__mocks__/location.mock';
 import { openmrsFetch, showSnackbar } from '@openmrs/esm-framework';
 import { mockSessionDataResponse } from '../../__mocks__/session.mock';
 import { mockUseAppointmentServiceData } from '../../__mocks__/appointments.mock';
@@ -128,7 +128,7 @@ describe('AppointmentForm', () => {
     await waitForLoadingToFinish();
 
     const cancelButton = screen.getByRole('button', { name: /Discard/i });
-    await waitFor(() => user.click(cancelButton));
+    await user.click(cancelButton);
 
     expect(testProps.closeWorkspace).toHaveBeenCalledTimes(1);
   });
@@ -152,15 +152,15 @@ describe('AppointmentForm', () => {
 
     expect(saveButton).not.toBeDisabled();
 
-    await waitFor(() => user.clear(dateInput));
-    await waitFor(() => user.type(dateInput, '4/4/2021'));
-    await waitFor(() => user.clear(timeInput));
-    await waitFor(() => user.type(timeInput, '09:30'));
-    await waitFor(() => user.selectOptions(timeFormat, 'AM'));
-    await waitFor(() => user.selectOptions(serviceSelect, ['Outpatient']));
-    await waitFor(() => user.selectOptions(appointmentTypeSelect, ['Scheduled']));
+    await user.clear(dateInput);
+    await user.type(dateInput, '4/4/2021');
+    await user.clear(timeInput);
+    await user.type(timeInput, '09:30');
+    await user.selectOptions(timeFormat, 'AM');
+    await user.selectOptions(serviceSelect, ['Outpatient']);
+    await user.selectOptions(appointmentTypeSelect, ['Scheduled']);
 
-    await waitFor(() => user.click(saveButton));
+    await user.click(saveButton);
   });
 
   it('renders an error snackbar if there was a problem scheduling an appointment', async () => {
@@ -188,14 +188,14 @@ describe('AppointmentForm', () => {
     const serviceSelect = screen.getByRole('combobox', { name: /Select a service/i });
     const appointmentTypeSelect = screen.getByRole('combobox', { name: /Select the type of appointment/i });
 
-    await waitFor(() => user.clear(dateInput));
-    await waitFor(() => user.type(dateInput, '4/4/2021'));
-    await waitFor(() => user.clear(timeInput));
-    await waitFor(() => user.type(timeInput, '09:30'));
-    await waitFor(() => user.selectOptions(timeFormat, 'AM'));
-    await waitFor(() => user.selectOptions(serviceSelect, ['Outpatient']));
-    await waitFor(() => user.selectOptions(appointmentTypeSelect, ['Scheduled']));
-    await waitFor(() => user.click(saveButton));
+    await user.clear(dateInput);
+    await user.type(dateInput, '4/4/2021');
+    await user.clear(timeInput);
+    await user.type(timeInput, '09:30');
+    await user.selectOptions(timeFormat, 'AM');
+    await user.selectOptions(serviceSelect, ['Outpatient']);
+    await user.selectOptions(appointmentTypeSelect, ['Scheduled']);
+    await user.click(saveButton);
   });
 });
 

--- a/packages/esm-patient-chart-app/src/__mocks__/location.mock.ts
+++ b/packages/esm-patient-chart-app/src/__mocks__/location.mock.ts
@@ -10,9 +10,3 @@ export const mockLocations = [
     name: 'Inpatient Ward',
   },
 ];
-
-export const mockLocationsDataResponse = {
-  data: {
-    results: mockLocations,
-  },
-};

--- a/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { usePagination, useVisitTypes } from '@openmrs/esm-framework';
 import { mockVisitTypes } from '../../__mocks__/visits.mock';
@@ -93,7 +93,7 @@ describe('VisitTypeOverview', () => {
     expect(hivVisit).toBeInTheDocument();
 
     const searchInput = screen.getByRole('searchbox');
-    await waitFor(() => user.type(searchInput, 'HIV'));
+    await user.type(searchInput, 'HIV');
 
     expect(outpatientVisit).toBeEmptyDOMElement();
     expect(hivVisit).toBeInTheDocument();

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { of, throwError } from 'rxjs';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { saveVisit, showSnackbar, useConfig } from '@openmrs/esm-framework';
 import { mockLocations } from '../../__mocks__/location.mock';

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import StartVisitDialog from './start-visit-dialog.component';
@@ -33,7 +33,7 @@ describe('StartVisit', () => {
 
     const startNewVisitButton = screen.getByRole('button', { name: /Start new visit/i });
 
-    await waitFor(() => user.click(startNewVisitButton));
+    await user.click(startNewVisitButton);
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('start-visit-workspace-form');
   });
@@ -53,7 +53,7 @@ describe('StartVisit', () => {
 
     const editPastVisitButton = screen.getByRole('button', { name: /Edit past visit/i });
 
-    await waitFor(() => user.click(editPastVisitButton));
+    await user.click(editPastVisitButton);
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('past-visits-overview');
   });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/curret-visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/curret-visit-summary.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import CurrentVisitSummary from './current-visit-summary.component';
 import { useVisit, getConfig } from '@openmrs/esm-framework';
 
@@ -65,13 +65,12 @@ describe('CurrentVisitSummary', () => {
     });
 
     render(<CurrentVisitSummary patientUuid="some-uuid" />);
-    await waitFor(() => {
-      expect(screen.getByText('Current Visit')).toBeInTheDocument();
-      expect(screen.getByText('Diagnoses')).toBeInTheDocument();
-      const buttonNames = ['Notes', 'Tests', 'Medications', 'Encounters'];
-      buttonNames.forEach((buttonName) => {
-        expect(screen.getByText(buttonName)).toBeInTheDocument();
-      });
+
+    expect(screen.getByText('Current Visit')).toBeInTheDocument();
+    expect(screen.getByText('Diagnoses')).toBeInTheDocument();
+    const buttonNames = ['Notes', 'Tests', 'Medications', 'Encounters'];
+    buttonNames.forEach((buttonName) => {
+      expect(screen.getByText(buttonName)).toBeInTheDocument();
     });
   });
 });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { usePagination } from '@openmrs/esm-framework';
-import { mockPatient, renderWithSwr } from '../../../../../../tools/test-helpers';
+import { renderWithSwr } from '../../../../../../tools/test-helpers';
 import { mockEncounters2 } from '../../../__mocks__/visits.mock';
 import EncountersTable from './encounters-table.component';
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { getConfig } from '@openmrs/esm-framework';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { visitOverviewDetailMockData, visitOverviewDetailMockDataNotEmpty } from '../../../__mocks__/visits.mock';
 import { mockPatient } from '../../../../../../tools/test-helpers';
@@ -41,21 +41,21 @@ describe('VisitSummary', () => {
     //should display notes tab panel
     const notesTab = screen.getByRole('tab', { name: /Notes/i });
 
-    await waitFor(() => user.click(notesTab));
+    await user.click(notesTab);
 
     expect(screen.getByText(/^No notes found$/)).toBeInTheDocument();
 
     // should display medication panel
     const medicationTab = screen.getByRole('tab', { name: /Medication/i });
 
-    await waitFor(() => user.click(medicationTab));
+    await user.click(medicationTab);
 
     expect(screen.getByText(/^No medications found$/)).toBeInTheDocument();
 
     // should display tests panel with test panel extension
     const testsTab = screen.getByRole('tab', { name: /Tests/i });
 
-    await waitFor(() => user.click(testsTab));
+    await user.click(testsTab);
 
     expect(screen.getByText(/test-results-filtered-overview/)).toBeInTheDocument();
   });
@@ -76,7 +76,7 @@ describe('VisitSummary', () => {
 
     //should display notes tab panel
     const notesTab = screen.getByRole('tab', { name: /Notes/i });
-    await waitFor(() => user.click(notesTab));
+    await user.click(notesTab);
 
     expect(screen.getAllByText(/Dr James Cook/i)[0]).toBeInTheDocument();
     expect(screen.getAllByText(/Admin/i)[0]).toBeInTheDocument();
@@ -84,11 +84,11 @@ describe('VisitSummary', () => {
 
     // should display medication panel
     const medicationTab = screen.getByRole('tab', { name: /Medication/i });
-    await waitFor(() => user.click(medicationTab));
+    await user.click(medicationTab);
 
     // should display tests panel with test panel extension
     const testsTab = screen.getByRole('tab', { name: /Tests/i });
-    await waitFor(() => user.click(testsTab));
+    await user.click(testsTab);
 
     expect(screen.getByText(/test-results-filtered-overview/)).toBeInTheDocument();
   });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { getConfig, usePagination } from '@openmrs/esm-framework';
 import { mockPatient, renderWithSwr } from '../../../../../../../tools/test-helpers';
 import { mockEncounters } from '../../../../__mocks__/visits.mock';
@@ -45,10 +45,8 @@ describe('EncounterList', () => {
 
     renderVisitsTable();
 
-    await waitFor(() => {
-      expect(screen.queryByRole('table')).not.toBeInTheDocument();
-      expect(screen.getByText(/no encounters found/i)).toBeInTheDocument();
-    });
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.getByText(/no encounters found/i)).toBeInTheDocument();
   });
 
   it("renders a tabular overview of the patient's clinical encounters", async () => {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch, getConfig, useConfig } from '@openmrs/esm-framework';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from '../../../../../tools/test-helpers';
@@ -95,7 +95,7 @@ describe('VisitDetailOverview', () => {
     expect(screen.getByText(/no notes found/i)).toBeInTheDocument();
     expect(screen.getByText(/no medications found/i)).toBeInTheDocument();
 
-    await waitFor(() => user.click(allVisitsTab));
+    await user.click(allVisitsTab);
 
     expect(allVisitsTab).toHaveAttribute('aria-selected', 'true');
     expect(visitSummariesTab).toHaveAttribute('aria-selected', 'false');

--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.test.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { isDesktop } from '@openmrs/esm-framework';
 import { launchPatientWorkspace, registerWorkspace } from '@openmrs/esm-patient-common-lib';
@@ -63,7 +63,7 @@ xdescribe('WorkspaceWindow', () => {
 
     expect(workspaceContainer).toHaveClass('hide');
 
-    await waitFor(() => launchPatientWorkspace('Clinical Form', { workspaceTitle: 'POC Triage' }));
+    await launchPatientWorkspace('Clinical Form', { workspaceTitle: 'POC Triage' });
 
     expect(await screen.findByRole('complementary')).toHaveClass('show');
   });

--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.test.tsx
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, render, waitFor, cleanup } from '@testing-library/react';
+import { screen, render, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useLayoutType } from '@openmrs/esm-framework';
 import { SiderailNavButton } from './siderail-nav-button.component';
@@ -62,7 +62,7 @@ describe('SiderailNavButton', () => {
 
     const button = screen.getByRole('button', { name: /Visit note/i });
     expect(button).toBeInTheDocument();
-    await waitFor(() => user.click(button));
+    await user.click(button);
     expect(handler).toBeCalled();
 
     expect(button).not.toHaveClass('active');
@@ -177,7 +177,7 @@ describe('SiderailNavButton', () => {
 
     const button = screen.getByRole('button');
     expect(button).toBeInTheDocument();
-    await waitFor(() => user.click(button));
+    await user.click(button);
     expect(handler).toBeCalled();
 
     expect(button).not.toHaveClass('active');

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
@@ -89,7 +89,7 @@ it('clicking the Add button or Record Conditions link launches the conditions fo
 
   const recordConditionsLink = screen.getByText(/record conditions/i);
 
-  await waitFor(() => user.click(recordConditionsLink));
+  await user.click(recordConditionsLink);
 
   expect(launchPatientWorkspace).toHaveBeenCalledTimes(1);
   expect(launchPatientWorkspace).toHaveBeenCalledWith('conditions-form-workspace', {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
+import { openmrsFetch, useConfig, usePagination } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 
 import { mockConditions, mockFhirConditionsResponse } from '../__mocks__/conditions.mock';
@@ -14,22 +14,9 @@ const testProps = {
   patientUuid: mockPatient.id,
 };
 
-const mockOpenmrsFetch = openmrsFetch as jest.Mock;
-const mockUsePagination = usePagination as jest.Mock;
-
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    useConfig: jest.fn().mockImplementation(() => ({ conditionPageSize: 5 })),
-    usePagination: jest.fn().mockImplementation(() => ({
-      currentPage: 1,
-      goTo: () => {},
-      results: [],
-    })),
-  };
-});
+const mockedUseConfig = useConfig as jest.Mock;
+const mockedOpenmrsFetch = openmrsFetch as jest.Mock;
+const mockedUsePagination = usePagination as jest.Mock;
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
@@ -41,8 +28,13 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
 });
 
 describe('ConditionsOverview: ', () => {
+  beforeEach(() => {
+    mockedOpenmrsFetch.mockClear();
+    mockedUseConfig.mockReturnValue({ conditionPageSize: 5 });
+  });
+
   it('renders an empty state view if conditions data is unavailable', async () => {
-    mockOpenmrsFetch.mockReturnValueOnce({ data: [] });
+    mockedOpenmrsFetch.mockReturnValueOnce({ data: [] });
 
     renderConditionsOverview();
 
@@ -55,7 +47,7 @@ describe('ConditionsOverview: ', () => {
     expect(screen.getByText(/Record conditions/i)).toBeInTheDocument();
   });
 
-  it('renders an error state view if there is a problem fetching conditions data', async () => {
+  it('renders an error state view if there is a problem fetching conditions', async () => {
     const error = {
       message: 'You are not logged in',
       response: {
@@ -64,7 +56,7 @@ describe('ConditionsOverview: ', () => {
       },
     };
 
-    mockOpenmrsFetch.mockRejectedValueOnce(error);
+    mockedOpenmrsFetch.mockRejectedValueOnce(error);
 
     renderConditionsOverview();
 
@@ -79,8 +71,8 @@ describe('ConditionsOverview: ', () => {
   it("renders an overview of the patient's conditions when present", async () => {
     const user = userEvent.setup();
 
-    mockOpenmrsFetch.mockReturnValueOnce({ data: mockFhirConditionsResponse });
-    mockUsePagination.mockImplementation(() => ({
+    mockedOpenmrsFetch.mockReturnValueOnce({ data: mockFhirConditionsResponse });
+    mockedUsePagination.mockImplementation(() => ({
       currentPage: 1,
       goTo: () => {},
       results: mockConditions,
@@ -116,7 +108,7 @@ describe('ConditionsOverview: ', () => {
   it('clicking the Add button or Record Conditions link launches the conditions form', async () => {
     const user = userEvent.setup();
 
-    mockOpenmrsFetch.mockReturnValueOnce({ data: [] });
+    mockedOpenmrsFetch.mockReturnValueOnce({ data: [] });
 
     renderConditionsOverview();
 

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
@@ -108,7 +108,7 @@ describe('ConditionsOverview: ', () => {
 
     const nextPageButton = screen.getByRole('button', { name: /next page/i });
 
-    await waitFor(() => user.click(nextPageButton));
+    await user.click(nextPageButton);
 
     expect(screen.getAllByRole('row').length).toEqual(6);
   });
@@ -124,7 +124,7 @@ describe('ConditionsOverview: ', () => {
 
     const recordConditionsLink = screen.getByText(/record conditions/i);
 
-    await waitFor(() => user.click(recordConditionsLink));
+    await user.click(recordConditionsLink);
 
     expect(launchPatientWorkspace).toHaveBeenCalledTimes(1);
     expect(launchPatientWorkspace).toHaveBeenCalledWith('conditions-form-workspace', {

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-item-tile.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-item-tile.component.tsx
@@ -35,7 +35,7 @@ export function LabOrderBasketItemTile({ orderBasketItem, onItemClick, onRemoveC
       onClick={() => shouldOnClickBeCalled.current && onItemClick()}
     >
       <div className={styles.orderBasketItemTile}>
-        <p className={styles.clipTextWithEllipsis}>
+        <div className={styles.clipTextWithEllipsis}>
           <span className={styles.orderActionNewLabel}>{t('orderActionNew', 'New')}</span>
           <br />
           <>
@@ -53,7 +53,7 @@ export function LabOrderBasketItemTile({ orderBasketItem, onItemClick, onRemoveC
               </>
             )}
           </span>
-        </p>
+        </div>
         <Button
           className={styles.removeButton}
           kind="ghost"

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.test.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, render, waitFor, within } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LabOrderBasketPanel from './lab-order-basket-panel.extension';
 import { type OrderBasketItem } from '@openmrs/esm-patient-common-lib';
@@ -54,8 +54,7 @@ describe('LabOrderBasketPanel: ', () => {
     expect(screen.getByText(/Lab orders \(2\)/i)).toBeInTheDocument();
     expect(screen.getByText(/HIV VIRAL LOAD/i)).toBeInTheDocument();
     expect(screen.getByText(/CD4 COUNT/i)).toBeInTheDocument();
-    const hiv = screen.getByText(/HIV VIRAL LOAD/i).closest('div');
-    const removeHivButton = within(hiv).getByRole('button', { name: /remove from basket/i });
+    const removeHivButton = screen.getAllByRole('button', { name: /remove from basket/i })[0];
     expect(removeHivButton).toBeVisible();
     await user.click(removeHivButton);
     rerender(<LabOrderBasketPanel />); // re-render because the mocked hook does not trigger a render

--- a/packages/esm-patient-labs-app/src/root.scss
+++ b/packages/esm-patient-labs-app/src/root.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars'; 
+@import '~@openmrs/esm-styleguide/src/vars';
 
 .productiveHeading01 {
   @include type.type-style("heading-compact-01");
@@ -57,11 +57,13 @@
 }
 
 .clipTextWithEllipsis {
+  font-size: 1rem;
+  line-height: 1.5;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
 }
 
-.text02 { 
+.text02 {
   color: $text-02;
 }

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.test.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, render, within } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getByTextWithMarkup } from '../../../../tools/test-helpers';
 import { mockDrugSearchResultApiData, mockPatientDrugOrdersApiData, patientUuid } from '../__mocks__/medication.mock';
@@ -46,8 +46,7 @@ describe('OrderBasketPanel: ', () => {
     expect(getByTextWithMarkup(/Renew\s*Sulfacetamide 0.1 — 10%/i)).toBeVisible();
     expect(getByTextWithMarkup(/Modify\s*Aspirin 162.5mg — 162.5mg — tablet/i)).toBeVisible();
     expect(getByTextWithMarkup(/Discontinue\s*Acetaminophen 325 mg — 325mg — tablet/i)).toBeVisible();
-    const aspirin81 = getByTextWithMarkup(/New\s*Aspirin 81mg — 81mg — Tablet/i).closest('div');
-    const removeAspirin81Button = within(aspirin81).getByRole('button', { name: /remove from basket/i });
+    const removeAspirin81Button = screen.getAllByRole('button', { name: /remove from basket/i })[0];
     expect(removeAspirin81Button).toBeVisible();
     await user.click(removeAspirin81Button);
     rerender(<DrugOrderBasketPanel />); // re-render because the mocked hook does not trigger a render

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.test.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, render, waitFor, within } from '@testing-library/react';
+import { screen, render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getByTextWithMarkup } from '../../../../tools/test-helpers';
 import { mockDrugSearchResultApiData, mockPatientDrugOrdersApiData, patientUuid } from '../__mocks__/medication.mock';
@@ -49,8 +49,8 @@ describe('OrderBasketPanel: ', () => {
     const aspirin81 = getByTextWithMarkup(/New\s*Aspirin 81mg — 81mg — Tablet/i).closest('div');
     const removeAspirin81Button = within(aspirin81).getByRole('button', { name: /remove from basket/i });
     expect(removeAspirin81Button).toBeVisible();
-    await waitFor(() => user.click(removeAspirin81Button));
+    await user.click(removeAspirin81Button);
     rerender(<DrugOrderBasketPanel />); // re-render because the mocked hook does not trigger a render
-    await waitFor(() => expect(screen.getByText(/Drug Orders \(3\)/i)).toBeInTheDocument());
+    await expect(screen.getByText(/Drug Orders \(3\)/i)).toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.component.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.component.tsx
@@ -27,7 +27,7 @@ export default function OrderBasketItemTile({ orderBasketItem, onItemClick, onRe
 
   const tileContent = (
     <div className={styles.orderBasketItemTile}>
-      <p className={styles.clipTextWithEllipsis}>
+      <div className={styles.clipTextWithEllipsis}>
         <OrderActionLabel orderBasketItem={orderBasketItem} />
         {orderBasketItem.isFreeTextDosage ? (
           <div>
@@ -77,7 +77,7 @@ export default function OrderBasketItemTile({ orderBasketItem, onItemClick, onRe
             </>
           )}
         </span>
-      </p>
+      </div>
       <Button
         className={styles.removeButton}
         kind="ghost"

--- a/packages/esm-patient-medications-app/src/root.scss
+++ b/packages/esm-patient-medications-app/src/root.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars'; 
+@import '~@openmrs/esm-styleguide/src/vars';
 
 .productiveHeading01 {
   @include type.type-style("heading-compact-01");
@@ -57,11 +57,13 @@
 }
 
 .clipTextWithEllipsis {
+  font-size: 1rem;
+  line-height: 1.5;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
 }
 
-.text02 { 
+.text02 {
   color: $text-02;
 }

--- a/packages/esm-patient-notes-app/src/visit-note-action-button.test.tsx
+++ b/packages/esm-patient-notes-app/src/visit-note-action-button.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useLayoutType } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
@@ -41,7 +41,7 @@ describe('VisitNoteActionButton', () => {
     const visitNoteButton = screen.getByRole('button', { name: /Visit note/i });
     expect(visitNoteButton).toBeInTheDocument();
 
-    await waitFor(() => user.click(visitNoteButton));
+    await user.click(visitNoteButton);
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('visit-notes-form-workspace');
     expect(visitNoteButton).toHaveClass('active');
@@ -58,7 +58,7 @@ describe('VisitNoteActionButton', () => {
     const visitNoteButton = screen.getByRole('button', { name: /Note/i });
     expect(visitNoteButton).toBeInTheDocument();
 
-    await waitFor(() => user.click(visitNoteButton));
+    await user.click(visitNoteButton);
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('visit-notes-form-workspace');
     expect(visitNoteButton).toHaveClass('active');

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { screen, within, waitFor } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
+import { openmrsFetch } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { mockEnrolledProgramsResponse } from '../__mocks__/programs.mock';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
@@ -90,12 +90,12 @@ describe('ProgramsDetailedSummary ', () => {
     expect(editButton).toBeInTheDocument();
 
     // Clicking "Add" launches the programs form in a workspace
-    await waitFor(() => user.click(addButton));
+    await user.click(addButton);
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace');
 
     // Clicking the edit button launches the edit form in a workspace
-    await waitFor(() => user.click(editButton));
+    await user.click(editButton);
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
       programEnrollmentId: mockEnrolledProgramsResponse[0].uuid,

--- a/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { throwError } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createErrorHandler, openmrsFetch, showSnackbar } from '@openmrs/esm-framework';
 import {
@@ -66,13 +66,13 @@ describe('ProgramsForm', () => {
     const selectLocationInput = screen.getAllByRole('combobox', { name: '' })[1];
     const selectProgramInput = screen.getAllByRole('combobox', { name: '' })[0];
 
-    await waitFor(() => user.type(enrollmentDateInput, '2020-05-05'));
-    await waitFor(() => user.selectOptions(selectProgramInput, [oncologyScreeningProgramUuid]));
-    await waitFor(() => user.selectOptions(selectLocationInput, [inpatientWardUuid]));
+    await user.type(enrollmentDateInput, '2020-05-05');
+    await user.selectOptions(selectProgramInput, [oncologyScreeningProgramUuid]);
+    await user.selectOptions(selectLocationInput, [inpatientWardUuid]);
 
     expect(screen.getByRole('option', { name: /Inpatient Ward/i })).toBeInTheDocument();
 
-    await waitFor(() => user.click(enrollButton));
+    await user.click(enrollButton);
 
     expect(mockCreateProgramEnrollment).toHaveBeenCalledTimes(1);
     expect(mockCreateProgramEnrollment).toHaveBeenCalledWith(
@@ -105,15 +105,15 @@ describe('ProgramsForm', () => {
 
     mockUpdateProgramEnrollment.mockReturnValueOnce(of({ status: 200, statusText: 'OK' }));
 
-    await waitFor(() => user.type(dateCompletedInput, '05/05/2020'));
+    await user.type(dateCompletedInput, '05/05/2020');
 
     expect(dateCompletedInput).toHaveValue('05/05/2020');
 
-    await waitFor(() => user.tab());
+    await user.tab();
 
     expect(enrollButton).not.toBeDisabled();
 
-    await waitFor(() => user.click(enrollButton));
+    await user.click(enrollButton);
 
     expect(mockUpdateProgramEnrollment).toHaveBeenCalledTimes(1);
     expect(mockUpdateProgramEnrollment).toHaveBeenCalledWith(
@@ -163,13 +163,13 @@ describe('ProgramsForm', () => {
     const selectLocationInput = screen.getAllByRole('combobox', { name: '' })[1];
     const selectProgramInput = screen.getAllByRole('combobox', { name: '' })[0];
 
-    await waitFor(() => user.type(enrollmentDateInput, '2020-05-05'));
-    await waitFor(() => user.selectOptions(selectProgramInput, [oncologyScreeningProgramUuid]));
-    await waitFor(() => user.selectOptions(selectLocationInput, [inpatientWardUuid]));
+    await user.type(enrollmentDateInput, '2020-05-05');
+    await user.selectOptions(selectProgramInput, [oncologyScreeningProgramUuid]);
+    await user.selectOptions(selectLocationInput, [inpatientWardUuid]);
 
     expect(enrollButton).not.toBeDisabled();
 
-    await waitFor(() => user.click(enrollButton));
+    await user.click(enrollButton);
 
     expect(mockCreateErrorHandler).toHaveBeenCalledTimes(1);
     expect(mockShowSnackbar).toHaveBeenCalledWith({

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
@@ -103,7 +103,7 @@ describe('ProgramsOverview', () => {
     expect(screen.getByRole('row', { name: /HIV Care and Treatment/i })).toBeInTheDocument();
 
     // Clicking "Add" launches the programs form in a workspace
-    await waitFor(() => user.click(addButton));
+    await user.click(addButton);
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace');
   });

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
@@ -105,7 +105,7 @@ describe('VitalsHeader: ', () => {
 
     const recordVitalsButton = screen.getByText(/Record vitals/i);
 
-    await waitFor(() => user.click(recordVitalsButton));
+    await user.click(recordVitalsButton);
 
     expect(mockLaunchWorkspace).toHaveBeenCalledTimes(1);
     expect(mockLaunchWorkspace).toHaveBeenCalledWith(patientVitalsBiometricsFormWorkspace);
@@ -156,7 +156,7 @@ describe('VitalsHeader: ', () => {
 
     const recordVitalsButton = screen.getByText(/Record vitals/i);
 
-    await waitFor(() => user.click(recordVitalsButton));
+    await user.click(recordVitalsButton);
     expect(mockLaunchWorkspace).toHaveBeenCalledWith('patient-form-entry-workspace', {
       formInfo: { encounterUuid: '', formUuid: updateVitalsConfigMock.vitals.formUuid },
       workspaceTitle: updateVitalsConfigMock.vitals.formName,

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type FetchResponse, showSnackbar } from '@openmrs/esm-framework';
 import { mockConceptMetadata, mockVitalsConfig, mockVitalsSignsConcept } from '../__mocks__/vitals.mock';
@@ -113,8 +113,8 @@ describe('VitalsBiometricsForm', () => {
     const weightInput = screen.getByRole('spinbutton', { name: /weight/i });
     const bmiInput = screen.getByRole('spinbutton', { name: /bmi/i });
 
-    await waitFor(() => user.type(heightInput, '180'));
-    await waitFor(() => user.type(weightInput, '62'));
+    await user.type(heightInput, '180');
+    await user.type(weightInput, '62');
 
     expect(bmiInput).toHaveValue(19.1);
   });
@@ -143,14 +143,14 @@ describe('VitalsBiometricsForm', () => {
     const muac = screen.getByRole('spinbutton', { name: /muac/i });
     const saveButton = screen.getByRole('button', { name: /Save and close/i });
 
-    await waitFor(() => user.type(heightInput, heightValue.toString()));
-    await waitFor(() => user.type(weightInput, weightValue.toString()));
-    await waitFor(() => user.type(systolic, systolicBloodPressureValue.toString()));
-    await waitFor(() => user.type(pulse, pulseValue.toString()));
-    await waitFor(() => user.type(oxygenSaturation, oxygenSaturationValue.toString()));
-    await waitFor(() => user.type(respirationRate, respiratoryRateValue.toString()));
-    await waitFor(() => user.type(temperature, temperatureValue.toString()));
-    await waitFor(() => user.type(muac, muacValue.toString()));
+    await user.type(heightInput, heightValue.toString());
+    await user.type(weightInput, weightValue.toString());
+    await user.type(systolic, systolicBloodPressureValue.toString());
+    await user.type(pulse, pulseValue.toString());
+    await user.type(oxygenSaturation, oxygenSaturationValue.toString());
+    await user.type(respirationRate, respiratoryRateValue.toString());
+    await user.type(temperature, temperatureValue.toString());
+    await user.type(muac, muacValue.toString());
 
     expect(bmiInput).toHaveValue(19.1);
     expect(systolic).toHaveValue(120);
@@ -160,7 +160,7 @@ describe('VitalsBiometricsForm', () => {
     expect(temperature).toHaveValue(37);
     expect(muac).toHaveValue(23);
 
-    await waitFor(() => user.click(saveButton));
+    await user.click(saveButton);
 
     expect(mockedSavePatientVitals).toHaveBeenCalledTimes(1);
     expect(mockedSavePatientVitals).toHaveBeenCalledWith(
@@ -217,18 +217,18 @@ describe('VitalsBiometricsForm', () => {
     const temperature = screen.getByRole('spinbutton', { name: /temperature/i });
     const muac = screen.getByRole('spinbutton', { name: /muac/i });
 
-    await waitFor(() => user.type(heightInput, heightValue.toString()));
-    await waitFor(() => user.type(weightInput, weightValue.toString()));
-    await waitFor(() => user.type(systolic, systolicBloodPressureValue.toString()));
-    await waitFor(() => user.type(pulse, pulseValue.toString()));
-    await waitFor(() => user.type(oxygenSaturation, oxygenSaturationValue.toString()));
-    await waitFor(() => user.type(respirationRate, respiratoryRateValue.toString()));
-    await waitFor(() => user.type(temperature, temperatureValue.toString()));
-    await waitFor(() => user.type(muac, muacValue.toString()));
+    await user.type(heightInput, heightValue.toString());
+    await user.type(weightInput, weightValue.toString());
+    await user.type(systolic, systolicBloodPressureValue.toString());
+    await user.type(pulse, pulseValue.toString());
+    await user.type(oxygenSaturation, oxygenSaturationValue.toString());
+    await user.type(respirationRate, respiratoryRateValue.toString());
+    await user.type(temperature, temperatureValue.toString());
+    await user.type(muac, muacValue.toString());
 
     const saveButton = screen.getByRole('button', { name: /save and close/i });
 
-    await waitFor(() => user.click(saveButton));
+    await user.click(saveButton);
 
     expect(mockedShowSnackbar).toHaveBeenCalledTimes(1);
     expect(mockedShowSnackbar).toHaveBeenCalledWith({

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch, usePagination } from '@openmrs/esm-framework';
 import {
@@ -94,7 +94,7 @@ describe('VitalsOverview', () => {
     ).toBeInTheDocument();
   });
 
-  /* 
+  /*
   //
     The following two tests are failing in the CI environment with the following error:
       `TypeError: Cannot read properties of undefined (reading 'baseVal')`
@@ -150,7 +150,7 @@ describe('VitalsOverview', () => {
       name: /chart view/i,
     });
 
-    await waitFor(() => user.click(chartViewButton));
+    await user.click(chartViewButton);
 
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
     expect(screen.getByText(/vital sign displayed/i)).toBeInTheD;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

Removes the @testing-library/react [waitFor](https://testing-library.com/docs/dom-testing-library/api-async/#waitfor) function from unit tests. Most invocations of waitFor in our unit tests are unnecessary. Consider the following example:

```tsx
const user = userEvent.setup();

await waitFor(() => user.click(pastAppointmentsTab));
```

Because we're already awaiting the click event, the `waitFor` in this instance is superfluous. Additionally, because `waitFor` imposes a default timeout, having many invocations of it in our test suite is likely why running tests often fails due to timeouts.

## Screenshots
*None*

## Related Issue
*None*

## Other
*None*