### PR TITLE
(fix) O3-2807: Quantity units default to dose unit when the quantity is not zero

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -166,6 +166,10 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel }: Drug
     },
   });
 
+  const {
+    field: { onChange: dispensingUnitsOnChange },
+  } = useController<MedicationOrderFormData>({ name: 'quantityUnits', control });
+
   const routeValue = watch('route')?.value;
   const unitValue = watch('unit')?.value;
   const dosage = watch('dosage');
@@ -368,6 +372,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel }: Drug
                         control={control}
                         name="unit"
                         type="comboBox"
+                        dispensingUnitsOnChange={dispensingUnitsOnChange}
                         size={isTablet ? 'lg' : 'md'}
                         id="dosingUnits"
                         items={drugDosingUnits}
@@ -732,16 +737,32 @@ const ControlledFieldInput = ({ name, control, type, ...restProps }) => {
       );
 
     if (type === 'comboBox')
-      return (
-        <ComboBox
-          selectedItem={value}
-          onChange={({ selectedItem }) => onChange(selectedItem)}
-          onBlur={onBlur}
-          ref={ref}
-          className={fieldState?.error?.message && styles.fieldError}
-          {...restProps}
-        />
-      );
+      if (name === 'unit') {
+        return (
+          <ComboBox
+            selectedItem={value}
+            onChange={({ selectedItem }) => {
+              onChange(selectedItem);
+              restProps.dispensingUnitsOnChange?.(selectedItem);
+            }}
+            onBlur={onBlur}
+            ref={ref}
+            className={fieldState?.error?.message && styles.fieldError}
+            {...restProps}
+          />
+        );
+      }
+
+    return (
+      <ComboBox
+        selectedItem={value}
+        onChange={({ selectedItem }) => onChange(selectedItem)}
+        onBlur={onBlur}
+        ref={ref}
+        className={fieldState?.error?.message && styles.fieldError}
+        {...restProps}
+      />
+    );
 
     return null;
   }, [fieldState?.error?.message, onBlur, onChange, ref, restProps, type, value]);

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -372,6 +372,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel }: Drug
                         control={control}
                         name="unit"
                         type="comboBox"
+                        watch={watch}
                         dispensingUnitsOnChange={dispensingUnitsOnChange}
                         size={isTablet ? 'lg' : 'md'}
                         id="dosingUnits"
@@ -743,7 +744,10 @@ const ControlledFieldInput = ({ name, control, type, ...restProps }) => {
             selectedItem={value}
             onChange={({ selectedItem }) => {
               onChange(selectedItem);
-              restProps.dispensingUnitsOnChange?.(selectedItem);
+              const dispensingQuantity = restProps.watch?.('pillsDispensed');
+              if (dispensingQuantity && Number(dispensingQuantity) > 0) {
+                restProps.dispensingUnitsOnChange?.(selectedItem);
+              }
             }}
             onBlur={onBlur}
             ref={ref}

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import capitalize from 'lodash-es/capitalize';
@@ -169,6 +169,16 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel }: Drug
   const {
     field: { onChange: dispensingUnitsOnChange },
   } = useController<MedicationOrderFormData>({ name: 'quantityUnits', control });
+  const {
+    field: { value: dispensingQuantity },
+  } = useController<MedicationOrderFormData>({ name: 'pillsDispensed', control });
+
+  useEffect(() => {
+    if (dispensingQuantity && Number(dispensingQuantity) > 0) {
+      const currentDosageUnit = watch('unit');
+      dispensingUnitsOnChange(currentDosageUnit);
+    }
+  }, [dispensingQuantity]);
 
   const routeValue = watch('route')?.value;
   const unitValue = watch('unit')?.value;


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
In the drug-order-form component, the dispensing quantity units will default to the dosage units if the quantity to be dispensed is greater than 0 while still giving the user the option to select their preferred quantity units. I attempt to achieve the result in two ways. Firstly changing the dosage units will trigger a corresponsing change in the quantity units but only if the quantity to be dispensed is not 0. Secondly, a change in the quantity to be dispensed to a value greater than 0 will trigger the quantity units to take on the value of the dosage units at the time. In both cases the user can still change the quantity units to a value other than the one defined in the dosing units.


## Related Issue
https://openmrs.atlassian.net/browse/O3-2807

## Other
<!-- Anything not covered above -->
