### PR TITLE
O3-2708 - (Fix) "Visit started" notification sticks around forever

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -407,6 +407,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
 
               showSnackbar({
                 isLowContrast: true,
+                timeoutInMs: 5000,
                 kind: 'success',
                 subtitle: !visitToEdit
                   ? t('visitStartedSuccessfully', '{{visit}} started successfully', {

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -231,6 +231,7 @@ describe('Visit Form', () => {
       subtitle: expect.stringContaining('started successfully'),
       kind: 'success',
       title: 'Visit started',
+      timeoutInMs: 5000,
     });
   });
 

--- a/packages/esm-patient-chart-app/translations/am.json
+++ b/packages/esm-patient-chart-app/translations/am.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "No diagnoses found",
   "noEncountersFound": "No encounters found",
   "noEncountersToDisplay": "No encounters to display",
-  "noMedicationsFound": "No medications found",
-  "noNotesFound": "No notes found",
   "noObservationsFound": "No observations found",
   "notes": "Notes",
   "Offline Actions dashboard": "Offline Actions dashboard",

--- a/packages/esm-patient-chart-app/translations/ar.json
+++ b/packages/esm-patient-chart-app/translations/ar.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "لم يتم العثور على تشخيصات",
   "noEncountersFound": "لم يتم العثور على لقاءات",
   "noEncountersToDisplay": "لا يوجد لقاءات لعرضها",
-  "noMedicationsFound": "لم يتم العثور على أدوية",
-  "noNotesFound": "لم يتم العثور على ملاحظات",
   "noObservationsFound": "لم يتم العثور على ملاحظات",
   "notes": "ملاحظات",
   "Offline Actions dashboard": "لوحة الإجراءات دون اتصال",

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "No diagnoses found",
   "noEncountersFound": "No encounters found",
   "noEncountersToDisplay": "No encounters to display",
-  "noMedicationsFound": "No medications found",
-  "noNotesFound": "No notes found",
   "noObservationsFound": "No observations found",
   "notes": "Notes",
   "Offline Actions dashboard": "Offline Actions dashboard",

--- a/packages/esm-patient-chart-app/translations/es.json
+++ b/packages/esm-patient-chart-app/translations/es.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "No se encontraron diagnósticos",
   "noEncountersFound": "No se encontraron encuentros",
   "noEncountersToDisplay": "No hay encuentros para mostrar",
-  "noMedicationsFound": "No se encontraron medicamentos",
-  "noNotesFound": "No se encontraron notas",
   "noObservationsFound": "No se encontraron observaciones",
   "notes": "Notas",
   "Offline Actions dashboard": "Panel de Acciones sin Conexión",

--- a/packages/esm-patient-chart-app/translations/fr.json
+++ b/packages/esm-patient-chart-app/translations/fr.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "Aucun diagnostic trouvé",
   "noEncountersFound": "Aucune rencontre trouvée",
   "noEncountersToDisplay": "Aucune rencontre à afficher",
-  "noMedicationsFound": "Aucun médicament trouvé",
-  "noNotesFound": "Aucune note trouvée",
   "noObservationsFound": "Aucune observation trouvée",
   "notes": "Notes",
   "Offline Actions dashboard": "Tableau de bord des actions hors ligne",

--- a/packages/esm-patient-chart-app/translations/he.json
+++ b/packages/esm-patient-chart-app/translations/he.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "לא נמצאו אבחנות",
   "noEncountersFound": "לא נמצאו ביקורים",
   "noEncountersToDisplay": "אין ביקורים להצגה",
-  "noMedicationsFound": "לא נמצאו תרופות",
-  "noNotesFound": "לא נמצאו הערות",
   "noObservationsFound": "לא נמצאו תצפיות",
   "notes": "הערות",
   "Offline Actions dashboard": "לוח הפעולות לא מקוונות",

--- a/packages/esm-patient-chart-app/translations/km.json
+++ b/packages/esm-patient-chart-app/translations/km.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "រកមិនឃើញរោគវិនិច្ឆ័យទេ",
   "noEncountersFound": "រកមិនឃើញការជួបគ្នាទេ",
   "noEncountersToDisplay": "ពុំមានព័ត៌មានការពិនិត្យបង្ហាញទេ",
-  "noMedicationsFound": "រកមិនឃើញឱសថព្យាបាលទេ",
-  "noNotesFound": "រកមិនឃើញកំណត់ចំណាំទេ",
   "noObservationsFound": "រកមិនឃើញការសង្កេតទេ",
   "notes": "រកមិនឃើញការកត់ចំណាំទេ",
   "Offline Actions dashboard": "ផ្ទាំងគ្រប់គ្រងសកម្មភាពក្រៅបណ្តាញ",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Add auto dismiss after 5 seconds on the visit started/updated snack bar

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2708](https://openmrs.atlassian.net/browse/O3-2708)

## Other
<!-- Anything not covered above -->
