### PR TITLE
(feat) Require a visit to launch the visit notes form

### DIFF
--- a/packages/esm-patient-notes-app/src/visit-note-action-button.component.tsx
+++ b/packages/esm-patient-notes-app/src/visit-note-action-button.component.tsx
@@ -1,12 +1,12 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pen } from '@carbon/react/icons';
-import { launchPatientWorkspace, SiderailNavButton } from '@openmrs/esm-patient-common-lib';
+import { SiderailNavButton, useLaunchWorkspaceRequiringVisit } from '@openmrs/esm-patient-common-lib';
 
 const VisitNoteActionButton: React.FC = () => {
   const { t } = useTranslation();
 
-  const handleClick = useCallback(() => launchPatientWorkspace('visit-notes-form-workspace'), []);
+  const launchVisitNotesWorkspace = useLaunchWorkspaceRequiringVisit('visit-notes-form-workspace');
 
   return (
     <SiderailNavButton
@@ -14,7 +14,7 @@ const VisitNoteActionButton: React.FC = () => {
       getIcon={(props) => <Pen {...props} />}
       label={t('visitNote', 'Visit note')}
       iconDescription={t('note', 'Note')}
-      handler={handleClick}
+      handler={launchVisitNotesWorkspace}
       type={'visit-note'}
     />
   );

--- a/packages/esm-patient-notes-app/src/visit-note-action-button.test.tsx
+++ b/packages/esm-patient-notes-app/src/visit-note-action-button.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useLayoutType } from '@openmrs/esm-framework';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { type LayoutType, useLayoutType } from '@openmrs/esm-framework';
+import { useLaunchWorkspaceRequiringVisit, useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
 import VisitNoteActionButton from './visit-note-action-button.component';
 
-const mockedUseLayoutType = useLayoutType as jest.Mock;
+const mockedUseLayoutType = jest.mocked(useLayoutType);
+const mockUseLaunchWorkspaceRequiringVisit = jest.mocked(useLaunchWorkspaceRequiringVisit);
 
 jest.mock('@carbon/react/icons', () => ({
   ...(jest.requireActual('@carbon/react/icons') as jest.Mock),
@@ -18,6 +19,8 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   return {
     ...originalModule,
     launchPatientWorkspace: jest.fn(),
+    useVisitOrOfflineVisit: jest.fn().mockReturnValue({ currentVisit: null }),
+    useLaunchWorkspaceRequiringVisit: jest.fn(),
   };
 });
 
@@ -43,14 +46,14 @@ describe('VisitNoteActionButton', () => {
 
     await user.click(visitNoteButton);
 
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('visit-notes-form-workspace');
+    expect(mockUseLaunchWorkspaceRequiringVisit).toHaveBeenCalledWith('visit-notes-form-workspace');
     expect(visitNoteButton).toHaveClass('active');
   });
 
   it('should display desktop view', async () => {
     const user = userEvent.setup();
 
-    mockedUseLayoutType.mockReturnValue('desktop');
+    mockedUseLayoutType.mockReturnValue('desktop' as LayoutType);
 
     render(<VisitNoteActionButton />);
 
@@ -60,7 +63,7 @@ describe('VisitNoteActionButton', () => {
 
     await user.click(visitNoteButton);
 
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('visit-notes-form-workspace');
+    expect(mockUseLaunchWorkspaceRequiringVisit).toHaveBeenCalledWith('visit-notes-form-workspace');
     expect(visitNoteButton).toHaveClass('active');
   });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

This just makes it so that you require an active visit to launch the Visit Notes form. Visit notes ought to be tied to a visit, which is the rationale behind this change. This also aligns the Visit Notes workspace behaviour with that of the Clinical Forms and the Order Basket workspaces.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/7b72441b-e705-4d21-a972-25aa6a7de3c9

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
