### PR TITLE
(refactor) Set global testTimeout in Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -39,5 +39,5 @@ module.exports = {
   testEnvironmentOptions: {
     url: 'http://localhost/',
   },
-  testTimeout: 30000,
+  testTimeout: 20000,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,4 +39,5 @@ module.exports = {
   testEnvironmentOptions: {
     url: 'http://localhost/',
   },
+  testTimeout: 30000,
 };

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.test.tsx
@@ -14,8 +14,6 @@ const mockUseAllergicReactions = useAllergicReactions as jest.Mock;
 const mockShowSnackbar = showSnackbar as jest.Mock;
 const mockShowToast = showToast as jest.Mock;
 
-jest.setTimeout(15000);
-
 jest.mock('./allergy-form.resource', () => {
   const originalModule = jest.requireActual('./allergy-form.resource');
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -8,8 +8,6 @@ import { mockPatient } from 'tools';
 import { useVisitAttributeType } from '../hooks/useVisitAttributeType';
 import StartVisitForm from './visit-form.component';
 
-jest.setTimeout(10000);
-
 const mockCloseWorkspace = jest.fn();
 const mockPromptBeforeClosing = jest.fn();
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.test.tsx
@@ -6,8 +6,6 @@ import { renderWithSwr } from 'tools';
 import { mockEncounters2 } from '__mocks__';
 import EncountersTable from './encounters-table.component';
 
-jest.setTimeout(10000);
-
 const testProps = {
   showAllEncounters: true,
   encounters: mockEncounters2,

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -6,8 +6,6 @@ import { mockPatient, renderWithSwr } from 'tools';
 import { mockEncounters } from '__mocks__';
 import VisitsTable from './visits-table.component';
 
-jest.setTimeout(10000);
-
 const testProps = {
   patientUuid: mockPatient.id,
   showAllEncounters: true,

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -10,8 +10,6 @@ const testProps = {
   patientUuid: mockPatient.id,
 };
 
-jest.setTimeout(5000);
-
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockUseConfig = useConfig as jest.Mock;
 const mockGetConfig = getConfig as jest.Mock;

--- a/packages/esm-patient-chart-app/translations/am.json
+++ b/packages/esm-patient-chart-app/translations/am.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "No diagnoses found",
   "noEncountersFound": "No encounters found",
   "noEncountersToDisplay": "No encounters to display",
-  "noMedicationsFound": "No medications found",
-  "noNotesFound": "No notes found",
   "noObservationsFound": "No observations found",
   "notes": "Notes",
   "Offline Actions dashboard": "Offline Actions dashboard",

--- a/packages/esm-patient-chart-app/translations/ar.json
+++ b/packages/esm-patient-chart-app/translations/ar.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "لم يتم العثور على تشخيصات",
   "noEncountersFound": "لم يتم العثور على لقاءات",
   "noEncountersToDisplay": "لا يوجد لقاءات لعرضها",
-  "noMedicationsFound": "لم يتم العثور على أدوية",
-  "noNotesFound": "لم يتم العثور على ملاحظات",
   "noObservationsFound": "لم يتم العثور على ملاحظات",
   "notes": "ملاحظات",
   "Offline Actions dashboard": "لوحة الإجراءات دون اتصال",

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "No diagnoses found",
   "noEncountersFound": "No encounters found",
   "noEncountersToDisplay": "No encounters to display",
-  "noMedicationsFound": "No medications found",
-  "noNotesFound": "No notes found",
   "noObservationsFound": "No observations found",
   "notes": "Notes",
   "Offline Actions dashboard": "Offline Actions dashboard",

--- a/packages/esm-patient-chart-app/translations/es.json
+++ b/packages/esm-patient-chart-app/translations/es.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "No se encontraron diagnósticos",
   "noEncountersFound": "No se encontraron encuentros",
   "noEncountersToDisplay": "No hay encuentros para mostrar",
-  "noMedicationsFound": "No se encontraron medicamentos",
-  "noNotesFound": "No se encontraron notas",
   "noObservationsFound": "No se encontraron observaciones",
   "notes": "Notas",
   "Offline Actions dashboard": "Panel de Acciones sin Conexión",

--- a/packages/esm-patient-chart-app/translations/fr.json
+++ b/packages/esm-patient-chart-app/translations/fr.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "Aucun diagnostic trouvé",
   "noEncountersFound": "Aucune rencontre trouvée",
   "noEncountersToDisplay": "Aucune rencontre à afficher",
-  "noMedicationsFound": "Aucun médicament trouvé",
-  "noNotesFound": "Aucune note trouvée",
   "noObservationsFound": "Aucune observation trouvée",
   "notes": "Notes",
   "Offline Actions dashboard": "Tableau de bord des actions hors ligne",

--- a/packages/esm-patient-chart-app/translations/he.json
+++ b/packages/esm-patient-chart-app/translations/he.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "לא נמצאו אבחנות",
   "noEncountersFound": "לא נמצאו ביקורים",
   "noEncountersToDisplay": "אין ביקורים להצגה",
-  "noMedicationsFound": "לא נמצאו תרופות",
-  "noNotesFound": "לא נמצאו הערות",
   "noObservationsFound": "לא נמצאו תצפיות",
   "notes": "הערות",
   "Offline Actions dashboard": "לוח הפעולות לא מקוונות",

--- a/packages/esm-patient-chart-app/translations/km.json
+++ b/packages/esm-patient-chart-app/translations/km.json
@@ -102,8 +102,6 @@
   "noDiagnosesFound": "រកមិនឃើញរោគវិនិច្ឆ័យទេ",
   "noEncountersFound": "រកមិនឃើញការជួបគ្នាទេ",
   "noEncountersToDisplay": "ពុំមានព័ត៌មានការពិនិត្យបង្ហាញទេ",
-  "noMedicationsFound": "រកមិនឃើញឱសថព្យាបាលទេ",
-  "noNotesFound": "រកមិនឃើញកំណត់ចំណាំទេ",
   "noObservationsFound": "រកមិនឃើញការសង្កេតទេ",
   "notes": "រកមិនឃើញការកត់ចំណាំទេ",
   "Offline Actions dashboard": "ផ្ទាំងគ្រប់គ្រងសកម្មភាពក្រៅបណ្តាញ",

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
@@ -8,8 +8,6 @@ import { getByTextWithMarkup, mockPatient } from 'tools';
 import { createCondition, useConditionsSearch } from './conditions.resource';
 import ConditionsForm from './conditions-form.component';
 
-jest.setTimeout(10000);
-
 jest.mock('zod', () => {
   const originalModule = jest.requireActual('zod');
   const mockedZod = {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
@@ -8,8 +8,6 @@ import { mockConditions, mockFhirConditionsResponse } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import ConditionsOverview from './conditions-overview.component';
 
-jest.setTimeout(15000);
-
 const testProps = {
   patientUuid: mockPatient.id,
 };

--- a/packages/esm-patient-flags-app/src/flags/flags-highlight-bar.test.tsx
+++ b/packages/esm-patient-flags-app/src/flags/flags-highlight-bar.test.tsx
@@ -7,8 +7,6 @@ import { mockPatientFlags } from '__mocks__';
 import { usePatientFlags } from './hooks/usePatientFlags';
 import FlagsHighlightBar from './flags-highlight-bar.component';
 
-jest.setTimeout(5000);
-
 const mockedUsePatientFlags = usePatientFlags as jest.Mock;
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
@@ -8,8 +8,6 @@ import { age, useConfig, useLayoutType, usePatient, useSession } from '@openmrs/
 import { type PostDataPrepFunction, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { createEmptyLabOrder } from './lab-order';
 
-jest.setTimeout(10000);
-
 const mockUseConfig = useConfig as jest.Mock;
 const mockUseSession = useSession as jest.Mock;
 const mockUsePatient = usePatient as jest.Mock;

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
@@ -7,8 +7,6 @@ import { mockPatient, patientChartBasePath, renderWithSwr } from 'tools';
 import NotesOverview from './notes-overview.component';
 import { useVisitNotes } from './visit-notes.resource';
 
-jest.setTimeout(20000);
-
 const testProps = {
   basePath: patientChartBasePath,
   patient: mockPatient,

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -14,8 +14,6 @@ import {
 import { mockPatient, getByTextWithMarkup } from 'tools';
 import VisitNotesForm from './visit-notes-form.component';
 
-jest.setTimeout(10000);
-
 const testProps = {
   patientUuid: mockPatient.id,
   closeWorkspace: jest.fn(),

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
@@ -7,8 +7,6 @@ import { mockEnrolledProgramsResponse } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import ProgramsDetailedSummary from './programs-detailed-summary.component';
 
-jest.setTimeout(20000);
-
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => {

--- a/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
@@ -9,8 +9,6 @@ import { createProgramEnrollment, updateProgramEnrollment } from './programs.res
 import { mockPatient } from 'tools';
 import ProgramsForm from './programs-form.component';
 
-jest.setTimeout(20000);
-
 const testProps = {
   closeWorkspace: jest.fn(),
   patientUuid: mockPatient.id,

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
@@ -8,8 +8,6 @@ import { mockEnrolledProgramsResponse } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import ProgramsOverview from './programs-overview.component';
 
-jest.setTimeout(5000);
-
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockUsePagination = usePagination as jest.Mock;
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes test timeouts from individual tests and moves them up into the global Jest config as a single `testTimeout` property whose value is set to `20000ms`. Hopefully this tackles the issue where tests time out non-deterministically. 

20000ms seems like a reasonable value, though it'd be worthwhile trying to lower this figure down as we move along so we strike a good balance with a value that's not too low to prematurely terminate valid long-running tests, and not too high to unnecessarily prolong the feedback loop for test failures.

## Screenshots
*None*

## Related Issue
*None*

## Other
*None*