### PR TITLE
(fix)03-2577 Results tree view should be collapsed by default

### DIFF
--- a/packages/esm-patient-labs-app/src/config-schema.ts
+++ b/packages/esm-patient-labs-app/src/config-schema.ts
@@ -16,7 +16,7 @@ export const configSchema = {
     _default: [
       {
         conceptUuid: 'ae485e65-2e3f-4297-b35e-c818bbefe894',
-        defaultOpen: true,
+        defaultOpen: false,
       },
       {
         conceptUuid: '8904fa2b-6a8f-437d-89ec-6fce3cd99093',


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR changes the tree view to not expand the first row of the results tree ie "Complete Blood Count" should be minimized under Hematology under Test Results in the patient chart. The rational is to ensure the tree remains unexpanded on load and not the opposite as seen below..
![Lab Results Viewer UI improvements needed](https://github.com/openmrs/openmrs-esm-patient-chart/assets/46714226/57a3a291-33cc-48c2-920b-363ebc21ef91)


## Screenshots
<img width="863" alt="Screenshot 2023-12-04 at 1 25 48 PM" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/46714226/973f7210-3c15-4722-ad43-1486ddbfef58">

## Related Issue
https://openmrs.atlassian.net/browse/O3-2577

## Other
<!-- Anything not covered above -->
