### PR TITLE
(fix) O3-2715: make clinical forms workspace not maximizable

### DIFF
--- a/packages/esm-patient-forms-app/src/index.ts
+++ b/packages/esm-patient-forms-app/src/index.ts
@@ -56,7 +56,6 @@ export function startupApp() {
     title: translateFrom('@openmrs/esm-patient-forms-app', 'clinicalForms', 'Clinical Forms'),
     load: getAsyncLifecycle(() => import('./forms/forms-workspace.component'), options),
     type: 'clinical-form',
-    canMaximize: true,
     width: 'wider',
   });
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
See [this ticket](https://openmrs.atlassian.net/browse/O3-2715). We want the Forms Dashboard workspace to not be maximiable.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/openmrs/openmrs-esm-patient-chart/assets/509602/0db5debf-6aa3-475d-8aa1-04d297a10d8d


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->