### PR TITLE
(feat) Add ResponsiveWrapper to common lib

### DIFF
--- a/packages/esm-patient-common-lib/src/index.ts
+++ b/packages/esm-patient-common-lib/src/index.ts
@@ -22,3 +22,4 @@ export * from './useVitalsConceptMetadata';
 export * from './workspaces';
 export * from './siderail-nav-button';
 export * from './form-entry-interop';
+export * from './responsive-wrapper';

--- a/packages/esm-patient-common-lib/src/responsive-wrapper/index.ts
+++ b/packages/esm-patient-common-lib/src/responsive-wrapper/index.ts
@@ -1,0 +1,1 @@
+export * from './responsive-wrapper.component';

--- a/packages/esm-patient-common-lib/src/responsive-wrapper/responsive-wrapper.component.tsx
+++ b/packages/esm-patient-common-lib/src/responsive-wrapper/responsive-wrapper.component.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Layer } from '@carbon/react';
+import { useLayoutType } from '@openmrs/esm-framework';
+
+type ResponsiveWrapperProps = {
+  children: React.ReactNode;
+};
+
+/**
+ * ResponsiveWrapper enables a responsive behavior for the component its wraps, providing a different rendering based on the current layout type.
+ * On desktop, it renders the children as is, while on a tablet, it wraps them in a Carbon Layer https://react.carbondesignsystem.com/?path=/docs/components-layer--overview component.
+ * This provides a light background for form inputs on tablets, in accordance with the design requirements.
+ */
+export default function ResponsiveWrapper({ children }: ResponsiveWrapperProps) {
+  const layout = useLayoutType();
+  const isTablet = layout === 'tablet';
+
+  if (isTablet) {
+    return <Layer>{children}</Layer>;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds a `ResponsiveWrapper` component to common-lib that makes it easier to provide responsive behaviour for form inputs. In our [form designs](https://zeroheight.com/23a080e38/p/448ac6-vitals-input), inputs have a light background on tablet and a grey background on desktop. This component wraps its children within a Carbon [Layer](https://react.carbondesignsystem.com/?path=/docs/components-layer--overview) component on tablet, and renders them as is on desktop. In older versions of carbon, form inputs such as `TextInput`, `NumberInput` and `Textarea` exposed a `light` prop that could be used to toggle similar behaviour. v11 of Carbon deprecated the `light` prop in favour of the `Layer` component. This component leverages `Layer` to provide consistent rendering behaviour on both desktop and tablet.

## Screenshots

### Light inputs on tablet, gray inputs on desktop

![CleanShot 2024-01-26 at 12  54 46@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/eb250563-9612-436c-b585-4dbdb26467fc)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
