### PR TITLE
(fix) Missing translations in forms workspace title and vitals overview component

### DIFF
--- a/e2e/specs/vitals.spec.ts
+++ b/e2e/specs/vitals.spec.ts
@@ -45,7 +45,7 @@ test('Record vital signs', async ({ page, api }) => {
 
   await test.step('And I should see the newly recorded vital signs on the page', async () => {
     await expect(headerRow).toContainText(/temp/i);
-    await expect(headerRow).toContainText(/bp/i);
+    await expect(headerRow).toContainText(/blood pressure/i);
     await expect(headerRow).toContainText(/pulse/i);
     await expect(headerRow).toContainText(/r. rate/i);
     await expect(headerRow).toContainText(/SPO2/i);

--- a/packages/esm-patient-forms-app/src/routes.json
+++ b/packages/esm-patient-forms-app/src/routes.json
@@ -43,7 +43,7 @@
       "component": "clinicalFormsWorkspace",
       "meta": {
         "title": {
-          "key": "clinicalForm",
+          "key": "clinicalForms",
           "default": "Clinical forms"
         },
         "type": "clinical-form",

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -77,23 +77,23 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, pageSize, 
   }, [patient, t, excludePatientIdentifierCodeTypes?.uuids]);
 
   const tableHeaders = [
-    { key: 'date', header: 'Date and time', isSortable: true },
+    { key: 'date', header: t('dateAndTime', 'Date and time'), isSortable: true },
     {
       key: 'temperature',
-      header: withUnit('Temp', conceptUnits.get(config.concepts.temperatureUuid) ?? ''),
+      header: withUnit(t('temperature', 'Temp'), conceptUnits.get(config.concepts.temperatureUuid) ?? ''),
     },
     {
       key: 'bloodPressure',
-      header: withUnit('BP', conceptUnits.get(config.concepts.systolicBloodPressureUuid) ?? ''),
+      header: withUnit(t('bloodPressure', 'BP'), conceptUnits.get(config.concepts.systolicBloodPressureUuid) ?? ''),
     },
-    { key: 'pulse', header: withUnit('Pulse', conceptUnits.get(config.concepts.pulseUuid) ?? '') },
+    { key: 'pulse', header: withUnit(t('pulse', 'Pulse'), conceptUnits.get(config.concepts.pulseUuid) ?? '') },
     {
       key: 'respiratoryRate',
-      header: withUnit('R. Rate', conceptUnits.get(config.concepts.respiratoryRateUuid) ?? ''),
+      header: withUnit(t('respiratoryRate', 'R. Rate'), conceptUnits.get(config.concepts.respiratoryRateUuid) ?? ''),
     },
     {
       key: 'spo2',
-      header: withUnit('SPO2', conceptUnits.get(config.concepts.oxygenSaturationUuid) ?? ''),
+      header: withUnit(t('spo2', 'SPO2'), conceptUnits.get(config.concepts.oxygenSaturationUuid) ?? ''),
     },
   ];
 

--- a/packages/esm-patient-vitals-app/translations/km.json
+++ b/packages/esm-patient-vitals-app/translations/km.json
@@ -11,7 +11,7 @@
   "calculatedBmi": "សន្ទស្សន៍ទម្ងន់ខ្លួន(calc.)",
   "checkForValidity": "តម្លៃមួយចំនួនដែលបានបញ្ចូលមិនត្រឹមត្រូវទេ",
   "date": "កាលបរិច្ឆេទ",
-  "dateAndTime": "Date and time",
+  "dateAndTime": "កាលបរិច្ឆេទ និងម៉ោង",
   "diastolic": "ដឺដ្យាស្តូលីក",
   "discard": "បោះបង់",
   "error": "មានបញ្ហាបច្ចេកទេស",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR adds the missing translations for:
1. Forms workspace title
The key used in the translation files is `clinicalForms`, and the key used in the workspace extension is `clinicalForm`.
2. Vitals overview table headers

## Screenshots
### Before

![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/6d2bee2f-512a-4b0c-82c2-55d3389d62b2)


### After
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/30844a0a-b7a3-42bc-9678-7c71680d8852)
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/8f84c9cc-02c7-47f3-a0c5-3b0be465ec7f)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
