### PR TITLE
(fix)03-O3-2729: Reduce white space.

### DIFF
--- a/packages/esm-patient-lists-app/src/workspaces/patient-list-details.scss
+++ b/packages/esm-patient-lists-app/src/workspaces/patient-list-details.scss
@@ -55,5 +55,5 @@
 }
 
 .tableContainer {
-  margin-top: layout.$spacing-07;
+  margin-top: layout.$spacing-02;
 }


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I  reduced the whitespace between the back-to-patient-list button and the patient-search section from  margin-top: layout.$spacing-07; to  margin-top: layout.$spacing-02;

## Screenshots
![Screenshot 2024-01-14 at 1 29 42 PM](https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/e9c13abe-8dda-49ba-8d97-1657605c9695)


## Related Issue
https://openmrs.atlassian.net/browse/O3-2729

## Other
<!-- Anything not covered above -->
