### PR TITLE
(fix) O3-2612: Attachments App Crashes O3, then blocks adding attachments for any patient

### DIFF
--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/media-uploader.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/media-uploader.component.tsx
@@ -48,7 +48,7 @@ const MediaUploaderComponent = () => {
       </p>
       <div className={styles.uploadFile}>
         <FileUploaderDropContainer
-          accept={allowedExtensions ?? '*'}
+          accept={allowedExtensions ?? ['*']}
           labelText={t('fileSizeInstructions', 'Drag and drop files here or click to upload')}
           tabIndex={0}
           multiple={multipleFiles}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes the type error occurring in the attachments app.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/1031876/0528eb8e-d210-4350-8f03-0c9209830185

## Related Issue
https://openmrs.atlassian.net/browse/O3-2612

