### PR TITLE
(feat) allergies detail widget should span 4 columns by default

### DIFF
--- a/packages/esm-patient-allergies-app/src/routes.json
+++ b/packages/esm-patient-allergies-app/src/routes.json
@@ -20,7 +20,7 @@
       "online": true,
       "offline": true,
       "meta": {
-        "columnSpan": 1
+        "columnSpan": 4
       }
     },
     {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Adjusted `columnSpan` for the allergies widget to use full width in `patient-chart-summary-slot`. Uncertain if existing configs allow overriding this. Feedback or confirmation on configurability from @ibacher and @denniskigen would be appreciated.

## Screenshots
![Screenshot 2024-02-01 at 17 36 25](https://github.com/openmrs/openmrs-esm-patient-chart/assets/28008754/e107a012-e39d-41d7-8327-df21c6229b55)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
