### PR TITLE
(fix) O3-2604: Add a “refresh data“ button to the test results viewer

### DIFF
--- a/packages/esm-patient-labs-app/src/test-results/results-viewer/results-viewer.extension.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/results-viewer/results-viewer.extension.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useContext, useState } from 'react';
 import classNames from 'classnames';
-import { useTranslation } from 'react-i18next';
+import { type TFunction, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { ContentSwitcher, Switch, Button } from '@carbon/react';
-import { Printer } from '@carbon/react/icons';
+import { Printer, Renew } from '@carbon/react/icons';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { navigate, showModal, useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { FilterContext, FilterProvider } from '../filter';
@@ -18,6 +18,11 @@ import styles from './results-viewer.styles.scss';
 
 type panelOpts = 'tree' | 'panel';
 type viewOpts = 'split' | 'full';
+
+interface RefreshDataButtonProps {
+  isTablet: boolean;
+  t: TFunction;
+}
 
 interface ResultsViewerProps {
   basePath: string;
@@ -62,6 +67,7 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
   const isExpanded = view === 'full';
   const trendlineView = testUuid && type === 'trendline';
   const showPrintButton = config.showPrintButton;
+  const responsiveSize = isTablet ? 'lg' : 'md';
 
   const navigateBackFromTrendlineView = useCallback(() => {
     navigate({
@@ -92,6 +98,7 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
               <Switch name="tree" text={t('tree', 'Tree')} />
             </ContentSwitcher>
           </div>
+          <RefreshDataButton isTablet={isTablet} t={t} />
         </div>
         {selectedSection === 'tree' ? (
           <TreeViewWrapper
@@ -131,42 +138,41 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
             totalResultsCount ? `(${totalResultsCount})` : ''
           }`}</h4>
           <div className={styles.leftHeaderActions}>
-            {showPrintButton && (
-              <Button
-                kind="ghost"
-                size={isTablet ? 'md' : 'sm'}
-                renderIcon={Printer}
-                iconDescription="Print results"
-                onClick={openPrintModal}
-              >
-                {t('print', 'Print')}
-              </Button>
-            )}
             <ContentSwitcher
-              size={isTablet ? 'lg' : 'md'}
+              size={responsiveSize}
               selectedIndex={['panel', 'tree'].indexOf(selectedSection)}
               onChange={({ name }: { name: panelOpts }) => setSelectedSection(name)}
             >
               <Switch name="panel" text={t('panel', 'Panel')} />
               <Switch name="tree" text={t('tree', 'Tree')} />
             </ContentSwitcher>
+            {showPrintButton && (
+              <Button
+                className={styles.button}
+                kind="ghost"
+                size={isTablet ? 'md' : 'sm'}
+                renderIcon={Printer}
+                iconDescription="Print results"
+                onClick={openPrintModal}
+              >
+                <span>{t('print', 'Print')}</span>
+              </Button>
+            )}
           </div>
         </div>
         <div className={styles.rightSectionHeader}>
           <div className={styles.viewOptsContentSwitcherContainer}>
             <ContentSwitcher
-              size={isTablet ? 'lg' : 'md'}
-              style={{ maxWidth: '10rem' }}
+              className={styles.viewOptionsSwitcher}
               onChange={({ name }: { name: viewOpts }) => setView(name)}
               selectedIndex={isExpanded ? 1 : 0}
+              size={responsiveSize}
             >
               <Switch name="split" text={t('split', 'Split')} disabled={loading} />
               <Switch name="full" text={t('full', 'Full')} disabled={loading} />
             </ContentSwitcher>
           </div>
-          <Button kind="ghost" size={isTablet ? 'md' : 'sm'} onClick={() => window.location.reload()}>
-            {t('refresh', 'Refresh Data')}
-          </Button>
+          <RefreshDataButton isTablet={isTablet} t={t} />
         </div>
       </div>
       <div className={styles.flex}>
@@ -191,5 +197,19 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
     </div>
   );
 };
+
+function RefreshDataButton({ isTablet, t }: RefreshDataButtonProps) {
+  return (
+    <Button
+      className={styles.button}
+      kind="ghost"
+      renderIcon={Renew}
+      size={isTablet ? 'md' : 'sm'}
+      onClick={() => window.location.reload()}
+    >
+      <span>{t('refreshData', 'Refresh data')}</span>
+    </Button>
+  );
+}
 
 export default RoutedResultsViewer;

--- a/packages/esm-patient-labs-app/src/test-results/results-viewer/results-viewer.extension.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/results-viewer/results-viewer.extension.tsx
@@ -164,6 +164,9 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
               <Switch name="full" text={t('full', 'Full')} disabled={loading} />
             </ContentSwitcher>
           </div>
+          <Button kind="ghost" size={isTablet ? 'md' : 'sm'} onClick={() => window.location.reload()}>
+            {t('refresh', 'Refresh Data')}
+          </Button>
         </div>
       </div>
       <div className={styles.flex}>

--- a/packages/esm-patient-labs-app/src/test-results/results-viewer/results-viewer.styles.scss
+++ b/packages/esm-patient-labs-app/src/test-results/results-viewer/results-viewer.styles.scss
@@ -1,6 +1,5 @@
-@use '@carbon/styles/scss/grid/_flexbox';
-@use '@carbon/styles/scss/spacing';
-@use '@carbon/styles/scss/type';
+@use '@carbon/layout';
+@use '@carbon/type';
 @import '@openmrs/esm-styleguide/src/vars';
 
 .resultsContainer {
@@ -40,9 +39,13 @@
   margin-left: auto;
 }
 
+.viewOptionsSwitcher {
+  max-width: 10rem;
+}
+
 .leftSection {
   width: 45%;
-  margin-right: spacing.$spacing-05;
+  margin-right: layout.$spacing-05;
 }
 
 .rightSection, .rightSectionHeader {
@@ -93,7 +96,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: spacing.$spacing-03;
+  margin-bottom: layout.$spacing-03;
   background-color: $openmrs-background-grey;
   position: sticky;
   top: 0;
@@ -114,12 +117,12 @@
 .floatingTreeButton {
   position: fixed;
   bottom: 5rem;
-  right: spacing.$spacing-05;
+  right: layout.$spacing-05;
   z-index: 99;
 
   button {
     background-color: $brand-01 !important;
-    padding: spacing.$spacing-05;
+    padding: layout.$spacing-05;
     border-radius: 50%;
   }
 
@@ -129,5 +132,20 @@
 }
 
 .panelViewTimeline {
-  margin-bottom: spacing.$spacing-07;
+  margin-bottom: layout.$spacing-07;
+}
+
+.button {
+  align-items: center;
+  margin-left: 1rem;
+
+  svg {
+    order: 1;
+    margin-right: layout.$spacing-03;
+    margin-left: 0 !important;
+  }
+
+  span {
+    order: 2;
+  }
 }

--- a/packages/esm-patient-labs-app/translations/en.json
+++ b/packages/esm-patient-labs-app/translations/en.json
@@ -38,6 +38,7 @@
   "recentResults": "Recent Results",
   "recentTestResults": "recent test results",
   "referenceRange": "Reference range",
+  "refresh": "Refresh Data",
   "removeFromBasket": "Remove from basket",
   "resetTreeText": "Reset tree",
   "resulted": "Resulted",

--- a/packages/esm-patient-labs-app/translations/en.json
+++ b/packages/esm-patient-labs-app/translations/en.json
@@ -38,7 +38,7 @@
   "recentResults": "Recent Results",
   "recentTestResults": "recent test results",
   "referenceRange": "Reference range",
-  "refresh": "Refresh Data",
+  "refreshData": "Refresh data",
   "removeFromBasket": "Remove from basket",
   "resetTreeText": "Reset tree",
   "resulted": "Resulted",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I created a "Refresh Data" button on the far right section header. When clicked, the window.location.reload() method reloads the current page, effectively refreshing the content with new changes.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/30e6ef9a-a896-4b62-870e-b96de76f507f


## Related Issue
https://openmrs.atlassian.net/browse/O3-2604

## Other
<!-- Anything not covered above -->
