### PR TITLE
(fix) O3-2655: Record Vitals: Error message for invalid values pops up only once

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -335,6 +335,7 @@ const VitalsAndBiometricsForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
                     diastolicBloodPressure,
                   )
                 }
+                showErrorMessage={showErrorMessage}
                 label={t('bloodPressure', 'Blood pressure')}
                 unitSymbol={conceptUnits.get(config.concepts.systolicBloodPressureUuid) ?? ''}
               />
@@ -358,6 +359,7 @@ const VitalsAndBiometricsForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
                   pulse && isValueWithinReferenceRange(conceptMetadata, config.concepts['pulseUuid'], pulse)
                 }
                 label={t('heartRate', 'Heart rate')}
+                showErrorMessage={showErrorMessage}
                 unitSymbol={conceptUnits.get(config.concepts.pulseUuid) ?? ''}
               />
             </Column>
@@ -557,6 +559,7 @@ const VitalsAndBiometricsForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
           <InlineNotification
             className={styles.errorNotification}
             lowContrast={false}
+            onClose={() => setHasInvalidVitals(false)}
             title={t('vitalsAndBiometricsSaveError', 'Error saving vitals and biometrics')}
             subtitle={t('checkForValidity', 'Some of the values entered are invalid')}
           />

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
@@ -238,6 +238,33 @@ describe('VitalsBiometricsForm', () => {
       title: 'Error saving vitals and biometrics',
     });
   });
+
+  it('Display an inline error notification on submit if value of vitals entered is invalid', async () => {
+    const user = userEvent.setup();
+
+    renderForm();
+    const systolic = screen.getByRole('spinbutton', { name: /systolic/i });
+    const pulse = screen.getByRole('spinbutton', { name: /pulse/i });
+    const oxygenSaturation = screen.getByRole('spinbutton', { name: /oxygen saturation/i });
+    const temperature = screen.getByRole('spinbutton', { name: /temperature/i });
+
+    await user.type(systolic, '1000');
+    await user.type(pulse, pulseValue.toString());
+    await user.type(oxygenSaturation, '200');
+    await user.type(temperature, temperatureValue.toString());
+
+    const saveButton = screen.getByRole('button', { name: /save and close/i });
+    await user.click(saveButton);
+
+    expect(screen.getByText(/Some of the values entered are invalid/i)).toBeInTheDocument();
+
+    // close the inline notification --> resubmit --> check for presence of inline notification
+    const closeInlineNotificationButton = screen.getByTitle(/close notification/i);
+    await user.click(closeInlineNotificationButton);
+    expect(screen.queryByText(/some of the values entered are invalid/i)).not.toBeInTheDocument();
+    await user.click(saveButton);
+    expect(screen.getByText(/Some of the values entered are invalid/i)).toBeInTheDocument();
+  });
 });
 
 function renderForm() {


### PR DESCRIPTION
## Requirements
- [x] My work includes tests or is validated by existing tests.

## Summary
There were two issue:
1. When an invalid value for vitals was entered e.g 400 beats per minute, which is physiologically not possible, the input field did not show the error and the valid range. An argument `showErrorMessage` was missing from `<VitalsAndBiometricsInput />` component.
2.  When we save the form with invalid values an inline notification pops up. If after closing the inline notification we again try to save the form with invalid values no notification pops up. This happened because state variable `hasInvalidVitals` did not change when we again pressed the save form button and hence no re-render was triggered. To fix it, I set the `onClose` property on the `<InlineNotification />` to `setHasInvalidVitals(false)`. This make sure that the re-render occur when I again press the submit button.

## Screenshots

## Input field validation
## Before
No **input field error** is shown when Blood pressure and Heart rate have invalid values.

![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/eb74fd5f-7ba1-46b6-ba20-dc46b0f8b606)

## After

![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/8a96dc19-6ea1-491d-ada6-7c36725e57db)


## Inline Notification

## Before
https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/cd78d400-349d-4677-83ed-c1f9b5539381

## After
https://github.com/openmrs/openmrs-esm-patient-chart/assets/45814713/437be6ec-cc18-4d87-9084-004a93bd54cf


## Related Issue
Link to JIRA ticket: [https://openmrs.atlassian.net/browse/O3-2655](https://openmrs.atlassian.net/browse/O3-2655)
