### PR TITLE
(fix) Scope data cell white-space styling to just the vitals table

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -77,7 +77,7 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
       <DataTable rows={rows} headers={tableHeaders} size={isTablet ? 'lg' : 'sm'} useZebraStyles>
         {({ rows, headers, getTableProps }) => (
           <TableContainer>
-            <Table aria-label="vitals" {...getTableProps()}>
+            <Table className={styles.table} aria-label="vitals" {...getTableProps()}>
               <TableHead>
                 <TableRow>
                   {headers.map((header) => (

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
@@ -2,8 +2,10 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 
-td {
-  white-space: nowrap;
+.table {
+  td {
+    white-space: nowrap;
+  }
 }
 
 .criticallyLow, .criticallyHigh, .low, .high {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR makes it so that the `white-space: nowrap` styling on table data cells of the vitals overview table is scoped to just that table by scoping the style under a CSS class.

## Screenshots

![vitals-table-data-cell-styling](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/0e71b623-d97e-4806-9f65-5dc8dad230fc)


## Related Issue
*None*

## Other

Related to #1542 
