### PR TITLE
(fix) Remove logical block start padding from icon only buttons

### DIFF
--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.scss
@@ -66,10 +66,6 @@
 .buttonContainer {
   display: flex;
   align-items: center;
-
-  :global(.cds--btn--icon-only) {
-    padding-block-start: 0.375rem;
-  }
 }
 
 .chevron {

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
@@ -66,10 +66,6 @@
 .buttonContainer {
   display: flex;
   align-items: center;
-
-  :global(.cds--btn--icon-only) {
-    padding-block-start: 0.375rem;
-  }
 }
 
 .chevron {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Removes logical block start padding from icon-only Carbon button components, a style override that has since been obviated by #1541.

## Screenshots

> Before

![CleanShot 2023-12-16 at 10  52 18@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/915deb14-e7c3-4982-bd5e-d35b848df3cd)

> After

![CleanShot 2023-12-16 at 10  52 03@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/c0bf3566-0185-41a1-8323-19bf9e180065)

## Related Issue
*None*

## Other
*None*
