### PR TITLE
(O3-2601)[feat] - Hide bottom navigation on tablet, when filling forms

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { ExtensionSlot, useLayoutType } from '@openmrs/esm-framework';
 import styles from './action-menu.scss';
 
@@ -8,9 +8,22 @@ interface ActionMenuInterface {
 
 export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
   const layout = useLayoutType();
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
+  const initialHeight = useRef(window.innerHeight);
+
+  useEffect(() => {
+    const handleKeyboardVisibilityChange = () => {
+      setKeyboardVisible(initialHeight.current > window.innerHeight);
+      if (initialHeight.current != window.innerHeight) {
+        initialHeight.current = window.innerHeight;
+      }
+    };
+    window.addEventListener('resize', handleKeyboardVisibilityChange);
+    return () => window.removeEventListener('resize', handleKeyboardVisibilityChange);
+  }, [initialHeight]);
 
   return (
-    <aside className={styles.sideRail}>
+    <aside className={`${styles.sideRail} ${keyboardVisible ? styles.hiddenSideRail : styles.showSideRail}`}>
       <div className={styles.container}>
         <ExtensionSlot className={styles.chartExtensions} name={'action-menu-chart-items-slot'} />
         {layout === 'small-desktop' || layout === 'large-desktop' ? <div className={styles.divider}></div> : null}

--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
@@ -100,12 +100,12 @@ $actionPanelOffset: 3rem;
 
 :global(.omrs-breakpoint-lt-desktop) {
   .hiddenSideRail {
-   visibility: hidden;
+   display: none;
   }
 }
 :global(.omrs-breakpoint-lt-desktop) {
   .showSideRail {
-   visibility: visible;
+   display: flex;
   }
 }
 

--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
@@ -98,6 +98,18 @@ $actionPanelOffset: 3rem;
   }
 }
 
+:global(.omrs-breakpoint-lt-desktop) {
+  .hiddenSideRail {
+   visibility: hidden;
+  }
+}
+:global(.omrs-breakpoint-lt-desktop) {
+  .showSideRail {
+   visibility: visible;
+  }
+}
+
+
 .divider {
   background-color: $text-03;
   margin: 0.75rem 0;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Hide bottom navigation on tablets when on screen is visible to fill forms

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/53287480/4a4e2848-5616-4d95-8dd2-0aad93170dc1)
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/53287480/b49b9869-b549-474c-828f-947947070ea6)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2601](https://openmrs.atlassian.net/browse/O3-2601)
## Other
<!-- Anything not covered above -->
