### PR TITLE
(fix) Fix display of menu items in the side rail and bottom nav

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { ExtensionSlot, useLayoutType } from '@openmrs/esm-framework';
+import classNames from 'classnames';
+import { ExtensionSlot } from '@openmrs/esm-framework';
 import styles from './action-menu.scss';
 
 interface ActionMenuInterface {
@@ -7,7 +8,6 @@ interface ActionMenuInterface {
 }
 
 export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
-  const layout = useLayoutType();
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const initialHeight = useRef(window.innerHeight);
 
@@ -23,11 +23,14 @@ export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
   }, [initialHeight]);
 
   return (
-    <aside className={`${styles.sideRail} ${keyboardVisible ? styles.hiddenSideRail : styles.showSideRail}`}>
+    <aside
+      className={classNames(styles.sideRail, {
+        [styles.hiddenSideRail]: keyboardVisible,
+        [styles.showSideRail]: !keyboardVisible,
+      })}
+    >
       <div className={styles.container}>
         <ExtensionSlot className={styles.chartExtensions} name={'action-menu-chart-items-slot'} />
-        {layout === 'small-desktop' || layout === 'large-desktop' ? <div className={styles.divider}></div> : null}
-        <ExtensionSlot className={styles.nonChartExtensions} name={'action-menu-non-chart-items-slot'} />
       </div>
     </aside>
   );

--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
@@ -49,29 +49,11 @@ $actionPanelOffset: 3rem;
 
   .chartExtensions {
     background-color: $ui-02;
-    flex-basis: 0.75%;
-    flex-grow: 3;
     display: flex;
     width: 100%;
 
     & > div {
       flex: 1;
-      cursor: pointer;
-    }
-  }
-
-  .nonChartExtensions {
-    background-color: $ui-02;
-    flex-basis: 0.25%;
-    flex-grow: 1;
-    display: flex;
-
-    & > div {
-      flex: 1 1 auto;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
       cursor: pointer;
     }
   }

--- a/packages/esm-patient-lists-app/src/routes.json
+++ b/packages/esm-patient-lists-app/src/routes.json
@@ -7,7 +7,7 @@
     {
       "name": "patient-lists-action-menu",
       "component": "patientListsActionMenu",
-      "slot": "action-menu-non-chart-items-slot"
+      "slot": "action-menu-chart-items-slot"
     }
   ]
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR aims to fix how menu items in the side rail and bottom nav look. More specifically, in the past, the Patient Lists side rail extension originated from the Patient Management repository. Thus, the original implementation provided different styling that applied to the Order Basket, Visit Note and Clinical Forms action buttons that denoted them as 'chart extensions', or extensions originating from the Patient Chart. Separate styling was provided for the Patient Lists action menu and side rail items that ensured they fill the remainder of the available space in the container.

After recent [work](#1471) that introduced a new Patient Lists frontend module to the Patient Chart, it doesn't make sense to maintain the old abstraction. Additionally, the current styling configuration introduces an unfortunate UI bug in distros that don't include the Patient Lists frontend module in their import map where a chunk of empty space gets rendered in the UI instead of the remaining chart extensions spreading out to fill the entirety of the container width:
  
![CleanShot 2024-02-08 at 11  39 05@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/b3efde64-e6ce-4068-8544-820dea920662)

This PR:

- Amends the slot that the Patient Lists workspace gets rendered into so that it shares the same slot as the other side rail items.
- Removes styling for 'non-chart' extensions, which is no longer necessary.
- Removes the `action-menu-non-chart-items-slot` extension slot.
- Removes the [divider](https://zeroheight.com/23a080e38/p/948cf1-siderail-and-bottom-nav/b/86907e) element from the side rail. I'm not too sure about this one. The docs say this about the divider:
  
  > A very subtle, 1px line that can be used to differentiate between workspace contexts, when there are many links in the siderail. Exists only on the desktop version.

I'm not entirely sure what contexts we're meant to be differentiating, and the basis to use to differentiate them.

## Screenshots

### How things look like for a distro that doesn't ship the Patient Lists frontend module:

#### Tablet

![CleanShot 2024-02-08 at 11  42 20@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/a1b09c99-8f7d-4cac-9d3a-00b20b82eadb)

#### Desktop

![CleanShot 2024-02-08 at 11  43 43@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/8f9f4f97-643f-4e4b-9cd1-4c3394494562)

## Related Issue
*None*

## Other
*None*
