### PR TITLE
(feat) Specify upload size limit and supported file types in file uploader

### DIFF
--- a/packages/esm-patient-attachments-app/src/attachments-config-schema.ts
+++ b/packages/esm-patient-attachments-app/src/attachments-config-schema.ts
@@ -3,6 +3,6 @@ export const attachmentsConfigSchema = {
   fileSize: {
     _type: Type.Number,
     _description: 'Max file size limit to upload (in MB)',
-    _default: 10,
+    _default: 1,
   },
 };

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ContentSwitcher, Loading, Switch } from '@carbon/react';
+import { List, Thumbnail_2, Add } from '@carbon/react/icons';
 import {
   type UploadedFile,
   type Attachment,
@@ -18,7 +19,6 @@ import AttachmentsGridOverview from './attachments-grid-overview.component';
 import AttachmentsTableOverview from './attachments-table-overview.component';
 import AttachmentPreview from './image-preview.component';
 import styles from './attachments-overview.scss';
-import { List, Thumbnail_2, Add } from '@carbon/react/icons';
 
 const AttachmentsOverview: React.FC<{ patientUuid: string }> = ({ patientUuid }) => {
   const { t } = useTranslation();
@@ -52,6 +52,7 @@ const AttachmentsOverview: React.FC<{ patientUuid: string }> = ({ patientUuid })
       onCompletion: () => mutate(),
       multipleFiles: true,
       collectDescription: true,
+      allowedExtensions: ['image/jpeg', 'image/png', 'image/webp'],
     });
   }, [patientUuid, mutate]);
 

--- a/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/image-preview.component.tsx
@@ -57,6 +57,7 @@ const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
         <div className={styles.overflowMenu}>
           <OverflowMenu className={styles.overflowMenu} flipped size={isTablet ? 'lg' : 'md'}>
             <OverflowMenuItem
+              className={styles.menuItem}
               hasDivider
               isDelete
               itemText={t('deleteImage', 'Delete image')}

--- a/packages/esm-patient-attachments-app/src/attachments/image-preview.scss
+++ b/packages/esm-patient-attachments-app/src/attachments/image-preview.scss
@@ -26,14 +26,6 @@
   color: $ui-01;
 }
 
-.closePreviewButton  {
-  display: flex;
-  flex-direction: column;
-  align-content: center;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
 .closePreviewButton > svg > path {
   fill: $ui-01 !important;
 }
@@ -70,4 +62,8 @@
 
 .imageDescription {
   margin-top: spacing.$spacing-03;
+}
+
+.menuItem {
+  max-width: none;
 }

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/media-uploader.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/media-uploader.component.tsx
@@ -45,9 +45,10 @@ const MediaUploaderComponent = () => {
   return (
     <div className="cds--file__container">
       <p className="cds--label-description">
-        {t('fileUploadSizeConstraints', 'File limit is {{fileSize}}MB', {
+        {t('fileUploadSizeConstraints', 'Size limit is {{fileSize}}MB', {
           fileSize,
         })}
+        . {t('supportedFileTypes', 'Supported file types are: JPEG, PNG, and WEBP')}.
       </p>
       <div className={styles.uploadFile}>
         <FileUploaderDropContainer

--- a/packages/esm-patient-attachments-app/translations/am.json
+++ b/packages/esm-patient-attachments-app/translations/am.json
@@ -35,6 +35,7 @@
   "imageDescription": "Image description",
   "name": "name",
   "successfullyDeleted": "successfully deleted",
+  "supportedFileTypes": "Supported file types are: JPEG, PNG, and WEBP",
   "type": "Type",
   "uploadComplete": "Upload complete",
   "uploadedSuccessfully": "uploaded successfully",

--- a/packages/esm-patient-attachments-app/translations/ar.json
+++ b/packages/esm-patient-attachments-app/translations/ar.json
@@ -35,6 +35,7 @@
   "imageDescription": "وصف الصورة",
   "name": "الاسم",
   "successfullyDeleted": "تم الحذف بنجاح",
+  "supportedFileTypes": "Supported file types are: JPEG, PNG, and WEBP",
   "type": "النوع",
   "uploadComplete": "اكتمل التحميل",
   "uploadedSuccessfully": "تم التحميل بنجاح",

--- a/packages/esm-patient-attachments-app/translations/en.json
+++ b/packages/esm-patient-attachments-app/translations/en.json
@@ -35,6 +35,7 @@
   "imageDescription": "Image description",
   "name": "name",
   "successfullyDeleted": "successfully deleted",
+  "supportedFileTypes": "Supported file types are: JPEG, PNG, and WEBP",
   "type": "Type",
   "uploadComplete": "Upload complete",
   "uploadedSuccessfully": "uploaded successfully",

--- a/packages/esm-patient-attachments-app/translations/es.json
+++ b/packages/esm-patient-attachments-app/translations/es.json
@@ -35,6 +35,7 @@
   "imageDescription": "Descripción de imagen",
   "name": "nombre",
   "successfullyDeleted": "eliminado con éxito",
+  "supportedFileTypes": "Supported file types are: JPEG, PNG, and WEBP",
   "type": "Tipo",
   "uploadComplete": "Carga completa",
   "uploadedSuccessfully": "cargado con éxito",

--- a/packages/esm-patient-attachments-app/translations/fr.json
+++ b/packages/esm-patient-attachments-app/translations/fr.json
@@ -35,6 +35,7 @@
   "imageDescription": "Description de l'image",
   "name": "Nom",
   "successfullyDeleted": "Supprimé avec succès",
+  "supportedFileTypes": "Supported file types are: JPEG, PNG, and WEBP",
   "type": "Type",
   "uploadComplete": "Téléchargement terminé",
   "uploadedSuccessfully": "téléchargé avec succès",

--- a/packages/esm-patient-attachments-app/translations/he.json
+++ b/packages/esm-patient-attachments-app/translations/he.json
@@ -35,6 +35,7 @@
   "imageDescription": "תיאור התמונה",
   "name": "שם",
   "successfullyDeleted": "נמחק בהצלחה",
+  "supportedFileTypes": "Supported file types are: JPEG, PNG, and WEBP",
   "type": "סוג",
   "uploadComplete": "ההעלאה הושלמה",
   "uploadedSuccessfully": "הועלה בהצלחה",

--- a/packages/esm-patient-attachments-app/translations/km.json
+++ b/packages/esm-patient-attachments-app/translations/km.json
@@ -35,6 +35,7 @@
   "imageDescription": "ការពិពណ៌នារូបភាព",
   "name": "ឈ្មោះ",
   "successfullyDeleted": "បានលុបចោលដោយជោគជ័យ",
+  "supportedFileTypes": "Supported file types are: JPEG, PNG, and WEBP",
   "type": "ប្រភេទ",
   "uploadComplete": "ការបង្ហោះបានបញ្ចប់",
   "uploadedSuccessfully": "បង្ហោះដោយជោគជ័យ",

--- a/packages/esm-patient-attachments-app/translations/zh.json
+++ b/packages/esm-patient-attachments-app/translations/zh.json
@@ -35,6 +35,7 @@
   "imageDescription": "图像描述",
   "name": "name",
   "successfullyDeleted": "删除成功",
+  "supportedFileTypes": "Supported file types are: JPEG, PNG, and WEBP",
   "type": "类型",
   "uploadComplete": "上传完成",
   "uploadedSuccessfully": "上传成功",

--- a/packages/esm-patient-attachments-app/translations/zh_CN.json
+++ b/packages/esm-patient-attachments-app/translations/zh_CN.json
@@ -35,6 +35,7 @@
   "imageDescription": "图像描述",
   "name": "name",
   "successfullyDeleted": "删除成功",
+  "supportedFileTypes": "Supported file types are: JPEG, PNG, and WEBP",
   "type": "类型",
   "uploadComplete": "上传完成",
   "uploadedSuccessfully": "上传成功",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR is a follow-up to https://github.com/openmrs/openmrs-esm-patient-chart/pull/1522. It tweaks the file uploader UI in the following ways:

- Sets the max file upload size limit to 1 MB (the related global property, `attachments.maxStorageFileSize` caps the limit at 1.2 MBs, but I felt that that is an awkward value to show in the UI)

	![attachment-upload-global-properties](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/1c9c4675-9f6f-47fc-b47a-3a5f14ae3216)

- Shows information about the accepted file types in the File Uploader modal (JPEG, PNG, and WEBP)
- Sets the `allowedExtensions` array of the uploader's context to `['image/jpeg', 'image/png', 'image/webp']` so that the uploader knows to only show files matching those extensions in the upload UI. Files that don't match will be blurred out and incapable of being selected.
- Fixes an issue with the sizing of the ImagePreview component's `Close` button and the `Delete image` overflow menu item (which I now realize does not need to be an overflow menu that has only one option. It should probably be a button instead). 

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/803a95a6-696a-41cb-8ce0-c795ff879349

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
