### PR TITLE
O3-2857 Add patient flag for active visits widget and dashboard link

### DIFF
--- a/packages/esm-patient-chart-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-chart-app/src/dashboard.meta.ts
@@ -9,3 +9,10 @@ export const encountersDashboardMeta = {
   path: 'Visits',
   title: 'Visits',
 };
+
+export const activeVisitDashboardMeta = {
+  slot: 'patient-chart-active-visit-dashboard-slot',
+  columns: 1,
+  path: 'Active Visit',
+  title: 'Active Visit',
+};

--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -8,11 +8,11 @@ import {
 import * as PatientCommonLib from '@openmrs/esm-patient-common-lib';
 import { createDashboardLink } from '@openmrs/esm-patient-common-lib';
 import { esmPatientChartSchema } from './config-schema';
+import { moduleName, spaBasePath } from './constants';
+import { summaryDashboardMeta, encountersDashboardMeta, activeVisitDashboardMeta } from './dashboard.meta';
+import { setupOfflineVisitsSync, setupCacheableRoutes } from './offline';
 import { genericDashboardConfigSchema } from './side-nav/generic-dashboard.component';
 import { genericNavGroupConfigSchema } from './side-nav/generic-nav-group.component';
-import { moduleName } from './constants';
-import { setupOfflineVisitsSync, setupCacheableRoutes } from './offline';
-import { summaryDashboardMeta, encountersDashboardMeta } from './dashboard.meta';
 import addPastVisitActionButtonComponent from './actions-buttons/add-past-visit.component';
 import cancelVisitActionButtonComponent from './actions-buttons/cancel-visit.component';
 import currentVisitSummaryComponent from './visit/visits-widget/current-visit-summary.component';
@@ -30,6 +30,7 @@ import startVisitActionButtonOnPatientSearch from './visit/start-visit-button.co
 import startVisitFormComponent from './visit/visit-form/visit-form.component';
 import stopVisitActionButtonComponent from './actions-buttons/stop-visit.component';
 import visitAttributeTagsComponent from './patient-banner-tags/visit-attribute-tags.component';
+import activeVisitDetailOverviewComponent from './visit/visits-widget/current-visit-summary.component';
 
 // This allows @openmrs/esm-patient-common-lib to be accessed by modules that are not
 // using webpack. This is used for ngx-formentry.
@@ -54,6 +55,11 @@ export function startupApp() {
     'print-patient-identifier-sticker',
     'Print patient identifier sticker',
     'Features to support printing a patient identifier sticker',
+  );
+  registerFeatureFlag(
+    'activeVisitSummaryTab',
+    'Active Visit Summary Tab',
+    'This feature displays a summary of all forms filled in an encounter instead of displaying the encounters tab.',
   );
 }
 
@@ -238,3 +244,16 @@ export const activeVisitActionsComponent = getAsyncLifecycle(
   () => import('./visit/visits-widget/active-visit-buttons/active-visit-buttons'),
   { featureName: 'active-visit-actions', moduleName },
 );
+
+export const activeVisitSummaryDashboardLink = getSyncLifecycle(
+  createDashboardLink({
+    ...activeVisitDashboardMeta,
+    moduleName,
+  }),
+  { featureName: 'activeVisitSummaryTab', moduleName },
+);
+
+export const activeVisitDetailOverview = getSyncLifecycle(activeVisitDetailOverviewComponent, {
+  featureName: 'active-visit-overview',
+  moduleName,
+});

--- a/packages/esm-patient-chart-app/src/routes.json
+++ b/packages/esm-patient-chart-app/src/routes.json
@@ -228,6 +228,30 @@
       "online": true,
       "offline": true,
       "order": 1
+    },
+    {
+      "name": "active-visit-summary-dashboard",
+      "slot": "patient-chart-dashboard-slot",
+      "component": "activeVisitSummaryDashboardLink",
+      "featureFlag": "activeVisitSummaryTab",
+      "meta": {
+        "slot": "patient-chart-active-visit-dashboard-slot",
+        "columns": 1,
+        "path": "Active Visit"
+      },
+      "order": 12,
+      "online": true,
+      "offline": true
+    },
+    {
+      "name": "active-visit-overview",
+      "component": "activeVisitDetailOverview",
+      "slot": "patient-chart-active-visit-dashboard-slot",
+      "order": 1,
+      "meta": {
+        "title": "Active Visits",
+        "view": "Active Visits"
+      }
     }
   ],
   "modals": [

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/active-visits-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/active-visits-summary.component.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { InlineLoading, Tab, Tabs, TabList, TabPanel, TabPanels } from '@carbon/react';
+import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
+import { ExtensionSlot, formatDatetime, parseDate } from '@openmrs/esm-framework';
+import { useTranslation } from 'react-i18next';
+import { useVisits } from './visit.resource';
+import VisitSummary from './past-visits-components/visit-summary.component';
+import styles from './visit-detail-overview.scss';
+
+interface ActiveVisitOverviewComponentProps {
+  patientUuid: string;
+}
+
+function ActiveVisitDetailOverviewComponent({ patientUuid }: ActiveVisitOverviewComponentProps) {
+  const { t } = useTranslation();
+  const { visits, error, isLoading, mutateVisits } = useVisits(patientUuid);
+
+  const activeVisits = visits?.filter((visit) => visit.stopDatetime === null);
+
+  if (isLoading) {
+    return (
+      <InlineLoading
+        status="active"
+        iconDescription={t('loading', 'Loading')}
+        description={t('loadingVisit', 'Loading active visits...')}
+      />
+    );
+  }
+
+  if (error) {
+    return <ErrorState headerTitle={t('failedToLoadActiveVisits', 'Failed loading active visits')} error={error} />;
+  }
+
+  return (
+    <div className={styles.tabs}>
+      <Tabs>
+        <TabList aria-label="Active visit tabs" contained>
+          {activeVisits?.map((visit, index) => (
+            <Tab label={visit?.visitType?.name} key={index} id={`${index}-id}`}>
+              {t('activeVisitType', '{{visitType}} Visit', { visitType: visit?.visitType?.name })}
+            </Tab>
+          ))}
+        </TabList>
+        <TabPanels>
+          {activeVisits?.map((visit, index) => (
+            <TabPanel key={index}>
+              {visit && (
+                <div className={styles.container}>
+                  <div className={styles.header}>
+                    <div className={styles.visitInfo}>
+                      <div>
+                        <h4 className={styles.visitType}>{visit.visitType.name}</h4>
+                        <div className={styles.displayFlex}>
+                          <h6 className={styles.dateLabel}>{t('start', 'Start')}:</h6>
+                          <span className={styles.date}>{formatDatetime(parseDate(visit.startDatetime))}</span>
+                          {visit.stopDatetime ? (
+                            <>
+                              <h6 className={styles.dateLabel}>{t('end', 'End')}:</h6>
+                              <span className={styles.date}>{formatDatetime(parseDate(visit.stopDatetime))}</span>
+                            </>
+                          ) : null}
+                        </div>
+                      </div>
+                      <div>
+                        <ExtensionSlot name="active-visit-actions" />
+                      </div>
+                    </div>
+                  </div>
+                  <VisitSummary visit={visit} patientUuid={patientUuid} />
+                </div>
+              )}
+            </TabPanel>
+          ))}
+        </TabPanels>
+      </Tabs>
+    </div>
+  );
+}
+
+export default ActiveVisitDetailOverviewComponent;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { useVisit, getConfig } from '@openmrs/esm-framework';
+import { useVisit, getConfig, useFeatureFlag } from '@openmrs/esm-framework';
 import { waitForLoadingToFinish } from 'tools';
 import CurrentVisitSummary from './current-visit-summary.component';
 
 const mockGetConfig = jest.mocked(getConfig);
 const mockUseVisits = jest.mocked(useVisit);
+const mockedUseFeatureFlag = useFeatureFlag as jest.Mock;
 
 describe('CurrentVisitSummary', () => {
   test('renders an empty state when there is no active visit', () => {
@@ -18,6 +19,7 @@ describe('CurrentVisitSummary', () => {
       isValidating: false,
       mutate: jest.fn(),
     });
+    mockedUseFeatureFlag.mockReturnValueOnce(false);
 
     render(<CurrentVisitSummary patientUuid="some-uuid" />);
     expect(screen.getByText(/current visit/i)).toBeInTheDocument();
@@ -26,6 +28,7 @@ describe('CurrentVisitSummary', () => {
 
   test('renders a visit summary when for the active visit', async () => {
     mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
+    mockedUseFeatureFlag.mockReturnValueOnce(false);
     mockUseVisits.mockReturnValueOnce({
       activeVisit: null,
       currentVisit: {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
-import { openmrsFetch, getConfig, useConfig, getDefaultsFromConfigSchema } from '@openmrs/esm-framework';
+import {
+  openmrsFetch,
+  getConfig,
+  useConfig,
+  getDefaultsFromConfigSchema,
+  useFeatureFlag,
+} from '@openmrs/esm-framework';
 import { esmPatientChartSchema, type ChartConfig } from '../../config-schema';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { visitOverviewDetailMockData } from '__mocks__';
@@ -10,6 +16,7 @@ import VisitDetailOverview from './visit-detail-overview.component';
 const mockGetConfig = getConfig as jest.Mock;
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockUseConfig = jest.mocked(useConfig<ChartConfig>);
+const mockedUseFeatureFlag = useFeatureFlag as jest.Mock;
 
 mockUseConfig.mockReturnValue({
   ...getDefaultsFromConfigSchema(esmPatientChartSchema),
@@ -60,6 +67,7 @@ describe('VisitDetailOverview', () => {
       ...getDefaultsFromConfigSchema(esmPatientChartSchema),
       showAllEncountersTab: true,
     });
+    mockedUseFeatureFlag.mockReturnValueOnce(false);
 
     renderWithSwr(<VisitDetailOverview patientUuid={mockPatient.id} />);
 
@@ -96,6 +104,7 @@ describe('VisitDetailOverview', () => {
       ...getDefaultsFromConfigSchema(esmPatientChartSchema),
       showAllEncountersTab: false,
     });
+    mockedUseFeatureFlag.mockReturnValueOnce(false);
 
     renderWithSwr(<VisitDetailOverview patientUuid={mockPatient.id} />);
 

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -1,4 +1,5 @@
 {
+  "activeVisitType": "{{visitType}} Visit",
   "addAPastVisit": "Add a past visit",
   "addPastVisit": "Add past visit",
   "addPastVisitText": "You can add a new past visit or update an old one. Choose from one of the options below to continue.",
@@ -67,6 +68,7 @@
   "errorUpdatingVisitDetails": "Error updating visit details",
   "errorWhenRestoringVisit": "Error occured when restoring {{visit}}",
   "failedDeleting": "couldn't be deleted",
+  "failedToLoadActiveVisits": "Failed loading active visits",
   "failedToLoadCurrentVisit": "Failed loading current visit",
   "female": "Female",
   "fieldRequired": "This field is required",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Added configurable current visit summary widget to view breakdown of encounters as opposed to using the encounters widget

## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/openmrs/openmrs-esm-patient-chart/assets/19533785/50a12090-2f9b-41be-bf70-400739a44078

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
