### PR TITLE
(fix) Anchor allergy form action buttons to page bottom

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -38,9 +39,8 @@ import {
   useAllergicReactions,
 } from './allergy-form.resource';
 import { useAllergies } from '../allergy-intolerance.resource';
-import styles from './allergy-form.scss';
 import { AllergenType } from '../../types';
-import classNames from 'classnames';
+import styles from './allergy-form.scss';
 
 const allergyFormSchema = z.object({
   allergen: z

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.scss
@@ -74,6 +74,12 @@
   margin: 1rem;
 }
 
+.form {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
 /* Desktop */
 :global(.omrs-breakpoint-gt-tablet) {
   .form {
@@ -86,5 +92,4 @@
   .form {
     height: calc(100vh - 9rem);
   }
-
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

The action buttons in the allergy form should be anchored to the bottom of the page, as is the case with other vanilla React forms in O3 such as the Start Visit and Vitals and Biometrics forms.

## Screenshots

### Before

![CleanShot 2024-02-08 at 4  45 42@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/2a78af5e-9b5c-4694-bb43-275229ea92d3)

### After

![fixed](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/e985241f-cf02-4b51-913c-7c25dc3859d3)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
