### PR TITLE
(fix) O3-2667: Fix appointment form not saving after appointment date change

### DIFF
--- a/packages/esm-patient-appointments-app/src/appointments/appointments-form/appointments-form.component.tsx
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-form/appointments-form.component.tsx
@@ -531,7 +531,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
                         datePickerType="single"
                         dateFormat={datePickerFormat}
                         value={value.startDate}
-                        onChange={([date]) => onChange({ startDate: date })}
+                        onChange={([date]) => onChange({ ...value, startDate: date })}
                       >
                         <DatePickerInput
                           id="datePickerInput"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The patient chart appointment creation form does not submit properly after changing the appointment date. The `onchange` function did not populate all the required fields properly. 

Note that this bug only happens for single appointments. Recurring appointments do not have the same issue.

## Screenshots
<!-- Required if you are making UI changes. -->
See video in https://openmrs.atlassian.net/browse/O3-2667

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
No additional test cases written, but test case written by Dilan Kavishka (not checked in currently should cover this.
