### PR TITLE
(fix) Remove excessive overrides from the siderail nav buttons

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
@@ -25,31 +25,10 @@ $actionPanelOffset: 3rem;
     align-items: center;
     border-left: 1px solid $text-03;
 
-    & div {
+    & .container {
       display: flex;
       align-items: center;
       flex-direction: column;
-
-      & button {
-        width: $icon-button-size;
-        height: $icon-button-size;
-        justify-content: center;
-        margin-top: spacing.$spacing-02;
-        margin-bottom: spacing.$spacing-02;
-        border-radius: 50%;
-
-        &:hover {
-          background-color: $color-gray-30;
-
-          :global(.cds--btn--ghost:focus) {
-            box-shadow: none;
-          }
-        }
-
-        &:focus {
-          border-color: $interactive-01;
-        }
-      }
     }
   }
 }

--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.component.tsx
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.component.tsx
@@ -15,7 +15,7 @@ interface TagsProps {
 function Tags({ isTablet, getIcon, formOpenInTheBackground, tagContent }: TagsProps) {
   return (
     <>
-      {getIcon({ size: !isTablet ? 16 : 20 })}
+      {getIcon({ size: 16 })}
 
       {formOpenInTheBackground ? (
         <span className={styles.interruptedTag}>!</span>

--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.component.tsx
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.component.tsx
@@ -15,7 +15,7 @@ interface TagsProps {
 function Tags({ isTablet, getIcon, formOpenInTheBackground, tagContent }: TagsProps) {
   return (
     <>
-      {getIcon({ size: isTablet ? 16 : 20 })}
+      {getIcon({ size: !isTablet ? 16 : 20 })}
 
       {formOpenInTheBackground ? (
         <span className={styles.interruptedTag}>!</span>
@@ -80,6 +80,7 @@ export const SiderailNavButton: React.FC<SiderailNavButtonProps> = ({
       kind="ghost"
       label={label}
       onClick={handler}
+      size="md"
     >
       <div className={styles.elementContainer}>
         <Tags

--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
@@ -15,8 +15,7 @@
   }
 
   &:focus {
-          border-color: $interactive-01;
-
+    border-color: $interactive-01;
   }
 
   & > span {
@@ -34,6 +33,7 @@
   display: flex;
   align-items: center;
   position: relative;
+  flex-direction: column;
 
   .countTag {
     position: absolute;
@@ -78,6 +78,20 @@
 
 /* Tablet */
 :global(.omrs-breakpoint-lt-desktop) {
+
+  .container {
+    margin-bottom: 0;
+    margin-top: 0;
+    border-radius: unset;
+    color: $ui-05;
+    max-width: none;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+  }
+
   .active {
     background-color: $color-blue-10;
     color: $interactive-01;

--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
@@ -3,17 +3,20 @@
 @import '~@openmrs/esm-styleguide/src/vars';
 
 .container {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-  width: 100%;
+  margin-top: spacing.$spacing-02;
+  margin-bottom: spacing.$spacing-02;
+  border-radius: 50%;
   color: $ui-05;
   max-width: none;
 
   &:hover {
+    background-color: $color-gray-30;
     color: $text-02;
+  }
+
+  &:focus {
+          border-color: $interactive-01;
+
   }
 
   & > span {

--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.test.tsx
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.test.tsx
@@ -173,7 +173,7 @@ describe('SiderailNavButton', () => {
     );
 
     expect(screen.getByTestId('pen-icon')).toBeInTheDocument();
-    expect(screen.getByTestId('pen-icon').innerHTML).toBe('size: 20');
+    expect(screen.getByTestId('pen-icon').innerHTML).toBe('size: 16');
 
     const button = screen.getByRole('button');
     expect(button).toBeInTheDocument();

--- a/packages/esm-patient-forms-app/src/clinical-form-action-button.test.tsx
+++ b/packages/esm-patient-forms-app/src/clinical-form-action-button.test.tsx
@@ -78,7 +78,7 @@ test('should display clinical form action button on desktop view', () => {
   mockedUseLayoutType.mockReturnValue('desktop');
 
   render(<ClinicalFormActionButton />);
-  expect(screen.getByTestId('document-icon').getAttribute('size')).toBe('20');
+  expect(screen.getByTestId('document-icon').getAttribute('size')).toBe('16');
 
   const clinicalActionButton = screen.getByRole('button', { name: /Form/i });
   expect(clinicalActionButton).not.toHaveTextContent('Clinical forms');

--- a/packages/esm-patient-notes-app/src/visit-note-action-button.test.tsx
+++ b/packages/esm-patient-notes-app/src/visit-note-action-button.test.tsx
@@ -54,7 +54,7 @@ describe('VisitNoteActionButton', () => {
 
     render(<VisitNoteActionButton />);
 
-    expect(screen.getByTestId('pen-icon').getAttribute('size')).toBe('20');
+    expect(screen.getByTestId('pen-icon').getAttribute('size')).toBe('16');
     const visitNoteButton = screen.getByRole('button', { name: /Note/i });
     expect(visitNoteButton).toBeInTheDocument();
 

--- a/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.test.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.test.tsx
@@ -90,7 +90,7 @@ describe('<OrderBasketActionButton/>', () => {
     mockedUseLayoutType.mockReturnValue('desktop');
     render(<OrderBasketActionButton />);
 
-    expect(screen.getByTestId('shopping-cart-icon').getAttribute('size')).toBe('20');
+    expect(screen.getByTestId('shopping-cart-icon').getAttribute('size')).toBe('16');
     const orderBasketButton = screen.getByRole('button', { name: /order basket/i });
     expect(orderBasketButton).toBeInTheDocument();
     await user.click(orderBasketButton);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Removes the excessive style overrides from siderail nav buttons. This will in turn remove the icon button overrides present in the esm-styleguide [here](https://github.com/openmrs/openmrs-esm-core/blob/0067e3973d27cb59bc63c1f0410a3526c9737afd/packages/framework/esm-styleguide/src/_overrides.scss#L41)

## Screenshots
<img width="803" alt="image" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/d24f9ad0-7ed6-4912-8c51-31ad67a774f2">


https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/a0bef579-9644-41f2-82a9-12351f2287fe


## Related Issue
None

## Other
<!-- Anything not covered above -->
