### PR TITLE
(refactor) O3-2815: Replace usages of `/ws/rest/v1` with `restBaseUrl`

### DIFF
--- a/e2e/commands/patient-operations.ts
+++ b/e2e/commands/patient-operations.ts
@@ -1,4 +1,4 @@
-import { APIRequestContext, expect } from '@playwright/test';
+import { type APIRequestContext, expect } from '@playwright/test';
 
 export interface Patient {
   uuid: string;

--- a/e2e/commands/visit-operations.ts
+++ b/e2e/commands/visit-operations.ts
@@ -1,5 +1,5 @@
-import { APIRequestContext, expect } from '@playwright/test';
-import { Visit } from '@openmrs/esm-framework';
+import { type APIRequestContext, expect } from '@playwright/test';
+import { type Visit } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 
 export const startVisit = async (api: APIRequestContext, patientId: string): Promise<Visit> => {

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -1,4 +1,4 @@
-import { APIRequestContext, PlaywrightWorkerArgs, WorkerFixture } from '@playwright/test';
+import { type APIRequestContext, type PlaywrightWorkerArgs, type WorkerFixture } from '@playwright/test';
 
 /**
  * A fixture which initializes an [`APIRequestContext`](https://playwright.dev/docs/api/class-apirequestcontext)

--- a/packages/esm-form-engine-app/src/hooks/useFormSchema.tsx
+++ b/packages/esm-form-engine-app/src/hooks/useFormSchema.tsx
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type OHRIFormSchema } from '@openmrs/openmrs-form-engine-lib';
 
 /**
@@ -10,7 +10,7 @@ import { type OHRIFormSchema } from '@openmrs/openmrs-form-engine-lib';
  * @returns An object containing the form schema, error, and loading state
  */
 const useFormSchema = (formUuid: string) => {
-  const url = formUuid ? `/ws/rest/v1/o3/forms/${formUuid}` : null;
+  const url = formUuid ? `${restBaseUrl}/o3/forms/${formUuid}` : null;
 
   const { data, error, isLoading } = useSWR<{ data: OHRIFormSchema }>(url, openmrsFetch);
 

--- a/packages/esm-form-entry-app/src/app/offline/caching.ts
+++ b/packages/esm-form-entry-app/src/app/offline/caching.ts
@@ -3,6 +3,7 @@ import {
   messageOmrsServiceWorker,
   omrsOfflineCachingStrategyHttpHeaderName,
   openmrsFetch,
+  restBaseUrl,
   setupDynamicOfflineDataHandler,
   subscribePrecacheStaticDependencies,
 } from '@openmrs/esm-framework';
@@ -12,8 +13,8 @@ import type { FormSchema } from '../types';
 export function setupStaticDataOfflinePrecaching() {
   subscribePrecacheStaticDependencies(async () => {
     const urlsToCache = [
-      '/ws/rest/v1/location?q=&v=custom:(uuid,display)',
-      '/ws/rest/v1/provider?q=&v=custom:(uuid,display,person:(uuid))',
+      `${restBaseUrl}/location?q=&v=custom:(uuid,display)`,
+      `${restBaseUrl}/provider?q=&v=custom:(uuid,display,person:(uuid))`,
     ];
 
     await Promise.all(
@@ -66,7 +67,7 @@ export function setupDynamicOfflineFormDataHandler() {
 }
 
 async function getCacheableFormUrls(formUuid: string) {
-  const getFormRes = await openmrsFetch<FormSchema>(`/ws/rest/v1/o3/forms/${formUuid}`);
+  const getFormRes = await openmrsFetch<FormSchema>(`${restBaseUrl}/o3/forms/${formUuid}`);
   const form = getFormRes.data;
 
   if (!form) {
@@ -78,11 +79,11 @@ async function getCacheableFormUrls(formUuid: string) {
     // - https://github.com/openmrs/openmrs-esm-patient-chart/blob/415790e1ad9b8bdbd1201958d21a06fa93ec7237/packages/esm-form-entry-app/src/app/openmrs-api/form-resource.service.ts#L21
     // - https://github.com/openmrs/openmrs-esm-patient-chart/blob/415790e1ad9b8bdbd1201958d21a06fa93ec7237/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts#L31
     // - https://github.com/openmrs/openmrs-esm-patient-chart/blob/415790e1ad9b8bdbd1201958d21a06fa93ec7237/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts#L164
-    `/ws/rest/v1/form/${formUuid}?v=full`,
+    `${restBaseUrl}/form/${formUuid}?v=full`,
 
     // Required by:
     // - https://github.com/openmrs/openmrs-esm-patient-chart/blob/415790e1ad9b8bdbd1201958d21a06fa93ec7237/packages/esm-form-entry-app/src/app/openmrs-api/form-resource.service.ts#L10
     // - https://github.com/openmrs/openmrs-esm-patient-chart/blob/415790e1ad9b8bdbd1201958d21a06fa93ec7237/packages/esm-form-entry-app/src/app/form-schema/form-schema.service.ts#L167
-    `/ws/rest/v1/o3/forms/${formUuid}`,
+    `${restBaseUrl}/o3/forms/${formUuid}`,
   ].filter(Boolean);
 }

--- a/packages/esm-form-entry-app/src/app/openmrs-api/encounter-resource.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/openmrs-api/encounter-resource.service.spec.ts
@@ -4,6 +4,7 @@ import { TestBed } from '@angular/core/testing';
 import { EncounterResourceService } from './encounter-resource.service';
 import { LocalStorageService } from '../local-storage/local-storage.service';
 import { OpenmrsApiModule } from './openmrs-api.module';
+import { restBaseUrl } from '@openmrs/esm-framework';
 
 describe('EncounterResourceService', () => {
   let httpMock: HttpTestingController;
@@ -97,7 +98,7 @@ describe('EncounterResourceService', () => {
         links: [
           {
             rel: 'self',
-            uri: 'https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/location',
+            uri: `https://amrs.ampath.or.ke:8443/amrs${restBaseUrl}/location`,
           },
         ],
       },
@@ -107,7 +108,7 @@ describe('EncounterResourceService', () => {
         links: [
           {
             rel: 'self',
-            uri: 'https://amrs.ampath.or.ke:8443/amrs/ws/rest/v1/encountertype',
+            uri: `https://amrs.ampath.or.ke:8443/amrs${restBaseUrl}/encountertype`,
           },
         ],
       },
@@ -196,7 +197,7 @@ describe('EncounterResourceService', () => {
         display: '',
         links: [
           {
-            uri: 'https://test1.ampath.or.ke:8443/amrs/ws/rest/v1/',
+            uri: `https://test1.ampath.or.ke:8443/amrs${restBaseUrl}`,
             rel: 'self',
           },
         ],
@@ -206,7 +207,7 @@ describe('EncounterResourceService', () => {
         display: 'Location-5',
         links: [
           {
-            uri: 'https://test1.ampath.or.ke:8443/amrs/ws/rest/v1',
+            uri: `https://test1.ampath.or.ke:8443/amrs${restBaseUrl}`,
             rel: 'self',
           },
         ],

--- a/packages/esm-form-entry-app/src/app/openmrs-api/form-resource.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/openmrs-api/form-resource.service.spec.ts
@@ -39,7 +39,7 @@ describe('FormResourceService Unit Tests', () => {
 
     const req = httpMock.expectOne(winRef.openmrsRestBase.trim() + 'form/' + uuid + '?v=full');
     expect(req.request.method).toBe('GET');
-    expect(req.request.urlWithParams).toContain('/ws/rest/v1/form/form-uuid?v=full');
+    expect(req.request.urlWithParams).toContain(`/ws/rest/v1/form/form-uuid?v=full`);
   }));
 
   it('should make API call with correct URL when getFormMetaDataByUuid is invoked with v', fakeAsync(() => {

--- a/packages/esm-form-entry-app/src/app/openmrs-api/form-resource.service.ts
+++ b/packages/esm-form-entry-app/src/app/openmrs-api/form-resource.service.ts
@@ -18,7 +18,7 @@ export class FormResourceService {
   }
 
   public getFormMetaDataByUuid(uuid: string, v: string = null) {
-    const url = `${this.windowRef.openmrsRestBase}form/${uuid}`;
+    const url = `${this.windowRef.openmrsRestBase}/form/${uuid}`;
     const params: HttpParams = new HttpParams().set('v', v && v.length > 0 ? v : 'full');
     return this.http.get<FormMetadataObject>(url, { params });
   }

--- a/packages/esm-form-entry-app/src/app/openmrs-api/program-resource.service.ts
+++ b/packages/esm-form-entry-app/src/app/openmrs-api/program-resource.service.ts
@@ -4,7 +4,7 @@ import { HttpClient } from '@angular/common/http';
 import { WindowRef } from '../window-ref';
 import { Form } from '@openmrs/ngx-formentry';
 import { MetaData } from '../types';
-import { parseDate, showSnackbar } from '@openmrs/esm-framework';
+import { parseDate, restBaseUrl, showSnackbar } from '@openmrs/esm-framework';
 import { SingleSpaPropsService } from '../single-spa-props/single-spa-props.service';
 import { EncounterResourceService } from './encounter-resource.service';
 import dayjs from 'dayjs';
@@ -19,7 +19,7 @@ export class ProgramResourceService {
   ) {}
 
   private programEnrollmentUrl(): string {
-    return `${this.windowRef.nativeWindow.openmrsBase}/ws/rest/v1/programenrollment`;
+    return `${this.windowRef.nativeWindow.openmrsBase}${restBaseUrl}/programenrollment`;
   }
 
   public handlePatientCareProgram(form: Form, encounterUuid: string): void {

--- a/packages/esm-form-entry-app/src/app/window-ref.ts
+++ b/packages/esm-form-entry-app/src/app/window-ref.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { restBaseUrl } from '@openmrs/esm-framework';
 
 function _window() {
   // return the global native browser window object
@@ -14,6 +15,6 @@ export class WindowRef {
   }
 
   get openmrsRestBase(): string {
-    return this.nativeWindow.openmrsBase + '/ws/rest/v1/';
+    return this.nativeWindow.openmrsBase + restBaseUrl;
   }
 }

--- a/packages/esm-form-entry-app/src/app/window-ref.ts
+++ b/packages/esm-form-entry-app/src/app/window-ref.ts
@@ -15,6 +15,6 @@ export class WindowRef {
   }
 
   get openmrsRestBase(): string {
-    return this.nativeWindow.openmrsBase + restBaseUrl;
+    return this.nativeWindow.openmrsBase + restBaseUrl + '/';
   }
 }

--- a/packages/esm-form-entry-app/src/index.ts
+++ b/packages/esm-form-entry-app/src/index.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import 'zone.js';
-import { defineConfigSchema, messageOmrsServiceWorker } from '@openmrs/esm-framework';
+import { defineConfigSchema, fhirBaseUrl, messageOmrsServiceWorker, restBaseUrl } from '@openmrs/esm-framework';
 import { setupDynamicOfflineFormDataHandler, setupStaticDataOfflinePrecaching } from './app/offline/caching';
 import { configSchema } from './config-schema';
 
@@ -22,42 +22,42 @@ export function startupApp() {
 
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/fhir2/R4/Observation.+',
+    pattern: `.+${fhirBaseUrl}/Observation.+`,
   });
 
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/obs.+',
+    pattern: `.+${restBaseUrl}/obs.+`,
   });
 
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/session.*',
+    pattern: `.+${restBaseUrl}/session.*`,
   });
 
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/provider.*',
+    pattern: `.+${restBaseUrl}/provider.*`,
   });
 
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/location.*',
+    pattern: `.+${restBaseUrl}/location.*`,
   });
 
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/person.*',
+    pattern: `.+${restBaseUrl}/person.*`,
   });
 
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/form.*',
+    pattern: `.+${restBaseUrl}/form.*`,
   });
 
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/o3/forms.*',
+    pattern: `.+${restBaseUrl}/o3/forms.*`,
   });
 
   defineConfigSchema(moduleName, configSchema);

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.resource.ts
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.resource.ts
@@ -1,5 +1,5 @@
 import useSWRImmutable from 'swr/immutable';
-import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import type { OpenMRSResource } from '../../types';
 import { AllergenType } from '../../types';
 import useSWR from 'swr';
@@ -54,7 +54,7 @@ export interface AllergicReaction {
 export function useAllergicReactions() {
   const allergyReactionUuid = useConfig().concepts.allergyReactionUuid;
   const { data: allergicReactionsData, isLoading } = useSWRImmutable<{ data: ConceptFetchResponse }>(
-    `/ws/rest/v1/concept/${allergyReactionUuid}?v=full`,
+    `${restBaseUrl}/concept/${allergyReactionUuid}?v=full`,
     openmrsFetch,
   );
 
@@ -74,15 +74,15 @@ export function useAllergens() {
   } = useConfig();
 
   const { data: drugAllergenData } = useSWRImmutable<{ data: ConceptFetchResponse }>(
-    `/ws/rest/v1/concept/${drugAllergenUuid}?v=full`,
+    `${restBaseUrl}/concept/${drugAllergenUuid}?v=full`,
     openmrsFetch,
   );
   const { data: environmentalAllergenData } = useSWRImmutable<{ data: ConceptFetchResponse }>(
-    `/ws/rest/v1/concept/${environmentalAllergenUuid}?v=full`,
+    `${restBaseUrl}/concept/${environmentalAllergenUuid}?v=full`,
     openmrsFetch,
   );
   const { data: foodAllergenData } = useSWRImmutable<{ data: ConceptFetchResponse }>(
-    `/ws/rest/v1/concept/${foodAllergenUuid}?v=full`,
+    `${restBaseUrl}/concept/${foodAllergenUuid}?v=full`,
     openmrsFetch,
   );
 
@@ -119,7 +119,7 @@ export function useAllergens() {
 export function useAllergenSearch(allergenToLookup: string) {
   const allergenConceptClassUuid = useConfig()?.concepts.allergenUuid;
 
-  const searchURL = `/ws/rest/v1/conceptsearch?conceptClasses=${allergenConceptClassUuid}&q=${allergenToLookup}`;
+  const searchURL = `${restBaseUrl}/conceptsearch?conceptClasses=${allergenConceptClassUuid}&q=${allergenToLookup}`;
 
   const { data, error, isLoading } = useSWR<{ data: { results: Array<CodedAllergen> } }, Error>(
     allergenToLookup ? searchURL : null,
@@ -134,7 +134,7 @@ export function useAllergenSearch(allergenToLookup: string) {
 }
 
 export function saveAllergy(payload: NewAllergy, patientUuid: string, abortController: AbortController) {
-  return openmrsFetch(`/ws/rest/v1/patient/${patientUuid}/allergy`, {
+  return openmrsFetch(`${restBaseUrl}/patient/${patientUuid}/allergy`, {
     headers: {
       'Content-Type': 'application/json',
     },

--- a/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
+++ b/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 import { map } from 'rxjs/operators';
 import capitalize from 'lodash-es/capitalize';
-import { fhirBaseUrl, openmrsFetch, openmrsObservableFetch } from '@openmrs/esm-framework';
+import { fhirBaseUrl, openmrsFetch, openmrsObservableFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type FHIRAllergy, type FHIRAllergyResponse, type ReactionSeverity } from '../types';
 
 export type Allergy = {
@@ -85,7 +85,7 @@ export function saveAllergy(patientAllergy: any, patientUuid: string, abortContr
     };
   });
 
-  return openmrsFetch(`/ws/rest/v1/patient/${patientUuid}/allergy`, {
+  return openmrsFetch(`${restBaseUrl}/patient/${patientUuid}/allergy`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -121,7 +121,7 @@ export function updatePatientAllergy(
     };
   });
 
-  return openmrsFetch(`/ws/rest/v1/patient/${patientUuid}/allergy/${allergyUuid.allergyUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/patient/${patientUuid}/allergy/${allergyUuid.allergyUuid}`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -144,7 +144,7 @@ export function updatePatientAllergy(
 }
 
 export function deletePatientAllergy(patientUuid: string, allergyUuid: any, abortController: AbortController) {
-  return openmrsFetch(`/ws/rest/v1/patient/${patientUuid}/allergy/${allergyUuid.allergyUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/patient/${patientUuid}/allergy/${allergyUuid.allergyUuid}`, {
     method: 'DELETE',
     signal: abortController.signal,
   });

--- a/packages/esm-patient-allergies-app/src/index.ts
+++ b/packages/esm-patient-allergies-app/src/index.ts
@@ -4,6 +4,7 @@ import {
   getAsyncLifecycle,
   getSyncLifecycle,
   messageOmrsServiceWorker,
+  restBaseUrl,
   translateFrom,
 } from '@openmrs/esm-framework';
 import { createDashboardLink, registerWorkspace } from '@openmrs/esm-patient-common-lib';
@@ -24,12 +25,12 @@ export const importTranslation = require.context('../translations', false, /.jso
 export function startupApp() {
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/concept.+',
+    pattern: `.+${restBaseUrl}/concept.+`,
   });
 
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/patient/.+/allergy.+',
+    pattern: `.+${restBaseUrl}/patient/.+/allergy.+`,
   });
 
   messageOmrsServiceWorker({

--- a/packages/esm-patient-appointments-app/src/appointments/appointments.resource.ts
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments.resource.ts
@@ -1,11 +1,11 @@
 import dayjs from 'dayjs';
 import useSWR from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type AppointmentsFetchResponse } from '../types';
 import isToday from 'dayjs/plugin/isToday';
 dayjs.extend(isToday);
 
-const appointmentsSearchUrl = `/ws/rest/v1/appointments/search`;
+const appointmentsSearchUrl = `${restBaseUrl}/appointments/search`;
 
 export function useAppointments(patientUuid: string, startDate: string, abortController: AbortController) {
   /*
@@ -62,7 +62,7 @@ export const cancelAppointment = async (toStatus: string, appointmentUuid: strin
   const omrsDateFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZZ';
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const statusChangeTime = dayjs(new Date()).format(omrsDateFormat);
-  const url = `/ws/rest/v1/appointments/${appointmentUuid}/status-change`;
+  const url = `${restBaseUrl}/appointments/${appointmentUuid}/status-change`;
   return await openmrsFetch(url, {
     body: { toStatus, onDate: statusChangeTime, timeZone: timeZone },
     method: 'POST',

--- a/packages/esm-patient-attachments-app/src/attachments/use-allowed-extensions.ts
+++ b/packages/esm-patient-attachments-app/src/attachments/use-allowed-extensions.ts
@@ -1,5 +1,5 @@
 import useSWRImmutable from 'swr/immutable';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 
 export interface GlobalProperty {
   uuid: string;
@@ -15,7 +15,7 @@ export const useAllowedExtensions = () => {
   // Global property from the attachments backend module https://github.com/openmrs/openmrs-module-attachments/blob/master/api/src/main/java/org/openmrs/module/attachments/AttachmentsConstants.java that contains the allowed file extensions
   const allowedExtensionsGlobalProperty: string = 'attachments.allowedFileExtensions';
   const customRepresentation = 'custom:(value)';
-  const url = `/ws/rest/v1/systemsetting?&v=${customRepresentation}&q=${allowedExtensionsGlobalProperty}`;
+  const url = `${restBaseUrl}/systemsetting?&v=${customRepresentation}&q=${allowedExtensionsGlobalProperty}`;
 
   const { data, error, isLoading } = useSWRImmutable<{ data: { results: Array<GlobalProperty> } }>(url, openmrsFetch);
 

--- a/packages/esm-patient-banner-app/src/contact-details/relationships.resource.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/relationships.resource.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 
 const customRepresentation =
   'custom:(display,uuid,personA:(uuid,age,display),personB:(uuid,age,display),relationshipType:(uuid,display,description,aIsToB,bIsToA))';
 
 export function useRelationships(patientUuid: string) {
-  const url = patientUuid ? `/ws/rest/v1/relationship?person=${patientUuid}&v=${customRepresentation}` : null;
+  const url = patientUuid ? `${restBaseUrl}/relationship?person=${patientUuid}&v=${customRepresentation}` : null;
   const { data, error, isLoading, isValidating } = useSWR<FetchResponse<RelationshipsResponse>, Error>(
     url,
     openmrsFetch,

--- a/packages/esm-patient-banner-app/src/hooks/usePatientAttributes.ts
+++ b/packages/esm-patient-banner-app/src/hooks/usePatientAttributes.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import useSWRImmutable from 'swr/immutable';
 import { type ConfigObject } from '../config-schema';
 import { type Patient } from '../types';
@@ -15,7 +15,7 @@ const customRepresentation =
  */
 export const usePatientAttributes = (patientUuid: string | null) => {
   const { data, error, isLoading } = useSWRImmutable<{ data: Patient }>(
-    patientUuid ? `/ws/rest/v1/patient/${patientUuid}?v=${customRepresentation}` : null,
+    patientUuid ? `${restBaseUrl}/patient/${patientUuid}?v=${customRepresentation}` : null,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-banner-app/src/index.ts
+++ b/packages/esm-patient-banner-app/src/index.ts
@@ -1,4 +1,4 @@
-import { defineConfigSchema, getSyncLifecycle, messageOmrsServiceWorker } from '@openmrs/esm-framework';
+import { defineConfigSchema, getSyncLifecycle, messageOmrsServiceWorker, restBaseUrl } from '@openmrs/esm-framework';
 import { configSchema } from './config-schema';
 import visitTagComponent from './banner-tags/visit-tag.component';
 import deceasedPatientTagComponent from './banner-tags/deceased-patient-tag.component';
@@ -16,7 +16,7 @@ export const importTranslation = require.context('../translations', false, /.jso
 export function startupApp() {
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/relationship.+',
+    pattern: `.+${restBaseUrl}/relationship.+`,
   });
 
   defineConfigSchema(moduleName, configSchema);

--- a/packages/esm-patient-chart-app/src/deceased/deceased.resource.ts
+++ b/packages/esm-patient-chart-app/src/deceased/deceased.resource.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { openmrsFetch, usePatient } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, usePatient } from '@openmrs/esm-framework';
 
 interface CauseOfDeathFetchResponse {
   uuid: string;
@@ -53,7 +53,7 @@ export function usePatientDeceased(patientUuid: string) {
 }
 
 const changePatientDeathStatus = (personUuid: string, payload: DeathPayload, abortController: AbortController) => {
-  return openmrsFetch(`/ws/rest/v1/person/${personUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/person/${personUuid}`, {
     headers: {
       'Content-type': 'application/json',
     },
@@ -97,7 +97,7 @@ export function markPatientAlive(personUuid: string, abortController: AbortContr
 
 export function useConceptAnswers(conceptUuid: string) {
   const { data, error, isLoading, isValidating } = useSWR<{ data: ConceptAnswersResponse }, Error>(
-    `/ws/rest/v1/concept/${conceptUuid}`,
+    `${restBaseUrl}/concept/${conceptUuid}`,
     (url) => (conceptUuid ? openmrsFetch(url) : undefined),
     {
       shouldRetryOnError(err) {
@@ -116,7 +116,7 @@ export function useConceptAnswers(conceptUuid: string) {
 
 export function useCauseOfDeathConcept() {
   const { data, error, isLoading, isValidating } = useSWR<{ data: CauseOfDeathFetchResponse }>(
-    `/ws/rest/v1/systemsetting/concept.causeOfDeath`,
+    `${restBaseUrl}/systemsetting/concept.causeOfDeath`,
     openmrsFetch,
     {
       shouldRetryOnError(err) {

--- a/packages/esm-patient-chart-app/src/offline.ts
+++ b/packages/esm-patient-chart-app/src/offline.ts
@@ -1,15 +1,21 @@
-import { messageOmrsServiceWorker, saveVisit, setupOfflineSync, usePatient } from '@openmrs/esm-framework';
+import {
+  fhirBaseUrl,
+  messageOmrsServiceWorker,
+  restBaseUrl,
+  saveVisit,
+  setupOfflineSync,
+} from '@openmrs/esm-framework';
 import { type OfflineVisit, visitSyncType } from '@openmrs/esm-patient-common-lib';
 
 export function setupCacheableRoutes() {
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/fhir2/R4/Patient/.+',
+    pattern: `.+${fhirBaseUrl}/R4/Patient/.+`,
   });
 
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/visit.+',
+    pattern: `.+${restBaseUrl}/visit.+`,
   });
 }
 

--- a/packages/esm-patient-chart-app/src/visit/hooks/useLocations.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useLocations.tsx
@@ -1,9 +1,9 @@
-import { type FetchResponse, type Location, openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, type Location, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { useEffect } from 'react';
 import useSWR from 'swr';
 
 export function useLocations(searchString?: string) {
-  let url = '/ws/rest/v1/location';
+  let url = `${restBaseUrl}/location`;
 
   if (searchString) {
     url += `?q=${searchString}`;

--- a/packages/esm-patient-chart-app/src/visit/hooks/useServiceQueue.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useServiceQueue.tsx
@@ -1,4 +1,4 @@
-import { openmrsFetch, toDateObjectStrict, toOmrsIsoString } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, toDateObjectStrict, toOmrsIsoString } from '@openmrs/esm-framework';
 
 export async function saveQueueEntry(
   visitUuid: string,
@@ -15,7 +15,7 @@ export async function saveQueueEntry(
     generateVisitQueueNumber(locationUuid, visitUuid, queueUuid, abortController, visitQueueNumberAttributeUuid),
   ]);
 
-  return openmrsFetch(`/ws/rest/v1/visit-queue-entry`, {
+  return openmrsFetch(`${restBaseUrl}/visit-queue-entry`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -51,7 +51,7 @@ export async function generateVisitQueueNumber(
   visitQueueNumberAttributeUuid: string,
 ) {
   await openmrsFetch(
-    `/ws/rest/v1/queue-entry-number?location=${location}&queue=${queueUuid}&visit=${visitUuid}&visitAttributeType=${visitQueueNumberAttributeUuid}`,
+    `${restBaseUrl}/queue-entry-number?location=${location}&queue=${queueUuid}&visit=${visitUuid}&visitAttributeType=${visitQueueNumberAttributeUuid}`,
     {
       method: 'GET',
       headers: {
@@ -63,7 +63,7 @@ export async function generateVisitQueueNumber(
 }
 
 export function removeQueuedPatient(queueUuid: string, queueEntryUuid: string, abortController: AbortController) {
-  return openmrsFetch(`/ws/rest/v1/queue/${queueUuid}/entry/${queueEntryUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/queue/${queueUuid}/entry/${queueEntryUuid}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/esm-patient-chart-app/src/visit/hooks/useUpcomingAppointments.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useUpcomingAppointments.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { openmrsFetch, type OpenmrsResource } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, type OpenmrsResource } from '@openmrs/esm-framework';
 
 export interface AppointmentPayload {
   patientUuid: string;
@@ -18,7 +18,7 @@ export interface AppointmentPayload {
 }
 
 export function saveAppointment(appointment: AppointmentPayload, abortController: AbortController) {
-  return openmrsFetch(`/ws/rest/v1/appointment`, {
+  return openmrsFetch(`${restBaseUrl}/appointment`, {
     method: 'POST',
     signal: abortController.signal,
     headers: {

--- a/packages/esm-patient-chart-app/src/visit/hooks/useVisitAttributeType.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useVisitAttributeType.tsx
@@ -1,4 +1,4 @@
-import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { useEffect, useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
@@ -36,7 +36,7 @@ const visitAttributeTypeCustomRepresentation =
 
 export function useVisitAttributeType(uuid) {
   const { data, error, isLoading } = useSWRImmutable<FetchResponse<VisitAttributeType>, Error>(
-    `/ws/rest/v1/visitattributetype/${uuid}?v=${visitAttributeTypeCustomRepresentation}`,
+    `${restBaseUrl}/visitattributetype/${uuid}?v=${visitAttributeTypeCustomRepresentation}`,
     openmrsFetch,
   );
 
@@ -59,7 +59,7 @@ export function useVisitAttributeType(uuid) {
 
 export function useConceptAnswersForVisitAttributeType(conceptUuid) {
   const { data, error, isLoading } = useSWRImmutable<FetchResponse<Concept>, Error>(
-    conceptUuid ? `/ws/rest/v1/concept/${conceptUuid}` : null,
+    conceptUuid ? `${restBaseUrl}/concept/${conceptUuid}` : null,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-chart-app/src/visit/queue-entry/queue.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/queue-entry/queue.resource.tsx
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { fhirBaseUrl, openmrsFetch, type Visit } from '@openmrs/esm-framework';
+import { fhirBaseUrl, openmrsFetch, restBaseUrl, type Visit } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
 export type QueuePriority = 'Emergency' | 'Not Urgent' | 'Priority' | 'Urgent';
 export type MappedQueuePriority = Omit<QueuePriority, 'Urgent'>;
@@ -71,7 +71,7 @@ interface UseVisitQueueEntries {
 }
 
 export function useVisitQueueEntry(patientUuid, visitUuid): UseVisitQueueEntries {
-  const apiUrl = `/ws/rest/v1/visit-queue-entry?patient=${patientUuid}`;
+  const apiUrl = `${restBaseUrl}/visit-queue-entry?patient=${patientUuid}`;
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<VisitQueueEntry> } }, Error>(
     apiUrl,
     openmrsFetch,

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {
-  useVisit,
-  openmrsFetch,
-  showSnackbar,
-  type FetchResponse,
-  showActionableNotification,
-} from '@openmrs/esm-framework';
+import { useVisit, openmrsFetch, showSnackbar, type FetchResponse } from '@openmrs/esm-framework';
 import { mockCurrentVisit, mockVisitQueueEntries } from '__mocks__';
 import { mockPatient } from 'tools';
 import { type MappedVisitQueueEntry, useVisitQueueEntry } from '../queue-entry/queue.resource';
@@ -28,6 +22,7 @@ jest.mock('@openmrs/esm-framework', () => {
     ...originalModule,
     useVisit: jest.fn(),
     openmrsFetch: jest.fn(),
+    restBaseUrl: '/ws/rest/v1',
   };
 });
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.resource.tsx
@@ -1,7 +1,7 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 
 export function deleteEncounter(encounterUuid: string, abortController: AbortController) {
-  return openmrsFetch(`/ws/rest/v1/encounter/${encounterUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/encounter/${encounterUuid}`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -1,6 +1,13 @@
 import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
-import { openmrsFetch, useConfig, type OpenmrsResource, type Privilege, type Visit } from '@openmrs/esm-framework';
+import {
+  openmrsFetch,
+  restBaseUrl,
+  useConfig,
+  type OpenmrsResource,
+  type Privilege,
+  type Visit,
+} from '@openmrs/esm-framework';
 import { type ChartConfig } from '../../config-schema';
 
 export function useInfiniteVisits(patientUuid: string) {
@@ -15,7 +22,7 @@ export function useInfiniteVisits(patientUuid: string) {
       return null;
     }
 
-    let url = `/ws/rest/v1/visit?patient=${patientUuid}&v=${customRepresentation}&limit=${pageSize}`;
+    let url = `${restBaseUrl}/visit?patient=${patientUuid}&v=${customRepresentation}&limit=${pageSize}`;
 
     if (pageIndex) {
       url += `&startIndex=${pageIndex * pageSize}`;
@@ -47,7 +54,7 @@ export function useVisits(patientUuid: string) {
     'custom:(uuid,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis),form:(uuid,display),encounterDatetime,orders:full,obs:full,encounterType:(uuid,display,viewPrivilege,editPrivilege),encounterProviders:(uuid,display,encounterRole:(uuid,display),provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient,attributes:(attributeType:ref,display,uuid,value)';
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<Visit> } }, Error>(
-    `/ws/rest/v1/visit?patient=${patientUuid}&v=${customRepresentation}`,
+    `${restBaseUrl}/visit?patient=${patientUuid}&v=${customRepresentation}`,
     openmrsFetch,
   );
   return {
@@ -60,7 +67,7 @@ export function useVisits(patientUuid: string) {
 }
 
 export function useEncounters(patientUuid: string) {
-  const endpointUrl = '/ws/rest/v1/encounter';
+  const endpointUrl = `${restBaseUrl}/encounter`;
   // setting this up to make it more generic and usable later
   const params = {
     patient: patientUuid,
@@ -99,7 +106,7 @@ export function usePastVisits(patientUuid: string) {
     'stopDatetime)';
 
   const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
-    `/ws/rest/v1/visit?patient=${patientUuid}&v=${customRepresentation}`,
+    `${restBaseUrl}/visit?patient=${patientUuid}&v=${customRepresentation}`,
     openmrsFetch,
   );
 
@@ -112,13 +119,13 @@ export function usePastVisits(patientUuid: string) {
 }
 
 export function deleteVisit(visitUuid: string) {
-  return openmrsFetch(`/ws/rest/v1/visit/${visitUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/visit/${visitUuid}`, {
     method: 'DELETE',
   });
 }
 
 export function restoreVisit(visitUuid: string) {
-  return openmrsFetch(`/ws/rest/v1/visit/${visitUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/visit/${visitUuid}`, {
     headers: {
       'content-type': 'application/json',
     },

--- a/packages/esm-patient-common-lib/src/orders/postOrders.ts
+++ b/packages/esm-patient-common-lib/src/orders/postOrders.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { getPatientUuidFromUrl } from '../get-patient-uuid-from-url';
 import { type OrderBasketStore, orderBasketStore } from './store';
 import { type OrderBasketItem, type OrderPost } from './types';
@@ -26,7 +26,7 @@ export async function postOrders(encounterUuid: string, abortController: AbortCo
 }
 
 function postOrder(body: OrderPost, abortController?: AbortController) {
-  return openmrsFetch(`/ws/rest/v1/order`, {
+  return openmrsFetch(`${restBaseUrl}/order`, {
     method: 'POST',
     signal: abortController?.signal,
     headers: { 'Content-Type': 'application/json' },

--- a/packages/esm-patient-common-lib/src/orders/useOrders.ts
+++ b/packages/esm-patient-common-lib/src/orders/useOrders.ts
@@ -1,12 +1,12 @@
 import useSWR, { mutate } from 'swr';
-import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { useCallback, useMemo } from 'react';
 import { type OrderTypeFetchResponse, type PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';
 
 export const careSettingUuid = '6f0c9a92-6f24-11e3-af88-005056821db0';
 
 export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any', orderType?: string) {
-  const baseOrdersUrl = `/ws/rest/v1/order?v=full&patient=${patientUuid}&careSetting=${careSettingUuid}&status=${status}`;
+  const baseOrdersUrl = `${restBaseUrl}/order?v=full&patient=${patientUuid}&careSetting=${careSettingUuid}&status=${status}`;
   const ordersUrl = orderType ? `${baseOrdersUrl}&orderType=${orderType}` : baseOrdersUrl;
 
   const { data, error, isLoading, isValidating } = useSWR<FetchResponse<PatientOrderFetchResponse>, Error>(
@@ -15,7 +15,7 @@ export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any', 
   );
 
   const mutateOrders = useCallback(
-    () => mutate((key) => typeof key === 'string' && key.startsWith(`/ws/rest/v1/order?patient=${patientUuid}`)),
+    () => mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?patient=${patientUuid}`)),
     [patientUuid],
   );
 
@@ -37,7 +37,7 @@ export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any', 
 }
 
 export function useOrderTypes() {
-  const orderTypesUrl = `/ws/rest/v1/ordertype`;
+  const orderTypesUrl = `${restBaseUrl}/ordertype`;
   const { data, error, isLoading, isValidating } = useSWR<FetchResponse<OrderTypeFetchResponse>, Error>(
     orderTypesUrl,
     openmrsFetch,

--- a/packages/esm-patient-common-lib/src/programs/usePatientProgramEnrollment.tsx
+++ b/packages/esm-patient-common-lib/src/programs/usePatientProgramEnrollment.tsx
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
 import { type PatientProgram } from '../types';
 import uniqBy from 'lodash-es/uniqBy';
@@ -7,7 +7,7 @@ const customRepresentation = `custom:(uuid,display,program,dateEnrolled,dateComp
 
 export const useActivePatientEnrollment = (patientUuid: string) => {
   const { data, error, isLoading } = useSWR<{ data: { results: Array<PatientProgram> } }>(
-    `/ws/rest/v1/programenrollment?patient=${patientUuid}&v=${customRepresentation}`,
+    `${restBaseUrl}/programenrollment?patient=${patientUuid}&v=${customRepresentation}`,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-common-lib/src/useSystemVisitSetting.ts
+++ b/packages/esm-patient-common-lib/src/useSystemVisitSetting.ts
@@ -1,10 +1,10 @@
 import useSWRImmutable from 'swr/immutable';
-import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
 
 export function useSystemVisitSetting() {
   const { data, isLoading, error } = useSWRImmutable<FetchResponse<{ value: 'true' | 'false' }>, Error>(
-    `/ws/rest/v1/systemsetting/visits.enabled?v=custom:(value)`,
+    `${restBaseUrl}/systemsetting/visits.enabled?v=custom:(value)`,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
+++ b/packages/esm-patient-common-lib/src/useVitalsConceptMetadata.tsx
@@ -1,11 +1,11 @@
 import useSWRImmutable from 'swr/immutable';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 
 export function useVitalsConceptMetadata() {
   const customRepresentation =
     'custom:(setMembers:(uuid,display,hiNormal,hiAbsolute,hiCritical,lowNormal,lowAbsolute,lowCritical,units))';
 
-  const apiUrl = `/ws/rest/v1/concept/?q=VITALS SIGNS&v=${customRepresentation}`;
+  const apiUrl = `${restBaseUrl}/concept/?q=VITALS SIGNS&v=${customRepresentation}`;
 
   const { data, error, isLoading } = useSWRImmutable<{ data: VitalsConceptMetadataResponse }, Error>(
     apiUrl,

--- a/packages/esm-patient-conditions-app/src/conditions/conditions.resource.ts
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions.resource.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { fhirBaseUrl, openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { fhirBaseUrl, openmrsFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import { type FHIRCondition, type FHIRConditionResponse } from '../types';
 
 export type Condition = {
@@ -106,7 +106,7 @@ export function useConditionsSearch(conditionToLookup: string) {
   const config = useConfig();
   const conditionConceptClassUuid = config?.conditionConceptClassUuid;
 
-  const conditionsSearchUrl = `/ws/rest/v1/conceptsearch?conceptClasses=${conditionConceptClassUuid}&q=${conditionToLookup}`;
+  const conditionsSearchUrl = `${restBaseUrl}/conceptsearch?conceptClasses=${conditionConceptClassUuid}&q=${conditionToLookup}`;
 
   const { data, error, isLoading } = useSWR<{ data: { results: Array<CodedCondition> } }, Error>(
     conditionToLookup ? conditionsSearchUrl : null,

--- a/packages/esm-patient-flags-app/src/flags/hooks/usePatientFlags.tsx
+++ b/packages/esm-patient-flags-app/src/flags/hooks/usePatientFlags.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import useSWR from 'swr';
-import { openmrsFetch, type FetchResponse } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, type FetchResponse } from '@openmrs/esm-framework';
 
 interface FlagFetchResponse {
   uuid: string;
@@ -23,7 +23,7 @@ interface FlagsFetchResponse {
  * @returns An array of patient identifiers
  */
 export function usePatientFlags(patientUuid: string) {
-  const url = `/ws/rest/v1/patientflags/patientflag?patient=${patientUuid}&v=full`;
+  const url = `${restBaseUrl}/patientflags/patientflag?patient=${patientUuid}&v=full`;
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<FetchResponse<FlagsFetchResponse>, Error>(
     patientUuid ? url : null,
@@ -64,7 +64,7 @@ export function useCurrentPath(): string {
 
 export function enablePatientFlag(flagUuid: string) {
   const controller = new AbortController();
-  const url = `/ws/rest/v1/patientflags/patientflag/${flagUuid}`;
+  const url = `${restBaseUrl}/patientflags/patientflag/${flagUuid}`;
 
   return openmrsFetch(url, {
     headers: {
@@ -78,7 +78,7 @@ export function enablePatientFlag(flagUuid: string) {
 
 export function disablePatientFlag(flagUuid: string) {
   const controller = new AbortController();
-  const url = `/ws/rest/v1/patientflags/patientflag/${flagUuid}`;
+  const url = `${restBaseUrl}/patientflags/patientflag/${flagUuid}`;
 
   return openmrsFetch(url, {
     headers: {

--- a/packages/esm-patient-forms-app/src/constants.ts
+++ b/packages/esm-patient-forms-app/src/constants.ts
@@ -1,9 +1,11 @@
+import { restBaseUrl } from '@openmrs/esm-framework';
+
 export const customFormRepresentation =
   '(uuid,name,display,encounterType:(uuid,name,viewPrivilege,editPrivilege),version,published,retired,resources:(uuid,name,dataType,valueReference))';
 export const customEncounterRepresentation = `custom:(uuid,encounterDatetime,encounterType:(uuid,name,viewPrivilege,editPrivilege),form:${customFormRepresentation}`;
 
-export const formEncounterUrl = `/ws/rest/v1/form?v=custom:${customFormRepresentation}`;
-export const formEncounterUrlPoc = `/ws/rest/v1/form?v=custom:${customFormRepresentation}&q=poc`;
+export const formEncounterUrl = `${restBaseUrl}/form?v=custom:${customFormRepresentation}`;
+export const formEncounterUrlPoc = `${restBaseUrl}/form?v=custom:${customFormRepresentation}&q=poc`;
 
 export const clinicalFormsWorkspace = 'clinical-forms-workspace';
 export const formEntryWorkspace = 'patient-form-entry-workspace';

--- a/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
@@ -2,11 +2,11 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import debounce from 'lodash-es/debounce';
 import fuzzy from 'fuzzy';
-import { DataTableSkeleton, Tile } from '@carbon/react';
+import { DataTableSkeleton } from '@carbon/react';
 import { formatDatetime, useLayoutType, ResponsiveWrapper } from '@openmrs/esm-framework';
+import type { CompletedFormInfo } from '../types';
 import FormsTable from './forms-table.component';
 import styles from './forms-list.scss';
-import type { CompletedFormInfo } from '../types';
 
 export type FormsListProps = {
   completedForms?: Array<CompletedFormInfo>;

--- a/packages/esm-patient-forms-app/src/forms/forms-table.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-table.component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   DataTable,
   Link,
@@ -12,10 +13,8 @@ import {
   TableToolbar,
   TableToolbarContent,
   TableToolbarSearch,
-  Tile,
 } from '@carbon/react';
 import styles from './forms-table.scss';
-import { useTranslation } from 'react-i18next';
 
 interface FormsTableProps {
   tableHeaders: Array<{

--- a/packages/esm-patient-forms-app/src/hooks/use-forms.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-forms.ts
@@ -3,6 +3,7 @@ import useSWR from 'swr';
 import {
   getDynamicOfflineDataEntries,
   openmrsFetch,
+  restBaseUrl,
   useConfig,
   userHasAccess,
   useSession,
@@ -43,7 +44,7 @@ export function useEncountersWithFormRef(
   endDate: Date = dayjs(new Date()).endOf('day').toDate(),
 ) {
   const url = patientUuid
-    ? `/ws/rest/v1/encounter?v=${customEncounterRepresentation}&patient=${patientUuid}&fromdate=${startDate.toISOString()}&todate=${endDate.toISOString()}`
+    ? `${restBaseUrl}/encounter?v=${customEncounterRepresentation}&patient=${patientUuid}&fromdate=${startDate.toISOString()}&todate=${endDate.toISOString()}`
     : null;
   return useSWR(url, openmrsFetch<ListResponse<EncounterWithFormRef>>);
 }

--- a/packages/esm-patient-forms-app/src/offline.ts
+++ b/packages/esm-patient-forms-app/src/offline.ts
@@ -3,6 +3,7 @@ import {
   messageOmrsServiceWorker,
   omrsOfflineCachingStrategyHttpHeaderName,
   openmrsFetch,
+  restBaseUrl,
   setupDynamicOfflineDataHandler,
   setupOfflineSync,
   type SyncProcessOptions,
@@ -68,7 +69,7 @@ async function syncEncounter(associatedOfflineVisit: Visit, encounter?: Encounte
     encounterDatetime: encounter.encounterDatetime ?? associatedOfflineVisit?.stopDatetime,
   };
 
-  await openmrsFetch('/ws/rest/v1/encounter', {
+  await openmrsFetch(`${restBaseUrl}/encounter`, {
     headers: { 'Content-Type': 'application/json' },
     method: 'POST',
     body,
@@ -80,7 +81,7 @@ async function syncPersonUpdate(personUuid?: string, personUpdate?: any) {
     return;
   }
 
-  await openmrsFetch(`/ws/rest/v1/person/${personUuid}`, {
+  await openmrsFetch(`${restBaseUrl}/person/${personUuid}`, {
     headers: { 'Content-Type': 'application/json' },
     method: 'POST',
     body: personUpdate,
@@ -125,7 +126,7 @@ export async function setupDynamicFormDataHandler() {
 }
 
 async function getCacheableFormUrls(formUuid: string) {
-  const getFormRes = await openmrsFetch<Form>(`/ws/rest/v1/form/${formUuid}?v=full`);
+  const getFormRes = await openmrsFetch<Form>(`${restBaseUrl}/form/${formUuid}?v=full`);
   const form = getFormRes.data;
 
   if (!form) {

--- a/packages/esm-patient-immunizations-app/src/hooks/useImmunizationsConceptSet.ts
+++ b/packages/esm-patient-immunizations-app/src/hooks/useImmunizationsConceptSet.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type ImmunizationWidgetConfigObject, type OpenmrsConcept } from '../types/fhir-immunization-domain';
 import useSWR from 'swr';
 
@@ -7,7 +7,7 @@ export function useImmunizationsConceptSet(config: ImmunizationWidgetConfigObjec
     'custom:(uuid,display,answers:(uuid,display),conceptMappings:(conceptReferenceTerm:(conceptSource:(name),code)))';
 
   const { data, error, isLoading } = useSWR<{ data: { results: Array<OpenmrsConcept> } }, Error>(
-    `/ws/rest/v1/concept?references=${config.immunizationConceptSet}&v=${conceptRepresentation}`,
+    `${restBaseUrl}/concept?references=${config.immunizationConceptSet}&v=${conceptRepresentation}`,
     openmrsFetch,
   );
   return {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
@@ -7,6 +7,11 @@ import { configSchema } from '../../config-schema';
 
 jest.mock('swr/immutable');
 
+jest.mock('@openmrs/esm-framework', () => ({
+  ...jest.requireActual('@openmrs/esm-framework'),
+  restBaseUrl: '/ws/rest/v1',
+}));
+
 const mockOpenrsFetch = openmrsFetch as jest.Mock;
 const mockUseConfig = useConfig as jest.Mock;
 const mockUseSWRImmutable = useSWRImmutable as jest.Mock;

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
 import fuzzy from 'fuzzy';
-import { type FetchResponse, openmrsFetch, useConfig, reportError } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, useConfig, restBaseUrl, reportError } from '@openmrs/esm-framework';
 import { type Concept } from '../../types';
 import { type ConfigObject } from '../../config-schema';
 
@@ -30,8 +30,8 @@ function useTestConceptsSWR(labOrderableConcepts?: Array<string>) {
   const { data, isLoading, error } = useSWRImmutable(
     () =>
       labOrderableConcepts
-        ? labOrderableConcepts.map((c) => `/ws/rest/v1/concept/${c}`)
-        : `/ws/rest/v1/concept?class=Test`,
+        ? labOrderableConcepts.map((c) => `${restBaseUrl}/concept/${c}`)
+        : `${restBaseUrl}/concept?class=Test`,
     (labOrderableConcepts ? openmrsFetchMultiple : openmrsFetch) as any,
     {
       shouldRetryOnError(err) {

--- a/packages/esm-patient-labs-app/src/lab-orders/api.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/api.ts
@@ -1,5 +1,5 @@
 import useSWR, { mutate } from 'swr';
-import { type FetchResponse, openmrsFetch, useConfig, showSnackbar } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, useConfig, restBaseUrl, showSnackbar } from '@openmrs/esm-framework';
 import { type ConfigObject } from '../config-schema';
 import { useCallback, useMemo } from 'react';
 import { type OrderBasketItem, type OrderPost, type PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';
@@ -14,7 +14,7 @@ export const careSettingUuid = '6f0c9a92-6f24-11e3-af88-005056821db0';
  */
 export function usePatientLabOrders(patientUuid: string, status: 'ACTIVE' | 'any') {
   const { labOrderTypeUuid: labOrderTypeUUID } = (useConfig() as ConfigObject).orders;
-  const ordersUrl = `/ws/rest/v1/order?patient=${patientUuid}&careSetting=${careSettingUuid}&status=${status}&orderType=${labOrderTypeUUID}`;
+  const ordersUrl = `${restBaseUrl}/order?patient=${patientUuid}&careSetting=${careSettingUuid}&status=${status}&orderType=${labOrderTypeUUID}`;
 
   const { data, error, isLoading, isValidating } = useSWR<FetchResponse<PatientOrderFetchResponse>, Error>(
     patientUuid ? ordersUrl : null,
@@ -22,7 +22,7 @@ export function usePatientLabOrders(patientUuid: string, status: 'ACTIVE' | 'any
   );
 
   const mutateOrders = useCallback(
-    () => mutate((key) => typeof key === 'string' && key.startsWith(`/ws/rest/v1/order?patient=${patientUuid}`)),
+    () => mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?patient=${patientUuid}`)),
     [patientUuid],
   );
 
@@ -47,7 +47,7 @@ export function useOrderReasons(conceptUuids: Array<string>) {
   const shouldFetch = conceptUuids && conceptUuids.length > 0;
   const url = shouldFetch ? getConceptReferenceUrls(conceptUuids) : null;
   const { data, error, isLoading } = useSWRImmutable<FetchResponse<ConceptResponse>, Error>(
-    shouldFetch ? `/ws/rest/v1/${url[0]}` : null,
+    shouldFetch ? `${restBaseUrl}/${url[0]}` : null,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-labs-app/src/test-results/grouped-timeline/useObstreeData.ts
+++ b/packages/esm-patient-labs-app/src/test-results/grouped-timeline/useObstreeData.ts
@@ -1,4 +1,4 @@
-import { usePatient, openmrsFetch } from '@openmrs/esm-framework';
+import { usePatient, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
 import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
@@ -31,7 +31,7 @@ const augmentObstreeData = (node, prefix) => {
 
 const useGetObstreeData = (conceptUuid) => {
   const { patientUuid } = usePatient();
-  const response = useSWR(`/ws/rest/v1/obstree?patient=${patientUuid}&concept=${conceptUuid}`, openmrsFetch);
+  const response = useSWR(`${restBaseUrl}/obstree?patient=${patientUuid}&concept=${conceptUuid}`, openmrsFetch);
   const result = useMemo(() => {
     if (response.data) {
       const { data, ...rest } = response;
@@ -52,7 +52,7 @@ const useGetManyObstreeData = (uuidArray: Array<string>) => {
   const { patientUuid } = usePatient();
   const getObstreeUrl = (index: number) => {
     if (index < uuidArray.length && patientUuid) {
-      return `/ws/rest/v1/obstree?patient=${patientUuid}&concept=${uuidArray[index]}`;
+      return `${restBaseUrl}/obstree?patient=${patientUuid}&concept=${uuidArray[index]}`;
     } else return null;
   };
   const { data, error, isLoading } = useSWRInfinite(getObstreeUrl, openmrsFetch, {

--- a/packages/esm-patient-labs-app/src/test-results/loadPatientTestData/helpers.ts
+++ b/packages/esm-patient-labs-app/src/test-results/loadPatientTestData/helpers.ts
@@ -1,3 +1,4 @@
+import { restBaseUrl } from '@openmrs/esm-framework';
 import {
   type PatientData,
   type ObsRecord,
@@ -127,7 +128,7 @@ export function loadPresentConcepts(entries: Array<ObsRecord>): Promise<Array<Co
     [...new Set(entries.map(getEntryConceptClassUuid))].map(
       (conceptUuid) =>
         conceptCache[conceptUuid] ||
-        (conceptCache[conceptUuid] = fetch(`${window.openmrsBase}/ws/rest/v1/concept/${conceptUuid}?v=full`).then(
+        (conceptCache[conceptUuid] = fetch(`${window.openmrsBase}${restBaseUrl}/concept/${conceptUuid}?v=full`).then(
           (res) => res.json(),
         )),
     ),

--- a/packages/esm-patient-labs-app/src/test-results/panel-view/usePanelData.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/panel-view/usePanelData.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { type FetchResponse, openmrsFetch, usePatient } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, usePatient, restBaseUrl } from '@openmrs/esm-framework';
 import useSWRInfinite from 'swr/infinite';
 import { extractMetaInformation, getConceptUuid } from './helper';
 import {
@@ -66,7 +66,7 @@ function useConcepts(conceptUuids: Array<string>) {
   const getUrl = useCallback(
     (index) => {
       if (conceptUuids && index < conceptUuids.length) {
-        return `/ws/rest/v1/concept/${conceptUuids[index]}?v=full`;
+        return `${restBaseUrl}/concept/${conceptUuids[index]}?v=full`;
       }
       return null;
     },

--- a/packages/esm-patient-labs-app/src/test-results/trendline/trendline-resource.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/trendline/trendline-resource.tsx
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 import { assessValue } from '../loadPatientTestData/helpers';
 import { useMemo } from 'react';
-import { type FetchResponse, openmrsFetch, showSnackbar } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, showSnackbar, restBaseUrl } from '@openmrs/esm-framework';
 import { type TreeNode } from '../filter/filter-types';
 
 function computeTrendlineData(treeNode: TreeNode): Array<TreeNode> {
@@ -35,7 +35,7 @@ export function useObstreeData(
   isValidating: boolean;
 } {
   const { data, error, isLoading, isValidating } = useSWR<FetchResponse<TreeNode>, Error>(
-    `/ws/rest/v1/obstree?patient=${patientUuid}&concept=${conceptUuid}`,
+    `${restBaseUrl}/obstree?patient=${patientUuid}&concept=${conceptUuid}`,
     openmrsFetch,
   );
   if (error) {

--- a/packages/esm-patient-lists-app/src/patient-lists.resource.ts
+++ b/packages/esm-patient-lists-app/src/patient-lists.resource.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { formatDate, openmrsFetch, parseDate } from '@openmrs/esm-framework';
+import { formatDate, openmrsFetch, parseDate, restBaseUrl } from '@openmrs/esm-framework';
 
 /**
  * Represents a cohort object returned by the OpenMRS Cohort resource https://github.com/openmrs/openmrs-module-cohort#readme.
@@ -80,7 +80,7 @@ export function usePatientLists() {
   // Custom representation of the cohort object to fetch only the required properties.
   const customRepresentation = `custom:(uuid,name,description,display,size,attributes,cohortType,startDate,endDate)`;
 
-  const listsUrl = `/ws/rest/v1/cohortm/cohort?`;
+  const listsUrl = `${restBaseUrl}/cohortm/cohort?`;
 
   const urlSearchParams = new URLSearchParams({
     v: customRepresentation,
@@ -121,7 +121,7 @@ export function usePatientLists() {
  * @returns An object containing the members of the patient list, loading state, and error state.
  */
 export function usePatientListMembers(listUuid: string, searchQuery = '', startIndex = '', pageSize = '') {
-  const listMembersUrl = `/ws/rest/v1/cohortm/cohortmember?`;
+  const listMembersUrl = `${restBaseUrl}/cohortm/cohortmember?`;
 
   const urlSearchParams = new URLSearchParams({
     cohort: listUuid,

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
@@ -4,8 +4,8 @@ import { type DefaultWorkspaceProps, launchPatientWorkspace, useOrderBasket } fr
 import { DrugOrderForm } from './drug-order-form.component';
 import { useSession } from '@openmrs/esm-framework';
 import { careSettingUuid, prepMedicationOrderPostData } from '../api/api';
-import type { DrugOrderBasketItem } from '../types';
 import { ordersEqual } from './drug-search/helpers';
+import type { DrugOrderBasketItem } from '../types';
 
 export interface AddDrugOrderWorkspaceAdditionalProps {
   order: DrugOrderBasketItem;

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.resource.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.resource.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
-import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import type { Drug } from '@openmrs/esm-patient-common-lib';
 import { type DrugOrderBasketItem, type DrugOrderTemplate, type OrderTemplate } from '../../types';
 
@@ -26,7 +26,7 @@ export function useDrugSearch(query: string): {
 } {
   const { data, error, isLoading } = useSWRImmutable<FetchResponse<{ results: Array<DrugSearchResult> }>, Error>(
     query
-      ? `/ws/rest/v1/drug?q=${query}&v=custom:(uuid,display,name,strength,dosageForm:(display,uuid),concept:(display,uuid))`
+      ? `${restBaseUrl}/drug?q=${query}&v=custom:(uuid,display,name,strength,dosageForm:(display,uuid),concept:(display,uuid))`
       : null,
     openmrsFetch,
   );
@@ -58,7 +58,7 @@ export function useDrugTemplate(drugUuid: string): {
       }>;
     }>,
     Error
-  >(drugUuid ? `/ws/rest/v1/ordertemplates/orderTemplate?drug=${drugUuid}` : null, openmrsFetch);
+  >(drugUuid ? `${restBaseUrl}/ordertemplates/orderTemplate?drug=${drugUuid}` : null, openmrsFetch);
 
   const results = useMemo(
     () => ({

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -1,5 +1,5 @@
 import useSWR, { mutate } from 'swr';
-import { type FetchResponse, openmrsFetch, toOmrsIsoString, useConfig } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, toOmrsIsoString, useConfig, restBaseUrl } from '@openmrs/esm-framework';
 import { type ConfigObject } from '../config-schema';
 import { useCallback, useMemo } from 'react';
 import { type OrderPost, type PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';
@@ -22,7 +22,7 @@ export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any') 
     'commentToFulfiller,drug:(uuid,display,strength,dosageForm:(display,uuid),concept),dose,doseUnits:ref,' +
     'frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,numRefills,dosingInstructions,' +
     'duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)';
-  const ordersUrl = `/ws/rest/v1/order?patient=${patientUuid}&careSetting=${careSettingUuid}&status=${status}&orderType=${drugOrderTypeUUID}&v=${customRepresentation}`;
+  const ordersUrl = `${restBaseUrl}/order?patient=${patientUuid}&careSetting=${careSettingUuid}&status=${status}&orderType=${drugOrderTypeUUID}&v=${customRepresentation}`;
 
   const { data, error, isLoading, isValidating } = useSWR<FetchResponse<PatientOrderFetchResponse>, Error>(
     patientUuid ? ordersUrl : null,
@@ -30,7 +30,7 @@ export function usePatientOrders(patientUuid: string, status: 'ACTIVE' | 'any') 
   );
 
   const mutateOrders = useCallback(
-    () => mutate((key) => typeof key === 'string' && key.startsWith(`/ws/rest/v1/order?patient=${patientUuid}`)),
+    () => mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?patient=${patientUuid}`)),
     [patientUuid],
   );
 

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -1,5 +1,5 @@
 import useSWR, { mutate } from 'swr';
-import { type FetchResponse, openmrsFetch, toOmrsIsoString, useConfig, restBaseUrl } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, useConfig, restBaseUrl } from '@openmrs/esm-framework';
 import { type ConfigObject } from '../config-schema';
 import { useCallback, useMemo } from 'react';
 import { type OrderPost, type PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';

--- a/packages/esm-patient-medications-app/src/api/order-config.ts
+++ b/packages/esm-patient-medications-app/src/api/order-config.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
 import {
@@ -34,7 +34,7 @@ export function useOrderConfig(): {
   };
 } {
   const { data, error, isLoading, isValidating } = useSWRImmutable<{ data: OrderConfig }, Error>(
-    `/ws/rest/v1/orderentryconfig`,
+    `${restBaseUrl}/orderentryconfig`,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-notes-app/src/config-schema.ts
+++ b/packages/esm-patient-notes-app/src/config-schema.ts
@@ -5,6 +5,5 @@ export const configSchema = {
 };
 
 export interface ConfigObject {
-  [x: string]: any;
   visitNoteConfig: VisitNoteConfigObject;
 }

--- a/packages/esm-patient-notes-app/src/config-schema.ts
+++ b/packages/esm-patient-notes-app/src/config-schema.ts
@@ -5,5 +5,6 @@ export const configSchema = {
 };
 
 export interface ConfigObject {
+  [x: string]: any;
   visitNoteConfig: VisitNoteConfigObject;
 }

--- a/packages/esm-patient-notes-app/src/index.ts
+++ b/packages/esm-patient-notes-app/src/index.ts
@@ -3,6 +3,7 @@ import {
   getAsyncLifecycle,
   getSyncLifecycle,
   messageOmrsServiceWorker,
+  restBaseUrl,
   translateFrom,
 } from '@openmrs/esm-framework';
 import { configSchema } from './config-schema';
@@ -22,7 +23,7 @@ export const importTranslation = require.context('../translations', false, /.jso
 export function startupApp() {
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: '.+/ws/rest/v1/encounter.+',
+    pattern: `.+${restBaseUrl}/encounter.+`,
   });
 
   defineConfigSchema(moduleName, configSchema);

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -33,6 +33,7 @@ import {
   useLayoutType,
   useSession,
   createAttachment,
+  restBaseUrl,
   ResponsiveWrapper,
 } from '@openmrs/esm-framework';
 import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
@@ -110,7 +111,8 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
 
   const currentImage = watch('image');
   const { mutateVisitNotes } = useVisitNotes(patientUuid);
-  const mutateAttachments = () => mutate((key) => typeof key === 'string' && key.startsWith(`/ws/rest/v1/attachment`));
+  const mutateAttachments = () =>
+    mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/attachment`));
   const locationUuid = session?.sessionLocation?.uuid;
   const providerUuid = session?.currentProvider?.uuid;
 

--- a/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 import { map } from 'rxjs/operators';
-import { openmrsFetch, openmrsObservableFetch, useConfig } from '@openmrs/esm-framework';
+import { openmrsFetch, openmrsObservableFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import {
   type EncountersFetchResponse,
   type RESTPatientNote,
@@ -29,7 +29,7 @@ export function useVisitNotes(patientUuid: string): UseVisitNotes {
     'encounterRole:(uuid,display),' +
     'provider:(uuid,person:(uuid,display))),' +
     'diagnoses';
-  const encountersApiUrl = `/ws/rest/v1/encounter?patient=${patientUuid}&obs=${visitDiagnosesConceptUuid}&v=${customRepresentation}`;
+  const encountersApiUrl = `${restBaseUrl}/encounter?patient=${patientUuid}&obs=${visitDiagnosesConceptUuid}&v=${customRepresentation}`;
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: EncountersFetchResponse }, Error>(
     encountersApiUrl,
@@ -65,12 +65,12 @@ export function useVisitNotes(patientUuid: string): UseVisitNotes {
 
 export function fetchConceptDiagnosisByName(searchTerm: string) {
   return openmrsObservableFetch<Array<Concept>>(
-    `/ws/rest/v1/concept?q=${searchTerm}&searchType=fuzzy&class=8d4918b0-c2cc-11de-8d13-0010c6dffd0f&q=&v=custom:(uuid,display)`,
+    `${restBaseUrl}/concept?q=${searchTerm}&searchType=fuzzy&class=8d4918b0-c2cc-11de-8d13-0010c6dffd0f&q=&v=custom:(uuid,display)`,
   ).pipe(map(({ data }) => data['results']));
 }
 
 export function saveVisitNote(abortController: AbortController, payload: VisitNotePayload) {
-  return openmrsFetch(`/ws/rest/v1/encounter`, {
+  return openmrsFetch(`${restBaseUrl}/encounter`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -81,7 +81,7 @@ export function saveVisitNote(abortController: AbortController, payload: VisitNo
 }
 
 export function savePatientDiagnosis(abortController: AbortController, payload: DiagnosisPayload) {
-  return openmrsFetch(`/ws/rest/v1/patientdiagnoses`, {
+  return openmrsFetch(`${restBaseUrl}/patientdiagnoses`, {
     headers: {
       'Content-Type': 'application/json',
     },

--- a/packages/esm-patient-orders-app/src/api/api.ts
+++ b/packages/esm-patient-orders-app/src/api/api.ts
@@ -1,6 +1,13 @@
 import { useCallback, useMemo } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
-import { type FetchResponse, openmrsFetch, type OpenmrsResource, parseDate, type Visit } from '@openmrs/esm-framework';
+import {
+  type FetchResponse,
+  openmrsFetch,
+  type OpenmrsResource,
+  parseDate,
+  type Visit,
+  restBaseUrl,
+} from '@openmrs/esm-framework';
 import { type OrderPost, useVisitOrOfflineVisit, useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
 
 export const careSettingUuid = '6f0c9a92-6f24-11e3-af88-005056821db0';
@@ -16,7 +23,7 @@ export function useMutatePatientOrders(patientUuid: string) {
   const mutateOrders = useCallback(
     () =>
       mutate((key) => {
-        return typeof key === 'string' && key.startsWith(`/ws/rest/v1/order?patient=${patientUuid}`);
+        return typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?patient=${patientUuid}`);
       }),
     [patientUuid, mutate],
   );
@@ -27,14 +34,14 @@ export function useMutatePatientOrders(patientUuid: string) {
 }
 
 export function getPatientEncounterId(patientUuid: string, abortController: AbortController) {
-  return openmrsFetch(`/ws/rest/v1/encounter?patient=${patientUuid}&order=desc&limit=1&v=custom:(uuid)`, {
+  return openmrsFetch(`${restBaseUrl}/encounter?patient=${patientUuid}&order=desc&limit=1&v=custom:(uuid)`, {
     signal: abortController.signal,
   });
 }
 
 export function getMedicationByUuid(abortController: AbortController, orderUuid: string) {
   return openmrsFetch(
-    `/ws/rest/v1/order/${orderUuid}?v=custom:(uuid,route:(uuid,display),action,urgency,display,drug:(display,strength),frequency:(display),dose,doseUnits:(display),orderer,dateStopped,dateActivated,previousOrder,numRefills,duration,durationUnits:(display),dosingInstructions)`,
+    `${restBaseUrl}/order/${orderUuid}?v=custom:(uuid,route:(uuid,display),action,urgency,display,drug:(display,strength),frequency:(display),dose,doseUnits:(display),orderer,dateStopped,dateActivated,previousOrder,numRefills,duration,durationUnits:(display),dosingInstructions)`,
     {
       signal: abortController.signal,
     },
@@ -69,7 +76,7 @@ export function createEmptyEncounter(
     obs: [],
   };
 
-  return openmrsFetch<OpenmrsResource>('/ws/rest/v1/encounter', {
+  return openmrsFetch<OpenmrsResource>('${restBaseUrl}/encounter', {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -80,7 +87,7 @@ export function createEmptyEncounter(
 }
 
 export function postOrder(body: OrderPost, abortController?: AbortController) {
-  return openmrsFetch(`/ws/rest/v1/order`, {
+  return openmrsFetch(`${restBaseUrl}/order`, {
     method: 'POST',
     signal: abortController?.signal,
     headers: { 'Content-Type': 'application/json' },
@@ -101,7 +108,7 @@ export function useOrderEncounter(patientUuid: string): {
   const nowDateString = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`;
   const todayEncounter = useSWR<FetchResponse<{ results: Array<OpenmrsResource> }>, Error>(
     !isLoadingSystemVisitSetting && !systemVisitEnabled && patientUuid
-      ? `/ws/rest/v1/encounter?patient=${patientUuid}&fromdate=${nowDateString}&limit=1`
+      ? `${restBaseUrl}/encounter?patient=${patientUuid}&fromdate=${nowDateString}&limit=1`
       : null,
     openmrsFetch,
   );

--- a/packages/esm-patient-orders-app/src/api/api.ts
+++ b/packages/esm-patient-orders-app/src/api/api.ts
@@ -76,7 +76,7 @@ export function createEmptyEncounter(
     obs: [],
   };
 
-  return openmrsFetch<OpenmrsResource>('${restBaseUrl}/encounter', {
+  return openmrsFetch<OpenmrsResource>(`${restBaseUrl}/encounter`, {
     headers: {
       'Content-Type': 'application/json',
     },

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -1,9 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import dayjs from 'dayjs';
 import capitalize from 'lodash-es/capitalize';
+import orderBy from 'lodash-es/orderBy';
+import { useTranslation } from 'react-i18next';
+import { useReactToPrint } from 'react-to-print';
 import {
-  DataTable,
   Button,
+  DataTable,
+  DataTableSkeleton,
+  Dropdown,
   IconButton,
   InlineLoading,
   OverflowMenu,
@@ -15,31 +20,27 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-  Dropdown,
-  DataTableSkeleton,
+  Tooltip,
 } from '@carbon/react';
+import { Add, User, Printer } from '@carbon/react/icons';
 import {
-  CardHeader,
   type Order,
   type OrderBasketItem,
-  PatientChartPagination,
-  useOrderBasket,
-  useLaunchWorkspaceRequiringVisit,
   type OrderType,
+  CardHeader,
   EmptyState,
   ErrorState,
-  usePatientOrders,
+  PatientChartPagination,
+  useLaunchWorkspaceRequiringVisit,
+  useOrderBasket,
   useOrderTypes,
+  usePatientOrders,
 } from '../../../esm-patient-common-lib';
-import { Add, User, Printer } from '@carbon/react/icons';
 import { age, formatDate, useConfig, useLayoutType, usePagination, usePatient } from '@openmrs/esm-framework';
-import { useTranslation } from 'react-i18next';
-import styles from './order-details-table.scss';
-import { useReactToPrint } from 'react-to-print';
 import { compare, orderPriorityToColor } from '../utils/utils';
 import PrintComponent from '../print/print.component';
-import { orderBy } from 'lodash-es';
-import { Tooltip } from '@carbon/react';
+import styles from './order-details-table.scss';
+
 interface OrderDetailsProps {
   title?: string;
   patientUuid: string;

--- a/packages/esm-patient-programs-app/src/programs/programs.resource.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs.resource.tsx
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 import { map as rxjsMap } from 'rxjs/operators';
-import { openmrsFetch, openmrsObservableFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, openmrsObservableFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type PatientProgram, type Program, type ProgramsFetchResponse } from '../types';
 import uniqBy from 'lodash-es/uniqBy';
 import filter from 'lodash-es/filter';
@@ -10,7 +10,7 @@ import map from 'lodash-es/map';
 export const customRepresentation = `custom:(uuid,display,program,dateEnrolled,dateCompleted,location:(uuid,display))`;
 
 export function useEnrollments(patientUuid: string) {
-  const enrollmentsUrl = `/ws/rest/v1/programenrollment?patient=${patientUuid}&v=${customRepresentation}`;
+  const enrollmentsUrl = `${restBaseUrl}/programenrollment?patient=${patientUuid}&v=${customRepresentation}`;
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: ProgramsFetchResponse }, Error>(
     patientUuid ? enrollmentsUrl : null,
     openmrsFetch,
@@ -35,7 +35,7 @@ export function useEnrollments(patientUuid: string) {
 
 export function useAvailablePrograms(enrollments?: Array<PatientProgram>) {
   const { data, error, isLoading } = useSWR<{ data: { results: Array<Program> } }, Error>(
-    `/ws/rest/v1/program?v=custom:(uuid,display,allWorkflows,concept:(uuid,display))`,
+    `${restBaseUrl}/program?v=custom:(uuid,display,allWorkflows,concept:(uuid,display))`,
     openmrsFetch,
   );
 
@@ -55,7 +55,7 @@ export function useAvailablePrograms(enrollments?: Array<PatientProgram>) {
 }
 
 export function getPatientProgramByUuid(programUuid: string) {
-  return openmrsObservableFetch<PatientProgram>(`/ws/rest/v1/programenrollment/${programUuid}`).pipe(
+  return openmrsObservableFetch<PatientProgram>(`${restBaseUrl}/programenrollment/${programUuid}`).pipe(
     rxjsMap(({ data }) => data),
   );
 }
@@ -65,7 +65,7 @@ export function createProgramEnrollment(payload, abortController) {
     return null;
   }
   const { program, patient, dateEnrolled, dateCompleted, location } = payload;
-  return openmrsObservableFetch(`/ws/rest/v1/programenrollment`, {
+  return openmrsObservableFetch(`${restBaseUrl}/programenrollment`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -80,7 +80,7 @@ export function updateProgramEnrollment(programEnrollmentUuid: string, payload, 
     return null;
   }
   const { program, dateEnrolled, dateCompleted, location } = payload;
-  return openmrsObservableFetch(`/ws/rest/v1/programenrollment/${programEnrollmentUuid}`, {
+  return openmrsObservableFetch(`${restBaseUrl}/programenrollment/${programEnrollmentUuid}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/esm-patient-vitals-app/src/common/data.resource.ts
+++ b/packages/esm-patient-vitals-app/src/common/data.resource.ts
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { type FHIRResource, type FetchResponse, fhirBaseUrl, openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import {
+  type FHIRResource,
+  type FetchResponse,
+  fhirBaseUrl,
+  restBaseUrl,
+  openmrsFetch,
+  useConfig,
+} from '@openmrs/esm-framework';
 import { type ObsRecord, useVitalsConceptMetadata, type ConceptMetadata } from '@openmrs/esm-patient-common-lib';
 import { type KeyedMutator } from 'swr';
 import useSWRInfinite from 'swr/infinite';
@@ -222,7 +229,7 @@ export function saveVitalsAndBiometrics(
   abortController: AbortController,
   location: string,
 ) {
-  return openmrsFetch<unknown>(`/ws/rest/v1/encounter`, {
+  return openmrsFetch<unknown>(`${restBaseUrl}/encounter`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -248,7 +255,7 @@ export function updateVitalsAndBiometrics(
   encounterUuid: string,
   location: string,
 ) {
-  return openmrsFetch(`/ws/rest/v1/encounter/${encounterUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/encounter/${encounterUuid}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/esm-patient-vitals-app/src/index.ts
+++ b/packages/esm-patient-vitals-app/src/index.ts
@@ -4,6 +4,7 @@ import {
   getAsyncLifecycle,
   getSyncLifecycle,
   messageOmrsServiceWorker,
+  restBaseUrl,
   translateFrom,
 } from '@openmrs/esm-framework';
 import { createDashboardLink, registerWorkspace } from '@openmrs/esm-patient-common-lib';
@@ -32,7 +33,7 @@ export function startupApp() {
 
   messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
-    pattern: `.+/ws/rest/v1/concept.+`,
+    pattern: `.+${restBaseUrl}/concept.+`,
   });
 
   defineConfigSchema(moduleName, configSchema);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4388,9 +4388,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-api@npm:5.4.1-pre.1567"
+"@openmrs/esm-api@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-api@npm:5.4.1-pre.1579"
   dependencies:
     "@types/fhir": 0.0.31
     lodash-es: ^4.17.21
@@ -4399,17 +4399,17 @@ __metadata:
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: cc99c640c0a710efa865d5d36738caf708f58d4278a63f108f7265b38fb6e2a0c98da76401a0673bb41152a924d5c7b2e39a0809bb5bfd65d6feaaaff2e3c23c
+  checksum: 2b519a8415754a98e0e2ffe11e88a22986aa6b0a18201c5c04fbe44f079438f816a86f121d68ffb33427cbe08619742f2f83a7d025dfdf0b7b0b7d4c4489093c
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-app-shell@npm:5.4.1-pre.1567"
+"@openmrs/esm-app-shell@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-app-shell@npm:5.4.1-pre.1579"
   dependencies:
     "@carbon/react": ~1.37.0
-    "@openmrs/esm-framework": 5.4.1-pre.1567
-    "@openmrs/esm-styleguide": 5.4.1-pre.1567
+    "@openmrs/esm-framework": 5.4.1-pre.1579
+    "@openmrs/esm-styleguide": 5.4.1-pre.1579
     dayjs: ^1.10.4
     dexie: ^3.0.3
     html-webpack-plugin: ^5.5.0
@@ -4434,44 +4434,44 @@ __metadata:
     workbox-strategies: ^6.1.5
     workbox-webpack-plugin: ^6.1.5
     workbox-window: ^6.1.5
-  checksum: 8686a32fb375d960dca8691b2d148f286cd668fc74b548c5bc5dc69473e147c2992d5c3cdc039cdd91d470c361b207a11fa85bd13aaf6e9400b0ed0d9b501473
+  checksum: de051b2e81eef8ccf0c5815433465d2c52092582c3939d13ed5ae3cb7499d305ad2001ad20f9ce9de6f2f3cb724139b99c53261c72eda727e4eaa4d977ac73a9
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-config@npm:5.4.1-pre.1567"
+"@openmrs/esm-config@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-config@npm:5.4.1-pre.1579"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 4e1a93b06a683d0fc7f0925c832e26da1deb32fc6c0c92384a304d562134232ebae0784f2d28cf81c25aebe518d698342c4f291bc8e221be0ee53ac7293acfe5
+  checksum: 6e3d36b58a83484f4c7740c1801cd908ec66db1c9af24a20cab17d837e8743cdfdfc0be5cf374ea7cac1b63fb367a18fc89b98bf542684ce09be001805b6e2ef
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.4.1-pre.1567"
+"@openmrs/esm-dynamic-loading@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.4.1-pre.1579"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: fe1595d833a91184dd6d23048d39b8445826256bf821a2099c382a2b79f12461403bd19d7741e6694863c5166a8f20d05b451b803fc66ba40c7cf2cc7fd533cd
+  checksum: 3fe307d896f8d44d0f86ec82e9f4d211967e76d59db6a0823f8683eb1857a314e0a68c58a947572d8cc2a3ba7adfe2dd056171a8d234f2d5267e9a6d19d620d0
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-error-handling@npm:5.4.1-pre.1567"
+"@openmrs/esm-error-handling@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-error-handling@npm:5.4.1-pre.1579"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 9748aec555c72120d9ba25a41a29ed0a480f2491e086a62d399e3ba78ccec372d15af3c09bcf82a0d80692799cf6faaa4d5eaf28f4ebdfb7857a6b74cd693ccd
+  checksum: cc73648eba285a437a919a0bc653fc4f9ed602777feb69a632c82e480bb2f02b6aec1c3c1e1b8b5d28ac48d040274362eb86f71462a5c9d667d8ee7e78dfdb58
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-extensions@npm:5.4.1-pre.1567"
+"@openmrs/esm-extensions@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-extensions@npm:5.4.1-pre.1579"
   dependencies:
     lodash-es: ^4.17.21
   peerDependencies:
@@ -4480,20 +4480,20 @@ __metadata:
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: df23a48c3abe27eb55624c0b78564c2b72c60c2160d9e83f11197cf3abd45c23df18a7e6203030452a975925404ab7adf9be43ec1bd261f533541f42818c936f
+  checksum: 056fee95eae60cd58c021de85902ea9fbd0552f19b2b65118aea5141c0d95d30d5bd287c403af2eff5a6b89680928fb2d5d990007e823a3b1593f9c7e644126a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-feature-flags@npm:5.4.1-pre.1567"
+"@openmrs/esm-feature-flags@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-feature-flags@npm:5.4.1-pre.1579"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: f530ca2f344ae668db2951d5132fe1737d35d240277caf514a49b024c6f285dce0bbe5a3d28c05e35f3ff84b61eef97c460a1ddbcef6cae8ad1a39bd49d7b2fb
+  checksum: bcfb544620eea3e2317efde35dbb63d68c93350dcbe1a9d9b26d424b3a1b651a69e82e30d5bcd186a0f3a69c842fb78c62bc17664af0bff203b76c1c7acf10dc
   languageName: node
   linkType: hard
 
@@ -4587,24 +4587,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-framework@npm:5.4.1-pre.1567, @openmrs/esm-framework@npm:next":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-framework@npm:5.4.1-pre.1567"
+"@openmrs/esm-framework@npm:5.4.1-pre.1579, @openmrs/esm-framework@npm:next":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-framework@npm:5.4.1-pre.1579"
   dependencies:
-    "@openmrs/esm-api": 5.4.1-pre.1567
-    "@openmrs/esm-config": 5.4.1-pre.1567
-    "@openmrs/esm-dynamic-loading": 5.4.1-pre.1567
-    "@openmrs/esm-error-handling": 5.4.1-pre.1567
-    "@openmrs/esm-extensions": 5.4.1-pre.1567
-    "@openmrs/esm-feature-flags": 5.4.1-pre.1567
-    "@openmrs/esm-globals": 5.4.1-pre.1567
-    "@openmrs/esm-navigation": 5.4.1-pre.1567
-    "@openmrs/esm-offline": 5.4.1-pre.1567
-    "@openmrs/esm-react-utils": 5.4.1-pre.1567
-    "@openmrs/esm-routes": 5.4.1-pre.1567
-    "@openmrs/esm-state": 5.4.1-pre.1567
-    "@openmrs/esm-styleguide": 5.4.1-pre.1567
-    "@openmrs/esm-utils": 5.4.1-pre.1567
+    "@openmrs/esm-api": 5.4.1-pre.1579
+    "@openmrs/esm-config": 5.4.1-pre.1579
+    "@openmrs/esm-dynamic-loading": 5.4.1-pre.1579
+    "@openmrs/esm-error-handling": 5.4.1-pre.1579
+    "@openmrs/esm-extensions": 5.4.1-pre.1579
+    "@openmrs/esm-feature-flags": 5.4.1-pre.1579
+    "@openmrs/esm-globals": 5.4.1-pre.1579
+    "@openmrs/esm-navigation": 5.4.1-pre.1579
+    "@openmrs/esm-offline": 5.4.1-pre.1579
+    "@openmrs/esm-react-utils": 5.4.1-pre.1579
+    "@openmrs/esm-routes": 5.4.1-pre.1579
+    "@openmrs/esm-state": 5.4.1-pre.1579
+    "@openmrs/esm-styleguide": 5.4.1-pre.1579
+    "@openmrs/esm-utils": 5.4.1-pre.1579
     dayjs: ^1.10.7
   peerDependencies:
     dayjs: 1.x
@@ -4615,7 +4615,7 @@ __metadata:
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: b7c58d27dc22589ec873b2b7a12cc10bf3764feec78172a46271824430de8bbfb14a4292c8c916a36f0146183f9d44b0fef67fc36f8aca60f412a3f18470653a
+  checksum: fc32934ee7b0a19424adff8214c8df83dace8e7b7c16f376a93963190c17de73526942e1fac41842c07bbc801ba6b6115f8c197463a5cc28d8c17f37a57be87d
   languageName: node
   linkType: hard
 
@@ -4641,29 +4641,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-globals@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-globals@npm:5.4.1-pre.1567"
+"@openmrs/esm-globals@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-globals@npm:5.4.1-pre.1579"
   peerDependencies:
     single-spa: 5.x
-  checksum: f88dc1a28469851c6aabf2390a353ef255d86930a44ed4f44d6e628241b5c8d920354e69d89703d877008e580271640ea8fc6b5da1caebcbe2a6552b82b7d630
+  checksum: bb1317f430bb189db4fa4a5b4b7114682eb71b2be1646c5f7d0fe420392f0aa2267fee60adfcdfc47ddddacca5c8b15826f2b75ef720d37ba254f2c410658b42
   languageName: node
   linkType: hard
 
-"@openmrs/esm-navigation@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-navigation@npm:5.4.1-pre.1567"
+"@openmrs/esm-navigation@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-navigation@npm:5.4.1-pre.1579"
   dependencies:
     path-to-regexp: 6.1.0
   peerDependencies:
     "@openmrs/esm-state": 5.x
-  checksum: 24b144363aab84bd9c79b3d05e0a5058e7bdcbe1a4e5a15af28f6d67bc89ff5ec99f4e484534e89bb30eadb8284bc845b749f617014e8d58f7fd4f6240e055a7
+  checksum: 2d67e3e4564c827f84594c876bbb53a26a66ca089fe6c365f0bfbbc7080fdc8779cfa9c43e6cf776116c4e307408a7de3704c23691fbeeff2a7a50e9bd6c88e4
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-offline@npm:5.4.1-pre.1567"
+"@openmrs/esm-offline@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-offline@npm:5.4.1-pre.1579"
   dependencies:
     dexie: ^3.0.3
     lodash-es: ^4.17.21
@@ -4675,7 +4675,7 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
-  checksum: ec7b0dbfcab6d1b3a24caac0cbd3f0e2ee0658791a152d6421e66bacfa7681d6c41710a5673d79070c8d66e01d29bb5eb1cbc1e6c4b7ec4f1df92b7363ea7404
+  checksum: 3b43e4945df6eb72171b45cc3edd25b5f0e5761c1d6a7050edfa7fdb47251fa8b054c0e7f2fb8f36c164d1c497007560465392099e87220beeb8e15e636f53a6
   languageName: node
   linkType: hard
 
@@ -5088,9 +5088,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-react-utils@npm:5.4.1-pre.1567"
+"@openmrs/esm-react-utils@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-react-utils@npm:5.4.1-pre.1579"
   dependencies:
     lodash-es: ^4.17.21
     single-spa-react: ^6.0.0
@@ -5108,34 +5108,34 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: ec49b7add5b6755cdf48c7670a87078fcdca0095d546972b5fb24144e3db07be69b4c9146fed02606803d1d521a545e11e5e9deef3fafc4b66c0f0e65fcb086e
+  checksum: 81bc2e304ae8d267d5941c18aa640d72495df26fbf8ac2e9b798c1bf888c3eed79c309d1af124139740baf6eea48b4323d2157e7addd4d9a80718f8f935a2933
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-routes@npm:5.4.1-pre.1567"
+"@openmrs/esm-routes@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-routes@npm:5.4.1-pre.1579"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-utils": 5.x
-  checksum: ea7d28eafe12b2ddfaf4f3530c02b417f2d3be2138d4e88b0a4f5038e10a257187709c9330d60b3e97592569d3c033fbfb6433f0799864bc82152ca7ff8bfccf
+  checksum: 9c21b5cb4aacdd89d304f518a7590b077ac7ff6d8abdcbd4a3c2e0c620416bcd80bd1d775efd38c92e7e2ea5cdc69fdb60842701650388444469fc8ab667063a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-state@npm:5.4.1-pre.1567"
+"@openmrs/esm-state@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-state@npm:5.4.1-pre.1579"
   dependencies:
     zustand: ^4.3.6
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 003ae94b96c1c315400790e1ff0b83f68b41e80348e803dfe84e560e9c52cfa24a76817f6b91d3a5c39895bedf3b0539e83e2a58fc2114fe8d84ecf8de1fdf24
+  checksum: 3355f1a894c86461890cbc11b25ff35bc248ab1e1876421f2457d59a84bcbe933bb1c1e5b2d22571dd75167b60d426f7940b45e350ea98507300a2b75773749a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-styleguide@npm:5.4.1-pre.1567"
+"@openmrs/esm-styleguide@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-styleguide@npm:5.4.1-pre.1579"
   dependencies:
     "@carbon/charts": ^1.12.0
     "@carbon/react": ~1.37.0
@@ -5154,20 +5154,20 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: 3544249a2c06b3678b56a028e6b825d977156a9358f389ded31b8721588e00373369f4420a18b92e05f1862161eebdef5cf11d82c8df7f273c3069459cbb22ec
+  checksum: 8914d0bf3412f68a6406638b04f4f2d5548c21c2efd1e15bd38aff5fac365f54319f2207c2d2c62cc06ff24b30e56bc4c8c85a952ea5caa985772a3ba306f7eb
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/esm-utils@npm:5.4.1-pre.1567"
+"@openmrs/esm-utils@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/esm-utils@npm:5.4.1-pre.1579"
   dependencies:
     semver: 7.3.2
   peerDependencies:
     dayjs: 1.x
     i18next: 19.x
     rxjs: 6.x
-  checksum: caba881df6a5b3bcd39fe35fe7e03b24f8ec66f7643b19d4482ac4e5c2e43f309ea06ff0e3ef59b38e861e440109d51ed6d2bf731a8bc251d724a34724edb380
+  checksum: cd5a9f0ebac77ea73a0ccb58cfbabb2d7dcf5f849b48e5f4a1fc783cd0a41c5291a107b38c7d50d73c97405e408066c70dacefd7d5076d0a61c2c3db844eb3e9
   languageName: node
   linkType: hard
 
@@ -5219,8 +5219,8 @@ __metadata:
   linkType: hard
 
 "@openmrs/openmrs-form-engine-lib@npm:next":
-  version: 1.0.0-pre.529
-  resolution: "@openmrs/openmrs-form-engine-lib@npm:1.0.0-pre.529"
+  version: 1.0.0-pre.541
+  resolution: "@openmrs/openmrs-form-engine-lib@npm:1.0.0-pre.541"
   dependencies:
     ace-builds: ^1.4.12
     enzyme: ^3.11.0
@@ -5243,13 +5243,13 @@ __metadata:
     react: 18.x
     react-i18next: 11.x
     rxjs: 6.x
-  checksum: 1997a32d3eff2733cdef8b6e4d8c049da975037d2fc3ed54d58a44add3f16f6d1cd02b81c2f4c4918c2ce7c7f73b20b5a4069772ca27dc415b5f803274ba1da5
+  checksum: 8921bb063b513dceef14a33e895e7a16569497fd0dcf9b49a66e51771b42c9051b4281afb2bc4d6e39c0723234c15d81f20c3fd2dd39282cf11c61ba94c24876
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.4.1-pre.1567":
-  version: 5.4.1-pre.1567
-  resolution: "@openmrs/webpack-config@npm:5.4.1-pre.1567"
+"@openmrs/webpack-config@npm:5.4.1-pre.1579":
+  version: 5.4.1-pre.1579
+  resolution: "@openmrs/webpack-config@npm:5.4.1-pre.1579"
   dependencies:
     "@swc/core": ^1.3.58
     clean-webpack-plugin: ^4.0.0
@@ -5266,7 +5266,7 @@ __metadata:
     webpack-stats-plugin: ^1.0.3
   peerDependencies:
     webpack: 5.x
-  checksum: 747fbddf68265f1b6bb3963a81ce553a38dcaf02d9e2e315c26a1ea8286557b6ec7d15c01ce0cfa3e9b32e9e0a1ceb3ebde35f7dead7eea35dca98d10d4dcae5
+  checksum: 7baec72e365751f506323e39c40218c5003e432ca541d612e42e27d222032eb6153b452fe928da6420877386ea121ea977a772e282b159633151bee778e0393b
   languageName: node
   linkType: hard
 
@@ -19413,12 +19413,12 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 5.4.1-pre.1567
-  resolution: "openmrs@npm:5.4.1-pre.1567"
+  version: 5.4.1-pre.1579
+  resolution: "openmrs@npm:5.4.1-pre.1579"
   dependencies:
     "@carbon/icons-react": 11.26.0
-    "@openmrs/esm-app-shell": 5.4.1-pre.1567
-    "@openmrs/webpack-config": 5.4.1-pre.1567
+    "@openmrs/esm-app-shell": 5.4.1-pre.1579
+    "@openmrs/webpack-config": 5.4.1-pre.1579
     "@pnpm/npm-conf": ^2.1.0
     "@swc/core": ^1.3.58
     autoprefixer: ^10.4.2
@@ -19449,7 +19449,7 @@ __metadata:
     yargs: ^17.6.2
   bin:
     openmrs: ./dist/cli.js
-  checksum: 1e74fc78d4fdda625702cafc622465cdebfdec976cc8e986b9c945135084d3102879317e105d1ae4c5c7c6a0ff42430cf6784cb668c3408de00edd7269a1c0b1
+  checksum: f92188716d77252c69e06862e2550f45867b9aa2a9ad19eb657c06fdc31f85382af032735ae3155bdaf0c46818735867c262ffd561fd5da5d1725572019ad582
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Change all instances of the hard-coded API base URL '/ws/rest/v1/' to use the restBaseUrl variable instead. To enhances maintainability and flexibility of the API base URL configuration.

## Screenshots
None

## Related Issue
https://openmrs.atlassian.net/browse/O3-2815

## Other
<!-- Anything not covered above -->
