### PR TITLE
(fix) O3-2718: inconsistent notification style upon cancelling an active visit

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/hooks/useDeleteVisit.hook.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useDeleteVisit.hook.tsx
@@ -36,30 +36,35 @@ export function useDeleteVisit(patientUuid: string, visit: Visit, onVisitDelete 
 
   const initiateDeletingVisit = () => {
     setIsDeletingVisit(true);
-    const isCurrentVisitDeleted = !visit?.stopDatetime;
+    const isCurrentVisitDeleted = !visit?.stopDatetime; // True if it's an active visit
 
     deleteVisit(visit?.uuid)
       .then(() => {
         mutateVisits();
         mutateCurrentVisit();
         // TODO: Needs to be replaced with Actionable Snackbar when Actionable
-        showActionableNotification({
-          title: !isCurrentVisitDeleted
-            ? t('visitDeleted', '{{visit}} deleted', {
-                visit: visit?.visitType?.display ?? t('visit', 'Visit'),
-              })
-            : t('visitCancelled', 'Visit cancelled'),
-          kind: 'success',
-          subtitle: !isCurrentVisitDeleted
-            ? t('visitDeletedSuccessfully', '{{visit}} deleted successfully', {
-                visit: visit?.visitType?.display ?? t('visit', 'Visit'),
-              })
-            : t('visitCancelSuccessMessage', 'Active {{visit}} cancelled successfully', {
-                visit: visit?.visitType?.display ?? t('visit', 'Visit'),
-              }),
-          actionButtonLabel: t('undo', 'Undo'),
-          onActionButtonClick: restoreDeletedVisit,
-        });
+        if (!isCurrentVisitDeleted) {
+          showActionableNotification({
+            title: t('visitDeleted', '{{visit}} deleted', {
+              visit: visit?.visitType?.display ?? t('visit', 'Visit'),
+            }),
+            subtitle: t('visitDeletedSuccessfully', '{{visit}} deleted successfully', {
+              visit: visit?.visitType?.display ?? t('visit', 'Visit'),
+            }),
+            kind: 'success',
+            actionButtonLabel: t('undo', 'Undo'),
+            onActionButtonClick: restoreDeletedVisit,
+          });
+        } else {
+          showSnackbar({
+            title: t('visitCancelled', 'Visit cancelled'),
+            subtitle: t('visitCancelSuccessMessage', 'Active {{visit}} cancelled successfully', {
+              visit: visit?.visitType?.display ?? t('visit', 'Visit'),
+            }),
+            isLowContrast: true,
+            kind: 'success',
+          });
+        }
         onVisitDelete?.();
       })
       .catch(() => {

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
@@ -17,7 +17,6 @@ import CancelVisitDialog from './cancel-visit-dialog.component';
 const mockedCloseModal = jest.fn();
 const mockedOpenmrsFetch = jest.mocked(openmrsFetch);
 const mockedRemoveQueuedPatient = jest.mocked(removeQueuedPatient);
-const mockedActionableNotification = jest.mocked(showActionableNotification);
 const mockedShowSnackbar = jest.mocked(showSnackbar);
 const mockedUseVisit = jest.mocked(useVisit) as jest.Mock;
 const mockedUseVisitQueueEntry = jest.mocked(useVisitQueueEntry);
@@ -92,12 +91,11 @@ describe('Cancel visit', () => {
       method: 'DELETE',
     });
 
-    expect(mockedActionableNotification).toHaveBeenCalledWith(
+    expect(mockedShowSnackbar).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: 'success',
         title: 'Visit cancelled',
         subtitle: 'Active Facility Visit cancelled successfully',
-        actionButtonLabel: 'Undo',
       }),
     );
   });


### PR DESCRIPTION
## Requirements
- [x] My work includes tests or is validated by existing tests.

## Summary
When an **Active Visit** is cancelled the notification is an `ActionableNotification`. This [issue on JIRA](https://openmrs.atlassian.net/browse/O3-2718) states that the notification on cancelling an active visit should not be an `ActionableNotification` but instead should be a simple `Snackbar`, which is consistent with styling of rest of app.
This PR fixes the above issue.

I have fixed the tests where was required.  Currently all tests pass.

## Screenshots

## Before

![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/54562dc5-9114-4041-b6a3-4d8889f4cdcd)

## After

![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/b10af7eb-2d00-4a73-9af5-7075ac673ba4)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
Link to JIRA ticket: [https://openmrs.atlassian.net/browse/O3-2718](https://openmrs.atlassian.net/browse/O3-2718
)