### PR TITLE
(fix) O3-2721: Fix empty state shown when a visit has no encounters

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -37,7 +37,7 @@ import {
   useSession,
   userHasAccess,
 } from '@openmrs/esm-framework';
-import { PatientChartPagination, launchFormEntryOrHtmlForms } from '@openmrs/esm-patient-common-lib';
+import { EmptyState, PatientChartPagination, launchFormEntryOrHtmlForms } from '@openmrs/esm-patient-common-lib';
 import type { HtmlFormEntryForm } from '@openmrs/esm-patient-forms-app/src/config-schema';
 import { deleteEncounter } from './visits-table.resource';
 import { type MappedEncounter } from '../../visit.resource';
@@ -172,10 +172,9 @@ const VisitTable: React.FC<VisitTableProps> = ({ showAllEncounters, visits, pati
     );
   };
 
+  // All encounters tab in visits
   if (!visits?.length) {
-    return (
-      <p className={classNames(styles.bodyLong01, styles.text02)}>{t('noEncountersFound', 'No encounters found')}</p>
-    );
+    return <EmptyState headerTitle={t('encounters', 'encounters')} displayText={t('encounters', 'Encounters')} />;
   }
 
   return (

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -47,8 +47,8 @@ describe('EncounterList', () => {
 
     renderVisitsTable();
 
-    await screen.findByText(/no encounters found/i);
-    expect(screen.getByText(/no encounters found/i)).toBeInTheDocument();
+    await screen.findByTitle(/empty data illustration/i);
+    expect(screen.getByText(/there are no encounters to display for this patient/i)).toBeInTheDocument();
   });
 
   it("renders a tabular overview of the patient's clinical encounters", async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the [Ugly empty message when visit has no encounters](https://openmrs.atlassian.net/browse/O3-2721)
When a visit have no encounters then a ugly message is displayed, which is not coherent with O3 style.


## Screenshots
**Before**
![image-20240105-193921](https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/cef4c74a-845d-4cba-9805-57b48bda637e)

**After**
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/11732ee8-0188-4ae0-b845-26282d387ff7)


## Related Issue
Link to Jira ticket: [https://openmrs.atlassian.net/browse/O3-2721](https://openmrs.atlassian.net/browse/O3-2721)
