### PR TITLE
(fix) O3-1594 BUG: Patient chart close button has inconsistent behavior

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/close-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/close-button.component.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { HeaderGlobalAction } from '@carbon/react';
+import { CloseFilled } from '@carbon/react/icons';
+import { getHistory, goBackInHistory, navigate, usePatient } from '@openmrs/esm-framework';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import styles from './close-button.scss';
+
+/**
+ * The close button keeps track of where each patient chart should close to, within the
+ * context of the session.
+ */
+export function CloseButton() {
+  const { t } = useTranslation();
+  const { patientUuid } = usePatient();
+
+  const onClosePatientChart = useCallback(() => {
+    const history = getHistory();
+    // Get the last page the user was on before opening the patient chart by going backward
+    // through the history until a URL does not include patientUuid
+    let onCloseTarget = '';
+    for (let i = history.length - 1; i >= 0; i--) {
+      if (!history[i].includes(patientUuid)) {
+        onCloseTarget = history[i];
+        break;
+      }
+    }
+    if (onCloseTarget) {
+      goBackInHistory({ toUrl: onCloseTarget });
+    } else {
+      navigate({ to: '${openmrsSpaBase}/home' });
+    }
+  }, [patientUuid]);
+
+  return (
+    <HeaderGlobalAction
+      className={styles.headerGlobalBarCloseButton}
+      aria-label={t('close', 'Close')}
+      onClick={onClosePatientChart}
+    >
+      <CloseFilled size={20} />
+    </HeaderGlobalAction>
+  );
+}

--- a/packages/esm-patient-chart-app/src/visit-header/close-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/close-button.component.tsx
@@ -6,10 +6,6 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './close-button.scss';
 
-/**
- * The close button keeps track of where each patient chart should close to, within the
- * context of the session.
- */
 export function CloseButton() {
   const { t } = useTranslation();
   const { patientUuid } = usePatient();

--- a/packages/esm-patient-chart-app/src/visit-header/close-button.scss
+++ b/packages/esm-patient-chart-app/src/visit-header/close-button.scss
@@ -1,0 +1,5 @@
+@import '~@openmrs/esm-styleguide/src/vars';
+
+.headerGlobalBarCloseButton {
+  @include brand-02(background-color);
+}

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Header, HeaderGlobalAction, HeaderGlobalBar, HeaderMenuButton, Tag, Tooltip } from '@carbon/react';
-import { CloseFilled } from '@carbon/react/icons';
+import { Button, Header, HeaderGlobalBar, HeaderMenuButton, Tag, Tooltip } from '@carbon/react';
 import {
   age,
   ConfigurableLink,
@@ -9,7 +8,6 @@ import {
   useLayoutType,
   usePatient,
   useVisit,
-  navigate,
   useConfig,
   showModal,
   ExtensionSlot,
@@ -21,6 +19,7 @@ import { EditQueueEntry } from '../visit/queue-entry/edit-queue-entry.component'
 import VisitHeaderSideMenu from './visit-header-side-menu.component';
 import styles from './visit-header.scss';
 import RetrospectiveVisitLabel from './retrospective-visit-label.component';
+import { CloseButton } from './close-button.component';
 
 interface PatientInfoProps {
   patient: fhir.Patient;
@@ -139,10 +138,6 @@ const VisitHeader: React.FC = () => {
 
   const toggleSideMenu = useCallback(() => setIsSideMenuExpanded((prevState) => !prevState), []);
 
-  const onClosePatientChart = useCallback(() => {
-    document.referrer === '' ? navigate({ to: `${window.spaBase}/home` }) : window.history.back();
-  }, []);
-
   const openModal = useCallback((patientUuid) => {
     const dispose = showModal('end-visit-dialog', {
       closeModal: () => dispose(),
@@ -198,13 +193,7 @@ const VisitHeader: React.FC = () => {
             )}
           </>
         )}
-        <HeaderGlobalAction
-          className={styles.headerGlobalBarCloseButton}
-          aria-label={t('close', 'Close')}
-          onClick={onClosePatientChart}
-        >
-          <CloseFilled size={20} />
-        </HeaderGlobalAction>
+        <CloseButton />
       </HeaderGlobalBar>
       <VisitHeaderSideMenu isExpanded={isSideMenuExpanded} toggleSideMenu={toggleSideMenu} />
     </Header>

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.scss
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.scss
@@ -8,10 +8,6 @@
   @include brand-02(background-color);
 }
 
-.headerGlobalBarCloseButton {
-  @include brand-02(background-color);
-}
-
 .headerName {
   display: flex;
 }

--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.test.tsx
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.test.tsx
@@ -19,10 +19,6 @@ jest.mock('@openmrs/esm-framework', () => {
   return {
     ...originalModule,
     isDesktop: jest.fn(),
-    getExtensionRegistration: (name) => mockExtensionRegistry[name],
-    registerExtension: (ext) => {
-      mockExtensionRegistry[ext.name] = ext;
-    },
     translateFrom: (module, key, defaultValue, options) => defaultValue,
     useBodyScrollLock: jest.fn(),
   };

--- a/packages/esm-patient-immunizations-app/translations/km.json
+++ b/packages/esm-patient-immunizations-app/translations/km.json
@@ -11,7 +11,7 @@
   "pleaseSelect": "Please select",
   "recentVaccination": "Recent vaccination",
   "save": "Save",
-  "seeAll": "ឃើញ​ទាំងអស់",
+  "seeAll": "ឃើញ\u200bទាំងអស់",
   "sequence": "Sequence",
   "singleDoseOn": "Single Dose on",
   "vaccinationDate": "Vaccination date",

--- a/packages/esm-patient-immunizations-app/translations/km.json
+++ b/packages/esm-patient-immunizations-app/translations/km.json
@@ -11,7 +11,7 @@
   "pleaseSelect": "Please select",
   "recentVaccination": "Recent vaccination",
   "save": "Save",
-  "seeAll": "ឃើញ\u200bទាំងអស់",
+  "seeAll": "ឃើញ​ទាំងអស់",
   "sequence": "Sequence",
   "singleDoseOn": "Single Dose on",
   "vaccinationDate": "Vaccination date",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2044,6 +2044,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.14.8":
+  version: 7.23.8
+  resolution: "@babel/runtime@npm:7.23.8"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: 0bd5543c26811153822a9f382fd39886f66825ff2a397a19008011376533747cd05c33a91f6248c0b8b0edf0448d7c167ebfba34786088f1b7eb11c65be7dfc3
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:7.22.5":
   version: 7.22.5
   resolution: "@babel/template@npm:7.22.5"
@@ -2184,7 +2193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/colors@npm:^11.20.1":
+"@carbon/colors@npm:^11.20.0, @carbon/colors@npm:^11.20.1":
   version: 11.20.1
   resolution: "@carbon/colors@npm:11.20.1"
   checksum: eb9d983c1ec4852f8542ea21f8bb31d383c417d55fe60a3d1ab8a0e85b617f41699b91657240f07f789b852abe48828f1546da92b1c46de9cfe21c81bb612fd7
@@ -2214,6 +2223,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/grid@npm:^11.21.0, @carbon/grid@npm:^11.21.1":
+  version: 11.21.1
+  resolution: "@carbon/grid@npm:11.21.1"
+  dependencies:
+    "@carbon/layout": ^11.20.1
+  checksum: e9bcb0940f6714f428864c8ec356c41c556e802694ede484259235cfc806a021fc498cc6e4f6e2014303ecfdf459ad4b0134820d0d92722f2ceafc9287321a0c
+  languageName: node
+  linkType: hard
+
 "@carbon/icon-helpers@npm:^10.44.0":
   version: 10.44.0
   resolution: "@carbon/icon-helpers@npm:10.44.0"
@@ -2225,6 +2243,32 @@ __metadata:
   version: 10.45.1
   resolution: "@carbon/icon-helpers@npm:10.45.1"
   checksum: 37e490ae7cec63512e1e8db107f7753503dffcc8eea7f932701cf62c4d6f1b94d857f10cd96836c25c1fc4fc01cbbbd0456f50493db941847e0c6e926c8d8541
+  languageName: node
+  linkType: hard
+
+"@carbon/icons-react@npm:11.26.0":
+  version: 11.26.0
+  resolution: "@carbon/icons-react@npm:11.26.0"
+  dependencies:
+    "@carbon/icon-helpers": ^10.44.0
+    "@carbon/telemetry": 0.1.0
+    prop-types: ^15.7.2
+  peerDependencies:
+    react: ">=16"
+  checksum: dabc6e7896d2a089aaabac78af9161720995f9e5b0f28694ac664459c5fae164a3d0c16b9cb22f6ab37f01b736cd2613cf232a6b6577b396afd8c083171cae67
+  languageName: node
+  linkType: hard
+
+"@carbon/icons-react@npm:^11.26.0, @carbon/icons-react@npm:^11.33.0":
+  version: 11.33.0
+  resolution: "@carbon/icons-react@npm:11.33.0"
+  dependencies:
+    "@carbon/icon-helpers": ^10.45.0
+    "@carbon/telemetry": 0.1.0
+    prop-types: ^15.7.2
+  peerDependencies:
+    react: ">=16"
+  checksum: 4d4ccb88135c04fd580251a5c75bb84d261f72d1c79b7af7017c329359402663f99454a74eedb26c0a9c8185e075f812edecf288510f040129e2530ad4177134
   languageName: node
   linkType: hard
 
@@ -2241,23 +2285,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icons-react@npm:^11.33.0":
-  version: 11.33.0
-  resolution: "@carbon/icons-react@npm:11.33.0"
-  dependencies:
-    "@carbon/icon-helpers": ^10.45.0
-    "@carbon/telemetry": 0.1.0
-    prop-types: ^15.7.2
-  peerDependencies:
-    react: ">=16"
-  checksum: 4d4ccb88135c04fd580251a5c75bb84d261f72d1c79b7af7017c329359402663f99454a74eedb26c0a9c8185e075f812edecf288510f040129e2530ad4177134
-  languageName: node
-  linkType: hard
-
 "@carbon/layout@npm:^11.19.0, @carbon/layout@npm:^11.7.0":
   version: 11.19.0
   resolution: "@carbon/layout@npm:11.19.0"
   checksum: 9786a9d13fc81132c33a05019fae1d6ed786739a285e276f76857d30bba7b5a58cb093c700fb7c8b697d7a199459c398f842d6a42351d02c3d67e7961fadd901
+  languageName: node
+  linkType: hard
+
+"@carbon/layout@npm:^11.20.0, @carbon/layout@npm:^11.20.1":
+  version: 11.20.1
+  resolution: "@carbon/layout@npm:11.20.1"
+  checksum: 8db3a31c08ab1fc62bd06404a72ca1e724c938d1ac73c708a63b06103fe054a5ab4294b1fba3471e3f55140ebe0e91e32872a2828dda73a32801fccb670acd35
   languageName: node
   linkType: hard
 
@@ -2268,7 +2306,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/react@npm:^1.12.0, @carbon/react@npm:^1.33.1, @carbon/react@npm:^1.37.0":
+"@carbon/motion@npm:^11.16.0":
+  version: 11.16.1
+  resolution: "@carbon/motion@npm:11.16.1"
+  checksum: 1b7644fb19a9154a7d690128ed2fe831232576308dfeb30c694d533e5f8d357dbaf1b3bed7d4c274acb407d84d1ade087583d4f9aec4a8ac1aa9dfffb6922098
+  languageName: node
+  linkType: hard
+
+"@carbon/react@npm:^1.12.0, @carbon/react@npm:^1.33.1":
   version: 1.40.0
   resolution: "@carbon/react@npm:1.40.0"
   dependencies:
@@ -2298,6 +2343,60 @@ __metadata:
     react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0
     sass: ^1.33.0
   checksum: 84e24e649dbdcf8c56b3603f1e7bc7dbb0d9c38b700c35f5134d23c07580012ef94f147676b86232aec7fcb58cc2e98a618fe6afa0793f21d1206f677a756358
+  languageName: node
+  linkType: hard
+
+"@carbon/react@npm:~1.37.0":
+  version: 1.37.0
+  resolution: "@carbon/react@npm:1.37.0"
+  dependencies:
+    "@babel/runtime": ^7.18.3
+    "@carbon/feature-flags": ^0.16.0
+    "@carbon/icons-react": ^11.26.0
+    "@carbon/layout": ^11.19.0
+    "@carbon/styles": ^1.37.0
+    "@carbon/telemetry": 0.1.0
+    classnames: 2.3.2
+    copy-to-clipboard: ^3.3.1
+    downshift: 8.1.0
+    flatpickr: 4.6.9
+    invariant: ^2.2.3
+    lodash.debounce: ^4.0.8
+    lodash.findlast: ^4.5.0
+    lodash.isequal: ^4.5.0
+    lodash.omit: ^4.5.0
+    lodash.throttle: ^4.1.1
+    prop-types: ^15.7.2
+    react-is: ^18.2.0
+    use-resize-observer: ^6.0.0
+    wicg-inert: ^3.1.1
+    window-or-global: ^1.0.1
+  peerDependencies:
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0
+    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0
+    sass: ^1.33.0
+  checksum: 40ba04d687462d178227080582a074ca6a7b7515f7f08f602fef9fd96bb90918e0051d5ce7adc9c9a5140bd9f724634a14fd06701afa23aa2bd023c6d14efd44
+  languageName: node
+  linkType: hard
+
+"@carbon/styles@npm:^1.37.0":
+  version: 1.47.0
+  resolution: "@carbon/styles@npm:1.47.0"
+  dependencies:
+    "@carbon/colors": ^11.20.0
+    "@carbon/feature-flags": ^0.16.0
+    "@carbon/grid": ^11.21.0
+    "@carbon/layout": ^11.20.0
+    "@carbon/motion": ^11.16.0
+    "@carbon/themes": ^11.28.0
+    "@carbon/type": ^11.25.0
+    "@ibm/plex": 6.0.0-next.6
+  peerDependencies:
+    sass: ^1.33.0
+  peerDependenciesMeta:
+    sass:
+      optional: true
+  checksum: 29dd2d1728bcff844632e242d4743706a74268c1b33e0b54b1f12f2811b86b5317a2a7022fa69c08a1eb494140d7d20e5c432db1b18bde6754a445d7bf857083
   languageName: node
   linkType: hard
 
@@ -2361,6 +2460,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/themes@npm:^11.28.0":
+  version: 11.28.0
+  resolution: "@carbon/themes@npm:11.28.0"
+  dependencies:
+    "@carbon/colors": ^11.20.0
+    "@carbon/layout": ^11.20.0
+    "@carbon/type": ^11.25.0
+    color: ^4.0.0
+  checksum: 52bc43b1b5ee846afc870c1898fadd3efe258fa66cb0e66672a1e20179c3833d6e517be433b339f6538887593342aba27f3130c0c3a61646c505eb16b24e06c2
+  languageName: node
+  linkType: hard
+
 "@carbon/type@npm:^11.10.0, @carbon/type@npm:^11.24.0":
   version: 11.24.0
   resolution: "@carbon/type@npm:11.24.0"
@@ -2368,6 +2479,16 @@ __metadata:
     "@carbon/grid": ^11.20.0
     "@carbon/layout": ^11.19.0
   checksum: 98c6a49cbe4cbcf1fef959b356e1e87c5197f2b19f72e7255abb3131dcc77f1832e0920d16d09cab0ea67dcc72f90f47ec6969052bf8e82302f7faf00f733795
+  languageName: node
+  linkType: hard
+
+"@carbon/type@npm:^11.25.0":
+  version: 11.25.1
+  resolution: "@carbon/type@npm:11.25.1"
+  dependencies:
+    "@carbon/grid": ^11.21.1
+    "@carbon/layout": ^11.20.1
+  checksum: 5184b9cddf050d06dbc3a369400c149e594cd281e090eb0fea972ef964b741ca94c20b828cb6c138be0812861d335d0abbabfe78b368483a5a97bf2ad7e1fc68
   languageName: node
   linkType: hard
 
@@ -4267,27 +4388,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-api@npm:5.2.1-pre.1168"
+"@openmrs/esm-api@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-api@npm:5.3.3-pre.1379"
   dependencies:
     "@types/fhir": 0.0.31
     lodash-es: ^4.17.21
   peerDependencies:
     "@openmrs/esm-config": 5.x
     "@openmrs/esm-error-handling": 5.x
+    "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: 7d80245995dd6541c7cab36fbe1b28335e42fd955d8daf62a1f86fc5c2d748640f0c117fb232aabe26ffec5fb5a1959502657357f60ffab981e9a5d7d705522d
+  checksum: f8a276f8b9fef599b0d1aafd64a280c174f4a26ae5e785b1b884e05825ef40f91a8c70fee2bce1b8d13a261456da7d6047fa1386b28c4e2e57519b7415823a72
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-app-shell@npm:5.2.1-pre.1168"
+"@openmrs/esm-app-shell@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-app-shell@npm:5.3.3-pre.1379"
   dependencies:
-    "@carbon/react": ^1.37.0
-    "@openmrs/esm-framework": 5.2.1-pre.1168
-    "@openmrs/esm-styleguide": 5.2.1-pre.1168
+    "@carbon/react": ~1.37.0
+    "@openmrs/esm-framework": 5.3.3-pre.1379
+    "@openmrs/esm-styleguide": 5.3.3-pre.1379
     dayjs: ^1.10.4
     dexie: ^3.0.3
     html-webpack-plugin: ^5.5.0
@@ -4312,55 +4434,44 @@ __metadata:
     workbox-strategies: ^6.1.5
     workbox-webpack-plugin: ^6.1.5
     workbox-window: ^6.1.5
-  checksum: 8cc7e727b002f4126ee6dfb4773aa4fa320c2fda54258f280bfa967fe717b0d5e5c6cb3d0f9df9064f54fa7f4d5ca3d8b9795730405c5c15ff92dd89ef4ce35f
+  checksum: 1f615706fe9ab85785e4fc118b0c3fe75bdc32c0717a2ce368a46c51d1ac0273d8d1e46cbe54a5cece36022c33efd894f39f63da09406b1ca07e32f76d02ba53
   languageName: node
   linkType: hard
 
-"@openmrs/esm-breadcrumbs@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-breadcrumbs@npm:5.2.1-pre.1168"
-  dependencies:
-    path-to-regexp: 6.1.0
-  peerDependencies:
-    "@openmrs/esm-state": 5.x
-  checksum: a86e86e69e491a27a749c5b949e334b90ee3ff63b2a3583a208ed95da043f94108711f1b1ae21acb0222e53ca42bbbe06e2ba11d3beeece75889b8dc2504d601
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-config@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-config@npm:5.2.1-pre.1168"
+"@openmrs/esm-config@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-config@npm:5.3.3-pre.1379"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 883d5b52c7997f63f86898b0e43f034edf9332c7fdc9eb4c125a8440d9f2a32516d0c4272e565e320889d1ec9cb683062545984d3a2cb912f83220c79dd7050d
+  checksum: cafb74eece01bf28c9842347334fbdd63d5f0771fbe6fd2caa9c22829f8e141c181e498b30cb79f46f14b8f8a4948b99ed8f9306a3f117a5638cfe021216ad90
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.2.1-pre.1168"
+"@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1379"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: a1b1e0042b48d4d28bbc58c6287f997dfffcdb259ab749e8638f5f4aabcc714d36b0af0698245d114ab13cb432fc7bf0d9a828de0896eec78034e664ef396d67
+  checksum: 77c4b7d9b93a22eb13858e67f7e7511642c767fe237a0d34fb414039072eda0ff2738f5cea988be80e29c49b2ced53acb9035f93e1157c072eeea10ba9745d60
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-error-handling@npm:5.2.1-pre.1168"
+"@openmrs/esm-error-handling@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-error-handling@npm:5.3.3-pre.1379"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 2c7d90d03aad3fae75b8b19b9cc3a4a8ea048d459ceac74f92819cc7afd36aefb164a27e0e4381487cb95ea84f1cd040df8b685a35764d54ee149be4aa1d1578
+  checksum: 49774b49ca3e51dcb051a1f5830c7aca71adc45b8f888987d4355c20c97594a1d0c1b264c7693120bb1447e5dfd2d6401e7fb0507abadd8855834f75840bcb45
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-extensions@npm:5.2.1-pre.1168"
+"@openmrs/esm-extensions@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-extensions@npm:5.3.3-pre.1379"
   dependencies:
     lodash-es: ^4.17.21
   peerDependencies:
@@ -4369,20 +4480,20 @@ __metadata:
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 73255c4cd7013a5f8642919c6c83ec851a7308e629d6853d8df1dc7c0740c0aa6c4940830f62e1cd991747f1a242055580fe10efd265b5c1d4b7a15afda4fb5f
+  checksum: 7b0bf44026499752f2e2407f52780b1a42caf748a461323f06e599b336397701ec287f489666cb119b2d43f9ebbe52cf595323acc8415a38b922af85e9dd7c73
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-feature-flags@npm:5.2.1-pre.1168"
+"@openmrs/esm-feature-flags@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-feature-flags@npm:5.3.3-pre.1379"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: e8bfa9c5c12e1e4dd73ecb1da98064c6ab2150add5f542da574207c963932b6a9cccd086373dbadcfec8298ffaba0efea6862f1e298b68821be9bcdc56ef7d26
+  checksum: 1cd5d9478456f0df5dcfdab78acc212da476d9e5f3eb0d530b12a7cbf6450218bcd8e24e3738681531e1833eb7ea22bff70ef7774ff69c7e485eea7637a90f61
   languageName: node
   linkType: hard
 
@@ -4477,23 +4588,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-framework@npm:5.2.1-pre.1168, @openmrs/esm-framework@npm:next":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-framework@npm:5.2.1-pre.1168"
+"@openmrs/esm-framework@npm:5.3.3-pre.1379, @openmrs/esm-framework@npm:next":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-framework@npm:5.3.3-pre.1379"
   dependencies:
-    "@openmrs/esm-api": 5.2.1-pre.1168
-    "@openmrs/esm-breadcrumbs": 5.2.1-pre.1168
-    "@openmrs/esm-config": 5.2.1-pre.1168
-    "@openmrs/esm-dynamic-loading": 5.2.1-pre.1168
-    "@openmrs/esm-error-handling": 5.2.1-pre.1168
-    "@openmrs/esm-extensions": 5.2.1-pre.1168
-    "@openmrs/esm-feature-flags": 5.2.1-pre.1168
-    "@openmrs/esm-globals": 5.2.1-pre.1168
-    "@openmrs/esm-offline": 5.2.1-pre.1168
-    "@openmrs/esm-react-utils": 5.2.1-pre.1168
-    "@openmrs/esm-state": 5.2.1-pre.1168
-    "@openmrs/esm-styleguide": 5.2.1-pre.1168
-    "@openmrs/esm-utils": 5.2.1-pre.1168
+    "@openmrs/esm-api": 5.3.3-pre.1379
+    "@openmrs/esm-config": 5.3.3-pre.1379
+    "@openmrs/esm-dynamic-loading": 5.3.3-pre.1379
+    "@openmrs/esm-error-handling": 5.3.3-pre.1379
+    "@openmrs/esm-extensions": 5.3.3-pre.1379
+    "@openmrs/esm-feature-flags": 5.3.3-pre.1379
+    "@openmrs/esm-globals": 5.3.3-pre.1379
+    "@openmrs/esm-navigation": 5.3.3-pre.1379
+    "@openmrs/esm-offline": 5.3.3-pre.1379
+    "@openmrs/esm-react-utils": 5.3.3-pre.1379
+    "@openmrs/esm-routes": 5.3.3-pre.1379
+    "@openmrs/esm-state": 5.3.3-pre.1379
+    "@openmrs/esm-styleguide": 5.3.3-pre.1379
+    "@openmrs/esm-utils": 5.3.3-pre.1379
     dayjs: ^1.10.7
   peerDependencies:
     dayjs: 1.x
@@ -4504,7 +4616,7 @@ __metadata:
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: 035c0e92d54bcd0e003394946cfb4fff6f71283da880544a14bd6ef3eea1cbc2793b6ff8d390834bdc6ca4f07d1bddb0dfb6f1a8f15dff94a06910ddaad41f14
+  checksum: 6e8c997f7d6cdd91a5f6c31da8a9b6f530a00b0f37baa910b4bf3e8aa38b8f03c3ed124d5bc99741d7e4adb5f5ed66fc1be625c3d6bf7eeb3e3bbd4fbf881087
   languageName: node
   linkType: hard
 
@@ -4530,18 +4642,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-globals@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-globals@npm:5.2.1-pre.1168"
+"@openmrs/esm-globals@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-globals@npm:5.3.3-pre.1379"
   peerDependencies:
     single-spa: 5.x
-  checksum: 8ee32c7fc5b4b5484a8be4d109bfbc27d991376e50d1a5bd4983920d79e7558d6dece9e3ce9cbb6319e737b285126a808d2555e510f1ed4f96c86a2730675ba5
+  checksum: 3205598ca36e71cc4cf28b8b1a9cedf3c9f7ead42fa59b20d756b5c3e230329df32c7330b952b2b435de606460f40c1726fb441e272f00d19b4aa9153841691a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-offline@npm:5.2.1-pre.1168"
+"@openmrs/esm-navigation@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-navigation@npm:5.3.3-pre.1379"
+  dependencies:
+    path-to-regexp: 6.1.0
+  peerDependencies:
+    "@openmrs/esm-state": 5.x
+  checksum: 630ad2cb9b7cda338dd8743979256d1bd749500b7a87bf3b3383f153bde82eb5f6750f05e58090a764d948e33b7ef6555144d80abd530c2716705f5bfa24e68c
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-offline@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-offline@npm:5.3.3-pre.1379"
   dependencies:
     dexie: ^3.0.3
     lodash-es: ^4.17.21
@@ -4553,7 +4676,7 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
-  checksum: b9605c88deabbcdbb18b03b15daa335a10f970611a7c2e9b9af26420a7dc4ac713d514617de73067512892365dc9bdacf7e9aca299493782e1a0b27cfb44a6a4
+  checksum: 0db220d11897c0f4101339ee0c923ebad5df3bb02bf6841cc12dda7144cbdb3ab1abbd66525b4e2dfb657dfaf5003e41b3eb65870d419aef0420f74bb8966ca5
   languageName: node
   linkType: hard
 
@@ -4963,9 +5086,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-react-utils@npm:5.2.1-pre.1168"
+"@openmrs/esm-react-utils@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-react-utils@npm:5.3.3-pre.1379"
   dependencies:
     lodash-es: ^4.17.21
     single-spa-react: ~5.0.0
@@ -4975,6 +5098,7 @@ __metadata:
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-extensions": 5.x
     "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-navigation": 5.x
     dayjs: 1.x
     i18next: 19.x
     react: 18.x
@@ -4982,27 +5106,37 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: bdbc8dc4b65bc5eb36f25dda684c1ac29a1dee2bd904852f7cbbc8d5af539c0e3155401d570e678029a6539918bad4cdddc3db75048757054e393aaae3c54da7
+  checksum: 4295093402b1ad11aeefb5942b42df333a296bb4cb2d419b26390f5315313e535fd6aff5f69ba0e6d01497ebc61233ed9b5e3d303e5b861d3b4b72d051b3d7dc
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-state@npm:5.2.1-pre.1168"
+"@openmrs/esm-routes@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-routes@npm:5.3.3-pre.1379"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-utils": 5.x
+  checksum: 077319491c757f9ced2a66c211ea3b348f38a87d49dba346b97f598da5c95b7e1942d01777ef80bb632567f40cf6fe062ed94a6b0cbf9c43b99c81cc3823e37f
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-state@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-state@npm:5.3.3-pre.1379"
   dependencies:
     zustand: ^4.3.6
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: a091c43f49feb1cf8e60fa9d5daf85696e0c7a22b0813fcefd54cb772ed34f9b28bacb9075d3e15dc9ceaa07542ac6041d0a093e6a750ffe1c6b1d6217ad2358
+  checksum: e2fc124e53a65108dc55cb5e46063b852bf375aacb55eb6194957c92a022786b37e92c42fb9fb76ba35fe709495e76832c370bd549c23d8c59372f4492f9f5a2
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-styleguide@npm:5.2.1-pre.1168"
+"@openmrs/esm-styleguide@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-styleguide@npm:5.3.3-pre.1379"
   dependencies:
     "@carbon/charts": ^1.12.0
-    "@carbon/react": ^1.37.0
+    "@carbon/react": ~1.37.0
     "@internationalized/date": ^3.5.0
     "@react-spectrum/datepicker": ^3.8.0
     "@react-spectrum/provider": ^3.9.0
@@ -5018,20 +5152,20 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: 2afa4a88b6dbf99d3298ceb4af54b21d1b04cc7384f60e9049964e1987946e3b50f40e5925b7b30d2cd5481d6f337978c7b1868e786c713f577f01249a367362
+  checksum: cb93ea305759e5123a2a211b2026aa0d673c76c2108c1588928d19537898508cde4a549526a271a5732d57f8b05902a61dc7108b74be7e391e57433f4568cba9
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/esm-utils@npm:5.2.1-pre.1168"
+"@openmrs/esm-utils@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/esm-utils@npm:5.3.3-pre.1379"
   dependencies:
     semver: 7.3.2
   peerDependencies:
     dayjs: 1.x
     i18next: 19.x
     rxjs: 6.x
-  checksum: a7062351221814e061dd0304692b36fc5e6c0512531d28e9342c31ce84c229bbe0d66099bef0d5f582bc1e0c4c4bad08404d09388cbc7cb29f6f14468a194651
+  checksum: a595685c1dccdb023638d498a5cb2d9771876774c3916bd88d5f95df62124afb0761f2726037234ceaaa433d4d845ea9a02f3c8ef6d8ab6aea12837c799261b0
   languageName: node
   linkType: hard
 
@@ -5111,9 +5245,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.2.1-pre.1168":
-  version: 5.2.1-pre.1168
-  resolution: "@openmrs/webpack-config@npm:5.2.1-pre.1168"
+"@openmrs/webpack-config@npm:5.3.3-pre.1379":
+  version: 5.3.3-pre.1379
+  resolution: "@openmrs/webpack-config@npm:5.3.3-pre.1379"
   dependencies:
     "@swc/core": ^1.3.58
     clean-webpack-plugin: ^4.0.0
@@ -5130,7 +5264,7 @@ __metadata:
     webpack-stats-plugin: ^1.0.3
   peerDependencies:
     webpack: 5.x
-  checksum: a8893c01c706f91af391ed8a605ccb082c066b542984184c1381b587a198cd5452ae55856dd19ba9465e481f7bcc86647bb3224eb4ef038662d7d2b8b1cf1799
+  checksum: e6b7f0ce23b2d453c08eae8c05b05b964edf30b44e37b7ac397f12efb469887c834d42d7268240dab19d9dcbc25b2f0ab91db660b626ddd14dd46d66a461ec68
   languageName: node
   linkType: hard
 
@@ -10078,6 +10212,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compute-scroll-into-view@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "compute-scroll-into-view@npm:2.0.4"
+  checksum: f3d1db9276c16af42155b572750514939cd0ab0a0f46498906f6811c5b654c5ff2b3f9bfd65958e57439e000a5e1ae092eb96b9e153d194a73e52ffd2380550c
+  languageName: node
+  linkType: hard
+
 "compute-scroll-into-view@npm:^3.0.3":
   version: 3.1.0
   resolution: "compute-scroll-into-view@npm:3.1.0"
@@ -11814,6 +11955,21 @@ __metadata:
   version: 10.0.0
   resolution: "dotenv@npm:10.0.0"
   checksum: f412c5fe8c24fbe313d302d2500e247ba8a1946492db405a4de4d30dd0eb186a88a43f13c958c5a7de303938949c4231c56994f97d05c4bc1f22478d631b4005
+  languageName: node
+  linkType: hard
+
+"downshift@npm:8.1.0":
+  version: 8.1.0
+  resolution: "downshift@npm:8.1.0"
+  dependencies:
+    "@babel/runtime": ^7.14.8
+    compute-scroll-into-view: ^2.0.4
+    prop-types: ^15.7.2
+    react-is: ^17.0.2
+    tslib: ^2.3.0
+  peerDependencies:
+    react: ">=16.12.0"
+  checksum: 5ede6190dc85ad295f623b30d3ad035a83b9ef5753084096e71e6fad5276a9abd3b1c1a26583958368e4e7fe14a40ef8b5a246f9f6eec058c4eba30a5104539d
   languageName: node
   linkType: hard
 
@@ -18636,6 +18792,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-watch@npm:^0.7.4":
+  version: 0.7.4
+  resolution: "node-watch@npm:0.7.4"
+  checksum: effca2aa3575afdc8caae2a422d5738ecf8322962f051574c5dd3c1a399b4bf188c3ad3cb32890fc5e530604f0f037bc0160ec94b37f8d3ae4b76006a98f9df3
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^6.0.0":
   version: 6.0.0
   resolution: "nopt@npm:6.0.0"
@@ -19248,16 +19411,18 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 5.2.1-pre.1168
-  resolution: "openmrs@npm:5.2.1-pre.1168"
+  version: 5.3.3-pre.1379
+  resolution: "openmrs@npm:5.3.3-pre.1379"
   dependencies:
-    "@openmrs/esm-app-shell": 5.2.1-pre.1168
-    "@openmrs/webpack-config": 5.2.1-pre.1168
+    "@carbon/icons-react": 11.26.0
+    "@openmrs/esm-app-shell": 5.3.3-pre.1379
+    "@openmrs/webpack-config": 5.3.3-pre.1379
     "@pnpm/npm-conf": ^2.1.0
     "@swc/core": ^1.3.58
     autoprefixer: ^10.4.2
     axios: ^0.21.1
     browserslist-config-openmrs: ^1.0.1
+    chalk: ^4.1.2
     copy-webpack-plugin: ^11.0.0
     cssnano: ^5.0.16
     ejs: ^3.1.8
@@ -19265,6 +19430,7 @@ __metadata:
     html-webpack-plugin: ^5.5.0
     inquirer: ^7.3.3
     mini-css-extract-plugin: ^2.4.5
+    node-watch: ^0.7.4
     npm-registry-fetch: ^14.0.3
     pacote: ^15.0.0
     postcss: ^8.4.6
@@ -19281,7 +19447,7 @@ __metadata:
     yargs: ^17.6.2
   bin:
     openmrs: ./dist/cli.js
-  checksum: 9c4823e604215ab00ccfdc4cbe93baf92f905a07b1a15015ef044903280125a60ba4b9e7bc80d245e9f7d2d961e99761e9472e356d911cb06a5c94a4ee591b73
+  checksum: 68a51404ea10bc8036e89201a7a268f0a0007a0cb3500ea2a343c542c268e6dbb887d7d26d7652e9eab62f33ec3aa9faa326e8cd9539ebf23abd2f145f90c3cf
   languageName: node
   linkType: hard
 
@@ -20976,7 +21142,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^17.0.0, react-is@npm:^17.0.1":
+"react-is@npm:^17.0.0, react-is@npm:^17.0.1, react-is@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8

--- a/yarn.lock
+++ b/yarn.lock
@@ -4388,9 +4388,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-api@npm:5.3.3-pre.1379"
+"@openmrs/esm-api@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-api@npm:5.3.3-pre.1395"
   dependencies:
     "@types/fhir": 0.0.31
     lodash-es: ^4.17.21
@@ -4399,17 +4399,17 @@ __metadata:
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: f8a276f8b9fef599b0d1aafd64a280c174f4a26ae5e785b1b884e05825ef40f91a8c70fee2bce1b8d13a261456da7d6047fa1386b28c4e2e57519b7415823a72
+  checksum: 0b8a37bf9a25f952d8a475aee6d32906a3ce4aca6086f935f6876a3481951595b56088dd4bb542581993ec41cd396f77735e8da79880cdaeb3acc40b39c7d89d
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-app-shell@npm:5.3.3-pre.1379"
+"@openmrs/esm-app-shell@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-app-shell@npm:5.3.3-pre.1395"
   dependencies:
     "@carbon/react": ~1.37.0
-    "@openmrs/esm-framework": 5.3.3-pre.1379
-    "@openmrs/esm-styleguide": 5.3.3-pre.1379
+    "@openmrs/esm-framework": 5.3.3-pre.1395
+    "@openmrs/esm-styleguide": 5.3.3-pre.1395
     dayjs: ^1.10.4
     dexie: ^3.0.3
     html-webpack-plugin: ^5.5.0
@@ -4423,7 +4423,7 @@ __metadata:
     react-router-dom: ^6.3.0
     rxjs: ^6.5.3
     semver: ^7.3.4
-    single-spa: ^5.9.2
+    single-spa: ^6.0.0
     swc-loader: ^0.2.3
     swr: ^2.2.2
     systemjs: ^6.8.3
@@ -4434,44 +4434,44 @@ __metadata:
     workbox-strategies: ^6.1.5
     workbox-webpack-plugin: ^6.1.5
     workbox-window: ^6.1.5
-  checksum: 1f615706fe9ab85785e4fc118b0c3fe75bdc32c0717a2ce368a46c51d1ac0273d8d1e46cbe54a5cece36022c33efd894f39f63da09406b1ca07e32f76d02ba53
+  checksum: 87b95b0001fedd9d5a673aa1acafabb666cb1e7cf87549f07af64e3c1056b8f2b582faad84ae1b01cce3cf6636f8d6ea24e3d6fd4ffda243cca6043bc4fc15da
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-config@npm:5.3.3-pre.1379"
+"@openmrs/esm-config@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-config@npm:5.3.3-pre.1395"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: cafb74eece01bf28c9842347334fbdd63d5f0771fbe6fd2caa9c22829f8e141c181e498b30cb79f46f14b8f8a4948b99ed8f9306a3f117a5638cfe021216ad90
+  checksum: b47f0d79e9c862b0e7c2f966bd60da595ed5dc7ffc625e64f04394f4ff2d84838c13585f2ef1c5ea9551408692db9ff44b6d6fb8b21a20189ae063f57b34c116
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1379"
+"@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1395"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 77c4b7d9b93a22eb13858e67f7e7511642c767fe237a0d34fb414039072eda0ff2738f5cea988be80e29c49b2ced53acb9035f93e1157c072eeea10ba9745d60
+  checksum: cd6ade860b21ad5fd29e7edd56ddc0766408c56ebd2472e5a5fa98b72d2f35a2d6b015a103aa708b31b070ef41a60ee7cc438a19050536fed7537cf1c0c56e3f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-error-handling@npm:5.3.3-pre.1379"
+"@openmrs/esm-error-handling@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-error-handling@npm:5.3.3-pre.1395"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 49774b49ca3e51dcb051a1f5830c7aca71adc45b8f888987d4355c20c97594a1d0c1b264c7693120bb1447e5dfd2d6401e7fb0507abadd8855834f75840bcb45
+  checksum: ac91abe684b0d8352783100f03aad806ca9256bce070a9935ac49a1b722aaa6b6573f7363a4cf7d4148c343ff136a6a0f55856df2fd16f74f1d44c8b48589bf7
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-extensions@npm:5.3.3-pre.1379"
+"@openmrs/esm-extensions@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-extensions@npm:5.3.3-pre.1395"
   dependencies:
     lodash-es: ^4.17.21
   peerDependencies:
@@ -4480,20 +4480,20 @@ __metadata:
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 7b0bf44026499752f2e2407f52780b1a42caf748a461323f06e599b336397701ec287f489666cb119b2d43f9ebbe52cf595323acc8415a38b922af85e9dd7c73
+  checksum: 55212a1da4f50fd8bc83e9ed55dd6b3db5359145f47dc0e08a6c09f476ac2575075d9927c0ea688093b498082ce7ae48668fb011ee140b65973f9cd5c4d26d5c
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-feature-flags@npm:5.3.3-pre.1379"
+"@openmrs/esm-feature-flags@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-feature-flags@npm:5.3.3-pre.1395"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 1cd5d9478456f0df5dcfdab78acc212da476d9e5f3eb0d530b12a7cbf6450218bcd8e24e3738681531e1833eb7ea22bff70ef7774ff69c7e485eea7637a90f61
+  checksum: caf6f777e51d63dd1191edf391a2fb250d944c986abaa05869fb971b772812cf915c852dc3118fb7edb23861ecd92067fe15a5f009b583830cef23b4ff3399dd
   languageName: node
   linkType: hard
 
@@ -4588,24 +4588,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-framework@npm:5.3.3-pre.1379, @openmrs/esm-framework@npm:next":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-framework@npm:5.3.3-pre.1379"
+"@openmrs/esm-framework@npm:5.3.3-pre.1395, @openmrs/esm-framework@npm:next":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-framework@npm:5.3.3-pre.1395"
   dependencies:
-    "@openmrs/esm-api": 5.3.3-pre.1379
-    "@openmrs/esm-config": 5.3.3-pre.1379
-    "@openmrs/esm-dynamic-loading": 5.3.3-pre.1379
-    "@openmrs/esm-error-handling": 5.3.3-pre.1379
-    "@openmrs/esm-extensions": 5.3.3-pre.1379
-    "@openmrs/esm-feature-flags": 5.3.3-pre.1379
-    "@openmrs/esm-globals": 5.3.3-pre.1379
-    "@openmrs/esm-navigation": 5.3.3-pre.1379
-    "@openmrs/esm-offline": 5.3.3-pre.1379
-    "@openmrs/esm-react-utils": 5.3.3-pre.1379
-    "@openmrs/esm-routes": 5.3.3-pre.1379
-    "@openmrs/esm-state": 5.3.3-pre.1379
-    "@openmrs/esm-styleguide": 5.3.3-pre.1379
-    "@openmrs/esm-utils": 5.3.3-pre.1379
+    "@openmrs/esm-api": 5.3.3-pre.1395
+    "@openmrs/esm-config": 5.3.3-pre.1395
+    "@openmrs/esm-dynamic-loading": 5.3.3-pre.1395
+    "@openmrs/esm-error-handling": 5.3.3-pre.1395
+    "@openmrs/esm-extensions": 5.3.3-pre.1395
+    "@openmrs/esm-feature-flags": 5.3.3-pre.1395
+    "@openmrs/esm-globals": 5.3.3-pre.1395
+    "@openmrs/esm-navigation": 5.3.3-pre.1395
+    "@openmrs/esm-offline": 5.3.3-pre.1395
+    "@openmrs/esm-react-utils": 5.3.3-pre.1395
+    "@openmrs/esm-routes": 5.3.3-pre.1395
+    "@openmrs/esm-state": 5.3.3-pre.1395
+    "@openmrs/esm-styleguide": 5.3.3-pre.1395
+    "@openmrs/esm-utils": 5.3.3-pre.1395
     dayjs: ^1.10.7
   peerDependencies:
     dayjs: 1.x
@@ -4616,7 +4616,7 @@ __metadata:
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: 6e8c997f7d6cdd91a5f6c31da8a9b6f530a00b0f37baa910b4bf3e8aa38b8f03c3ed124d5bc99741d7e4adb5f5ed66fc1be625c3d6bf7eeb3e3bbd4fbf881087
+  checksum: 20139755fcd23524aa9faa3cb907ac2e5e18c10407b1b14c1b6e2c287046c3e4aa586af3d4bce1f7e4c0ed5d97e1b10f03eb2925d2f924d1d4b001898c1a7d1a
   languageName: node
   linkType: hard
 
@@ -4642,29 +4642,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-globals@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-globals@npm:5.3.3-pre.1379"
+"@openmrs/esm-globals@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-globals@npm:5.3.3-pre.1395"
   peerDependencies:
     single-spa: 5.x
-  checksum: 3205598ca36e71cc4cf28b8b1a9cedf3c9f7ead42fa59b20d756b5c3e230329df32c7330b952b2b435de606460f40c1726fb441e272f00d19b4aa9153841691a
+  checksum: 054a14d9ca203e0295cb0d05d28ea35a604f1c6f65f4485b3cbc674bb0d95ec78e9b2a22cc84b3d0b41cc9cb60f53e6a6dc88b7d5d8465544d5a2dfc8a445d0a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-navigation@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-navigation@npm:5.3.3-pre.1379"
+"@openmrs/esm-navigation@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-navigation@npm:5.3.3-pre.1395"
   dependencies:
     path-to-regexp: 6.1.0
   peerDependencies:
     "@openmrs/esm-state": 5.x
-  checksum: 630ad2cb9b7cda338dd8743979256d1bd749500b7a87bf3b3383f153bde82eb5f6750f05e58090a764d948e33b7ef6555144d80abd530c2716705f5bfa24e68c
+  checksum: 0e6815fe207826fced33f53dd229c9398130e1b8cdf53dadb3dbeaaa12380b9c8d9da26de2dc0f4477acd8c2a8d4583f1da76cc9de86c9890816157c379c2723
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-offline@npm:5.3.3-pre.1379"
+"@openmrs/esm-offline@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-offline@npm:5.3.3-pre.1395"
   dependencies:
     dexie: ^3.0.3
     lodash-es: ^4.17.21
@@ -4676,7 +4676,7 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
-  checksum: 0db220d11897c0f4101339ee0c923ebad5df3bb02bf6841cc12dda7144cbdb3ab1abbd66525b4e2dfb657dfaf5003e41b3eb65870d419aef0420f74bb8966ca5
+  checksum: 1c04f836b479a7e8b47a3e2123ed857387c696ea42ebf2954748ff91e4005821bf4f558333098ca16766a2f8d6e5aa9b4312d7ac9498e26971a2765e1bec6e68
   languageName: node
   linkType: hard
 
@@ -5086,12 +5086,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-react-utils@npm:5.3.3-pre.1379"
+"@openmrs/esm-react-utils@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-react-utils@npm:5.3.3-pre.1395"
   dependencies:
     lodash-es: ^4.17.21
-    single-spa-react: ~5.0.0
+    single-spa-react: ^6.0.0
   peerDependencies:
     "@openmrs/esm-api": 5.x
     "@openmrs/esm-config": 5.x
@@ -5106,34 +5106,34 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 4295093402b1ad11aeefb5942b42df333a296bb4cb2d419b26390f5315313e535fd6aff5f69ba0e6d01497ebc61233ed9b5e3d303e5b861d3b4b72d051b3d7dc
+  checksum: c4e970cfe82c3a580bb083b41e262ce2d740d140fbed68bf63972398ac247336da99b1e15b83dfd8ec0901b5c2874695a000ef2c25e0496168a9a89f5cf941ba
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-routes@npm:5.3.3-pre.1379"
+"@openmrs/esm-routes@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-routes@npm:5.3.3-pre.1395"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-utils": 5.x
-  checksum: 077319491c757f9ced2a66c211ea3b348f38a87d49dba346b97f598da5c95b7e1942d01777ef80bb632567f40cf6fe062ed94a6b0cbf9c43b99c81cc3823e37f
+  checksum: 9f9637dc8cdc97c8d9a657af5e962a62e442a24570fd7f8ee6ff05d5c49db87d9fe5680d755144634e07768cd34dcb5591f2a93a2839ad4563ab72063a545684
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-state@npm:5.3.3-pre.1379"
+"@openmrs/esm-state@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-state@npm:5.3.3-pre.1395"
   dependencies:
     zustand: ^4.3.6
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: e2fc124e53a65108dc55cb5e46063b852bf375aacb55eb6194957c92a022786b37e92c42fb9fb76ba35fe709495e76832c370bd549c23d8c59372f4492f9f5a2
+  checksum: c23baf770dd4d554dadf864534e2b366cfd3d1a4ab7b6d356d3c6636c834bdccf1ae9d3592c4553811d22202b83a2f100811ed1c5134343c390cf45affe90573
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-styleguide@npm:5.3.3-pre.1379"
+"@openmrs/esm-styleguide@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-styleguide@npm:5.3.3-pre.1395"
   dependencies:
     "@carbon/charts": ^1.12.0
     "@carbon/react": ~1.37.0
@@ -5152,20 +5152,20 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: cb93ea305759e5123a2a211b2026aa0d673c76c2108c1588928d19537898508cde4a549526a271a5732d57f8b05902a61dc7108b74be7e391e57433f4568cba9
+  checksum: 17ea56e9a1e4b8197e77a7503c0c9078bf3bbf3faceaa6ead845dea21672f32a68e5c5256c6aa0301bf3d11ffda15e0a0a3479f9a61288c2eda5536887922164
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/esm-utils@npm:5.3.3-pre.1379"
+"@openmrs/esm-utils@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/esm-utils@npm:5.3.3-pre.1395"
   dependencies:
     semver: 7.3.2
   peerDependencies:
     dayjs: 1.x
     i18next: 19.x
     rxjs: 6.x
-  checksum: a595685c1dccdb023638d498a5cb2d9771876774c3916bd88d5f95df62124afb0761f2726037234ceaaa433d4d845ea9a02f3c8ef6d8ab6aea12837c799261b0
+  checksum: 7995953a6f86cd84c303cff9b0729e968a53d976d13c83bb5502b0168d38118da1eedad82e6d8c64ca700f093f7d5d0105265f3e94cb9d6c10a71c6da75c81d9
   languageName: node
   linkType: hard
 
@@ -5245,9 +5245,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.3.3-pre.1379":
-  version: 5.3.3-pre.1379
-  resolution: "@openmrs/webpack-config@npm:5.3.3-pre.1379"
+"@openmrs/webpack-config@npm:5.3.3-pre.1395":
+  version: 5.3.3-pre.1395
+  resolution: "@openmrs/webpack-config@npm:5.3.3-pre.1395"
   dependencies:
     "@swc/core": ^1.3.58
     clean-webpack-plugin: ^4.0.0
@@ -5264,7 +5264,7 @@ __metadata:
     webpack-stats-plugin: ^1.0.3
   peerDependencies:
     webpack: 5.x
-  checksum: e6b7f0ce23b2d453c08eae8c05b05b964edf30b44e37b7ac397f12efb469887c834d42d7268240dab19d9dcbc25b2f0ab91db660b626ddd14dd46d66a461ec68
+  checksum: 4158f3e46591a5ecca3cc7ced0c2c81ac8928d78a8ac6e5b89b89b3458a5e75501400670db6df249a0ce1179d05425bc2afc5ba59e4b5e576bba261af8d2dd78
   languageName: node
   linkType: hard
 
@@ -19411,12 +19411,12 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 5.3.3-pre.1379
-  resolution: "openmrs@npm:5.3.3-pre.1379"
+  version: 5.3.3-pre.1395
+  resolution: "openmrs@npm:5.3.3-pre.1395"
   dependencies:
     "@carbon/icons-react": 11.26.0
-    "@openmrs/esm-app-shell": 5.3.3-pre.1379
-    "@openmrs/webpack-config": 5.3.3-pre.1379
+    "@openmrs/esm-app-shell": 5.3.3-pre.1395
+    "@openmrs/webpack-config": 5.3.3-pre.1395
     "@pnpm/npm-conf": ^2.1.0
     "@swc/core": ^1.3.58
     autoprefixer: ^10.4.2
@@ -19447,7 +19447,7 @@ __metadata:
     yargs: ^17.6.2
   bin:
     openmrs: ./dist/cli.js
-  checksum: 68a51404ea10bc8036e89201a7a268f0a0007a0cb3500ea2a343c542c268e6dbb887d7d26d7652e9eab62f33ec3aa9faa326e8cd9539ebf23abd2f145f90c3cf
+  checksum: 188e2f1a52e2f2bf1cf308dd0435ed68b983513bfc592f979d8d099cac24a8fc462eb6f8f3f89e9114079459322a50ee810c92edd039110092368f35c625c577
   languageName: node
   linkType: hard
 
@@ -22569,9 +22569,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"single-spa-react@npm:~5.0.0":
-  version: 5.0.2
-  resolution: "single-spa-react@npm:5.0.2"
+"single-spa-react@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "single-spa-react@npm:6.0.1"
   dependencies:
     browserslist-config-single-spa: ^1.0.1
   peerDependencies:
@@ -22583,14 +22583,14 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 3c2503384ab27aed7e4f9f5c6a40cf5aae120cae1749244aba12647159354c143ac03669bfc41a43533077c874866b7042dad9463abe253da198da3f200d8fe1
+  checksum: aefe69502735a5a4062a0539d61e2b1e84c50146e333838d688ee3f511f101cc07f94daa27ab399e5286a2c3399278e5da8c87fdc5ca36648504de2b338e45b6
   languageName: node
   linkType: hard
 
-"single-spa@npm:^5.9.2":
-  version: 5.9.4
-  resolution: "single-spa@npm:5.9.4"
-  checksum: 8547b5db3d1c6788f44833b1bf7a89697a72a4ca4b801c3f9ddbf4e2949a40bc1d9e9a24650460c7a16f5a668d4e332fc237acacb84f329031815c19578a5907
+"single-spa@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "single-spa@npm:6.0.0"
+  checksum: 4efc6248e5ba3b2c02090869a1d85c8fdb77994465d760233ff58462d35614503fefcb2330999b15ef7e43508181939a41628410912f9a1cc01860b192580d11
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Uses the new history utilities in esm-core to fix the patient-chart close button.

## Screenshots

The videos are 90% loading screens and are hard to follow because the cursor doesn't show up. So I've described them below.

Before: I access Lucy Karl's chart from patient-lists, refresh the page, and hit close. This takes me to the Home page. Then I go back to patient-lists, ctrl-click Lucy Karl's chart, change to that tab, and hit close. Nothing happens.

https://github.com/openmrs/openmrs-esm-patient-chart/assets/1031876/45ce0141-67ae-4c0c-a8c8-4bf1858bf0c6

After: I access Lucy Karl's chart from patient-lists, refresh the page, and hit close. This takes me back to patient-lists. Then I ctrl-click Lucy Karl's chart, change to that tab, and hit close. It takes me back to patient-lists in that new tab.

https://github.com/openmrs/openmrs-esm-patient-chart/assets/1031876/110d7c19-6f94-4220-8ae5-8cdf5d1c79d7

## Related Issue

https://openmrs.atlassian.net/browse/O3-1594
