### PR TITLE
(fix) O3 2804: Reuse the ResponsiveWrapper component from esm-framework

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.scss
+++ b/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .label01 {
   @include type.type-style("label-01");
@@ -30,7 +30,7 @@
   :global(.cds--cc--layout-row) {
     height: 0;
   }
-  
+
   :global(.layout-child) {
     margin-top: spacing.$spacing-03;
   }
@@ -45,15 +45,15 @@
 .verticalTabs {
   margin: 1rem 0;
   scroll-behavior: smooth;
-  
+
   > ul {
     flex-direction: column !important;
   }
-  
+
   :global(.cds--tabs--scrollable .cds--tabs--scrollable__nav-item+.cds--tabs--scrollable__nav-item) {
     margin-left: 0rem;
   }
-  
+
   :global(.cds--tabs--scrollable .cds--tabs--scrollable__nav-link) {
     border-bottom: 0 !important;
     border-left: 2px solid $color-gray-30;
@@ -88,7 +88,7 @@
     max-height: fit-content;
     overflow-x: visible;
   }
-  
+
   > button :global(.cds--tabs .cds--tabs__nav-link) {
     border-bottom: none;
   }

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.scss
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .widgetContainer {
   background-color: $ui-background;

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .widgetCard {
   border: 1px solid $ui-03;
@@ -8,7 +8,7 @@
 
 .allergyCriticality {
   display: flex;
-  align-items: center; 
+  align-items: center;
   text-transform: uppercase;
 }
 

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
@@ -10,7 +10,6 @@ import {
   FormGroup,
   InlineLoading,
   InlineNotification,
-  Layer,
   RadioButton,
   RadioButtonGroup,
   Row,
@@ -28,6 +27,7 @@ import {
   showToast,
   useConfig,
   useLayoutType,
+  ResponsiveWrapper,
 } from '@openmrs/esm-framework';
 import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import {
@@ -211,7 +211,7 @@ function AllergyForm(props: DefaultWorkspaceProps) {
               )}
             />
           )}
-          <ResponsiveWrapper isTablet={isTablet}>
+          <ResponsiveWrapper>
             <FormGroup legendText={t('allergen', 'Allergen')} data-testid="allergens-container">
               <Controller
                 name="allergen"
@@ -233,7 +233,7 @@ function AllergyForm(props: DefaultWorkspaceProps) {
             </FormGroup>
           </ResponsiveWrapper>
           {selectedAllergen?.uuid === otherConceptUuid && (
-            <ResponsiveWrapper isTablet={isTablet}>
+            <ResponsiveWrapper>
               <Controller
                 name="nonCodedAllergen"
                 control={control}
@@ -265,7 +265,7 @@ function AllergyForm(props: DefaultWorkspaceProps) {
             </div>
             {selectedAllergicReactions?.includes(otherConceptUuid) ? (
               <div className={styles.input}>
-                <ResponsiveWrapper isTablet={isTablet}>
+                <ResponsiveWrapper>
                   <Controller
                     name="nonCodedAllergicReaction"
                     control={control}
@@ -322,7 +322,7 @@ function AllergyForm(props: DefaultWorkspaceProps) {
             </FormGroup>
           </div>
           <div>
-            <ResponsiveWrapper isTablet={isTablet}>
+            <ResponsiveWrapper>
               <Controller
                 name="comment"
                 control={control}
@@ -364,10 +364,6 @@ function AllergyForm(props: DefaultWorkspaceProps) {
       </div>
     </Form>
   );
-}
-
-function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
 }
 
 function AllergicReactionsField({

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import '../../root.scss';
 
 .header {

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.scss
@@ -1,4 +1,4 @@
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .widgetCard {
   border: 1px solid $ui-03;

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-tile.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-tile.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .label {
   @include type.type-style('label-01');

--- a/packages/esm-patient-allergies-app/src/root.scss
+++ b/packages/esm-patient-allergies-app/src/root.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars'; 
+@import '@openmrs/esm-styleguide/src/vars';
 
 .productiveHeading01 {
   @include type.type-style("heading-compact-01");

--- a/packages/esm-patient-appointments-app/src/appointments/appointments-base.scss
+++ b/packages/esm-patient-appointments-app/src/appointments/appointments-base.scss
@@ -1,7 +1,7 @@
 @use '@carbon/colors';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 // TO DO Move this styles to style - guide
 // https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-styleguide/src/_vars.scss

--- a/packages/esm-patient-appointments-app/src/appointments/upcoming-appointments-card.scss
+++ b/packages/esm-patient-appointments-app/src/appointments/upcoming-appointments-card.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .container {
   margin: spacing.$spacing-05;
@@ -20,16 +20,16 @@
       margin: 0rem 0rem;
     }
   }
-  
+
   .input {
     margin: 0rem 1rem 1rem;
   }
- 
+
   .headerLabel {
     @include type.type-style('label-01');
     color: $text-02;
   }
-  
+
   .checkboxContainer {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader.scss
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import '../root.scss';
 
 .cameraSection {

--- a/packages/esm-patient-attachments-app/src/root.scss
+++ b/packages/esm-patient-attachments-app/src/root.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .productiveHeading02 {
   @include type.type-style("heading-compact-02");

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.scss
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.scss
@@ -1,6 +1,6 @@
 @use '@carbon/colors';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .container {
   border-top: 0.063rem solid $ui-03;
@@ -18,11 +18,11 @@
   .patientName {
     color: $ui-01;
   }
-  
+
   .demographics, .row, .identifierTag, .identifier, .contactDetails .heading {
     color: $ui-02;
   }
-  
+
   .toggleContactDetailsButton, .toggleContactDetailsButton > svg, .actionsButtonText {
     color: colors.$blue-40;
   }

--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.scss
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 @mixin container{
   color: $text-02;

--- a/packages/esm-patient-banner-app/src/ui-components/overflow-menu.scss
+++ b/packages/esm-patient-banner-app/src/ui-components/overflow-menu.scss
@@ -1,5 +1,5 @@
 @use '@carbon/colors';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .container {
   margin-top: -1.25rem;

--- a/packages/esm-patient-chart-app/src/deceased/base-concept-answer.component.tsx
+++ b/packages/esm-patient-chart-app/src/deceased/base-concept-answer.component.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import debounce from 'lodash-es/debounce';
 import isEmpty from 'lodash-es/isEmpty';
-import { Layer, RadioButton, RadioButtonGroup, Search } from '@carbon/react';
+import { RadioButton, RadioButtonGroup, Search } from '@carbon/react';
 import { EmptyState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
-import { useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { useLayoutType, usePagination, ResponsiveWrapper } from '@openmrs/esm-framework';
 import type { ConceptAnswer } from './deceased.resource';
 import styles from './deceased-form.scss';
 
@@ -41,7 +41,7 @@ const BaseConceptAnswer: React.FC<BaseConceptAnswerProps> = ({ onChange, isPatie
         isTablet ? styles.conceptAnswerOverviewWrapperTablet : styles.conceptAnswerOverviewWrapperDesktop,
       )}
     >
-      <ResponsiveWrapper isTablet={isTablet}>
+      <ResponsiveWrapper>
         <Search
           onChange={(event) => handleSearch(event.target.value)}
           placeholder={t('searchForCauseOfDeath', 'Search for a cause of death')}
@@ -82,9 +82,5 @@ const BaseConceptAnswer: React.FC<BaseConceptAnswerProps> = ({ onChange, isPatie
     </div>
   );
 };
-
-function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
-}
 
 export default BaseConceptAnswer;

--- a/packages/esm-patient-chart-app/src/deceased/deceased-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/deceased/deceased-form.component.tsx
@@ -7,14 +7,13 @@ import {
   DatePicker,
   DatePickerInput,
   Form,
-  Layer,
   Row,
   DatePickerSkeleton,
   DataTableSkeleton,
 } from '@carbon/react';
 import { WarningFilled } from '@carbon/react/icons';
 import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
-import { ExtensionSlot, useLayoutType, showSnackbar, showModal } from '@openmrs/esm-framework';
+import { ExtensionSlot, useLayoutType, showSnackbar, showModal, ResponsiveWrapper } from '@openmrs/esm-framework';
 import { markPatientDeceased, usePatientDeathConcepts, usePatientDeceased } from './deceased.resource';
 import BaseConceptAnswer from './base-concept-answer.component';
 
@@ -85,7 +84,7 @@ const MarkPatientDeceasedForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
             {!conceptAnswers ? (
               <DatePickerSkeleton />
             ) : (
-              <ResponsiveWrapper isTablet={isTablet}>
+              <ResponsiveWrapper>
                 <DatePicker
                   dateFormat="d/m/Y"
                   datePickerType="single"
@@ -140,9 +139,5 @@ const MarkPatientDeceasedForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid,
     </Form>
   );
 };
-
-function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
-}
 
 export default MarkPatientDeceasedForm;

--- a/packages/esm-patient-chart-app/src/loader/loader.scss
+++ b/packages/esm-patient-chart-app/src/loader/loader.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .loading {
   display: flex;

--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 $icon-button-size: 2.5rem;
 $actionPanelOffset: 3rem;

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../../root.scss";
 
 .dashboardTitle {

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 $actionNavOffset: 45px;
 $actionPanelOffset: 256px;

--- a/packages/esm-patient-chart-app/src/patient-details-tile/patient-details-tile.scss
+++ b/packages/esm-patient-chart-app/src/patient-details-tile/patient-details-tile.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .container:after {
 	content: '';
@@ -20,5 +20,5 @@
 
 .name {
 	@include type.type-style('body-compact-02');
-	
+
 }

--- a/packages/esm-patient-chart-app/src/root.scss
+++ b/packages/esm-patient-chart-app/src/root.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 :root {
   --bottom-nav-height: 4rem;

--- a/packages/esm-patient-chart-app/src/visit-header/close-button.scss
+++ b/packages/esm-patient-chart-app/src/visit-header/close-button.scss
@@ -1,4 +1,4 @@
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .headerGlobalBarCloseButton {
   @include brand-02(background-color);

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.scss
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.scss
@@ -1,7 +1,7 @@
 @use '@carbon/styles/scss/colors';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .topNavHeader {
   top: var(--omrs-offline-banner-height);

--- a/packages/esm-patient-chart-app/src/visit/past-visit-overview.scss
+++ b/packages/esm-patient-chart-app/src/visit/past-visit-overview.scss
@@ -1,4 +1,4 @@
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .button {
   height: 4rem;

--- a/packages/esm-patient-chart-app/src/visit/queue-entry/edit-queue-entry.scss
+++ b/packages/esm-patient-chart-app/src/visit/queue-entry/edit-queue-entry.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .editStatusBtn {
     margin-left: spacing.$spacing-04;

--- a/packages/esm-patient-chart-app/src/visit/queue-entry/edit-queue-entry.scss
+++ b/packages/esm-patient-chart-app/src/visit/queue-entry/edit-queue-entry.scss
@@ -3,11 +3,11 @@
 @import '@openmrs/esm-styleguide/src/vars';
 
 .editStatusBtn {
-    margin-left: spacing.$spacing-04;
-    border: none;
+  margin-left: spacing.$spacing-04;
+  border: none;
 }
 
 .editStatusIcon {
-    fill: white;
-    color: white;
+  fill: white;
+  color: white;
 }

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import styles from './visit-form.scss';
 import { Controller, useFormContext } from 'react-hook-form';
 import { type VisitFormData } from './visit-form.resource';
-import { DatePicker, DatePickerInput, Layer, SelectItem, TimePicker, TimePickerSelect } from '@carbon/react';
+import { DatePicker, DatePickerInput, SelectItem, TimePicker, TimePickerSelect } from '@carbon/react';
 import classNames from 'classnames';
-import { useLayoutType } from '@openmrs/esm-framework';
+import { useLayoutType, ResponsiveWrapper } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { type amPm } from '@openmrs/esm-patient-common-lib';
 
@@ -46,7 +46,7 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
           name={dateFieldName}
           control={control}
           render={({ field: { onBlur, onChange, value } }) => (
-            <ResponsiveWrapper isTablet={isTablet}>
+            <ResponsiveWrapper>
               <DatePicker
                 dateFormat="d/m/Y"
                 datePickerType="single"
@@ -69,7 +69,7 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
             </ResponsiveWrapper>
           )}
         />
-        <ResponsiveWrapper isTablet={isTablet}>
+        <ResponsiveWrapper>
           <Controller
             name={timeFieldName}
             control={control}
@@ -112,7 +112,3 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
 };
 
 export default VisitDateTimeField;
-
-function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
-}

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.scss
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import '../../root.scss';
 
 .container {

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-type-overview.scss
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-type-overview.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .visitTypeOverviewWrapper {
 	margin: spacing.$spacing-05 0rem;
@@ -35,7 +35,7 @@
 	min-height: spacing.$spacing-10;
 	width: 100%;
 	@include type.type-style('body-compact-01');
-	
+
 }
 
 .radioButton {

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.scss
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .bodyShort02 {
   @include type.type-style("body-compact-02");

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.scss
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .bodyShort02 {
   @include type.type-style("body-compact-02");

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.scss
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 
 .header {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .tableContainer {
   padding: 0;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../../../root.scss";
 
 .diagnosisLabel {
@@ -74,9 +74,9 @@
     max-height: fit-content;
     overflow-x: visible;
   }
-  
+
   > button :global(.cds--tabs .cds--tabs__nav-link) {
     border-bottom: none;
   }
 }
-  
+

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../../../../root.scss";
 
 .tableContainer {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../../root.scss";
 
 .visitType {

--- a/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
+++ b/packages/esm-patient-chart-app/src/workspace/workspace-window.scss
@@ -1,7 +1,7 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/colors';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../root.scss";
 
 $container-width: calc(100% - 3rem);

--- a/packages/esm-patient-common-lib/src/cards/card-header.scss
+++ b/packages/esm-patient-common-lib/src/cards/card-header.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .desktopHeader, .tabletHeader {
   display: flex;
@@ -18,7 +18,7 @@
   }
 }
 
-.desktopHeader {  
+.desktopHeader {
   height: 3rem;
   h4 {
     @include type.type-style('heading-compact-02');
@@ -26,7 +26,7 @@
   }
 }
 
-.tabletHeader {  
+.tabletHeader {
   height: 4.5rem;
   h4 {
     @include type.type-style('heading-03');

--- a/packages/esm-patient-common-lib/src/empty-state/empty-state.scss
+++ b/packages/esm-patient-common-lib/src/empty-state/empty-state.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .action {
   margin-bottom: spacing.$spacing-03;
@@ -31,7 +31,7 @@
   text-align: left;
   text-transform: capitalize;
   margin-bottom: spacing.$spacing-05;
-  
+
   h4:after {
     content: "";
     display: block;

--- a/packages/esm-patient-common-lib/src/error-state/error-state.scss
+++ b/packages/esm-patient-common-lib/src/error-state/error-state.scss
@@ -1,10 +1,10 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .errorMessage {
   @include type.type-style("heading-compact-02");
-  
+
   margin-top: 2.25rem;
   margin-bottom: spacing.$spacing-03;
 }

--- a/packages/esm-patient-common-lib/src/pagination/pagination.scss
+++ b/packages/esm-patient-common-lib/src/pagination/pagination.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .bodyShort01 {
   @include type.type-style("body-compact-01");
@@ -30,8 +30,8 @@
 
 .tablet :global(.cds--pagination) {
   min-height: 0rem;
-  height: 3rem; 
-  width: auto;   
+  height: 3rem;
+  width: auto;
   border: none;
 
   & :global(.cds--select-input), :global(.cds--btn), :global(.cds--pagination__right) {

--- a/packages/esm-patient-common-lib/src/root.scss
+++ b/packages/esm-patient-common-lib/src/root.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars'; 
+@import '@openmrs/esm-styleguide/src/vars';
 
 // Why do we have this copied everywhere? Can't we just import it from the styleguide?
 
@@ -64,6 +64,6 @@
   white-space: nowrap;
 }
 
-.text02 { 
+.text02 {
   color: $text-02;
 }

--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .container {
   margin-top: spacing.$spacing-02;

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .condition {
   padding: 1rem 0.75rem;

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -17,7 +17,7 @@ import {
 } from '@carbon/react';
 import { WarningFilled } from '@carbon/react/icons';
 import { useFormContext, Controller } from 'react-hook-form';
-import { showSnackbar, useDebounce, useLayoutType, useSession } from '@openmrs/esm-framework';
+import { showSnackbar, useDebounce, useLayoutType, useSession, ResponsiveWrapper } from '@openmrs/esm-framework';
 import {
   type CodedCondition,
   type ConditionDataTableRow,
@@ -211,7 +211,7 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
                 name="search"
                 control={control}
                 render={({ field: { onChange, value, onBlur } }) => (
-                  <ResponsiveWrapper isTablet={isTablet}>
+                  <ResponsiveWrapper>
                     <Search
                       autoFocus
                       ref={searchInputRef}
@@ -283,7 +283,7 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
             name="onsetDateTime"
             control={control}
             render={({ field: { onChange, onBlur, value } }) => (
-              <ResponsiveWrapper isTablet={isTablet}>
+              <ResponsiveWrapper>
                 <DatePicker
                   id="onsetDate"
                   datePickerType="single"
@@ -324,7 +324,7 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
             name="endDate"
             control={control}
             render={({ field: { onBlur, onChange, value } }) => (
-              <ResponsiveWrapper isTablet={isTablet}>
+              <ResponsiveWrapper>
                 <DatePicker
                   id="endDate"
                   datePickerType="single"
@@ -346,9 +346,5 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
     </div>
   );
 };
-
-function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
-}
 
 export default ConditionsWidget;

--- a/packages/esm-patient-flags-app/src/flags/flags-list.component.tsx
+++ b/packages/esm-patient-flags-app/src/flags/flags-list.component.tsx
@@ -3,9 +3,9 @@ import debounce from 'lodash-es/debounce';
 import isEmpty from 'lodash-es/isEmpty';
 import orderBy from 'lodash-es/orderBy';
 import { useTranslation } from 'react-i18next';
-import { Button, ButtonSet, Dropdown, Form, InlineLoading, Layer, Search, Tile, Toggle, Stack } from '@carbon/react';
+import { Button, ButtonSet, Dropdown, Form, InlineLoading, Search, Tile, Toggle, Stack } from '@carbon/react';
 import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
-import { useLayoutType, showSnackbar, parseDate, formatDate } from '@openmrs/esm-framework';
+import { useLayoutType, showSnackbar, parseDate, formatDate, ResponsiveWrapper } from '@openmrs/esm-framework';
 import { usePatientFlags, enablePatientFlag, disablePatientFlag } from './hooks/usePatientFlags';
 import { getFlagType } from './utils';
 import styles from './flags-list.scss';
@@ -110,7 +110,7 @@ const FlagsList: React.FC<DefaultWorkspaceProps> = ({
     <Form className={styles.formWrapper}>
       {/* The <div> below is required to maintain the page layout styling */}
       <div>
-        <ResponsiveWrapper isTablet={isTablet}>
+        <ResponsiveWrapper>
           <Search
             labelText={t('searchForAFlag', 'Search for a flag')}
             placeholder={t('searchForAFlag', 'Search for a flag')}
@@ -222,9 +222,5 @@ const FlagsList: React.FC<DefaultWorkspaceProps> = ({
     </Form>
   );
 };
-
-function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
-}
 
 export default FlagsList;

--- a/packages/esm-patient-forms-app/src/forms/empty-form.scss
+++ b/packages/esm-patient-forms-app/src/forms/empty-form.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../root.scss";
 
 .tile {
@@ -39,7 +39,7 @@
   text-align: left;
   text-transform: capitalize;
   margin-bottom: spacing.$spacing-05;
-  
+
   h4:after {
     content: "";
     display: block;

--- a/packages/esm-patient-forms-app/src/forms/form-view.scss
+++ b/packages/esm-patient-forms-app/src/forms/form-view.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import '../root.scss';
 
 .heading {

--- a/packages/esm-patient-forms-app/src/forms/forms-dashboard.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-dashboard.component.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
-import { Layer, Tile } from '@carbon/react';
-import { useConfig, useConnectivity, usePatient } from '@openmrs/esm-framework';
+import { Tile } from '@carbon/react';
+import { useConfig, useConnectivity, usePatient, ResponsiveWrapper } from '@openmrs/esm-framework';
 import {
   type DefaultWorkspaceProps,
   EmptyDataIllustration,
@@ -21,10 +21,6 @@ const FormsDashboard: React.FC<DefaultWorkspaceProps> = () => {
   const { patient, patientUuid } = usePatient();
   const { data: forms, error, mutateForms } = useForms(patientUuid, undefined, undefined, !isOnline, config.orderBy);
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
-
-  function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-    return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
-  }
 
   const handleFormOpen = useCallback(
     (formUuid: string, encounterUuid: string, formName: string) => {
@@ -55,7 +51,7 @@ const FormsDashboard: React.FC<DefaultWorkspaceProps> = () => {
 
   if (forms?.length === 0) {
     return (
-      <ResponsiveWrapper isTablet>
+      <ResponsiveWrapper>
         <Tile className={styles.emptyState}>
           <EmptyDataIllustration />
           <p className={styles.emptyStateContent}>{t('noFormsToDisplay', 'There are no forms to display.')}</p>

--- a/packages/esm-patient-forms-app/src/forms/forms-dashboard.scss
+++ b/packages/esm-patient-forms-app/src/forms/forms-dashboard.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .emptyState {
   text-align: center;

--- a/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import debounce from 'lodash-es/debounce';
 import fuzzy from 'fuzzy';
-import { DataTableSkeleton, Layer, Tile } from '@carbon/react';
-import { formatDatetime, useLayoutType } from '@openmrs/esm-framework';
+import { DataTableSkeleton, Tile } from '@carbon/react';
+import { formatDatetime, useLayoutType, ResponsiveWrapper } from '@openmrs/esm-framework';
 import FormsTable from './forms-table.component';
 import styles from './forms-list.scss';
 import type { CompletedFormInfo } from '../types';
@@ -14,10 +14,6 @@ export type FormsListProps = {
   sectionName?: string;
   handleFormOpen: (formUuid: string, encounterUuid: string, formName: string) => void;
 };
-
-function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
-}
 
 /*
  * For the benefit of our automated translations:
@@ -88,7 +84,7 @@ const FormsList: React.FC<FormsListProps> = ({ completedForms, error, sectionNam
 
   if (sectionName === 'forms') {
     return (
-      <ResponsiveWrapper isTablet>
+      <ResponsiveWrapper>
         <FormsTable
           tableHeaders={tableHeaders}
           tableRows={tableRows}
@@ -100,7 +96,7 @@ const FormsList: React.FC<FormsListProps> = ({ completedForms, error, sectionNam
     );
   } else {
     return (
-      <ResponsiveWrapper isTablet>
+      <ResponsiveWrapper>
         <div className={isTablet ? styles.tabletHeading : styles.desktopHeading}>
           <h4>{t(sectionName)}</h4>
         </div>

--- a/packages/esm-patient-forms-app/src/forms/forms-list.scss
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .emptyState {
   text-align: center;
@@ -34,7 +34,7 @@
   margin-top: spacing.$spacing-05;
   margin-left: spacing.$spacing-03;
   margin-bottom: spacing.$spacing-05;
-  
+
   h4:after {
     content: "";
     display: block;

--- a/packages/esm-patient-forms-app/src/forms/forms-table.scss
+++ b/packages/esm-patient-forms-app/src/forms/forms-table.scss
@@ -1,7 +1,7 @@
 @use '@carbon/styles/scss/colors';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .container {
   padding: 2rem;

--- a/packages/esm-patient-forms-app/src/forms/forms.scss
+++ b/packages/esm-patient-forms-app/src/forms/forms.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .bodyShort01 {
   @include type.type-style("body-compact-01");

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-forms-overview-card.scss
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-forms-overview-card.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../root.scss";
 
 .overviewCard {
@@ -10,7 +10,7 @@
     @extend .productiveHeading01;
     color: $text-02;
   }
-  
+
   .headerContainer {
     display: flex;
     justify-content: space-between;

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-forms.styles.scss
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-forms.styles.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../root.scss";
 
 .pageHeaderContainer {

--- a/packages/esm-patient-forms-app/src/root.scss
+++ b/packages/esm-patient-forms-app/src/root.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .productiveHeading01 {
   @include type.type-style("heading-compact-01");

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.scss
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.scss
@@ -1,4 +1,4 @@
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .widgetCard {
   border: 1px solid $ui-03;

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
@@ -8,7 +8,6 @@ import {
   Dropdown,
   Form,
   InlineNotification,
-  Layer,
   SelectItem,
   Stack,
   TextInput,
@@ -23,6 +22,7 @@ import {
   toOmrsIsoString,
   toDateObjectStrict,
   showSnackbar,
+  ResponsiveWrapper,
 } from '@openmrs/esm-framework';
 import { useForm, Controller, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -227,7 +227,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
         <Stack gap={1} className={styles.container}>
           <section className={` ${styles.row}`}>
             <div className={styles.dateTimeSection}>
-              <ResponsiveWrapper isTablet={isTablet}>
+              <ResponsiveWrapper>
                 <Controller
                   name="vaccinationDate"
                   control={control}
@@ -254,7 +254,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
                   )}
                 />
               </ResponsiveWrapper>
-              <ResponsiveWrapper isTablet={isTablet}>
+              <ResponsiveWrapper>
                 <Controller
                   name="vaccinationTime"
                   control={control}
@@ -290,7 +290,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
             </div>
           </section>
           <section>
-            <ResponsiveWrapper isTablet={isTablet}>
+            <ResponsiveWrapper>
               <Controller
                 name="vaccineUuid"
                 control={control}
@@ -329,7 +329,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
           )}
           {vaccineUuid && (
             <section>
-              <ResponsiveWrapper isTablet={isTablet}>
+              <ResponsiveWrapper>
                 <DoseInput
                   vaccine={vaccineUuid}
                   sequences={immunizationsConfig.sequenceDefinitions}
@@ -339,7 +339,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
             </section>
           )}
           <section>
-            <ResponsiveWrapper isTablet={isTablet}>
+            <ResponsiveWrapper>
               <Controller
                 name="manufacturer"
                 control={control}
@@ -358,7 +358,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
             </ResponsiveWrapper>
           </section>
           <section>
-            <ResponsiveWrapper isTablet={isTablet}>
+            <ResponsiveWrapper>
               <Controller
                 name="lotNumber"
                 control={control}
@@ -377,7 +377,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
             </ResponsiveWrapper>
           </section>
           <section>
-            <ResponsiveWrapper isTablet={isTablet}>
+            <ResponsiveWrapper>
               <Controller
                 name="expirationDate"
                 control={control}
@@ -417,9 +417,5 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
     </FormProvider>
   );
 };
-
-function ResponsiveWrapper({ children, isTablet }: ResponsiveWrapperProps) {
-  return isTablet ? <Layer className={styles.layer}>{children} </Layer> : <Fragment>{children}</Fragment>;
-}
 
 export default ImmunizationsForm;

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.scss
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .container {
   margin: spacing.$spacing-05;

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.scss
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.scss
@@ -1,4 +1,4 @@
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .widgetCard {
   border: 1px solid $ui-03;

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../../root";
 
 .container {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.scss
@@ -1,7 +1,7 @@
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/colors';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../../root";
 
 

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { Button, ButtonSkeleton, Layer, Search, SkeletonText, Tile } from '@carbon/react';
+import { Button, ButtonSkeleton, Search, SkeletonText, Tile } from '@carbon/react';
 import { ArrowRight, ShoppingCartArrowDown, ShoppingCartArrowUp } from '@carbon/react/icons';
-import { useDebounce, useLayoutType, useSession } from '@openmrs/esm-framework';
+import { useDebounce, useLayoutType, useSession, ResponsiveWrapper } from '@openmrs/esm-framework';
 import { closeWorkspace, launchPatientWorkspace, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { type LabOrderBasketItem, prepLabOrderPostData } from '../api';
 import { type TestType, useTestTypes } from './useTestTypes';
@@ -32,7 +32,7 @@ export function TestTypeSearch({ openLabForm }: TestTypeSearchProps) {
 
   return (
     <>
-      <ResponsiveWrapper isTablet={isTablet}>
+      <ResponsiveWrapper>
         <Search
           autoFocus
           size="lg"
@@ -50,10 +50,6 @@ export function TestTypeSearch({ openLabForm }: TestTypeSearchProps) {
       />
     </>
   );
-}
-
-function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
 }
 
 interface TestTypeSearchResultsProps {

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-item-tile.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-item-tile.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../../root";
 
 .clickableTileDesktop {

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.scss
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../../root";
 
 .desktopTile {

--- a/packages/esm-patient-labs-app/src/root.scss
+++ b/packages/esm-patient-labs-app/src/root.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .productiveHeading01 {
   @include type.type-style("heading-compact-01");

--- a/packages/esm-patient-labs-app/src/test-results/filter/filter-set.styles.scss
+++ b/packages/esm-patient-labs-app/src/test-results/filter/filter-set.styles.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .stickyFilterSet {
   position: sticky;

--- a/packages/esm-patient-labs-app/src/test-results/grouped-timeline/grouped-timeline.styles.scss
+++ b/packages/esm-patient-labs-app/src/test-results/grouped-timeline/grouped-timeline.styles.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .timelineHeader {
   position: sticky;
@@ -147,7 +147,7 @@
 
   div {
     @include type.type-style('heading-compact-01');
-    
+
     left: 0;
     width: 100%;
     word-wrap: normal;
@@ -178,7 +178,7 @@
 .low {
   p {
     @include type.type-style('heading-compact-01');
-    
+
   }
 }
 

--- a/packages/esm-patient-labs-app/src/test-results/overview/common-datatable.scss
+++ b/packages/esm-patient-labs-app/src/test-results/overview/common-datatable.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .tableContainer :global(.cds--data-table-header) {
   padding: 0.75rem 1rem 0.25rem 1rem;
@@ -46,7 +46,7 @@ tr {
       content: " ↓↓";
     }
   }
-  
+
   &.critically-high {
     td:nth-child(2)::after {
       content: " ↑↑";

--- a/packages/esm-patient-labs-app/src/test-results/overview/common-overview.scss
+++ b/packages/esm-patient-labs-app/src/test-results/overview/common-overview.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .card {
   border: 1px solid $ui-03;

--- a/packages/esm-patient-labs-app/src/test-results/overview/recent-overview.scss
+++ b/packages/esm-patient-labs-app/src/test-results/overview/recent-overview.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .widgetCard {
   border: 1px solid $ui-03;
@@ -22,7 +22,7 @@
   }
 }
 
-.desktopHeader {  
+.desktopHeader {
   height: 3rem;
   h4 {
     @include type.type-style('heading-compact-02');
@@ -30,7 +30,7 @@
   }
 }
 
-.tabletHeader {  
+.tabletHeader {
   height: 4.5rem;
   h4 {
     @include type.type-style('heading-03');

--- a/packages/esm-patient-labs-app/src/test-results/panel-timeline/timeline.scss
+++ b/packages/esm-patient-labs-app/src/test-results/panel-timeline/timeline.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .grid {
   width: fit-content;
@@ -133,7 +133,7 @@
 .low {
   p {
     @include type.type-style('heading-compact-01');
-    
+
   }
 }
 

--- a/packages/esm-patient-labs-app/src/test-results/panel-view/panel-view.scss
+++ b/packages/esm-patient-labs-app/src/test-results/panel-view/panel-view.scss
@@ -1,7 +1,7 @@
 @use '@carbon/styles/scss/grid/_flexbox';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import '../results-viewer/results-viewer.styles.scss';
 
 .panelViewHeader {

--- a/packages/esm-patient-labs-app/src/test-results/panel-view/result-panel.scss
+++ b/packages/esm-patient-labs-app/src/test-results/panel-view/result-panel.scss
@@ -1,7 +1,7 @@
 @use '@carbon/styles/scss/grid/_flexbox';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .labSetPanel {
   width: 100%;

--- a/packages/esm-patient-labs-app/src/test-results/print-modal/print-modal.extension.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/print-modal/print-modal.extension.tsx
@@ -6,7 +6,6 @@ import {
   DataTable,
   DatePicker,
   DatePickerInput,
-  Layer,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -19,7 +18,15 @@ import {
   TableRow,
 } from '@carbon/react';
 import { useReactToPrint } from 'react-to-print';
-import { age, formatDate, useConfig, useLayoutType, usePatient, useSession } from '@openmrs/esm-framework';
+import {
+  age,
+  formatDate,
+  useConfig,
+  useLayoutType,
+  usePatient,
+  useSession,
+  ResponsiveWrapper,
+} from '@openmrs/esm-framework';
 import usePanelData from '../panel-view/usePanelData';
 import styles from './print-modal.scss';
 
@@ -94,7 +101,7 @@ function PrintModal({ patientUuid, closeDialog }) {
     <div>
       <ModalHeader closeModal={closeDialog} title={t('printTestResults', 'Print test results')} />
       <ModalBody className={styles.modalBody}>
-        <ResponsiveWrapper isTablet={isTablet}>
+        <ResponsiveWrapper>
           <DatePicker
             className={styles.datePickers}
             datePickerType="range"
@@ -200,10 +207,6 @@ function PrintModal({ patientUuid, closeDialog }) {
       ) : null}
     </div>
   );
-}
-
-function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
 }
 
 export default PrintModal;

--- a/packages/esm-patient-labs-app/src/test-results/results-viewer/results-viewer.styles.scss
+++ b/packages/esm-patient-labs-app/src/test-results/results-viewer/results-viewer.styles.scss
@@ -1,7 +1,7 @@
 @use '@carbon/styles/scss/grid/_flexbox';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .resultsContainer {
   padding: 0;
@@ -66,7 +66,7 @@
   min-width: 2.5rem;
 }
 
-.leftHeaderActions > :global(.cds--content-switcher), 
+.leftHeaderActions > :global(.cds--content-switcher),
 .viewOptsContentSwitcherContainer :global(.cds--content-switcher) {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/packages/esm-patient-labs-app/src/test-results/tablet-overlay/tablet-overlay.scss
+++ b/packages/esm-patient-labs-app/src/test-results/tablet-overlay/tablet-overlay.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .tabletOverlay {
   position: fixed;

--- a/packages/esm-patient-labs-app/src/test-results/trendline/trendline.scss
+++ b/packages/esm-patient-labs-app/src/test-results/trendline/trendline.scss
@@ -1,13 +1,13 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @import "~@carbon/charts/styles.css";
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .container {
   :global(.cds--cc--area path.area) {
     stroke: none;
     fill: #a7f0ba;
-  }  
+  }
 }
 
 .ui-shell-header-modal-bar-default {
@@ -62,7 +62,7 @@
     svg {
       order: 1;
       margin-right: 0.5rem;
-    }  
+    }
 
     span {
       order: 2;

--- a/packages/esm-patient-labs-app/src/test-results/ui-elements/resetFiltersEmptyState/index.scss
+++ b/packages/esm-patient-labs-app/src/test-results/ui-elements/resetFiltersEmptyState/index.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .action {
   @include type.type-style("body-long-01");

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
@@ -23,9 +23,8 @@ export default function DrugSearch({ openOrderForm }: DrugSearchProps) {
     searchInputRef.current?.focus();
   };
 
-  const handleSearchTermChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearchTermChange = (event: React.ChangeEvent<HTMLInputElement>) =>
     setSearchTerm(event.target.value ?? '');
-  };
 
   return (
     <div className={styles.searchPopupContainer}>
@@ -40,11 +39,6 @@ export default function DrugSearch({ openOrderForm }: DrugSearchProps) {
           value={searchTerm}
         />
       </ResponsiveWrapper>
-      <OrderBasketSearchResults
-        searchTerm={debouncedSearchTerm}
-        openOrderForm={openOrderForm}
-        focusAndClearSearchInput={focusAndClearSearchInput}
-      />
       <OrderBasketSearchResults
         searchTerm={debouncedSearchTerm}
         openOrderForm={openOrderForm}

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Layer, Search } from '@carbon/react';
-import { useConfig, useDebounce, useLayoutType } from '@openmrs/esm-framework';
+import { Search } from '@carbon/react';
+import { useConfig, useDebounce, ResponsiveWrapper } from '@openmrs/esm-framework';
+import { type ConfigObject } from '../../config-schema';
 import { type DrugOrderBasketItem } from '../../types';
 import OrderBasketSearchResults from './order-basket-search-results.component';
 import styles from './order-basket-search.scss';
-import { type ConfigObject } from '../../config-schema';
 
 export interface DrugSearchProps {
   openOrderForm: (searchResult: DrugOrderBasketItem) => void;
@@ -13,7 +13,6 @@ export interface DrugSearchProps {
 
 export default function DrugSearch({ openOrderForm }: DrugSearchProps) {
   const { t } = useTranslation();
-  const isTablet = useLayoutType() === 'tablet';
   const [searchTerm, setSearchTerm] = useState('');
   const { debounceDelayInMs } = useConfig<ConfigObject>();
   const debouncedSearchTerm = useDebounce(searchTerm, debounceDelayInMs ?? 300);
@@ -30,7 +29,7 @@ export default function DrugSearch({ openOrderForm }: DrugSearchProps) {
 
   return (
     <div className={styles.searchPopupContainer}>
-      <ResponsiveWrapper isTablet={isTablet}>
+      <ResponsiveWrapper>
         <Search
           autoFocus
           size="lg"
@@ -46,10 +45,11 @@ export default function DrugSearch({ openOrderForm }: DrugSearchProps) {
         openOrderForm={openOrderForm}
         focusAndClearSearchInput={focusAndClearSearchInput}
       />
+      <OrderBasketSearchResults
+        searchTerm={debouncedSearchTerm}
+        openOrderForm={openOrderForm}
+        focusAndClearSearchInput={focusAndClearSearchInput}
+      />
     </div>
   );
-}
-
-function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
 }

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../root";
 
 .desktopTile {

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.scss
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 @import "../root";
 
 .clickableTileDesktop {

--- a/packages/esm-patient-medications-app/src/root.scss
+++ b/packages/esm-patient-medications-app/src/root.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .productiveHeading01 {
   @include type.type-style("heading-compact-01");

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.scss
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .widgetCard {
   border: 1px solid $ui-03;
@@ -20,7 +20,7 @@
 
 .copy {
   @include type.type-style('body-01');
-  
+
   display: flex;
   flex-direction: column;
 }

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -13,7 +13,6 @@ import {
   DatePickerInput,
   Form,
   FormGroup,
-  Layer,
   Row,
   Search,
   SkeletonText,
@@ -33,6 +32,7 @@ import {
   useLayoutType,
   useSession,
   createAttachment,
+  ResponsiveWrapper,
 } from '@openmrs/esm-framework';
 import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import type { ConfigObject } from '../config-schema';
@@ -338,7 +338,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
               name="noteDate"
               control={control}
               render={({ field: { onChange, value } }) => (
-                <ResponsiveWrapper isTablet={isTablet}>
+                <ResponsiveWrapper>
                   <DatePicker
                     dateFormat="d/m/Y"
                     datePickerType="single"
@@ -518,7 +518,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
                       </ul>
                     );
                   return (
-                    <ResponsiveWrapper isTablet={isTablet}>
+                    <ResponsiveWrapper>
                       <Tile className={styles.emptyResults}>
                         <span>
                           {t('noMatchingDiagnoses', 'No diagnoses found matching')}{' '}
@@ -541,7 +541,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
               name="clinicalNote"
               control={control}
               render={({ field: { onChange, onBlur, value } }) => (
-                <ResponsiveWrapper isTablet={isTablet}>
+                <ResponsiveWrapper>
                   <TextArea
                     id="additionalNote"
                     rows={rows}
@@ -638,7 +638,7 @@ function DiagnosisSearch({ name, control, labelText, placeholder, handleSearch, 
       control={control}
       render={({ field: { value, onChange, onBlur }, fieldState }) => (
         <>
-          <ResponsiveWrapper isTablet={isTablet}>
+          <ResponsiveWrapper>
             <Search
               ref={inputRef}
               size={isTablet ? 'lg' : 'md'}
@@ -660,8 +660,4 @@ function DiagnosisSearch({ name, control, labelText, placeholder, handleSearch, 
       )}
     />
   );
-}
-
-function ResponsiveWrapper({ children, isTablet }: { children: React.ReactNode; isTablet: boolean }) {
-  return isTablet ? <Layer>{children} </Layer> : <>{children}</>;
 }

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -20,6 +20,7 @@ import {
   Tag,
   TextArea,
   Tile,
+  Layer,
 } from '@carbon/react';
 import { Add, Edit, WarningFilled } from '@carbon/react/icons';
 import {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .heading {
   @include type.type-style("heading-03");
@@ -136,7 +136,7 @@
   .form {
     height: var(--tablet-workspace-window-height);
   }
-  
+
   .row {
     display: flex;
     gap: 4rem;

--- a/packages/esm-patient-orders-app/src/root.scss
+++ b/packages/esm-patient-orders-app/src/root.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars'; 
+@import '@openmrs/esm-styleguide/src/vars';
 
 .productiveHeading01 {
   @include type.type-style("heading-compact-01");
@@ -62,6 +62,6 @@
   white-space: nowrap;
 }
 
-.text02 { 
+.text02 {
   color: $text-02;
 }

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.scss
@@ -1,4 +1,4 @@
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .widgetCard {
   border: 1px solid $ui-03;

--- a/packages/esm-patient-programs-app/src/programs/programs-form.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .loading {
   margin-left: 1rem;

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.scss
@@ -1,4 +1,4 @@
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .widgetCard {
   border: 1px solid $ui-03;

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-base.scss
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-base.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .widgetCard {
   border: 1px solid $ui-03;

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.scss
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .label01 {
   @include type.type-style("label-01");

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .container {
   display: flex;

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .vitals-header {
   display: flex;

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.scss
@@ -1,7 +1,7 @@
 @use '@carbon/colors';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .productiveHeading03 {
   @include type.type-style("heading-03");

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -1,10 +1,10 @@
 import React, { Fragment, useId, useState } from 'react';
 import classNames from 'classnames';
 import { type Control, Controller } from 'react-hook-form';
-import { FormLabel, Layer, NumberInput, TextArea } from '@carbon/react';
+import { FormLabel, NumberInput, TextArea } from '@carbon/react';
 import { Warning } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
-import { useLayoutType } from '@openmrs/esm-framework';
+import { useLayoutType, ResponsiveWrapper } from '@openmrs/esm-framework';
 import { generatePlaceholder } from '../common';
 import { type VitalsBiometricsFormData } from './vitals-biometrics-form.component';
 import styles from './vitals-biometrics-input.scss';
@@ -133,7 +133,7 @@ const VitalsAndBiometricsInput: React.FC<VitalsAndBiometricsInputProps> = ({
 
                 return (
                   <Fragment key={fieldProperty.id}>
-                    <ResponsiveWrapper isTablet={isTablet}>
+                    <ResponsiveWrapper>
                       <Controller
                         name={fieldProperty.id}
                         control={control}
@@ -173,7 +173,7 @@ const VitalsAndBiometricsInput: React.FC<VitalsAndBiometricsInputProps> = ({
 
               if (fieldProperty.type === 'textarea') {
                 return (
-                  <ResponsiveWrapper key={fieldProperty.id} isTablet={isTablet}>
+                  <ResponsiveWrapper key={fieldProperty.id}>
                     <Controller
                       name={fieldProperty.id}
                       control={control}
@@ -216,9 +216,5 @@ const VitalsAndBiometricsInput: React.FC<VitalsAndBiometricsInputProps> = ({
     </>
   );
 };
-
-function ResponsiveWrapper({ children, isTablet }: ResponsiveWrapperProps) {
-  return isTablet ? <Layer className={styles.layer}>{children} </Layer> : <Fragment>{children}</Fragment>;
-}
 
 export default VitalsAndBiometricsInput;

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.scss
@@ -1,7 +1,7 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/colors';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .label01 {
   @include type.type-style("label-01");

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .label01 {
   @include type.type-style("label-01");

--- a/packages/esm-patient-vitals-app/src/weight-tile/weight-tile.scss
+++ b/packages/esm-patient-vitals-app/src/weight-tile/weight-tile.scss
@@ -2,17 +2,16 @@
 @import '@openmrs/esm-styleguide/src/vars';
 
 .label {
-	@include type.type-style('label-01');
-	color: $text-02;
+  @include type.type-style('label-01');
+  color: $text-02;
 }
 
 .content {
-	@include type.type-style('body-compact-01');
-	color: $text-02;
-	margin-top: 5px;
+  @include type.type-style('body-compact-01');
+  color: $text-02;
+  margin-top: 5px;
 }
 
 .value {
-	@include type.type-style('body-compact-01');
-
+  @include type.type-style('body-compact-01');
 }

--- a/packages/esm-patient-vitals-app/src/weight-tile/weight-tile.scss
+++ b/packages/esm-patient-vitals-app/src/weight-tile/weight-tile.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/type';
-@import '~@openmrs/esm-styleguide/src/vars';
+@import '@openmrs/esm-styleguide/src/vars';
 
 .label {
 	@include type.type-style('label-01');
@@ -14,5 +14,5 @@
 
 .value {
 	@include type.type-style('body-compact-01');
-	
+
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

This replaces all instances of `ResponsiveWrapper` with the similarly-named reusable component that's defined in the `@openmrs/esm-framework` library. It also removes all custom implementations of the component in this repo as well as unused imports of the `Layer` carbon component and the `useLayoutType` hook. 

## Related Issue

[O3-2804](https://openmrs.atlassian.net/jira/software/c/projects/O3/issues/O3-2804)