### PR TITLE
(test) Enhance "Start Visit" E2E Test

### DIFF
--- a/e2e/specs/start-visit.spec.ts
+++ b/e2e/specs/start-visit.spec.ts
@@ -36,8 +36,11 @@ test('Start a visit', async ({ page, api }) => {
     await expect(chartPage.page.locator('form').getByRole('button', { name: /start a visit/i })).toBeVisible();
   });
 
-  await test.step('And if I select a visit type and then I click the `Start a visit` button', async () => {
+  await test.step('When I select the visit type: `OPD Visit`', async () => {
     await chartPage.page.getByText(/opd visit/i).click();
+  });
+
+  await test.step('And I click the `Start Visit` button', async () => {
     await chartPage.page
       .locator('form')
       .getByRole('button', { name: /start a visit/i })
@@ -50,7 +53,22 @@ test('Start a visit', async ({ page, api }) => {
 
   await test.step('And I should see the Active Visit tag on the patient header', async () => {
     await expect(chartPage.page.getByLabel(/active visit/i)).toBeVisible();
+  });
+
+  await test.step('When I click the `End Visit` button', async () => {
     await chartPage.page.getByRole('button', { name: /end visit/i }).click();
+  });
+
+  await test.step('Then I should see a confirmation modal', async () => {
+    await expect(chartPage.page.getByText(/are you sure you want to end this active visit?/i)).toBeVisible();
+  });
+
+  await test.step('When I click the `End Visit` button to confirm', async () => {
+    await chartPage.page.getByRole('button', { name: 'danger End Visit' }).click();
+  });
+
+  await test.step('Then I should see a success notification', async () => {
+    await expect(chartPage.page.getByText(/ended current visit successfully/i)).toBeVisible();
   });
 });
 

--- a/e2e/specs/start-visit.spec.ts
+++ b/e2e/specs/start-visit.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { test } from '../core';
-import { type Patient, generateRandomPatient } from '../commands';
+import { type Patient, generateRandomPatient, deletePatient } from '../commands';
 import { ChartPage } from '../pages';
 
 let patient: Patient;
@@ -52,4 +52,8 @@ test('Start a visit', async ({ page, api }) => {
     await expect(chartPage.page.getByLabel(/active visit/i)).toBeVisible();
     await chartPage.page.getByRole('button', { name: /end visit/i }).click();
   });
+});
+
+test.afterEach(async ({ api }) => {
+  await deletePatient(api, patient.uuid);
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

This test had 3 issues:
1. Data was not cleaned after the test
    When a developer run E2E tests on their local machine with proxy this didn't have a afterEach hook to delete the created patient for the test.. This is the reason for ended up "John Smith" patients with OPD visits. 
2. The test didn't cover all steps needed to end the visit. 
    Previously it was just clicking on the "End visit" button, and didn't confirm the model.
3. BDD Steps weren't properly defined
   Some steps weren't following BDD conventions. And some weren't properly divided into steps.

I fixed above issues with this PR.

<img width="1429" alt="image" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/33048395/d3403450-41a9-47b3-8dd7-1ef353697856">


## Screenshots
<!-- Required if you are making UI changes. -->

<img width="987" alt="image" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/33048395/1ecc494d-2282-48ed-afa8-c72d9f859ac8">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-2866

## Other
<!-- Anything not covered above -->
