### PR TITLE
(fix) Fix medications display in visit summary

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
@@ -26,7 +26,10 @@ const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications }) =>
                     <div>
                       <p className={styles.bodyLong01}>
                         <strong>{capitalize(medication?.order?.drug?.display)}</strong>{' '}
-                        {medication?.order?.drug?.strength?.toLowerCase() && (
+                        {medication?.order?.drug?.strength && (
+                          <>&mdash; {medication?.order?.drug?.strength?.toLowerCase()}</>
+                        )}{' '}
+                        {medication?.order?.doseUnits?.display && (
                           <>&mdash; {medication?.order?.doseUnits?.display?.toLowerCase()}</>
                         )}{' '}
                       </p>
@@ -35,6 +38,9 @@ const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications }) =>
                         <span className={styles.dosage}>
                           {medication?.order?.dose} {medication?.order?.doseUnits?.display?.toLowerCase()}
                         </span>{' '}
+                        {medication.order?.route?.display && (
+                          <span>&mdash; {medication?.order?.route?.display?.toLowerCase()} &mdash; </span>
+                        )}
                         {medication?.order?.frequency?.display?.toLowerCase()} &mdash;{' '}
                         {!medication?.order?.duration
                           ? t('orderIndefiniteDuration', 'Indefinite duration')

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import classNames from 'classnames';
 import capitalize from 'lodash-es/capitalize';
 import { useTranslation } from 'react-i18next';
-import type { OrderItem } from '../visit.resource';
-import { formatDate, formatTime, parseDate } from '@openmrs/esm-framework';
-import styles from '../visit-detail-overview.scss';
 import { EmptyState } from '@openmrs/esm-patient-common-lib';
+import { formatDate, formatTime, parseDate } from '@openmrs/esm-framework';
+import type { OrderItem } from '../visit.resource';
+import styles from '../visit-detail-overview.scss';
 
 interface MedicationSummaryProps {
   medications: Array<OrderItem>;
@@ -24,60 +23,65 @@ const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications }) =>
               medication?.order?.orderType?.display === 'Drug Order' && (
                 <React.Fragment key={i}>
                   <div className={styles.medicationContainer}>
-                    <p className={styles.medicationRecord}>
-                      <strong>{capitalize(medication?.order?.drug?.display)}</strong> &mdash;{' '}
-                      {medication?.order?.drug?.strength?.toLowerCase()}
-                      &mdash; {medication?.order?.doseUnits?.display?.toLowerCase()} &mdash;{' '}
-                      <span>
+                    <div>
+                      <p className={styles.bodyLong01}>
+                        <strong>{capitalize(medication?.order?.drug?.display)}</strong>{' '}
+                        {medication?.order?.drug?.strength?.toLowerCase() && (
+                          <>&mdash; {medication?.order?.doseUnits?.display?.toLowerCase()}</>
+                        )}{' '}
+                      </p>
+                      <p className={styles.bodyLong01}>
                         <span className={styles.label01}> {t('dose', 'Dose').toUpperCase()} </span>{' '}
-                      </span>
-                      <span className={styles.dosage}>
-                        {medication?.order?.dose} {medication?.order?.doseUnits?.display?.toLowerCase()}
-                      </span>{' '}
-                      &mdash; {medication?.order?.route?.display?.toLowerCase()} &mdash;{' '}
-                      {medication?.order?.frequency?.display?.toLowerCase()} &mdash;{' '}
-                      {!medication?.order?.duration
-                        ? t('orderIndefiniteDuration', 'Indefinite duration')
-                        : t('orderDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
-                            duration: medication?.order?.duration,
-                            durationUnit: medication?.order?.durationUnits?.display?.toLowerCase(),
-                          })}
-                      {medication?.order?.numRefills !== 0 && (
-                        <span>
-                          <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
-                          {medication?.order?.numRefills}
-                          {''}
-                        </span>
-                      )}
-                      {medication?.order?.dosingInstructions && (
-                        <span> &mdash; {medication?.order?.dosingInstructions?.toLocaleLowerCase()}</span>
-                      )}
-                      {medication?.order?.orderReasonNonCoded ? (
-                        <span>
-                          &mdash; <span className={styles.label01}>{t('indication', 'Indication').toUpperCase()}</span>{' '}
-                          {medication?.order?.orderReasonNonCoded}
-                        </span>
-                      ) : null}
-                      {medication?.order?.quantity ? (
-                        <span>
-                          <span className={styles.label01}> &mdash; {t('quantity', 'Quantity').toUpperCase()}</span>{' '}
-                          {medication?.order?.quantity}
-                        </span>
-                      ) : null}
-                      {medication?.order?.dateStopped ? (
-                        <span className={styles.bodyShort01}>
-                          <span className={styles.label01}>
-                            {medication?.order?.quantity ? ` — ` : ''} {t('endDate', 'End date').toUpperCase()}
-                          </span>{' '}
-                          {formatDate(new Date(medication?.order?.dateStopped))}
-                        </span>
-                      ) : null}
-                    </p>
+                        <span className={styles.dosage}>
+                          {medication?.order?.dose} {medication?.order?.doseUnits?.display?.toLowerCase()}
+                        </span>{' '}
+                        {medication?.order?.frequency?.display?.toLowerCase()} &mdash;{' '}
+                        {!medication?.order?.duration
+                          ? t('orderIndefiniteDuration', 'Indefinite duration')
+                          : t('orderDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
+                              duration: medication?.order?.duration,
+                              durationUnit: medication?.order?.durationUnits?.display?.toLowerCase(),
+                            })}
+                        {medication?.order?.numRefills !== 0 && (
+                          <span>
+                            <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
+                            {medication?.order?.numRefills}
+                            {''}
+                          </span>
+                        )}
+                        {medication?.order?.dosingInstructions && (
+                          <span> &mdash; {medication?.order?.dosingInstructions?.toLocaleLowerCase()}</span>
+                        )}
+                      </p>
+                      <p className={styles.bodyLong01}>
+                        {medication?.order?.orderReasonNonCoded ? (
+                          <span>
+                            <span className={styles.label01}>{t('indication', 'Indication').toUpperCase()}</span>{' '}
+                            {medication?.order?.orderReasonNonCoded}
+                          </span>
+                        ) : null}
+                        {medication?.order?.quantity ? (
+                          <span>
+                            <span className={styles.label01}> &mdash; {t('quantity', 'Quantity').toUpperCase()}</span>{' '}
+                            {medication?.order?.quantity}
+                          </span>
+                        ) : null}
+                        {medication?.order?.dateStopped ? (
+                          <span className={styles.bodyShort01}>
+                            <span className={styles.label01}>
+                              {medication?.order?.quantity ? ` — ` : ''} {t('endDate', 'End date').toUpperCase()}
+                            </span>{' '}
+                            {formatDate(new Date(medication?.order?.dateStopped))}
+                          </span>
+                        ) : null}
+                      </p>
+                    </div>
                   </div>
 
                   <p className={styles.metadata}>
-                    {formatTime(parseDate(medication?.order?.dateActivated))} &middot; {medication?.provider?.name},{' '}
-                    {medication?.provider?.role}
+                    {formatTime(parseDate(medication?.order?.dateActivated))}
+                    {medication?.provider?.name && <> &middot; {medication?.provider?.name}</>}
+                    {medication?.provider?.role && <>, {medication?.provider?.role}</>}
                   </p>
                 </React.Fragment>
               ),

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.scss
@@ -91,7 +91,7 @@
 
 .encounterEmptyState {
   text-align: center;
-  margin: 0 1rem 1rem 1rem; 
+  margin: 0 1rem 1rem 1rem;
 }
 
 .observation {
@@ -129,10 +129,12 @@
 
 .medicationRecord {
   display: flex;
-  flex-flow: row wrap;
-  align-items: center;
-  @include type.type-style('body-01');
-  color: $text-02;
+  flex-direction: column;
+  justify-content: space-between;
+
+  .bodyLong01 {
+    margin: 0.25rem 0;
+  }
 }
 
 .medicationContainer {
@@ -166,7 +168,7 @@
 .metadata {
   @include type.type-style('label-01');
   color: $text-02;
-  margin: spacing.$spacing-02 0;
+  margin: spacing.$spacing-03 0 spacing.$spacing-05;
 }
 
 .observationsEmptyState {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the medications UI in the visit summary dashboard to align them closer with the [designs](https://zeroheight.com/23a080e38/p/41d6df-data-tile).

## Screenshots

> Before

![CleanShot 2024-01-17 at 5  08 19@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/51b36f52-e4ed-4cfa-9adb-e42dbb456a59)

> After

![CleanShot 2024-01-17 at 10  43 55@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/29b78038-0033-49fa-b2eb-3c424f135fc6)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
