### PR TITLE
(fix) O3-2735: Display units for patient age in header

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -85,9 +85,7 @@ const PatientInfo: React.FC<PatientInfoProps> = ({ patient }) => {
           label={
             <>
               <p className={styles.tooltipPatientName}>{name}</p>
-              <p className={styles.tooltipPatientInfo}>{`${parseInt(age(patient?.birthDate))}, ${getGender(
-                patient?.gender,
-              )}`}</p>
+              <p className={styles.tooltipPatientInfo}>{`${age(patient?.birthDate)}, ${getGender(patient?.gender)}`}</p>
             </>
           }
         >
@@ -98,9 +96,7 @@ const PatientInfo: React.FC<PatientInfoProps> = ({ patient }) => {
       ) : (
         <span className={styles.patientName}>{name} </span>
       )}
-      <span className={styles.patientInfo}>
-        {parseInt(age(patient.birthDate))}, {getGender(patient.gender)}
-      </span>
+      <span className={styles.patientInfo}>{`${age(patient?.birthDate)}, ${getGender(patient?.gender)}`}</span>
       {queueEntry && (
         <>
           <div className={styles.navDivider} />


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
 - Patients header is rendered according to the patient's age in terms of years, months and weeks.
 - Optional chaining is added in `birthdate` and `gender`.

## Screenshots
> Before
<img width="1440" alt="Screenshot 2024-02-05 at 8 40 58 PM" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/94985341/d7fe4b4e-4a41-453a-a638-499ed06a689e">

> After 

https://github.com/openmrs/openmrs-esm-patient-chart/assets/94985341/e1248b17-de01-4fb3-98fa-5ddebf356dea




## Related Issue

[O3-2735](https://openmrs.atlassian.net/browse/O3-2735)

## Other
parseInt `parses a value as a string and returns the first integer` is not required as we are registering patients with current age in integer or in terms of number of month( Not as a whole value )