### PR TITLE
(chore) Upgrade tree-model to 1.0.7

### DIFF
--- a/packages/esm-form-entry-app/package.json
+++ b/packages/esm-form-entry-app/package.json
@@ -59,7 +59,7 @@
     "single-spa-angular": "^8.1.1",
     "slick-carousel": "^1.8.1",
     "systemjs-webpack-interop": "^2.3.7",
-    "tree-model": "^1.0.5",
+    "tree-model": "^1.0.7",
     "tslib": "^2.4.1",
     "uuid": "^8.3.2",
     "zone.js": "~0.11.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4974,7 +4974,7 @@ __metadata:
     slick-carousel: ^1.8.1
     style-loader: 2.x
     systemjs-webpack-interop: ^2.3.7
-    tree-model: ^1.0.5
+    tree-model: ^1.0.7
     tslib: ^2.4.1
     uuid: ^8.3.2
     webpack: ~5.89.0
@@ -24951,7 +24951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tree-model@npm:^1.0.5":
+"tree-model@npm:^1.0.7":
   version: 1.0.7
   resolution: "tree-model@npm:1.0.7"
   dependencies:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Upgrades tree-model to 1.0.7, for consistency with [openmrs-ngx-formentry](https://github.com/openmrs/openmrs-ngx-formentry/). This was the only discrepancy I noticed between the Angular 15 upgrades in that repository and this one, when looking into [O3-2611](https://openmrs.atlassian.net/browse/O3-2611) (which this does not fix). As far as I can tell this doesn't do anything.
