### PR TITLE
(e2e) Test start visit workflow

### DIFF
--- a/e2e/specs/start-visit.spec.ts
+++ b/e2e/specs/start-visit.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from '@playwright/test';
+import { test } from '../core';
+import { type Patient, generateRandomPatient } from '../commands';
+import { ChartPage } from '../pages';
+
+let patient: Patient;
+
+test.beforeEach(async ({ api }) => {
+  patient = await generateRandomPatient(api);
+});
+
+test('Start a visit', async ({ page, api }) => {
+  const chartPage = new ChartPage(page);
+
+  await test.step('When I visit the chart summary page', async () => {
+    await chartPage.goTo(patient.uuid);
+  });
+
+  await test.step('And I click the `Start a visit` button ', async () => {
+    await chartPage.page.getByRole('button', { name: /start a visit/i }).click();
+  });
+
+  await test.step('Then I should see the `Start Visit` form in the workspace', async () => {
+    await expect(chartPage.page.getByText(/visit start date and time/i)).toBeVisible();
+    await expect(chartPage.page.getByPlaceholder(/dd\/mm\/yyyy/i)).toBeVisible();
+    await expect(chartPage.page.getByPlaceholder(/hh\:mm/i)).toBeVisible();
+    await expect(chartPage.page.getByRole('combobox', { name: /select a location/i })).toBeVisible();
+    await expect(chartPage.page.getByText(/visit type/i)).toBeVisible();
+    await expect(chartPage.page.getByRole('search', { name: /search for a visit type/i })).toBeVisible();
+    await expect(chartPage.page.getByLabel(/Facility Visit/i)).toBeVisible();
+    await expect(chartPage.page.getByLabel(/Home Visit/i)).toBeVisible();
+    await expect(chartPage.page.getByLabel(/OPD Visit/i)).toBeVisible();
+    await expect(chartPage.page.getByLabel(/Offline Visit/i)).toBeVisible();
+    await expect(chartPage.page.getByLabel(/Group Session/i)).toBeVisible();
+    await expect(chartPage.page.getByRole('button', { name: /discard/i })).toBeVisible();
+    await expect(chartPage.page.locator('form').getByRole('button', { name: /start a visit/i })).toBeVisible();
+  });
+
+  await test.step('And if I select a visit type and then I click the `Start a visit` button', async () => {
+    await chartPage.page.getByText(/opd visit/i).click();
+    await chartPage.page
+      .locator('form')
+      .getByRole('button', { name: /start a visit/i })
+      .click();
+  });
+
+  await test.step('Then I should see a success notification', async () => {
+    await expect(chartPage.page.getByText(/opd visit started successfully/i)).toBeVisible();
+  });
+
+  await test.step('And I should see the Active Visit tag on the patient header', async () => {
+    await expect(chartPage.page.getByLabel(/active visit/i)).toBeVisible();
+    await chartPage.page.getByRole('button', { name: /end visit/i }).click();
+  });
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR adds an e2e test for the Start Visit workflow which simulates:

- Clicking the `Start a visit` button in the navigation bar and launching the Start Visit form in the workspace. 
- Asserting that various UI elements are visible, including the start date and time fields
- Filling the form by selecting a visit type
- Submitting the form by clicking the `Start visit` button
- Asserting that a success notification gets displayed
- Asserting that an `Active Visit` tag gets rendered in the Patient Header

## Screenshots

![CleanShot 2023-11-30 at 1  12 54@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/e084f67c-6d02-4db7-b787-4a9c7731fd5d)

## Related Issue
*None*

## Other
*None*