### PR TITLE
(fix) Log a warning if workspaces are registered as extensions

### DIFF
--- a/packages/esm-patient-common-lib/src/types/workspace.ts
+++ b/packages/esm-patient-common-lib/src/types/workspace.ts
@@ -3,8 +3,12 @@ export type WorkspaceWindowState = 'maximized' | 'hidden' | 'normal';
 
 /** The default parameters received by all workspaces */
 export interface DefaultWorkspaceProps {
-  closeWorkspace(ignoreChanges: boolean): void;
-  closeWorkspace(): void;
+  /**
+   * Call this function to close the workspace. If ignoreChanges is true, the user will not be
+   * prompted to save changes before closing, even if the `testFcn` passed to `promptBeforeClosing`
+   * returns `true`.
+   */
+  closeWorkspace(ignoreChanges?: boolean): void;
   /**
    * Call this with a no-args function that returns true if the user should be prompted before
    * this workspace is closed; e.g. if there is unsaved data.

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
@@ -58,6 +58,7 @@ export function registerWorkspace(workspace: WorkspaceRegistration) {
   };
 }
 
+const workspaceExtensionWarningsIssued = new Set();
 /**
  * This exists for compatibility with the old way of registering
  * workspaces (as extensions).
@@ -70,6 +71,12 @@ function getWorkspaceRegistration(name: string): WorkspaceRegistration {
   } else {
     const workspaceExtension = getExtensionRegistration(name);
     if (workspaceExtension) {
+      if (!workspaceExtensionWarningsIssued.has(name)) {
+        console.warn(
+          `The workspace '${name}' is registered as an extension. This is deprecated. Please use the 'registerWorkspace' function instead.`,
+        );
+        workspaceExtensionWarningsIssued.add(name);
+      }
       return {
         name: workspaceExtension.name,
         title: getTitleFromExtension(workspaceExtension),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Log a warning in the console if a workspace has been registered as an extension, to indicate that this is deprecated.
