### PR TITLE
(feat) Add infinite loading to the visits summary page

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -118,6 +118,11 @@ export const esmPatientChartSchema = {
       "Whether the visit location field in the Start Visit form should be view-only. If so, the visit location will always be set to the user's login location.",
     _default: false,
   },
+  numberOfVisitsToLoad: {
+    _type: Type.Number,
+    _description: 'The number of visits to load initially in the Visits Summary tab. Defaults to 5',
+    _default: 5,
+  },
 };
 export interface ChartConfig {
   offlineVisitTypeUuid: string;
@@ -140,4 +145,5 @@ export interface ChartConfig {
     name: string;
   };
   disableChangingVisitLocation: boolean;
+  numberOfVisitsToLoad: number;
 }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { InlineLoading, Tab, Tabs, TabList, TabPanel, TabPanels } from '@carbon/react';
+import { Button, InlineLoading, Tab, Tabs, TabList, TabPanel, TabPanels } from '@carbon/react';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { formatDatetime, parseDate, useConfig, ExtensionSlot } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import type { ChartConfig } from '../../config-schema';
-import { mapEncounters, useVisits } from './visit.resource';
+import { mapEncounters, useInfiniteVisits } from './visit.resource';
 import VisitsTable from './past-visits-components/visits-table';
 import VisitSummary from './past-visits-components/visit-summary.component';
 import styles from './visit-detail-overview.scss';
@@ -15,11 +15,13 @@ interface VisitOverviewComponentProps {
 
 function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentProps) {
   const { t } = useTranslation();
-  const { visits, isError, isLoading, mutateVisits } = useVisits(patientUuid);
+  const { visits, error, hasMore, isLoading, isValidating, mutateVisits, setSize, size } =
+    useInfiniteVisits(patientUuid);
   const { showAllEncountersTab } = useConfig<ChartConfig>();
+  const shouldLoadMore = size !== visits?.length;
 
   const visitsWithEncounters = visits
-    ?.filter((visit) => visit.encounters.length)
+    ?.filter((visit) => visit?.encounters?.length)
     ?.flatMap((visitWithEncounters) => {
       return mapEncounters(visitWithEncounters);
     });
@@ -43,38 +45,54 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
           <TabPanel>
             {isLoading ? (
               <InlineLoading description={`${t('loading', 'Loading')} ...`} role="progressbar" />
-            ) : isError ? (
-              <ErrorState headerTitle={t('visits', 'visits')} error={isError} />
+            ) : error ? (
+              <ErrorState headerTitle={t('visits', 'visits')} error={error} />
             ) : visits?.length ? (
-              visits.map((visit, i) => (
-                <div className={styles.container} key={i}>
-                  <div className={styles.header}>
-                    <div className={styles.visitInfo}>
-                      <div>
-                        <h4 className={styles.visitType}>{visit?.visitType?.display}</h4>
-                        <div className={styles.displayFlex}>
-                          <h6 className={styles.dateLabel}>{t('start', 'Start')}:</h6>
-                          <span className={styles.date}>{formatDatetime(parseDate(visit?.startDatetime))}</span>
-                          {visit?.stopDatetime ? (
-                            <>
-                              <h6 className={styles.dateLabel}>{t('end', 'End')}:</h6>
-                              <span className={styles.date}>{formatDatetime(parseDate(visit?.stopDatetime))}</span>
-                            </>
-                          ) : null}
+              <>
+                {visits.map((visit, i) => (
+                  <div className={styles.container} key={i}>
+                    <div className={styles.header}>
+                      <div className={styles.visitInfo}>
+                        <div>
+                          <h4 className={styles.visitType}>{visit?.visitType?.display}</h4>
+                          <div className={styles.displayFlex}>
+                            <h6 className={styles.dateLabel}>{t('start', 'Start')}:</h6>
+                            <span className={styles.date}>{formatDatetime(parseDate(visit?.startDatetime))}</span>
+                            {visit?.stopDatetime ? (
+                              <>
+                                <h6 className={styles.dateLabel}>{t('end', 'End')}:</h6>
+                                <span className={styles.date}>{formatDatetime(parseDate(visit?.stopDatetime))}</span>
+                              </>
+                            ) : null}
+                          </div>
+                        </div>
+                        <div>
+                          <ExtensionSlot
+                            name="visit-detail-overview-actions"
+                            className={styles.visitDetailOverviewActions}
+                            state={{ patientUuid, visit }}
+                          />
                         </div>
                       </div>
-                      <div>
-                        <ExtensionSlot
-                          name="visit-detail-overview-actions"
-                          className={styles.visitDetailOverviewActions}
-                          state={{ patientUuid, visit }}
-                        />
-                      </div>
                     </div>
+                    <VisitSummary visit={visit} patientUuid={patientUuid} />
                   </div>
-                  <VisitSummary visit={visit} patientUuid={patientUuid} />
-                </div>
-              ))
+                ))}
+
+                {hasMore ? (
+                  <Button
+                    className={styles.loadMoreButton}
+                    disabled={isValidating && shouldLoadMore}
+                    onClick={() => setSize(size + 1)}
+                  >
+                    {isValidating && shouldLoadMore ? (
+                      <InlineLoading description={`${t('loading', 'Loading')} ...`} role="progressbar" />
+                    ) : (
+                      t('loadMore', 'Load more')
+                    )}
+                  </Button>
+                ) : null}
+              </>
             ) : (
               <EmptyState headerTitle={t('visits', 'visits')} displayText={t('Visits', 'Visits')} />
             )}
@@ -83,8 +101,8 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
             <TabPanel>
               {isLoading ? (
                 <InlineLoading description={`${t('loading', 'Loading')} ...`} role="progressbar" />
-              ) : isError ? (
-                <ErrorState headerTitle={t('visits', 'visits')} error={isError} />
+              ) : error ? (
+                <ErrorState headerTitle={t('visits', 'visits')} error={error} />
               ) : visits?.length ? (
                 <VisitsTable
                   mutateVisits={mutateVisits}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.scss
@@ -189,6 +189,16 @@
   align-items: center;
 }
 
+.loadMoreButton {
+  :global(.cds--inline-loading) {
+    min-height: 1rem !important;
+  }
+
+  :global(.cds--inline-loading__text) {
+    font-size: unset !important;
+  }
+}
+
 // Overriding styles for RTL support
 html[dir='rtl'] {
   .header {
@@ -199,4 +209,3 @@ html[dir='rtl'] {
     }
   }
 }
-

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@openmrs/esm-framework', () => {
     getVisitsForPatient: jest.fn(),
     createErrorHandler: jest.fn(),
     useLayoutType: jest.fn(),
-    // useConfig: jest.fn().mockImplementation(() => ({ showAllEncountersTab: true })),
+    useConfig: jest.fn().mockImplementation(() => ({ numberOfVisitsToLoad: 5 })),
     userHasAccess: jest.fn().mockImplementation((privilege, _) => (privilege ? false : true)),
     ExtensionSlot: jest.fn().mockImplementation((ext) => ext.name),
     useConnectedExtensions: jest.fn(() => []),

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -80,6 +80,7 @@
   "invalidVisitStopDate": "Visit stop date time cannot be on or before visit start date time",
   "loading": "Loading",
   "loadingVisit": "Loading current visit...",
+  "loadMore": "Load more",
   "location": "Location",
   "male": "Male",
   "markAlive": "Mark alive",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

Loading all visits in the Visits summary page upfront can make for a bad user experience when a patient has many visits with numerous observations.

This PR adds a new hook to the visits resource, `useInfiniteVisits` that fetches a certain number of visits when the visits summary page is first loaded. This number is determined by the `numberOfVisitsToLoad` configuration property. I've added a button at the bottom of the page labelled `Load more`. Clicking this button loads `numberOfVisitsToLoad` more visits, and can be clicked until there are no more visits to load. At that point, the button gets hidden.

With these changes, we can make data fetching more efficient and make the potentially UI more responsive.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/363f44a5-7acc-4f4c-83db-622323d4e112

## Related Issue

https://openmrs.atlassian.net/browse/O3-2830

## Other

One thing I've not done here is get rid of the `useVisits` hook entirely. It's still getting used in a couple of places which leverage it's bound `mutate` function to revalidate visits data. It's probably safe to do, but I erred on the side of caution.

Another avenue where performance gains can be made is culling the data we're requesting through the custom representation in the URL:

```tsx
const customRepresentation =
    'custom:(uuid,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis),form:(uuid,display),encounterDatetime,orders:full,obs:full,encounterType:(uuid,display,viewPrivilege,editPrivilege),encounterProviders:(uuid,display,encounterRole:(uuid,display),provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient,attributes:(attributeType:ref,display,uuid,value)';
```

We're fetching the full version of both obs and orders. This is not ideal and should likely be optimized further. I've not explored that in this PR, however.