### PR TITLE
(fix) O3-2650: Fix the alignment of the close button content on the attachment preview

### DIFF
--- a/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
@@ -42,6 +42,7 @@ const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
           iconDescription={t('closePreview', 'Close preview')}
           label={t('closePreview', 'Close preview')}
           kind="ghost"
+          size="md"
           className={styles.closePreviewButton}
           hasIconOnly
           renderIcon={Close}

--- a/packages/esm-patient-attachments-app/src/attachments/image-preview.scss
+++ b/packages/esm-patient-attachments-app/src/attachments/image-preview.scss
@@ -26,6 +26,14 @@
   color: $ui-01;
 }
 
+.closePreviewButton  {
+  display: flex;
+  flex-direction: column;
+  align-content: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
 .closePreviewButton > svg > path {
   fill: $ui-01 !important;
 }
@@ -55,7 +63,7 @@
   fill: $ui-01;
 }
 
-.overflowMenu:hover button svg circle, 
+.overflowMenu:hover button svg circle,
 .overflowMenu:focus button svg circle {
   fill: $ui-05;
 }

--- a/packages/esm-patient-attachments-app/src/attachments/image-preview.scss
+++ b/packages/esm-patient-attachments-app/src/attachments/image-preview.scss
@@ -32,8 +32,6 @@
   align-content: center;
   justify-content: center;
   flex-wrap: wrap;
-  height: 40px;
-  width: 40px;
 }
 
 .closePreviewButton > svg > path {

--- a/packages/esm-patient-attachments-app/src/attachments/image-preview.scss
+++ b/packages/esm-patient-attachments-app/src/attachments/image-preview.scss
@@ -32,6 +32,8 @@
   align-content: center;
   justify-content: center;
   flex-wrap: wrap;
+  height: 40px;
+  width: 40px;
 }
 
 .closePreviewButton > svg > path {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Fix the alignment of the close button content on the attachment preview

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/53287480/6d49b57c-0c5f-48a3-9862-7f92dc19d656)
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/53287480/50eb6e5f-b216-4db6-95cf-f33ffdadf8fc)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2650](https://openmrs.atlassian.net/browse/O3-2650)

## Other
<!-- Anything not covered above -->
