### PR TITLE
(fix) O3-2671: Lab orders added directly to the basket should be marked incomplete 

### DIFF
--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
@@ -130,11 +130,13 @@ describe('AddLabOrder', () => {
     expect(cd4).toBeInTheDocument();
     const cd4OrderButton = within(cd4.closest('div').parentElement).getByText('Add to basket');
     await userEvent.click(cd4OrderButton);
-    expect(hookResult.current.orders).toEqual([createEmptyLabOrder(mockTestTypes[1], 'test-provider-uuid')]);
+    expect(hookResult.current.orders).toEqual([
+      { ...createEmptyLabOrder(mockTestTypes[1], 'test-provider-uuid'), isOrderIncomplete: true },
+    ]);
+
     expect(mockCloseWorkspace).toHaveBeenCalled();
     expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('order-basket');
   });
-
   test('back to order basket', async () => {
     const user = userEvent.setup();
     const { mockCloseWorkspace } = renderAddLabOrderWorkspace();

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
@@ -159,13 +159,14 @@ const TestTypeSearchResultItem: React.FC<TestTypeSearchResultItemProps> = ({ tes
 
   const addToBasket = useCallback(() => {
     const labOrder = createLabOrder(testType);
+    labOrder.isOrderIncomplete = true;
     setOrders([...orders, labOrder]);
     closeWorkspace('add-lab-order', true);
     launchPatientWorkspace('order-basket');
   }, [orders, setOrders, createLabOrder, testType]);
 
   const removeFromBasket = useCallback(() => {
-    setOrders(orders.filter((order) => order.testType.conceptUuid != testType.conceptUuid));
+    setOrders(orders.filter((order) => order.testType.conceptUuid !== testType.conceptUuid));
   }, [orders, setOrders, testType.conceptUuid]);
 
   return (

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-item-tile.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-item-tile.component.tsx
@@ -25,6 +25,10 @@ export function LabOrderBasketItemTile({ orderBasketItem, onItemClick, onRemoveC
   // Hence, we manually prevent the handleClick callback from being invoked as soon as the button is pressed once.
   const shouldOnClickBeCalled = useRef(true);
 
+  const labelClassName = classNames(styles.orderActionNewLabel, {
+    [styles.orderActionIncompleteLabel]: orderBasketItem.isOrderIncomplete,
+  });
+
   return (
     <ClickableTile
       role="listitem"
@@ -36,7 +40,9 @@ export function LabOrderBasketItemTile({ orderBasketItem, onItemClick, onRemoveC
     >
       <div className={styles.orderBasketItemTile}>
         <div className={styles.clipTextWithEllipsis}>
-          <span className={styles.orderActionNewLabel}>{t('orderActionNew', 'New')}</span>
+          <span className={labelClassName}>
+            {orderBasketItem.isOrderIncomplete ? t('incomplete', 'Incomplete') : t('orderActionNew', 'New')}
+          </span>
           <br />
           <>
             <span className={styles.name}>{orderBasketItem.testType?.label}</span>

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-item-tile.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-item-tile.scss
@@ -33,6 +33,13 @@
   padding: 0 0.25rem;
 }
 
+.orderActionIncompleteLabel {
+  @extend .label;
+  color: white;
+  background-color: $danger;
+  padding: 0 0.25rem;
+}
+
 .orderErrorText {
   color: $danger;
   display: flex;

--- a/packages/esm-patient-labs-app/translations/am.json
+++ b/packages/esm-patient-labs-app/translations/am.json
@@ -13,6 +13,7 @@
   "errorLoadingTestTypes": "Error occured when loading test types",
   "female": "Female",
   "full": "Full",
+  "incomplete": "Incomplete",
   "labOrders": "Lab orders",
   "labReferenceNumber": "Lab reference number",
   "loading": "Loading",

--- a/packages/esm-patient-labs-app/translations/ar.json
+++ b/packages/esm-patient-labs-app/translations/ar.json
@@ -13,6 +13,7 @@
   "errorLoadingTestTypes": "حدث خطأ أثناء تحميل أنواع الاختبارات",
   "female": "Female",
   "full": "Full",
+  "incomplete": "Incomplete",
   "labOrders": "Lab orders",
   "labReferenceNumber": "رقم المرجع المخبري",
   "loading": "جار التحميل",

--- a/packages/esm-patient-labs-app/translations/en.json
+++ b/packages/esm-patient-labs-app/translations/en.json
@@ -13,6 +13,7 @@
   "errorLoadingTestTypes": "Error occured when loading test types",
   "female": "Female",
   "full": "Full",
+  "incomplete": "Incomplete",
   "labOrders": "Lab orders",
   "labReferenceNumber": "Lab reference number",
   "loading": "Loading",

--- a/packages/esm-patient-labs-app/translations/es.json
+++ b/packages/esm-patient-labs-app/translations/es.json
@@ -13,6 +13,7 @@
   "errorLoadingTestTypes": "Error al cargar los tipos de pruebas",
   "female": "Female",
   "full": "Full",
+  "incomplete": "Incomplete",
   "labOrders": "Lab orders",
   "labReferenceNumber": "Número de referencia del laboratorio",
   "loading": "Cargando",

--- a/packages/esm-patient-labs-app/translations/fr.json
+++ b/packages/esm-patient-labs-app/translations/fr.json
@@ -13,6 +13,7 @@
   "errorLoadingTestTypes": "Une erreur s'est produite lors du chargement des types de tests",
   "female": "Female",
   "full": "Full",
+  "incomplete": "Incomplete",
   "labOrders": "Lab orders",
   "labReferenceNumber": "Numéro de référence du laboratoire",
   "loading": "Chargement",

--- a/packages/esm-patient-labs-app/translations/he.json
+++ b/packages/esm-patient-labs-app/translations/he.json
@@ -13,6 +13,7 @@
   "errorLoadingTestTypes": "אירעה שגיאה בעת טעינת סוגי הבדיקות",
   "female": "Female",
   "full": "Full",
+  "incomplete": "Incomplete",
   "labOrders": "Lab orders",
   "labReferenceNumber": "מספר התייחסות של המעבדה",
   "loading": "טוען",

--- a/packages/esm-patient-labs-app/translations/km.json
+++ b/packages/esm-patient-labs-app/translations/km.json
@@ -13,6 +13,7 @@
   "errorLoadingTestTypes": "មានបញ្ហាក្នុងការផ្ទុកប្រភេទតេស្ត",
   "female": "Female",
   "full": "Full",
+  "incomplete": "Incomplete",
   "labOrders": "Lab orders",
   "labReferenceNumber": "លេខយោងប្រតិបត្តិការប្រតិបត្តិការ",
   "loading": "កំពុងផ្ទុក",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

I've made the status tag for lab order items dynamic based on whether the order is complete or incomplete (based on `orderBasketItem.isOrderIncomplete`). If the order is incomplete, an `Incomplete` status tag gets rendered. Existing functionality for marking complete orders with a `New` status tag is maintained.

Design documentation for Order items https://zeroheight.com/23a080e38/p/030b9a-order-item

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/6b0b050f-79ee-450e-ac47-95890778bbe3

## Related Issue
https://openmrs.atlassian.net/browse/O3-2671

## Other
<!-- Anything not covered above -->
