### PR TITLE
(fix) O3-2609: Fix rendering issue in the patient details tile extension

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-details-tile/patient-details-tile.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-details-tile/patient-details-tile.component.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import capitalize from 'lodash-es/capitalize';
+import { InlineLoading } from '@carbon/react';
 import { age, formatDate, usePatient, parseDate } from '@openmrs/esm-framework';
 import styles from './patient-details-tile.scss';
 
@@ -8,7 +10,12 @@ interface PatientDetailsTileInterface {
 }
 
 const PatientDetailsTile: React.FC<PatientDetailsTileInterface> = ({ patientUuid }) => {
-  const { patient } = usePatient(patientUuid);
+  const { patient, isLoading } = usePatient(patientUuid);
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return <InlineLoading role="progressbar" description={`${t('loading', 'Loading')} ...`} />;
+  }
 
   return (
     <div className={styles.container}>

--- a/packages/esm-patient-chart-app/src/patient-details-tile/patient-details-tile.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-details-tile/patient-details-tile.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import capitalize from 'lodash-es/capitalize';
-import { age, formatDate, usePatient } from '@openmrs/esm-framework';
+import { age, formatDate, usePatient, parseDate } from '@openmrs/esm-framework';
 import styles from './patient-details-tile.scss';
 
 interface PatientDetailsTileInterface {
@@ -17,7 +17,7 @@ const PatientDetailsTile: React.FC<PatientDetailsTileInterface> = ({ patientUuid
       </p>
       <div className={styles.details}>
         <span>{capitalize(patient?.gender)}</span> &middot; <span>{age(patient?.birthDate)}</span> &middot;{' '}
-        <span>{formatDate(new Date(patient?.birthDate), { mode: 'wide', time: false })} </span>
+        <span>{formatDate(parseDate(patient?.birthDate), { mode: 'wide', time: false })}</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This PR fixes the birthDate format which was crashing the visit header extension in the visit not while in Tablet mode

## Screenshots
- Before
<img width="900" alt="Screenshot 2023-12-12 at 02 56 59" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/30952856/80d59f1a-4165-428b-b6d6-c3731c04940d">

- Fixed version
<img width="899" alt="Screenshot 2023-12-12 at 02 49 02" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/30952856/5de957fb-39cf-4387-b9bc-0e459790bf6a">


## Related Issue
- https://openmrs.atlassian.net/browse/O3-2609

