### PR TITLE
(fix) O3-2611: Workaround for fixing form entry styles

### DIFF
--- a/packages/esm-form-entry-app/src/index.ts
+++ b/packages/esm-form-entry-app/src/index.ts
@@ -3,7 +3,8 @@ import 'zone.js';
 import { defineConfigSchema, messageOmrsServiceWorker } from '@openmrs/esm-framework';
 import { setupDynamicOfflineFormDataHandler, setupStaticDataOfflinePrecaching } from './app/offline/caching';
 import { configSchema } from './config-schema';
-import './styles.css';
+
+// FIXME This workaround originated from and should be replaced with a better solution https://github.com/single-spa/single-spa-angular/issues/463#issuecomment-1468350850
 // @ts-ignore
 require('./styles.css?ngGlobalStyle');
 

--- a/packages/esm-form-entry-app/src/index.ts
+++ b/packages/esm-form-entry-app/src/index.ts
@@ -4,6 +4,8 @@ import { defineConfigSchema, messageOmrsServiceWorker } from '@openmrs/esm-frame
 import { setupDynamicOfflineFormDataHandler, setupStaticDataOfflinePrecaching } from './app/offline/caching';
 import { configSchema } from './config-schema';
 import './styles.css';
+// @ts-ignore
+require('./styles.css?ngGlobalStyle');
 
 const moduleName = '@openmrs/esm-form-entry-app';
 

--- a/packages/esm-form-entry-app/src/index.ts
+++ b/packages/esm-form-entry-app/src/index.ts
@@ -4,7 +4,7 @@ import { defineConfigSchema, messageOmrsServiceWorker } from '@openmrs/esm-frame
 import { setupDynamicOfflineFormDataHandler, setupStaticDataOfflinePrecaching } from './app/offline/caching';
 import { configSchema } from './config-schema';
 
-// FIXME This workaround originated from and should be replaced with a better solution https://github.com/single-spa/single-spa-angular/issues/463#issuecomment-1468350850
+// FIXME: Workaround https://github.com/single-spa/single-spa-angular/issues/463#issuecomment-1468350850
 // @ts-ignore
 require('./styles.css?ngGlobalStyle');
 

--- a/packages/esm-form-entry-app/src/styles.css
+++ b/packages/esm-form-entry-app/src/styles.css
@@ -1,1 +1,3 @@
 /* You can add global styles to this file, and also import other style files */
+@import url('~@openmrs/ngx-formentry/styles/ngx-formentry.css');
+@import url('~@openmrs/ngx-formentry/styles/picker.min.css');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5566,30 +5566,30 @@ __metadata:
   linkType: hard
 
 "@openmrs/ngx-formentry@npm:next":
-  version: 4.0.1-pre.330
-  resolution: "@openmrs/ngx-formentry@npm:4.0.1-pre.330"
+  version: 5.0.1-pre.345
+  resolution: "@openmrs/ngx-formentry@npm:5.0.1-pre.345"
   dependencies:
     tslib: ^2.3.0
   peerDependencies:
-    "@angular/animations": ^14.3.0
-    "@angular/cdk": ^14.2.7
-    "@angular/common": ^14.3.0
-    "@angular/compiler": ^14.3.0
-    "@angular/compiler-cli": ^14.3.0
-    "@angular/core": ^14.3.0
-    "@angular/forms": ^14.3.0
+    "@angular/animations": ^15.2.10
+    "@angular/cdk": ^15.2.9
+    "@angular/common": ^15.2.10
+    "@angular/compiler": ^15.2.10
+    "@angular/compiler-cli": ^15.2.10
+    "@angular/core": ^15.2.10
+    "@angular/forms": ^15.2.10
     "@carbon/styles": ^1.11.0
-    "@ng-select/ng-select": ^9.1.0
+    "@ng-select/ng-select": ^10.0.4
     "@ngx-translate/core": ^14.0.0
     "@openmrs/ngx-file-uploader": "*"
-    lodash: "*"
+    lodash: ^4.17.21
     moment: ^2.29.4
     ngx-webcam: ^0.4.1
     reflect-metadata: ^0.1.13
     shelljs: ^0.7.8
-    slick-carousel: ^1.6.0
-    tree-model: ^1.0.5
-  checksum: a881cd3d65b0f77cf1c845c4c9358f45fd6653e70fc70f0ad71798dd14c972907a3e58860d977924c6b69bbface198eacf8aadd828fd22d8ff6e677da5e3c0c3
+    slick-carousel: ^1.8.1
+    tree-model: ^1.0.7
+  checksum: eccf979176f8d98e0a215753e49f1d59277c0f8f7e03fd4b81a71e8605830c8acf96cdc5c00d998dd6556f2582868c00442ac121a50de1153e0e977cadfe9768
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Adds a workaround to try and solve the problem of additional styles for the date picker and the form entry app not loading in the Patient Chart. This is based on this [suggestion](https://github.com/single-spa/single-spa-angular/issues/463#issuecomment-1468350850) which works, though it's not perfect.

Related to: https://github.com/openmrs/openmrs-ngx-formentry/pull/105.

## Screenshots

> Before

![CleanShot 2023-11-28 at 12  32 58@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/e7ce87b8-1c78-45c1-b847-b8f0ab1dfdf5)

> After

![CleanShot 2023-11-28 at 12  41 33@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/363dc22c-20c8-4bef-83b0-d5ce38dc911b)

![CleanShot 2023-11-28 at 12  40 56@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/8cbebe8a-7f2a-4584-91f6-dbe07810d6ad)

## Related Issue

https://openmrs.atlassian.net/browse/O3-2611

## Other
<!-- Anything not covered above -->
