### PR TITLE
(Fix) O3-2716: Add Workspace "unsaved changes" modal prompt on navigating away from patient chart

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -16,7 +16,6 @@ import {
   navigate,
 } from '@openmrs/esm-framework';
 import {
-  getWorkspaceStore,
   launchPatientWorkspace,
   type Prompt,
   useSystemVisitSetting,

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
@@ -45,6 +45,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   return {
     ...originalModule,
     launchPatientWorkspace: jest.fn(),
+    getWorkspaceStore: jest.fn(() => ({ getState: jest.fn() })),
   };
 });
 

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
@@ -46,6 +46,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
     ...originalModule,
     launchPatientWorkspace: jest.fn(),
     getWorkspaceStore: jest.fn(() => ({ getState: jest.fn() })),
+    useWorkspaces: jest.fn(() => ({ workspaces: [] })),
   };
 });
 

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.test.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.test.ts
@@ -357,7 +357,7 @@ describe('workspace system', () => {
     expect(store.getState().openWorkspaces[0].name).toBe('diabetes');
     expect(store.getState().prompt.title).toBe('You have unsaved changes');
     store.getState().prompt.onConfirm();
-    expect(store.getState().openWorkspaces[0].name).toBe('hiv');
+    expect(store.getState().openWorkspaces[0].name).toBe('diabetes');
   });
 
   test('is compatible with workspaces registered as extensions', () => {

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.test.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.test.ts
@@ -390,9 +390,9 @@ describe('workspace system', () => {
     launchPatientWorkspace('hiv');
     store.getState().openWorkspaces[0].promptBeforeClosing(() => true);
     store.getState().openWorkspaces[0].closeWorkspace(false);
-    expect(store.getState().prompt.title).toBe('Unsaved Changes');
+    expect(store.getState().prompt.title).toBe('You have unsaved changes');
     expect(store.getState().prompt.body).toBe(
-      'You have unsaved changes in the side panel. Do you want to discard these changes?',
+      'There are unsaved changes in HIV. Do you want to discard these changes?',
     );
     expect(store.getState().prompt.confirmText).toBe('Discard');
     store.getState().prompt.onConfirm();

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
@@ -23,8 +23,8 @@ export interface WorkspaceStoreState {
 
 export interface OpenWorkspace extends WorkspaceRegistration {
   additionalProps: object;
-  closeWorkspace(promptBeforeClosing?: boolean): boolean;
-  closeWorkspace(): boolean;
+  closeWorkspace(promptBeforeClosing?: boolean): void;
+  closeWorkspace(): void;
   promptBeforeClosing(testFcn: () => boolean): void;
 }
 
@@ -247,7 +247,6 @@ export function cancelPrompt() {
 export function closeWorkspace(name: string, ignoreChanges: boolean) {
   const store = getWorkspaceStore();
   const promptCheckFcn = getPromptBeforeClosingFcn(name);
-
   const updateStoreWithClosedWorkspace = () => {
     const state = store.getState();
     const newOpenWorkspaces = state.openWorkspaces.filter((w) => w.name != name);
@@ -262,7 +261,7 @@ export function closeWorkspace(name: string, ignoreChanges: boolean) {
 
   if (!ignoreChanges && promptCheckFcn && promptCheckFcn()) {
     const prompt: Prompt = {
-      title: translateFrom('@openmrs/esm-patient-chart-app', 'unsavedChangesTitleText', 'Unsaved Changes'),
+      title: translateFrom('@openmrs/esm-patient-chart-app', 'unsavedChanges', 'You have unsaved changes'),
       body: translateFrom(
         '@openmrs/esm-patient-chart-app',
         'unsavedChangeText',
@@ -274,10 +273,8 @@ export function closeWorkspace(name: string, ignoreChanges: boolean) {
       confirmText: translateFrom('@openmrs/esm-patient-chart-app', 'discard', 'Discard'),
     };
     store.setState({ ...store.getState(), prompt });
-    return false;
   } else {
     updateStoreWithClosedWorkspace();
-    return true;
   }
 }
 

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
@@ -23,8 +23,8 @@ export interface WorkspaceStoreState {
 
 export interface OpenWorkspace extends WorkspaceRegistration {
   additionalProps: object;
-  closeWorkspace(promptBeforeClosing?: boolean): void;
-  closeWorkspace(): void;
+  closeWorkspace(promptBeforeClosing?: boolean): boolean;
+  closeWorkspace(): boolean;
   promptBeforeClosing(testFcn: () => boolean): void;
 }
 
@@ -166,7 +166,7 @@ export function launchPatientWorkspace(name: string, additionalProps?: object) {
   const workspace = getWorkspaceRegistration(name);
   const newWorkspace = {
     ...workspace,
-    closeWorkspace: (ignoreChanges = true) => closeWorkspace(name, ignoreChanges),
+    closeWorkspace: (ignoreChanges = false) => closeWorkspace(name, ignoreChanges),
     promptBeforeClosing: (testFcn) => promptBeforeClosing(name, testFcn),
     additionalProps,
   };
@@ -274,8 +274,10 @@ export function closeWorkspace(name: string, ignoreChanges: boolean) {
       confirmText: translateFrom('@openmrs/esm-patient-chart-app', 'discard', 'Discard'),
     };
     store.setState({ ...store.getState(), prompt });
+    return false;
   } else {
     updateStoreWithClosedWorkspace();
+    return true;
   }
 }
 

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
@@ -247,6 +247,7 @@ export function cancelPrompt() {
 export function closeWorkspace(name: string, ignoreChanges: boolean) {
   const store = getWorkspaceStore();
   const promptCheckFcn = getPromptBeforeClosingFcn(name);
+  const workspace = store.getState().openWorkspaces.filter((w) => w.name == name)[0];
   const updateStoreWithClosedWorkspace = () => {
     const state = store.getState();
     const newOpenWorkspaces = state.openWorkspaces.filter((w) => w.name != name);
@@ -264,8 +265,9 @@ export function closeWorkspace(name: string, ignoreChanges: boolean) {
       title: translateFrom('@openmrs/esm-patient-chart-app', 'unsavedChanges', 'You have unsaved changes'),
       body: translateFrom(
         '@openmrs/esm-patient-chart-app',
-        'unsavedChangeText',
-        `You have unsaved changes in the side panel. Do you want to discard these changes?`,
+        'unsavedChangesInFormToBeClosed',
+        'There are unsaved changes in {{formName}}. Do you want to discard these changes?',
+        { formName: workspace.title ?? workspace.name },
       ),
       onConfirm: () => {
         updateStoreWithClosedWorkspace();

--- a/packages/esm-patient-immunizations-app/translations/km.json
+++ b/packages/esm-patient-immunizations-app/translations/km.json
@@ -11,7 +11,7 @@
   "pleaseSelect": "Please select",
   "recentVaccination": "Recent vaccination",
   "save": "Save",
-  "seeAll": "ឃើញ​ទាំងអស់",
+  "seeAll": "ឃើញ\u200bទាំងអស់",
   "sequence": "Sequence",
   "singleDoseOn": "Single Dose on",
   "vaccinationDate": "Vaccination date",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes the navigation from the patient chat where the prompt on unsaved changes is not triggered. So the PR adds an event listener whenever navigating away to always prompt users if there are any open workspaces

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/openmrs/openmrs-esm-patient-chart/assets/53287480/af866801-aeed-4728-a102-4679a6f00663


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2716)](https://openmrs.atlassian.net/browse/O3-2716)

## Other
<!-- Anything not covered above -->
