### PR TITLE
(fix) O3-2719: Inconsistent UI in visit summaries tabs when Empty State

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
@@ -71,7 +71,7 @@ describe('CurrentVisitSummary', () => {
     expect(screen.getByText('Diagnoses')).toBeInTheDocument();
     const buttonNames = ['Notes', 'Tests', 'Medications', 'Encounters'];
     buttonNames.forEach((buttonName) => {
-      expect(screen.getByText(buttonName)).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: buttonName })).toBeInTheDocument();
     });
   });
 });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import type { OrderItem } from '../visit.resource';
 import { formatDate, formatTime, parseDate } from '@openmrs/esm-framework';
 import styles from '../visit-detail-overview.scss';
+import { EmptyState } from '@openmrs/esm-patient-common-lib';
 
 interface MedicationSummaryProps {
   medications: Array<OrderItem>;
@@ -14,78 +15,81 @@ const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications }) =>
   const { t } = useTranslation();
 
   return (
-    <div className={styles.medicationRecord}>
+    <>
       {medications.length > 0 ? (
-        medications.map(
-          (medication, i) =>
-            medication?.order?.dose &&
-            medication?.order?.orderType?.display === 'Drug Order' && (
-              <React.Fragment key={i}>
-                <div className={styles.medicationContainer}>
-                  <p className={styles.medicationRecord}>
-                    <strong>{capitalize(medication?.order?.drug?.display)}</strong> &mdash;{' '}
-                    {medication?.order?.drug?.strength?.toLowerCase()}
-                    &mdash; {medication?.order?.doseUnits?.display?.toLowerCase()} &mdash;{' '}
-                    <span>
-                      <span className={styles.label01}> {t('dose', 'Dose').toUpperCase()} </span>{' '}
-                    </span>
-                    <span className={styles.dosage}>
-                      {medication?.order?.dose} {medication?.order?.doseUnits?.display?.toLowerCase()}
-                    </span>{' '}
-                    &mdash; {medication?.order?.route?.display?.toLowerCase()} &mdash;{' '}
-                    {medication?.order?.frequency?.display?.toLowerCase()} &mdash;{' '}
-                    {!medication?.order?.duration
-                      ? t('orderIndefiniteDuration', 'Indefinite duration')
-                      : t('orderDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
-                          duration: medication?.order?.duration,
-                          durationUnit: medication?.order?.durationUnits?.display?.toLowerCase(),
-                        })}
-                    {medication?.order?.numRefills !== 0 && (
+        <div className={styles.medicationRecord}>
+          {medications.map(
+            (medication, i) =>
+              medication?.order?.dose &&
+              medication?.order?.orderType?.display === 'Drug Order' && (
+                <React.Fragment key={i}>
+                  <div className={styles.medicationContainer}>
+                    <p className={styles.medicationRecord}>
+                      <strong>{capitalize(medication?.order?.drug?.display)}</strong> &mdash;{' '}
+                      {medication?.order?.drug?.strength?.toLowerCase()}
+                      &mdash; {medication?.order?.doseUnits?.display?.toLowerCase()} &mdash;{' '}
                       <span>
-                        <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
-                        {medication?.order?.numRefills}
-                        {''}
+                        <span className={styles.label01}> {t('dose', 'Dose').toUpperCase()} </span>{' '}
                       </span>
-                    )}
-                    {medication?.order?.dosingInstructions && (
-                      <span> &mdash; {medication?.order?.dosingInstructions?.toLocaleLowerCase()}</span>
-                    )}
-                    {medication?.order?.orderReasonNonCoded ? (
-                      <span>
-                        &mdash; <span className={styles.label01}>{t('indication', 'Indication').toUpperCase()}</span>{' '}
-                        {medication?.order?.orderReasonNonCoded}
-                      </span>
-                    ) : null}
-                    {medication?.order?.quantity ? (
-                      <span>
-                        <span className={styles.label01}> &mdash; {t('quantity', 'Quantity').toUpperCase()}</span>{' '}
-                        {medication?.order?.quantity}
-                      </span>
-                    ) : null}
-                    {medication?.order?.dateStopped ? (
-                      <span className={styles.bodyShort01}>
-                        <span className={styles.label01}>
-                          {medication?.order?.quantity ? ` — ` : ''} {t('endDate', 'End date').toUpperCase()}
-                        </span>{' '}
-                        {formatDate(new Date(medication?.order?.dateStopped))}
-                      </span>
-                    ) : null}
-                  </p>
-                </div>
+                      <span className={styles.dosage}>
+                        {medication?.order?.dose} {medication?.order?.doseUnits?.display?.toLowerCase()}
+                      </span>{' '}
+                      &mdash; {medication?.order?.route?.display?.toLowerCase()} &mdash;{' '}
+                      {medication?.order?.frequency?.display?.toLowerCase()} &mdash;{' '}
+                      {!medication?.order?.duration
+                        ? t('orderIndefiniteDuration', 'Indefinite duration')
+                        : t('orderDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
+                            duration: medication?.order?.duration,
+                            durationUnit: medication?.order?.durationUnits?.display?.toLowerCase(),
+                          })}
+                      {medication?.order?.numRefills !== 0 && (
+                        <span>
+                          <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
+                          {medication?.order?.numRefills}
+                          {''}
+                        </span>
+                      )}
+                      {medication?.order?.dosingInstructions && (
+                        <span> &mdash; {medication?.order?.dosingInstructions?.toLocaleLowerCase()}</span>
+                      )}
+                      {medication?.order?.orderReasonNonCoded ? (
+                        <span>
+                          &mdash; <span className={styles.label01}>{t('indication', 'Indication').toUpperCase()}</span>{' '}
+                          {medication?.order?.orderReasonNonCoded}
+                        </span>
+                      ) : null}
+                      {medication?.order?.quantity ? (
+                        <span>
+                          <span className={styles.label01}> &mdash; {t('quantity', 'Quantity').toUpperCase()}</span>{' '}
+                          {medication?.order?.quantity}
+                        </span>
+                      ) : null}
+                      {medication?.order?.dateStopped ? (
+                        <span className={styles.bodyShort01}>
+                          <span className={styles.label01}>
+                            {medication?.order?.quantity ? ` — ` : ''} {t('endDate', 'End date').toUpperCase()}
+                          </span>{' '}
+                          {formatDate(new Date(medication?.order?.dateStopped))}
+                        </span>
+                      ) : null}
+                    </p>
+                  </div>
 
-                <p className={styles.metadata}>
-                  {formatTime(parseDate(medication?.order?.dateActivated))} &middot; {medication?.provider?.name},{' '}
-                  {medication?.provider?.role}
-                </p>
-              </React.Fragment>
-            ),
-        )
+                  <p className={styles.metadata}>
+                    {formatTime(parseDate(medication?.order?.dateActivated))} &middot; {medication?.provider?.name},{' '}
+                    {medication?.provider?.role}
+                  </p>
+                </React.Fragment>
+              ),
+          )}
+        </div>
       ) : (
-        <p className={classNames(styles.bodyLong01, styles.text02)}>
-          {t('noMedicationsFound', 'No medications found')}
-        </p>
+        <EmptyState
+          displayText={t('medications', 'medications')}
+          headerTitle={t('medications', 'Medications')}
+        ></EmptyState>
       )}
-    </div>
+    </>
   );
 };
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/notes-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/notes-summary.component.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import type { Note } from '../visit.resource';
 import styles from '../visit-detail-overview.scss';
+import { EmptyState } from '@openmrs/esm-patient-common-lib';
 
 interface NotesSummaryProps {
   notes: Array<Note>;
@@ -24,7 +25,7 @@ const NotesSummary: React.FC<NotesSummaryProps> = ({ notes }) => {
           </div>
         ))
       ) : (
-        <p className={classNames(styles.bodyLong01, styles.text02)}>{t('noNotesFound', 'No notes found')}</p>
+        <EmptyState displayText={t('notes', 'notes')} headerTitle="Notes"></EmptyState>
       )}
     </>
   );

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
@@ -43,14 +43,14 @@ describe('VisitSummary', () => {
 
     await user.click(notesTab);
 
-    expect(screen.getByText(/^No notes found$/)).toBeInTheDocument();
+    expect(screen.getByText(/^There are no notes to display for this patient$/)).toBeInTheDocument();
 
     // should display medication panel
     const medicationTab = screen.getByRole('tab', { name: /Medication/i });
 
     await user.click(medicationTab);
 
-    expect(screen.getByText(/^No medications found$/)).toBeInTheDocument();
+    expect(screen.getByText(/^There are no medications to display for this patient$/)).toBeInTheDocument();
 
     // should display tests panel with test panel extension
     const testsTab = screen.getByRole('tab', { name: /Tests/i });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -92,8 +92,8 @@ describe('VisitDetailOverview', () => {
     expect(screen.getByRole('heading', { name: /ech/i })).toBeInTheDocument();
     expect(screen.getByText(/^diagnoses$/i)).toBeInTheDocument();
     expect(screen.getByText(/no diagnoses found/i)).toBeInTheDocument();
-    expect(screen.getByText(/no notes found/i)).toBeInTheDocument();
-    expect(screen.getByText(/no medications found/i)).toBeInTheDocument();
+    expect(screen.getByText(/There are no notes to display for this patient/i)).toBeInTheDocument();
+    expect(screen.getByText(/There are no medications to display for this patient/i)).toBeInTheDocument();
 
     await user.click(allVisitsTab);
 
@@ -123,8 +123,8 @@ describe('VisitDetailOverview', () => {
     expect(screen.getByRole('heading', { name: /ech/i })).toBeInTheDocument();
     expect(screen.getByText(/^diagnoses$/i)).toBeInTheDocument();
     expect(screen.getByText(/no diagnoses found/i)).toBeInTheDocument();
-    expect(screen.getByText(/no notes found/i)).toBeInTheDocument();
-    expect(screen.getByText(/no medications found/i)).toBeInTheDocument();
+    expect(screen.getByText(/There are no notes to display for this patient/i)).toBeInTheDocument();
+    expect(screen.getByText(/There are no medications to display for this patient/i)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Requirements
- [x] My work includes tests or is validated by existing tests.

## Summary
Inconsistent styles are present in **Visit summaries** tabs when Empty state is present. e.g Empty state for **Notes** tab is a simple text saying `No notes found` while for **Tests** tab it's a styled `<EmptyState />` component. 
In this PR I have changed all of the empty state of tabs to the `<EmptyState />` component so that the style is consistent.
I have also modified tests accordingly

## Screenshots

## Before
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/9ff84a4f-5885-4c8b-b3a6-2d642629cdf7)
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/38210f17-ae5b-4838-a5b1-b16fac911321)

## After
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/01bb8000-8332-4e10-956c-44bd8b2a41f2)
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/d16f6392-8d02-4c89-b953-5619922eb116)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
Link to JIRA ticket: [https://openmrs.atlassian.net/browse/O3-2719](https://openmrs.atlassian.net/browse/O3-2719)
