### PR TITLE
(feat) O3-2782: Show an inline notification for camera access errors in the add attachment modal

### DIFF
--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader.component.tsx
@@ -1,47 +1,36 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef, useContext } from 'react';
-import { type UploadedFile, type FetchResponse, showSnackbar } from '@openmrs/esm-framework';
-import CameraMediaUploaderContext from './camera-media-uploader-context.resources';
 import { useTranslation } from 'react-i18next';
+import { Tabs, Tab, TabList, TabPanels, TabPanel, ModalHeader, ModalBody, InlineNotification } from '@carbon/react';
+import { type FetchResponse, type UploadedFile } from '@openmrs/esm-framework';
 import CameraComponent from './camera.component';
-import styles from './camera-media-uploader.scss';
-import { Tabs, Tab, TabList, TabPanels, TabPanel, ModalHeader, ModalBody } from '@carbon/react';
-import MediaUploaderComponent from './media-uploader.component';
+import CameraMediaUploaderContext from './camera-media-uploader-context.resources';
 import FileReviewContainer from './file-review.component';
+import MediaUploaderComponent from './media-uploader.component';
 import UploadingStatusComponent from './uploading-status.component';
+import styles from './camera-media-uploader.scss';
 
 interface CameraMediaUploaderModalProps {
-  multipleFiles?: boolean;
-  cameraOnly?: boolean;
-  collectDescription?: boolean;
-  saveFile: (file: UploadedFile) => Promise<FetchResponse<any>>;
-  closeModal: () => void;
-  onCompletion?: () => void;
   allowedExtensions: Array<string> | null;
+  cameraOnly?: boolean;
+  closeModal: () => void;
+  collectDescription?: boolean;
+  multipleFiles?: boolean;
+  onCompletion?: () => void;
+  saveFile: (file: UploadedFile) => Promise<FetchResponse<any>>;
 }
 
 const CameraMediaUploaderModal: React.FC<CameraMediaUploaderModalProps> = ({
-  cameraOnly,
-  multipleFiles,
-  collectDescription,
-  saveFile,
-  closeModal,
-  onCompletion,
   allowedExtensions,
+  cameraOnly,
+  closeModal,
+  collectDescription,
+  multipleFiles,
+  onCompletion,
+  saveFile,
 }) => {
-  const [error, setError] = useState<Error>(undefined);
+  const [error, setError] = useState<Error>(null);
   const [filesToUpload, setFilesToUpload] = useState<Array<UploadedFile>>([]);
   const [uploadFilesToServer, setUploadFilesToServer] = useState(false);
-  const { t } = useTranslation();
-
-  useEffect(() => {
-    if (error) {
-      showSnackbar({
-        subtitle: error.message,
-        kind: 'error',
-        title: t('cameraError', 'Camera Error'),
-      });
-    }
-  }, [error, t]);
 
   const handleTakePhoto = useCallback((file: string) => {
     setFilesToUpload([
@@ -106,7 +95,7 @@ const CameraMediaUploaderModal: React.FC<CameraMediaUploaderModalProps> = ({
 const CameraMediaUploadTabs = () => {
   const { t } = useTranslation();
   const [view, setView] = useState('upload');
-  const { cameraOnly, closeModal } = useContext(CameraMediaUploaderContext);
+  const { cameraOnly, closeModal, error } = useContext(CameraMediaUploaderContext);
   const mediaStream = useRef<MediaStream | undefined>();
 
   const stopCameraStream = useCallback(() => {
@@ -134,6 +123,15 @@ const CameraMediaUploadTabs = () => {
           </TabList>
           <TabPanels>
             <TabPanel>
+              {error ? (
+                <InlineNotification
+                  subtitle={t(
+                    'cameraAccessErrorMessage',
+                    'Please enable camera access in your browser settings and try again.',
+                  )}
+                  title={t('cameraError', 'Camera error')}
+                />
+              ) : null}
               {view === 'camera' && <CameraComponent mediaStream={mediaStream} stopCameraStream={stopCameraStream} />}
             </TabPanel>
             <TabPanel>

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/camera.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/camera.component.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect, useContext, type MutableRefObject } from 'react';
+import React, { useCallback, useEffect, useContext, type MutableRefObject } from 'react';
 import Camera from 'react-html5-camera-photo';
 import CameraMediaUploaderContext from './camera-media-uploader-context.resources';
 import 'react-html5-camera-photo/build/css/index.css';
@@ -29,6 +29,7 @@ const CameraComponent: React.FC<CameraComponentProps> = ({ mediaStream, stopCame
       onCameraStart={setMediaStream}
       onCameraStop={stopCameraStream}
       onCameraError={setError}
+      isDisplayStartCameraError={false}
     />
   );
 };

--- a/packages/esm-patient-attachments-app/translations/am.json
+++ b/packages/esm-patient-attachments-app/translations/am.json
@@ -10,6 +10,7 @@
   "Attachments": "Attachments",
   "attachmentsInLowerCase": "attachments",
   "attachmentsInProperFormat": "Attachments",
+  "cameraAccessErrorMessage": "Please enable camera access in your browser settings and try again.",
   "cameraError": "Camera Error",
   "cancel": "Cancel",
   "changeImage": "Change image",

--- a/packages/esm-patient-attachments-app/translations/ar.json
+++ b/packages/esm-patient-attachments-app/translations/ar.json
@@ -10,6 +10,7 @@
   "Attachments": "المرفقات",
   "attachmentsInLowerCase": "attachments",
   "attachmentsInProperFormat": "Attachments",
+  "cameraAccessErrorMessage": "Please enable camera access in your browser settings and try again.",
   "cameraError": "خطأ في الكاميرا",
   "cancel": "إلغاء",
   "changeImage": "غير الصورة",

--- a/packages/esm-patient-attachments-app/translations/en.json
+++ b/packages/esm-patient-attachments-app/translations/en.json
@@ -10,6 +10,7 @@
   "Attachments": "Attachments",
   "attachmentsInLowerCase": "attachments",
   "attachmentsInProperFormat": "Attachments",
+  "cameraAccessErrorMessage": "Please enable camera access in your browser settings and try again.",
   "cameraError": "Camera Error",
   "cancel": "Cancel",
   "changeImage": "Change image",

--- a/packages/esm-patient-attachments-app/translations/es.json
+++ b/packages/esm-patient-attachments-app/translations/es.json
@@ -10,6 +10,7 @@
   "Attachments": "Archivos adjuntos",
   "attachmentsInLowerCase": "attachments",
   "attachmentsInProperFormat": "Attachments",
+  "cameraAccessErrorMessage": "Please enable camera access in your browser settings and try again.",
   "cameraError": "Error de cámara",
   "cancel": "Cancelar",
   "changeImage": "Cambiar imagen",

--- a/packages/esm-patient-attachments-app/translations/fr.json
+++ b/packages/esm-patient-attachments-app/translations/fr.json
@@ -10,6 +10,7 @@
   "Attachments": "Pièces jointes",
   "attachmentsInLowerCase": "attachments",
   "attachmentsInProperFormat": "Attachments",
+  "cameraAccessErrorMessage": "Please enable camera access in your browser settings and try again.",
   "cameraError": "Erreur avec l'appareil photo",
   "cancel": "Annuller",
   "changeImage": "Changer l'image",

--- a/packages/esm-patient-attachments-app/translations/he.json
+++ b/packages/esm-patient-attachments-app/translations/he.json
@@ -10,6 +10,7 @@
   "Attachments": "קבצים מצורפים",
   "attachmentsInLowerCase": "קבצים מצורפים",
   "attachmentsInProperFormat": "קבצים מצורפים",
+  "cameraAccessErrorMessage": "Please enable camera access in your browser settings and try again.",
   "cameraError": "שגיאת מצלמה",
   "cancel": "ביטול",
   "changeImage": "שנה תמונה",

--- a/packages/esm-patient-attachments-app/translations/km.json
+++ b/packages/esm-patient-attachments-app/translations/km.json
@@ -10,6 +10,7 @@
   "Attachments": "ឯកសារភ្ជាប់",
   "attachmentsInLowerCase": "ឯកសារភ្ជាប់",
   "attachmentsInProperFormat": "ឯកសារភ្ជាប់",
+  "cameraAccessErrorMessage": "Please enable camera access in your browser settings and try again.",
   "cameraError": "កំហុសកាមេរ៉ា",
   "cancel": "បោះបង់",
   "changeImage": "ផ្លាស់ប្តូររូបភាព",

--- a/packages/esm-patient-attachments-app/translations/zh.json
+++ b/packages/esm-patient-attachments-app/translations/zh.json
@@ -10,6 +10,7 @@
   "Attachments": "附件",
   "attachmentsInLowerCase": "附件",
   "attachmentsInProperFormat": "附件",
+  "cameraAccessErrorMessage": "Please enable camera access in your browser settings and try again.",
   "cameraError": "相机错误",
   "cancel": "取消",
   "changeImage": "更改图像",

--- a/packages/esm-patient-attachments-app/translations/zh_CN.json
+++ b/packages/esm-patient-attachments-app/translations/zh_CN.json
@@ -10,6 +10,7 @@
   "Attachments": "附件",
   "attachmentsInLowerCase": "附件",
   "attachmentsInProperFormat": "附件",
+  "cameraAccessErrorMessage": "Please enable camera access in your browser settings and try again.",
   "cameraError": "相机错误",
   "cancel": "取消",
   "changeImage": "更改图像",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds an inline notification when user has camera disabled when adding attachments by camera, or any other camera errors

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/53287480/b8b8bae7-d7c9-4768-a3b9-07799874014d)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2782](https://openmrs.atlassian.net/browse/O3-2782)

## Other
<!-- Anything not covered above -->
