### PR TITLE
(fix) O3-2694: fixed cancel button caption alignment

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.scss
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.scss
@@ -180,6 +180,7 @@
 
   & button {
     width: 100%;
-    padding-inline-end: 0;
+    padding-inline: 15px 0;
+    padding-block: calc(0.875rem - 3px);
   }
 }

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.scss
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.scss
@@ -180,7 +180,6 @@
 
   & button {
     width: 100%;
-    padding-inline: 15px 0;
-    padding-block: calc(0.875rem - 3px);
+    padding: spacing.$spacing-04 spacing.$spacing-05;
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Minor fix for Cancel button alignment if RTL-based language is selected

## Screenshots
![2024-01-04 17 47 00](https://github.com/openmrs/openmrs-esm-patient-chart/assets/17073192/a7040333-f8a8-42be-8967-1dea42970fb0)
![2024-01-04 17 49 08](https://github.com/openmrs/openmrs-esm-patient-chart/assets/17073192/3462b66e-c1e4-4ac3-a73a-4193cd96bd94)


## Related Issue
[O3-2694](https://openmrs.atlassian.net/browse/O3-2694)
