### PR TITLE
(chore) Add GitHub Actions flows to automate Transifex

### DIFF
--- a/.github/workflows/tx-pull.yml
+++ b/.github/workflows/tx-pull.yml
@@ -1,0 +1,31 @@
+on:
+  workflow_dispatch:
+  schedule:
+    # every day at 8 PM UTC
+    - cron: "0 20 30 * *"
+
+name: "Scheduled Transifex Update"
+
+jobs:
+  pull-translations-from-transifex:
+    name: pull-translations-from-transifex
+    
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Push source file using transifex client
+        uses: transifex/cli-action@v2
+        with:
+          token: ${{ secrets.TRANSIFEX_TOKEN }}
+          args: pull
+      - name: Create PR if necessary
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "(chore) Update translations from Transifex"
+          title: "(chore) Update translations from Transifex"
+          body: "Automated updates of translations pulled from Transifex"
+          branch: "chore/update-transifex"
+          author: "OpenMRS Bot <infrastructure@openmrs.org>"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tx-push.yml
+++ b/.github/workflows/tx-push.yml
@@ -1,0 +1,21 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+name: "Update Transifex on Push"
+
+jobs:
+  push-translations-to-transifex:
+    name: push-translations-to-transifex
+
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    
+    steps:
+      - uses: actions/checkout@v4
+      - name: Push source file using transifex client
+        uses: transifex/cli-action@v2
+        with:
+          token: ${{ secrets.TRANSIFEX_TOKEN }}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

This PR adds two GitHub Actions workflows aimed at automating (to an extent) our use of Transifex. Specifically:

- `tx-push`: Run on every push to main, this pushes the translation files to Transifex to ensure the strings on Transifex are up-to-date.
- `tx-pull`: This is a scheduled job run daily at 8:30 PM UTC, which is fairly arbitrary. It pulls changes from Transifex and, if any updates are made (🤞), it should create a PR to update those files. Subsequent updates before a PR is merged should update the PR in question.

Aside from the time difference on `tx-pull`, this is identical to openmrs/openmrs-esm-core#887

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
