### PR TITLE
(fix) Workspace buttons should not be anchored at the end of the screen

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
@@ -2,12 +2,12 @@ import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { ExtensionSlot, useLayoutType } from '@openmrs/esm-framework';
 import styles from './action-menu.scss';
+import { useWorkspaces } from '@openmrs/esm-patient-common-lib';
 
-interface ActionMenuInterface {
-  open: boolean;
-}
+interface ActionMenuInterface {}
 
-export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
+export const ActionMenu: React.FC<ActionMenuInterface> = () => {
+  const { active, workspaceWindowState } = useWorkspaces();
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const initialHeight = useRef(window.innerHeight);
   const isTablet = useLayoutType() === 'tablet';
@@ -22,7 +22,7 @@ export const ActionMenu: React.FC<ActionMenuInterface> = ({ open }) => {
     return () => window.removeEventListener('resize', handleKeyboardVisibilityChange);
   }, [initialHeight]);
 
-  if (open && isTablet) {
+  if (active && workspaceWindowState !== 'hidden' && isTablet) {
     return null;
   }
 

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
@@ -77,7 +77,7 @@ const PatientChart: React.FC = () => {
             </>
           )}
         </div>
-        <ActionMenu open={active} />
+        <ActionMenu />
       </>
     </main>
   );

--- a/packages/esm-patient-chart-app/src/root.scss
+++ b/packages/esm-patient-chart-app/src/root.scss
@@ -5,7 +5,7 @@
 :root {
   --bottom-nav-height: 4rem;
   --workspace-header-height: 3rem;
-  --tablet-workspace-window-height: calc(100vh - var(--omrs-navbar-height) - var(--bottom-nav-height));
+  --tablet-workspace-window-height: calc(100vh - var(--omrs-navbar-height));
   --desktop-workspace-window-height: calc(100vh - var(--omrs-navbar-height) - var(--workspace-header-height));
 }
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.scss
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.scss
@@ -42,6 +42,12 @@
   margin: 0.5rem 1rem;
 }
 
+.form {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: calc(100vh - 6rem);
+}
 
 .button {
   height: 4rem;
@@ -52,11 +58,8 @@
 }
 
 .tablet {
-  padding: 1rem;
+  padding: 1.5rem 1rem;
   background-color: $ui-02;
-  position: fixed;
-  bottom: 0rem;
-  width: 100%;
 }
 
 .desktop {
@@ -84,17 +87,6 @@
   color: $text-02;
 }
 
-/* Desktop */
-:global(.omrs-breakpoint-gt-tablet) {
-  .form {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    height: calc(100vh - 6rem);
-  }
-}
-
-/* Tablet */
 :global(.omrs-breakpoint-lt-desktop) {
   .container {
     & section {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
@@ -43,11 +43,8 @@
 }
 
 .tablet {
-  padding: 1rem;
+  padding: 1.5rem 1rem;
   background-color: $ui-02;
-  position: fixed;
-  bottom: 0rem;
-  width: 100%;
 }
 
 .desktop {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.scss
@@ -73,9 +73,6 @@
   .buttonSet {
     padding: spacing.$spacing-06 spacing.$spacing-05;
     background-color: $ui-02;
-    position: fixed;
-    bottom: 0;
-    width: 100%;
   }
 
   .errorContainer {

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
@@ -9,16 +9,15 @@
 }
 
 .orderForm {
-  flex-grow: 1;
+  flex-grow:1;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   padding: layout.$spacing-03 0 0 layout.$spacing-05;
 
-
   input[data-invalid]:focus {
-    outline: 2px solid colors.$red-60;
-    outline-offset: -2px;
+    outline: 2px solid  colors.$red-60;
+     outline-offset: -2px;
   }
 
   :global(.cds--css-grid) {
@@ -102,7 +101,7 @@
   margin-bottom: layout.$spacing-05;
 }
 
-.pullColumnContentRight>div {
+.pullColumnContentRight > div {
   float: right;
 }
 
@@ -126,8 +125,8 @@
 
 .numberInput {
   :global(.cds--number__input-wrapper) input {
-    min-width: unset !important;
-    padding-right: layout.$spacing-05;
+  min-width: unset !important;
+  padding-right: layout.$spacing-05;
   }
 }
 
@@ -139,8 +138,7 @@
 
   button {
     display: flex;
-    padding-left: 0 !important;
-
+   padding-left: 0 !important;
     svg {
       order: 1;
       margin-right: layout.$spacing-03;
@@ -227,9 +225,6 @@
   .buttonSet {
     padding: layout.$spacing-06 layout.$spacing-05;
     background-color: colors.$white-0;
-    position: fixed;
-    bottom: 0rem;
-    width: 100%;
   }
 }
 
@@ -238,8 +233,7 @@
     outline: 2.5px solid colors.$red-60;
   }
 
-  input:focus,
-  textarea:focus {
+  input:focus, textarea:focus {
     outline: 2.5px solid colors.$red-60;
   }
 }
@@ -247,3 +241,4 @@
 .errorLabel {
   color: colors.$red-60;
 }
+

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -66,11 +66,8 @@
 }
 
 .tablet {
-  padding: 1rem 1rem;
+  padding: 1.5rem 1rem;
   background-color: $ui-02;
-  position: fixed;
-  bottom: 0rem;
-  width: 100%;
 }
 
 .desktop {
@@ -96,7 +93,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  // height: var(--desktop-workspace-window-height);
+  height: var(--desktop-workspace-window-height);
 }
 
 .grid {

--- a/packages/esm-patient-orders-app/src/order-basket/order-basket.scss
+++ b/packages/esm-patient-orders-app/src/order-basket/order-basket.scss
@@ -52,8 +52,5 @@
   .buttonSet {
     padding: 1.5rem 1rem;
     background-color: $ui-02;
-    position: fixed;
-    bottom: 0rem;
-    width: 100%;
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR is the revert of #1650. The #1650 brought up a few issues such as:
1. The buttons were anchored at the bottom of the screen, and the content of the workspace was stuck behind the buttons and users were not getting the fields even after they kept scrolling [O3-2856](https://openmrs.atlassian.net/browse/O3-2856) [O3-2538](https://openmrs.atlassian.net/browse/O3-2853)
2. The workspace window didn't expand to the full height of the screen
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/e8afbaf5-dbf9-4bcf-a292-284cd7b2cd39)


## Screenshots
Mimicking small tablet screens:


https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/b71f4e38-4aea-4cbc-822c-46d0e8e8d9d8


## Related Issue
https://issues.openmrs.org/browse/O3-2853
https://issues.openmrs.org/browse/O3-2856

## Other
<!-- Anything not covered above -->
