### PR TITLE
(fix) O3-2713: Fix positioning of side rail action badges

### DIFF
--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
@@ -43,8 +43,8 @@
     background-color: $danger;
     padding: 0 4px;
     border-radius: 50%;
-    top: -10px;
-    right: -10px;
+    top: -14px;
+    right: -12px;
   }
 
   .interruptedTag {

--- a/packages/esm-patient-immunizations-app/translations/km.json
+++ b/packages/esm-patient-immunizations-app/translations/km.json
@@ -11,7 +11,7 @@
   "pleaseSelect": "Please select",
   "recentVaccination": "Recent vaccination",
   "save": "Save",
-  "seeAll": "ឃើញ​ទាំងអស់",
+  "seeAll": "ឃើញ\u200bទាំងអស់",
   "sequence": "Sequence",
   "singleDoseOn": "Single Dose on",
   "vaccinationDate": "Vaccination date",

--- a/packages/esm-patient-immunizations-app/translations/km.json
+++ b/packages/esm-patient-immunizations-app/translations/km.json
@@ -11,7 +11,7 @@
   "pleaseSelect": "Please select",
   "recentVaccination": "Recent vaccination",
   "save": "Save",
-  "seeAll": "ឃើញ\u200bទាំងអស់",
+  "seeAll": "ឃើញ​ទាំងអស់",
   "sequence": "Sequence",
   "singleDoseOn": "Single Dose on",
   "vaccinationDate": "Vaccination date",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the positioning of alert badges shown for icon links in the side rail.

Design doc - https://zeroheight.com/23a080e38/p/948cf1-siderail-and-bottom-nav/b/86907e

## Screenshots
<!-- Required if you are making UI changes. -->

#### Before
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/53287480/97ab3f02-ea67-45ef-9006-c48cf30a047d)

#### Improvement
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/53287480/f31f5f54-47ac-4946-9a45-43efd6fcd84f)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
[O3-2713](https://openmrs.atlassian.net/browse/O3-2713)