### PR TITLE
(fix) Remove direct dependency between common lib and forms apps

### DIFF
--- a/packages/esm-patient-common-lib/src/form-entry-interop.ts
+++ b/packages/esm-patient-common-lib/src/form-entry-interop.ts
@@ -1,7 +1,14 @@
-import { OpenmrsResource, navigate } from '@openmrs/esm-framework';
-import type { HtmlFormEntryForm } from '@openmrs/esm-patient-forms-app/src/config-schema';
+import { navigate } from '@openmrs/esm-framework';
 import isEmpty from 'lodash-es/isEmpty';
 import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
+
+interface HtmlFormEntryForm {
+  formUuid: string;
+  formName: string;
+  formUiResource: string;
+  formUiPage: 'enterHtmlFormWithSimpleUi' | 'enterHtmlFormWithStandardUi';
+  formEditUiPage: 'editHtmlFormWithSimpleUi' | 'editHtmlFormWithStandardUi';
+}
 
 export function launchFormEntryOrHtmlForms(
   htmlFormEntryForms: Array<HtmlFormEntryForm>,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This removes a direct dependency between `esm-patient-forms-app` and `esm-patient-common-lib` where common lib was importing a type annotation from the forms app. I've just redeclared the type annotation in the library.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
