### PR TITLE
(fix) O3-2826: Fix reading properties of null (reading 'deceasedDateTime') when navigating to the patient chart.

### DIFF
--- a/packages/esm-patient-banner-app/src/banner-tags/visit-tag.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/visit-tag.component.tsx
@@ -12,7 +12,7 @@ interface VisitTagProps {
 
 function VisitTag({ patientUuid, patient }: VisitTagProps) {
   const { activeVisit } = useVisitOrOfflineVisit(patientUuid);
-  const isNotDeceased = !patient.deceasedDateTime;
+  const isNotDeceased = !patient?.deceasedDateTime;
   return activeVisit && isNotDeceased ? <ActiveVisitTag activeVisit={activeVisit} /> : null;
 }
 

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -154,8 +154,8 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
             )}
           </div>
           <div className={styles.demographics}>
-            <span>{getGender(patient.gender)}</span> &middot; <span>{age(patient.birthDate)}</span> &middot;{' '}
-            <span>{formatDate(parseDate(patient.birthDate), { mode: 'wide', time: false })}</span>
+            <span>{getGender(patient?.gender)}</span> &middot; <span>{age(patient?.birthDate)}</span> &middot;{' '}
+            <span>{formatDate(parseDate(patient?.birthDate), { mode: 'wide', time: false })}</span>
           </div>
           <div className={styles.row}>
             <div className={styles.identifiers}>

--- a/packages/esm-patient-chart-app/src/deceased/deceased.resource.ts
+++ b/packages/esm-patient-chart-app/src/deceased/deceased.resource.ts
@@ -46,8 +46,8 @@ export function usePatientDeceased(patientUuid: string) {
   }
 
   return {
-    deathDate: patient.deceasedDateTime,
-    isDead: patient.deceasedBoolean ?? Boolean(patient.deceasedDateTime),
+    deathDate: patient?.deceasedDateTime,
+    isDead: patient?.deceasedBoolean ?? Boolean(patient?.deceasedDateTime),
     isLoading: isPatientLoading,
   };
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds a `null` checker on patient to avoid reading properties from `null` while navigating to patient chart where `patient` is null

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2826](https://openmrs.atlassian.net/browse/O3-2826)

## Other
<!-- Anything not covered above -->
