### PR TITLE
(fix) Saving the medication should not send the dateActivated in the payload

### DIFF
--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -84,7 +84,6 @@ export function prepMedicationOrderPostData(
       dosingInstructions: order.isFreeTextDosage ? order.freeTextDosage : order.patientInstructions,
       concept: order.drug.concept.uuid,
       orderReasonNonCoded: order.indication,
-      dateActivated: toOmrsIsoString(new Date()),
     };
   } else if (order.action === 'REVISE') {
     return {
@@ -113,7 +112,6 @@ export function prepMedicationOrderPostData(
       dosingInstructions: order.isFreeTextDosage ? order.freeTextDosage : order.patientInstructions,
       concept: order.drug.concept.uuid,
       orderReasonNonCoded: order.indication,
-      dateActivated: toOmrsIsoString(new Date()),
     };
   } else if (order.action === 'DISCONTINUE') {
     return {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Saving a medication should not send the `dateActivated` in the payload, since the request seems to be failing if the time in the user's computer is not synced properly.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/adbb8380-27a9-4baa-9f58-74360383973f



## Related Issue
None

## Other
None
