### PR TITLE
(fix) Make it so visit diagnosis error doesn't crash the app

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -567,7 +567,7 @@ function DiagnosisSearch({ name, control, labelText, placeholder, handleSearch, 
               labelText={labelText}
               className={error && styles.diagnosisErrorOutline}
               placeholder={placeholder}
-              renderIcon={error && <WarningFilled fill="red" />}
+              renderIcon={error && ((props) => <WarningFilled fill="red" {...props} />)}
               onChange={(e) => {
                 onChange(e);
                 handleSearch(name);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Visit form was crashing when submitted with no diagnosis.


## Screenshots

Before

https://github.com/openmrs/openmrs-esm-patient-chart/assets/1031876/ddaf2504-48ea-4fcd-9ee1-d8f5b495ff2a

After

https://github.com/openmrs/openmrs-esm-patient-chart/assets/1031876/0e6776a2-bff7-431c-9059-7d321b1b7929


