### PR TITLE
(chore) Migrate to newer Transifex version

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,99 +1,131 @@
 [main]
 host = https://www.transifex.com
 
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-form-entry-app]
+file_filter            = packages/esm-form-entry-app/translations/<lang>.json
+source_file            = packages/esm-form-entry-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-form-entry-app]
-file_filter = packages/esm-form-entry-app/translations/<lang>.json
-source_file = packages/esm-form-entry-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-generic-patient-widgets-app]
+file_filter            = packages/esm-generic-patient-widgets-app/translations/<lang>.json
+source_file            = packages/esm-generic-patient-widgets-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-attachments-app]
-file_filter = packages/esm-patient-attachments-app/translations/<lang>.json
-source_file = packages/esm-patient-attachments-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-allergies-app]
+file_filter            = packages/esm-patient-allergies-app/translations/<lang>.json
+source_file            = packages/esm-patient-allergies-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-medications-app]
-file_filter = packages/esm-patient-medications-app/translations/<lang>.json
-source_file = packages/esm-patient-medications-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-appointments-app]
+file_filter            = packages/esm-patient-appointments-app/translations/<lang>.json
+source_file            = packages/esm-patient-appointments-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-vitals-app]
-file_filter = packages/esm-patient-vitals-app/translations/<lang>.json
-source_file = packages/esm-patient-vitals-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-attachments-app]
+file_filter            = packages/esm-patient-attachments-app/translations/<lang>.json
+source_file            = packages/esm-patient-attachments-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-generic-patient-widgets-app]
-file_filter = packages/esm-generic-patient-widgets-app/translations/<lang>.json
-source_file = packages/esm-generic-patient-widgets-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-banner-app]
+file_filter            = packages/esm-patient-banner-app/translations/<lang>.json
+source_file            = packages/esm-patient-banner-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-banner-app]
-file_filter = packages/esm-patient-banner-app/translations/<lang>.json
-source_file = packages/esm-patient-banner-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-biometrics-app]
+file_filter            = packages/esm-patient-biometrics-app/translations/<lang>.json
+source_file            = packages/esm-patient-biometrics-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-conditions-app]
-file_filter = packages/esm-patient-conditions-app/translations/<lang>.json
-source_file = packages/esm-patient-conditions-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-chart-app]
+file_filter            = packages/esm-patient-chart-app/translations/<lang>.json
+source_file            = packages/esm-patient-chart-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-notes-app]
-file_filter = packages/esm-patient-notes-app/translations/<lang>.json
-source_file = packages/esm-patient-notes-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-conditions-app]
+file_filter            = packages/esm-patient-conditions-app/translations/<lang>.json
+source_file            = packages/esm-patient-conditions-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-allergies-app]
-file_filter = packages/esm-patient-allergies-app/translations/<lang>.json
-source_file = packages/esm-patient-allergies-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-forms-app]
+file_filter            = packages/esm-patient-forms-app/translations/<lang>.json
+source_file            = packages/esm-patient-forms-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-biometrics-app]
-file_filter = packages/esm-patient-biometrics-app/translations/<lang>.json
-source_file = packages/esm-patient-biometrics-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-immunizations-app]
+file_filter            = packages/esm-patient-immunizations-app/translations/<lang>.json
+source_file            = packages/esm-patient-immunizations-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-forms-app]
-file_filter = packages/esm-patient-forms-app/translations/<lang>.json
-source_file = packages/esm-patient-forms-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-labs-app]
+file_filter            = packages/esm-patient-labs-app/translations/<lang>.json
+source_file            = packages/esm-patient-labs-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-programs-app]
-file_filter = packages/esm-patient-programs-app/translations/<lang>.json
-source_file = packages/esm-patient-programs-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-medications-app]
+file_filter            = packages/esm-patient-medications-app/translations/<lang>.json
+source_file            = packages/esm-patient-medications-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-appointments-app]
-file_filter = packages/esm-patient-appointments-app/translations/<lang>.json
-source_file = packages/esm-patient-appointments-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-notes-app]
+file_filter            = packages/esm-patient-notes-app/translations/<lang>.json
+source_file            = packages/esm-patient-notes-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-chart-app]
-file_filter = packages/esm-patient-chart-app/translations/<lang>.json
-source_file = packages/esm-patient-chart-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-programs-app]
+file_filter            = packages/esm-patient-programs-app/translations/<lang>.json
+source_file            = packages/esm-patient-programs-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-immunizations-app]
-file_filter = packages/esm-patient-immunizations-app/translations/<lang>.json
-source_file = packages/esm-patient-immunizations-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON
+[o:openmrs:p:openmrs-esm-patient-chart:r:esm-patient-vitals-app]
+file_filter            = packages/esm-patient-vitals-app/translations/<lang>.json
+source_file            = packages/esm-patient-vitals-app/translations/en.json
+source_lang            = en
+type                   = KEYVALUEJSON
+replace_edited_strings = false
+keep_translations      = false
 
-[openmrs-esm-patient-chart.esm-patient-labs-app]
-file_filter = packages/esm-patient-labs-app/translations/<lang>.json
-source_file = packages/esm-patient-labs-app/translations/en.json
-source_lang = en
-type = KEYVALUEJSON


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

## Summary
It appears that Transifex has a new backward incompatible API and CLI which requires to migrate the config file.

`tx migrate` is the command to run.

## Related Talk post 
https://talk.openmrs.org/t/how-can-i-change-the-ui-language-to-chinese-in-openmrs-3/41286/7?u=mksrom

## Other
This needs to be applied to every repo covered by Transifex.