### PR TITLE
(fix) DateActivation not being sent from the frontend

### DIFF
--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -1,5 +1,5 @@
 import useSWR, { mutate } from 'swr';
-import { type FetchResponse, openmrsFetch, toOmrsIsoString, useConfig } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, useConfig } from '@openmrs/esm-framework';
 import { type ConfigObject } from '../config-schema';
 import { useCallback, useMemo } from 'react';
 import { type OrderPost, type PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';
@@ -84,7 +84,6 @@ export function prepMedicationOrderPostData(
       dosingInstructions: order.isFreeTextDosage ? order.freeTextDosage : order.patientInstructions,
       concept: order.drug.concept.uuid,
       orderReasonNonCoded: order.indication,
-      dateActivated: toOmrsIsoString(new Date()),
     };
   } else if (order.action === 'REVISE') {
     return {
@@ -113,7 +112,6 @@ export function prepMedicationOrderPostData(
       dosingInstructions: order.isFreeTextDosage ? order.freeTextDosage : order.patientInstructions,
       concept: order.drug.concept.uuid,
       orderReasonNonCoded: order.indication,
-      dateActivated: toOmrsIsoString(new Date()),
     };
   } else if (order.action === 'DISCONTINUE') {
     return {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The `dateActivated` will not be sent to the server from the frontend, since the date & time of the user's computer might not be in sync properly. The `dateActivated` is added by the server and hence the check for the time sent by the FE if it is in future.

One user case is explained here:
The user’s computer is actually out of sync with the real time, which is in future with real time. Whenever the user places a new order, we send the dateActivation in the order payload to the server, which is the current date and time of the user, called by new Date, which is actually a few ms ahead of the real time.
Now, when this payload is received at the server, for the server, the dateActivation is actually in future of the server’s time, and hence the server throws an error saying “Date activation cannot be in the future”.
Another solution we tried is that the user can shift their clock a few minutes back, and then the user can try saving the order.
Now, whenever the order is placed, first an encounter is created and after the encounter is created, the order is placed. Now the dateActivation being few minutes back, the same dateActivation conflicts with the encounterDatetime which is set by the server, hence throwing the error: “Date Activation cannot be before the encounter Date time”.
So the time precision required is very close.

## Screenshots



https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/345787d4-b513-40de-b9eb-f48c97428ff0



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
