### PR TITLE
(fix) Fix workspace header action button borders

### DIFF
--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
@@ -4,6 +4,8 @@
 @import '~@openmrs/esm-styleguide/src/vars';
 @import "../root.scss";
 
+$container-width: calc(100% - 3rem);
+
 .header {
   box-sizing: content-box;
   border-bottom: 1px solid $text-03;
@@ -45,10 +47,9 @@
 }
 
 .fullWidth {
-  // Subtract side rail width
-  width: calc(100% - 3rem);
+  // Subtract the width of the side rail from the viewport
+  width: $container-width;
 }
-
 
 /* Desktop */
 :global(.omrs-breakpoint-gt-tablet) {
@@ -76,6 +77,7 @@
 
   .narrowWorkspace {
     width: 26.25rem;
+
     .dynamicWidth {
       width: 26.25rem;
     }
@@ -84,16 +86,12 @@
   .headerGlobalBar {
     button {
       background-color: $ui-02;
-      border-right: 1px solid $ui-03;
+      border-right: 1px solid colors.$gray-20;
 
-      &>svg{
+      & > svg {
         fill:colors.$cool-gray-100 !important; // force svg to be visible
       }
     }
-    button:last-child {
-      border-right: none;
-    }
-    
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes the borders of action buttons in the workspace header to match the design guidelines outlined [here](https://zeroheight.com/23a080e38/p/483a22-workspace).

## Screenshots

> Before

![CleanShot 2023-11-28 at 9  53 15@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/5290dca5-3b88-414b-99b7-badec4be1205)

> After

![CleanShot 2023-11-28 at 9  51 50@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/81df6602-d85a-4592-b91f-6a0abd937ac6)


## Related Issue
*None*

## Other
*None*