### PR TITLE
(feat) Add ability to conditionally show visit attributes

### DIFF
--- a/e2e/specs/start-visit.spec.ts
+++ b/e2e/specs/start-visit.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from '@playwright/test';
+import { test } from '../core';
+import { type Patient, generateRandomPatient } from '../commands';
+import { ChartPage } from '../pages';
+
+let patient: Patient;
+
+test.beforeEach(async ({ api }) => {
+  patient = await generateRandomPatient(api);
+});
+
+test('Start a visit', async ({ page, api }) => {
+  const chartPage = new ChartPage(page);
+
+  await test.step('When I visit the chart summary page', async () => {
+    await chartPage.goTo(patient.uuid);
+  });
+
+  await test.step('And I click the `Start a visit` button ', async () => {
+    await chartPage.page.getByRole('button', { name: /start a visit/i }).click();
+  });
+
+  await test.step('Then I should see the `Start Visit` form in the workspace', async () => {
+    await expect(chartPage.page.getByText(/visit start date and time/i)).toBeVisible();
+    await expect(chartPage.page.getByPlaceholder(/dd\/mm\/yyyy/i)).toBeVisible();
+    await expect(chartPage.page.getByPlaceholder(/hh\:mm/i)).toBeVisible();
+    await expect(chartPage.page.getByRole('combobox', { name: /select a location/i })).toBeVisible();
+    await expect(chartPage.page.getByText(/visit type/i)).toBeVisible();
+    await expect(chartPage.page.getByRole('search', { name: /search for a visit type/i })).toBeVisible();
+    await expect(chartPage.page.getByLabel(/Facility Visit/i)).toBeVisible();
+    await expect(chartPage.page.getByLabel(/Home Visit/i)).toBeVisible();
+    await expect(chartPage.page.getByLabel(/OPD Visit/i)).toBeVisible();
+    await expect(chartPage.page.getByLabel(/Offline Visit/i)).toBeVisible();
+    await expect(chartPage.page.getByLabel(/Group Session/i)).toBeVisible();
+    await expect(chartPage.page.getByRole('button', { name: /discard/i })).toBeVisible();
+    await expect(chartPage.page.locator('form').getByRole('button', { name: /start a visit/i })).toBeVisible();
+  });
+
+  await test.step('And if I select a visit type and then I click the `Start a visit` button', async () => {
+    await chartPage.page.getByText(/opd visit/i).click();
+    await chartPage.page
+      .locator('form')
+      .getByRole('button', { name: /start a visit/i })
+      .click();
+  });
+
+  await test.step('Then I should see a success notification', async () => {
+    await expect(chartPage.page.getByText(/opd visit started successfully/i)).toBeVisible();
+  });
+
+  await test.step('And I should see the Active Visit tag on the patient header', async () => {
+    await expect(chartPage.page.getByLabel(/active visit/i)).toBeVisible();
+    await chartPage.page.getByRole('button', { name: /end visit/i }).click();
+  });
+});

--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -128,6 +128,7 @@ export interface ChartConfig {
     uuid: string;
     required: boolean;
     displayInThePatientBanner: boolean;
+    showWhenExpression?: string;
   }>;
   showServiceQueueFields: boolean;
   visitQueueNumberAttributeUuid: string;

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
@@ -1,7 +1,4 @@
-import { useConfig } from '@openmrs/esm-framework';
 import React, { useEffect, useMemo } from 'react';
-import { type ChartConfig } from '../../config-schema';
-import { useConceptAnswersForVisitAttributeType, useVisitAttributeType } from '../hooks/useVisitAttributeType';
 import {
   TextInput,
   TextInputSkeleton,
@@ -17,6 +14,9 @@ import {
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { Controller, type ControllerRenderProps, useFormContext } from 'react-hook-form';
+import { useConfig } from '@openmrs/esm-framework';
+import { type ChartConfig } from '../../config-schema';
+import { useConceptAnswersForVisitAttributeType, useVisitAttributeType } from '../hooks/useVisitAttributeType';
 import { type VisitFormData } from './visit-form.resource';
 import styles from './visit-attribute-type.scss';
 
@@ -32,23 +32,45 @@ interface VisitAttributeTypeFieldsProps {
   >;
 }
 
+/**
+ * The `evaluateExpression` function is used to evaluate the optional showWhenExpression for an attribute type. If a showWhenExpression is provided evaluates to true, the attribute type field is rendered. Otherwise, if no showWhenExpression is provided, the attribute type field gets rendered by default.
+ *
+ * @param {string} expression - The showWhenExpression for the attribute type field.
+ * @param {VisitAttributes} visitAttributes - The visit attributes object
+ * @returns {boolean} - The result of the expression evaluation
+ */
+
+function evaluateExpression(expression: string, visitAttributes: VisitAttributes) {
+  const [left, operator, right] = expression.split(' ');
+  const attributeUuid = left.match(/\['(.*?)'\]/)[1];
+  const attributeValue = right.replace(/'/g, '');
+
+  switch (operator) {
+    case '===':
+      return visitAttributes[attributeUuid] === attributeValue;
+    case '!==':
+      return visitAttributes[attributeUuid] !== attributeValue;
+    default:
+      return false;
+  }
+}
+
 const VisitAttributeTypeFields: React.FC<VisitAttributeTypeFieldsProps> = ({ setErrorFetchingResources }) => {
-  const { visitAttributeTypes } = useConfig() as ChartConfig;
+  const { visitAttributeTypes } = useConfig<ChartConfig>();
   const { control, getValues } = useFormContext<VisitFormData>();
 
   if (visitAttributeTypes?.length) {
     return (
       <>
-        {visitAttributeTypes.map((attributeType) => {
-          const shouldShowAttribute = () => {
-            if (!attributeType?.showWhenExpression) return true;
-            const { visitAttributes } = getValues();
-            const attributeEval = new Function('visitAttributes', `return ${attributeType.showWhenExpression}`);
-            return attributeEval(visitAttributes);
-          };
+        {visitAttributeTypes.map((attributeType, indx) => {
+          const { visitAttributes } = getValues();
+
+          const showAttributeType = attributeType?.showWhenExpression
+            ? evaluateExpression(attributeType?.showWhenExpression, visitAttributes)
+            : true;
 
           return (
-            shouldShowAttribute() && (
+            showAttributeType && (
               <Controller
                 key={attributeType.uuid}
                 name={`visitAttributes.${attributeType.uuid}`}

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
@@ -56,7 +56,7 @@ const VisitAttributeTypeFields: React.FC<VisitAttributeTypeFieldsProps> = ({ set
   if (visitAttributeTypes?.length) {
     return (
       <>
-        {visitAttributeTypes.map((attributeType, indx) => {
+        {visitAttributeTypes.map((attributeType) => {
           const { visitAttributes } = getValues();
 
           const showAttributeType = attributeType?.showWhenExpression
@@ -254,4 +254,5 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
 
   return <div className={styles.visitAttributeField}>{fieldToRender}</div>;
 };
+
 export default VisitAttributeTypeFields;

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useMemo } from 'react';
 import {
-  TextInput,
-  TextInputSkeleton,
-  TextArea,
-  NumberInput,
-  SelectSkeleton,
-  Select,
-  SelectItem,
   Checkbox,
   DatePicker,
   DatePickerInput,
+  NumberInput,
+  Select,
+  SelectItem,
+  SelectSkeleton,
+  TextArea,
+  TextInput,
+  TextInputSkeleton,
 } from '@carbon/react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
@@ -33,26 +33,20 @@ interface VisitAttributeTypeFieldsProps {
 }
 
 /**
- * The `evaluateExpression` function is used to evaluate the optional showWhenExpression for an attribute type. If a showWhenExpression is provided evaluates to true, the attribute type field is rendered. Otherwise, if no showWhenExpression is provided, the attribute type field gets rendered by default.
+ * Evaluates a given expression using the provided visitAttributes.
  *
- * @param {string} expression - The showWhenExpression for the attribute type field.
- * @param {VisitAttributes} visitAttributes - The visit attributes object
- * @returns {boolean} - The result of the expression evaluation
+ * @param {string} expression - The expression to be evaluated. This should be a string of JavaScript code.
+ * @param {VisitAttributes} visitAttributes - An object containing visit attributes which will be used in the evaluation of the expression.
+ *
+ * @returns {boolean} - The boolean value of the result of the evaluated expression.
+ *
  */
-
 function evaluateExpression(expression: string, visitAttributes: VisitAttributes) {
-  const [left, operator, right] = expression.split(' ');
-  const attributeUuid = left.match(/\['(.*?)'\]/)[1];
-  const attributeValue = right.replace(/'/g, '');
+  const func = new Function('visitAttributes', `return ${expression};`);
 
-  switch (operator) {
-    case '===':
-      return visitAttributes[attributeUuid] === attributeValue;
-    case '!==':
-      return visitAttributes[attributeUuid] !== attributeValue;
-    default:
-      return false;
-  }
+  const result = func(visitAttributes);
+
+  return Boolean(result);
 }
 
 const VisitAttributeTypeFields: React.FC<VisitAttributeTypeFieldsProps> = ({ setErrorFetchingResources }) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR allows showing visit attribute types conditionally based on JavaScript expressions defined in the configuration schema. It adds an `evaluateExpression` function which is invoked when a visitAttributeType has a `showWhenExpression` property.  This function splits the expression into its constituent parts and ultimately runs it and returns the result of its evaluation. If the expression is truthy, then the visit attribute gets rendered. If the expression is falsy, then the visit attribute does not get rendered.

If the visitAttributeType does not have a `showWhenExpression` defined property, the condition short-circuits to true and it gets rendered by default.

With this approach, the conditionally rendered visit attributes get included in the payload when the user submits the form.

Sample config:

```tsx
{
  "@openmrs/esm-patient-chart-app": {
    "visitAttributeTypes": [
      {
        "uuid": "caf2124f-00a9-4620-a250-efd8535afd6d"
      },
      {
        "uuid": "c39b684c-250f-4781-a157-d6ad7353bc90",
        "showWhenExpression": "visitAttributes['caf2124f-00a9-4620-a250-efd8535afd6d'] === '1c30ee58-82d4-4ea4-a8c1-4bf2f9dfc8cf'"
      },
      {
        "uuid": "2d0fa959-6780-41f1-85b1-402045935068",
        "showWhenExpression": "visitAttributes['c39b684c-250f-4781-a157-d6ad7353bc90'] === '159356AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && visitAttributes['caf2124f-00a9-4620-a250-efd8535afd6d'] === '1c30ee58-82d4-4ea4-a8c1-4bf2f9dfc8cf'"
      },
      {
        "uuid": "0f4f3306-f01b-43c6-af5b-fdb60015cb02",
        "showWhenExpression": "visitAttributes['c39b684c-250f-4781-a157-d6ad7353bc90'] === '159356AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && visitAttributes['caf2124f-00a9-4620-a250-efd8535afd6d'] === '1c30ee58-82d4-4ea4-a8c1-4bf2f9dfc8cf'"
      },
      {
        "uuid": "50e6a142-89fd-437d-a071-48434f850e43",
        "showWhenExpression": "visitAttributes['caf2124f-00a9-4620-a250-efd8535afd6d'] === 'c844c73e-75e0-4020-98d1-739af20a6f63'"
      }
    ]
  }
}
```

## Screenshots
https://github.com/openmrs/openmrs-esm-patient-chart/assets/28008754/ea11dd7c-3551-44c1-a286-a529f78409bc

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
