### PR TITLE
(fix) Fix medications not loading when quantity unit property is null

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -122,7 +122,7 @@ const MedicationsDetailsTable: React.FC<ActiveMedicationsProps> = ({
             {medication.quantity ? (
               <span>
                 <span className={styles.label01}> &mdash; {t('quantity', 'Quantity').toUpperCase()}</span>{' '}
-                {medication.quantity} {medication.quantityUnits.display}
+                {medication.quantity} {medication?.quantityUnits?.display}
               </span>
             ) : null}
             {medication.dateStopped ? (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![before](https://github.com/openmrs/openmrs-esm-patient-chart/assets/4432218/eb2212ca-cc97-4184-8285-4598392e5d6c)



After: 
![after](https://github.com/openmrs/openmrs-esm-patient-chart/assets/4432218/abeab769-1401-4aec-b4a8-351bc104d43d)




## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
