### PR TITLE
(fix) O3-2763: Fixed form page height

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
@@ -21,15 +21,14 @@
       "
       class="form-container"
     >
-      <div>
-        <form class="cds--form no-padding" *ngIf="form" [formGroup]="form.rootNode.control">
-          <ofe-form-renderer
-            [formSubmissionTemplate]="buttonsTemplate"
-            [labelMap]="labelMap"
-            [node]="form.rootNode"
-          ></ofe-form-renderer>
-        </form>
-      </div>
+      <form class="cds--form no-padding" *ngIf="form" [formGroup]="form.rootNode.control">
+        <ofe-form-renderer
+          [formSubmissionTemplate]="buttonsTemplate"
+          [labelMap]="labelMap"
+          [node]="form.rootNode"
+          class="form-renderer"
+        ></ofe-form-renderer>
+      </form>
       <ng-template #buttonsTemplate>
         <div *ngIf="showDiscardSubmitButtons" class="saveAndCloseButtons">
           <button

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.scss
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.scss
@@ -113,6 +113,15 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+
+  & > .cds--form {
+    height: inherit;
+  }
+}
+
+.form-renderer {
+  display: block;
+  height: inherit;
 }
 
 .button-set {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
In cases where the form contains only one or several fields and the last of them is a multi-select, the dropdown is cut off and an unnecessary scroll appears. This PR prevents form page collapsing.

### STR on Dev3
Open the `Repeating Sample Form `/ `Second Page`

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/17073192/10da237e-6cf3-4ed6-aee4-6ba7428477b0)
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/17073192/0a960138-3f3d-4ad0-8486-6fecf34e5250)

## Related Issue
[O3-2763](https://openmrs.atlassian.net/browse/O3-2763)

## Other
[Related PR](https://github.com/openmrs/openmrs-ngx-formentry/pull/122)
