### PR TITLE
(chore) Upgrade Playwright version in Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ yarn test-e2e
 
 Read the [e2e testing guide](https://o3-docs.openmrs.org/docs/frontend-modules/testing) to learn more about End-to-End tests in this project.
 
+### Updating Playwright
+
+The Playwright version in the [Bamboo e2e Dockerfile](e2e/support/bamboo/playwright.Dockerfile#L2) and the `package.json` file must match. If you update the Playwright version in one place, you must update it in the other.
+
 ## Troubleshooting
 
 If you notice that your local version of the application is not working or that there's a mismatch between what you see locally versus what's in [dev3](https://dev3.openmrs.org/openmrs/spa), you likely have outdated versions of core libraries. To update core libraries, run the following commands:

--- a/e2e/support/bamboo/playwright.Dockerfile
+++ b/e2e/support/bamboo/playwright.Dockerfile
@@ -1,12 +1,12 @@
 # The image version should match the Playwright version specified in the package.json file
-FROM mcr.microsoft.com/playwright:v1.39.0-jammy
+FROM mcr.microsoft.com/playwright:v1.40.1-jammy
 
 ARG USER_ID
 ARG GROUP_ID
 
 RUN if ! getent group $GROUP_ID > /dev/null; then \
-    groupadd -g $GROUP_ID myusergroup; \
-fi
+  groupadd -g $GROUP_ID myusergroup; \
+  fi
 
 RUN useradd -u $USER_ID -g $GROUP_ID -m playwrightuser
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR updates the version of Playwright used in the E2E docker image. This fixes a [regression](https://ci.openmrs.org/browse/REFAPP-D3X-2152) in the Bamboo build.

## Screenshots

![CleanShot 2024-01-03 at 11  01 43@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/19ac0a9a-e628-4a35-b05f-696ec68117bf)

## Related Issue
*None*

## Other
*None*
