### PR TITLE
(feat) O3 2888: Show non-coded allergen and allergic reaction names in summary table

### DIFF
--- a/__mocks__/allergies.mock.ts
+++ b/__mocks__/allergies.mock.ts
@@ -73,22 +73,42 @@ export const mockAllergyResult = {
 
 export const mockFhirAllergyIntoleranceResponse = {
   resourceType: 'Bundle',
-  id: '17d21c4c-7248-4170-bcd8-ac4ee0146109',
-  meta: { lastUpdated: '2021-05-24T12:44:20.131+00:00' },
+  id: '4de79f04-276a-4db1-9a36-ef9772533cd3',
+  meta: {
+    lastUpdated: '2024-03-04T10:22:54.083+00:00',
+    tag: [
+      {
+        system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue',
+        code: 'SUBSETTED',
+        display: 'Resource encoded in summary mode',
+      },
+    ],
+  },
   type: 'searchset',
-  total: 5,
+  total: 6,
   link: [
     {
       relation: 'self',
-      url: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/AllergyIntolerance?patient.identifier=100GEJ',
+      url: 'https://dev3.openmrs.org/openmrs/ws/fhir2/R4/AllergyIntolerance?_summary=data&patient=6c9d6265-5942-4da2-9f2b-7d23fd247859',
     },
   ],
   entry: [
     {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/AllergyIntolerance/2b8e9963-a734-4cb8-b778-68f8f360c321',
+      fullUrl: 'https://dev3.openmrs.org/openmrs/ws/fhir2/R4/AllergyIntolerance/25dbb3d5-cf2b-4e6b-a44f-81a8a89edbc7',
       resource: {
         resourceType: 'AllergyIntolerance',
-        id: '2b8e9963-a734-4cb8-b778-68f8f360c321',
+        id: '25dbb3d5-cf2b-4e6b-a44f-81a8a89edbc7',
+        meta: {
+          versionId: '1709544197000',
+          lastUpdated: '2024-03-04T09:23:17.000+00:00',
+          tag: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue',
+              code: 'SUBSETTED',
+              display: 'Resource encoded in summary mode',
+            },
+          ],
+        },
         clinicalStatus: {
           coding: [
             {
@@ -119,19 +139,24 @@ export const mockFhirAllergyIntoleranceResponse = {
               display: 'Aspirin',
             },
           ],
+          text: 'Aspirin',
         },
         patient: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
+          reference: 'Patient/6c9d6265-5942-4da2-9f2b-7d23fd247859',
           type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
+          display: 'Joshua Test (OpenMRS ID: 1000NK1)',
         },
-        recordedDate: '2020-11-03T06:01:39+00:00',
+        recordedDate: '2024-03-04T09:23:17+00:00',
         recorder: {
-          reference: 'Practitioner/45ce6c2e-dd5a-11e6-9d9c-0242ac150002',
+          reference: 'Practitioner/82f18b44-6814-11e8-923f-e9a88dcb533f',
           type: 'Practitioner',
           display: 'Super User',
         },
-        note: [{ text: 'Comments' }],
+        note: [
+          {
+            text: 'Comments',
+          },
+        ],
         reaction: [
           {
             substance: {
@@ -141,6 +166,7 @@ export const mockFhirAllergyIntoleranceResponse = {
                   display: 'Aspirin',
                 },
               ],
+              text: 'Aspirin',
             },
             manifestation: [
               {
@@ -150,6 +176,7 @@ export const mockFhirAllergyIntoleranceResponse = {
                     display: 'Mental status change',
                   },
                 ],
+                text: 'Mental status change',
               },
             ],
             severity: 'severe',
@@ -158,10 +185,21 @@ export const mockFhirAllergyIntoleranceResponse = {
       },
     },
     {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/AllergyIntolerance/b929af4c-497c-49cc-8fc0-15d11db0e8e8',
+      fullUrl: 'https://dev3.openmrs.org/openmrs/ws/fhir2/R4/AllergyIntolerance/46e378a7-3397-4922-b964-255177df413b',
       resource: {
         resourceType: 'AllergyIntolerance',
-        id: 'b929af4c-497c-49cc-8fc0-15d11db0e8e8',
+        id: '46e378a7-3397-4922-b964-255177df413b',
+        meta: {
+          versionId: '1709544283000',
+          lastUpdated: '2024-03-04T09:24:43.000+00:00',
+          tag: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue',
+              code: 'SUBSETTED',
+              display: 'Resource encoded in summary mode',
+            },
+          ],
+        },
         clinicalStatus: {
           coding: [
             {
@@ -192,19 +230,24 @@ export const mockFhirAllergyIntoleranceResponse = {
               display: 'Morphine',
             },
           ],
+          text: 'Morphine',
         },
         patient: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
+          reference: 'Patient/6c9d6265-5942-4da2-9f2b-7d23fd247859',
           type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
+          display: 'Joshua Test (OpenMRS ID: 1000NK1)',
         },
-        recordedDate: '2020-11-03T06:02:25+00:00',
+        recordedDate: '2024-03-04T09:24:43+00:00',
         recorder: {
-          reference: 'Practitioner/45ce6c2e-dd5a-11e6-9d9c-0242ac150002',
+          reference: 'Practitioner/82f18b44-6814-11e8-923f-e9a88dcb533f',
           type: 'Practitioner',
           display: 'Super User',
         },
-        note: [{ text: 'Comments' }],
+        note: [
+          {
+            text: 'Comments',
+          },
+        ],
         reaction: [
           {
             substance: {
@@ -214,6 +257,7 @@ export const mockFhirAllergyIntoleranceResponse = {
                   display: 'Morphine',
                 },
               ],
+              text: 'Morphine',
             },
             manifestation: [
               {
@@ -223,6 +267,7 @@ export const mockFhirAllergyIntoleranceResponse = {
                     display: 'Mental status change',
                   },
                 ],
+                text: 'Mental status change',
               },
             ],
             severity: 'severe',
@@ -231,11 +276,21 @@ export const mockFhirAllergyIntoleranceResponse = {
       },
     },
     {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/AllergyIntolerance/509bc6b5-b124-49a1-aa98-718787dda6cc',
+      fullUrl: 'https://dev3.openmrs.org/openmrs/ws/fhir2/R4/AllergyIntolerance/cc4c8baf-abf3-41c9-b5f4-abf76eca2d2c',
       resource: {
         resourceType: 'AllergyIntolerance',
-        id: '509bc6b5-b124-49a1-aa98-718787dda6cc',
-
+        id: 'cc4c8baf-abf3-41c9-b5f4-abf76eca2d2c',
+        meta: {
+          versionId: '1709544486000',
+          lastUpdated: '2024-03-04T09:28:06.000+00:00',
+          tag: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue',
+              code: 'SUBSETTED',
+              display: 'Resource encoded in summary mode',
+            },
+          ],
+        },
         clinicalStatus: {
           coding: [
             {
@@ -266,19 +321,24 @@ export const mockFhirAllergyIntoleranceResponse = {
               display: 'Penicillins',
             },
           ],
+          text: 'Penicillins',
         },
         patient: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
+          reference: 'Patient/6c9d6265-5942-4da2-9f2b-7d23fd247859',
           type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
+          display: 'Joshua Test (OpenMRS ID: 1000NK1)',
         },
-        recordedDate: '2021-01-22T11:12:25+00:00',
+        recordedDate: '2024-03-04T09:28:06+00:00',
         recorder: {
-          reference: 'Practitioner/45ce6c2e-dd5a-11e6-9d9c-0242ac150002',
+          reference: 'Practitioner/82f18b44-6814-11e8-923f-e9a88dcb533f',
           type: 'Practitioner',
           display: 'Super User',
         },
-        note: [{ text: 'Patient allergies have been noted down' }],
+        note: [
+          {
+            text: 'Patient allergies have been noted down',
+          },
+        ],
         reaction: [
           {
             substance: {
@@ -288,32 +348,9 @@ export const mockFhirAllergyIntoleranceResponse = {
                   display: 'Penicillins',
                 },
               ],
+              text: 'Penicillins',
             },
             manifestation: [
-              {
-                coding: [
-                  {
-                    code: '142412AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-                    display: 'Diarrhea',
-                  },
-                ],
-              },
-              {
-                coding: [
-                  {
-                    code: '143264AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-                    display: 'Cough',
-                  },
-                ],
-              },
-              {
-                coding: [
-                  {
-                    code: '159347AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-                    display: 'Musculoskeletal pain',
-                  },
-                ],
-              },
               {
                 coding: [
                   {
@@ -321,6 +358,7 @@ export const mockFhirAllergyIntoleranceResponse = {
                     display: 'Mental status change',
                   },
                 ],
+                text: 'Mental status change',
               },
               {
                 coding: [
@@ -329,6 +367,34 @@ export const mockFhirAllergyIntoleranceResponse = {
                     display: 'Angioedema',
                   },
                 ],
+                text: 'Angioedema',
+              },
+              {
+                coding: [
+                  {
+                    code: '143264AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                    display: 'Cough',
+                  },
+                ],
+                text: 'Cough',
+              },
+              {
+                coding: [
+                  {
+                    code: '142412AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                    display: 'Diarrhea',
+                  },
+                ],
+                text: 'Diarrhea',
+              },
+              {
+                coding: [
+                  {
+                    code: '159347AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                    display: 'Musculoskeletal pain',
+                  },
+                ],
+                text: 'Musculoskeletal pain',
               },
             ],
             severity: 'severe',
@@ -337,10 +403,21 @@ export const mockFhirAllergyIntoleranceResponse = {
       },
     },
     {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/AllergyIntolerance/4704c1a8-5ecd-4cd6-b060-d9663f393551',
+      fullUrl: 'https://dev3.openmrs.org/openmrs/ws/fhir2/R4/AllergyIntolerance/c80bcc21-1222-4a00-a14a-5fc4d12fd213',
       resource: {
         resourceType: 'AllergyIntolerance',
-        id: '4704c1a8-5ecd-4cd6-b060-d9663f393551',
+        id: 'c80bcc21-1222-4a00-a14a-5fc4d12fd213',
+        meta: {
+          versionId: '1709544648000',
+          lastUpdated: '2024-03-04T09:30:48.000+00:00',
+          tag: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue',
+              code: 'SUBSETTED',
+              display: 'Resource encoded in summary mode',
+            },
+          ],
+        },
         clinicalStatus: {
           coding: [
             {
@@ -371,19 +448,24 @@ export const mockFhirAllergyIntoleranceResponse = {
               display: 'Fish',
             },
           ],
+          text: 'Fish',
         },
         patient: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
+          reference: 'Patient/6c9d6265-5942-4da2-9f2b-7d23fd247859',
           type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
+          display: 'Joshua Test (OpenMRS ID: 1000NK1)',
         },
-        recordedDate: '2021-04-29T05:57:54+00:00',
+        recordedDate: '2024-03-04T09:30:48+00:00',
         recorder: {
-          reference: 'Practitioner/0ae5c4d6-c9bc-4e85-9aeb-73ee4da98678',
+          reference: 'Practitioner/82f18b44-6814-11e8-923f-e9a88dcb533f',
           type: 'Practitioner',
-          display: 'user-dev dev Developer',
+          display: 'Super User',
         },
-        note: [{ text: 'Some Comments' }],
+        note: [
+          {
+            text: 'Some Comments',
+          },
+        ],
         reaction: [
           {
             substance: {
@@ -393,6 +475,7 @@ export const mockFhirAllergyIntoleranceResponse = {
                   display: 'Fish',
                 },
               ],
+              text: 'Fish',
             },
             manifestation: [
               {
@@ -402,6 +485,7 @@ export const mockFhirAllergyIntoleranceResponse = {
                     display: 'Anaphylaxis',
                   },
                 ],
+                text: 'Anaphylaxis',
               },
               {
                 coding: [
@@ -410,6 +494,7 @@ export const mockFhirAllergyIntoleranceResponse = {
                     display: 'Angioedema',
                   },
                 ],
+                text: 'Angioedema',
               },
               {
                 coding: [
@@ -418,6 +503,7 @@ export const mockFhirAllergyIntoleranceResponse = {
                     display: 'Fever',
                   },
                 ],
+                text: 'Fever',
               },
               {
                 coding: [
@@ -426,6 +512,7 @@ export const mockFhirAllergyIntoleranceResponse = {
                     display: 'Hives',
                   },
                 ],
+                text: 'Hives',
               },
             ],
             severity: 'mild',
@@ -434,10 +521,21 @@ export const mockFhirAllergyIntoleranceResponse = {
       },
     },
     {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/AllergyIntolerance/ed330db7-6da6-40d3-b853-5c41a428464e',
+      fullUrl: 'https://dev3.openmrs.org/openmrs/ws/fhir2/R4/AllergyIntolerance/95ba9a38-3fd5-42c1-82c7-f2f5945da9b8',
       resource: {
         resourceType: 'AllergyIntolerance',
-        id: 'ed330db7-6da6-40d3-b853-5c41a428464e',
+        id: '95ba9a38-3fd5-42c1-82c7-f2f5945da9b8',
+        meta: {
+          versionId: '1709544728000',
+          lastUpdated: '2024-03-04T09:32:08.000+00:00',
+          tag: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue',
+              code: 'SUBSETTED',
+              display: 'Resource encoded in summary mode',
+            },
+          ],
+        },
         clinicalStatus: {
           coding: [
             {
@@ -468,15 +566,16 @@ export const mockFhirAllergyIntoleranceResponse = {
               display: 'ACE inhibitors',
             },
           ],
+          text: 'ACE inhibitors',
         },
         patient: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
+          reference: 'Patient/6c9d6265-5942-4da2-9f2b-7d23fd247859',
           type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
+          display: 'Joshua Test (OpenMRS ID: 1000NK1)',
         },
-        recordedDate: '2021-05-01T01:10:08+00:00',
+        recordedDate: '2024-03-04T09:32:08+00:00',
         recorder: {
-          reference: 'Practitioner/45ce6c2e-dd5a-11e6-9d9c-0242ac150002',
+          reference: 'Practitioner/82f18b44-6814-11e8-923f-e9a88dcb533f',
           type: 'Practitioner',
           display: 'Super User',
         },
@@ -489,6 +588,7 @@ export const mockFhirAllergyIntoleranceResponse = {
                   display: 'ACE inhibitors',
                 },
               ],
+              text: 'ACE inhibitors',
             },
             manifestation: [
               {
@@ -498,9 +598,124 @@ export const mockFhirAllergyIntoleranceResponse = {
                     display: 'Anaphylaxis',
                   },
                 ],
+                text: 'Anaphylaxis',
               },
             ],
             severity: 'moderate',
+          },
+        ],
+      },
+    },
+    {
+      fullUrl: 'https://dev3.openmrs.org/openmrs/ws/fhir2/R4/AllergyIntolerance/ceb07cd6-7df3-49b7-b448-6a8282472352',
+      resource: {
+        resourceType: 'AllergyIntolerance',
+        id: 'ceb07cd6-7df3-49b7-b448-6a8282472352',
+        meta: {
+          versionId: '1709547772000',
+          lastUpdated: '2024-03-04T10:22:52.000+00:00',
+          tag: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue',
+              code: 'SUBSETTED',
+              display: 'Resource encoded in summary mode',
+            },
+          ],
+        },
+        clinicalStatus: {
+          coding: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
+              code: 'active',
+              display: 'Active',
+            },
+          ],
+          text: 'Active',
+        },
+        verificationStatus: {
+          coding: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification',
+              code: 'confirmed',
+              display: 'Confirmed',
+            },
+          ],
+          text: 'Confirmed',
+        },
+        type: 'allergy',
+        criticality: 'high',
+        code: {
+          coding: [
+            {
+              code: '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              display: 'Other',
+            },
+            {
+              system: 'https://cielterminology.org',
+              code: '5622',
+            },
+            {
+              system: 'http://snomed.info/sct/',
+              code: '74964007',
+            },
+          ],
+          text: 'non-coded allergen',
+        },
+        patient: {
+          reference: 'Patient/6c9d6265-5942-4da2-9f2b-7d23fd247859',
+          type: 'Patient',
+          display: 'Joshua Test (OpenMRS ID: 1000NK1)',
+        },
+        recordedDate: '2024-03-04T10:22:52+00:00',
+        recorder: {
+          reference: 'Practitioner/82f18b44-6814-11e8-923f-e9a88dcb533f',
+          type: 'Practitioner',
+          display: 'Super User',
+        },
+        note: [
+          {
+            text: 'non coded allergic note',
+          },
+        ],
+        reaction: [
+          {
+            substance: {
+              coding: [
+                {
+                  code: '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                  display: 'Other',
+                },
+                {
+                  system: 'https://cielterminology.org',
+                  code: '5622',
+                },
+                {
+                  system: 'http://snomed.info/sct/',
+                  code: '74964007',
+                },
+              ],
+              text: 'non-coded allergen',
+            },
+            manifestation: [
+              {
+                coding: [
+                  {
+                    code: '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                    display: 'Other',
+                  },
+                  {
+                    system: 'https://cielterminology.org',
+                    code: '5622',
+                  },
+                  {
+                    system: 'http://snomed.info/sct/',
+                    code: '74964007',
+                  },
+                ],
+                text: 'non-coded allergic reaction',
+              },
+            ],
+            severity: 'severe',
           },
         ],
       },

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
@@ -60,7 +60,7 @@ describe('AllergiesDetailedSummary: ', () => {
     const expectedAllergies = [
       /ACE inhibitors moderate Anaphylaxis/i,
       /Fish mild Anaphylaxis, Angioedema, Fever, Hives Some Comments/i,
-      /Penicillins severe Diarrhea, Cough, Musculoskeletal pain, Mental status change, Angioedema Patient allergies have been noted down/i,
+      /Penicillins severe Mental status change, Angioedema, Cough, Diarrhea, Musculoskeletal pain Patient allergies have been noted down/i,
       /Morphine severe Mental status change Comments/i,
       /Aspirin severe Mental status change Comments/i,
     ];
@@ -72,6 +72,18 @@ describe('AllergiesDetailedSummary: ', () => {
     expectedAllergies.forEach((allergy) =>
       expect(screen.getByRole('row', { name: new RegExp(allergy) })).toBeInTheDocument(),
     );
+  });
+
+  it("renders non-coded allergen name and non-coded allergic reaction name in the detailed summary of the patient's allergies", async () => {
+    mockOpenmrsFetch.mockReturnValueOnce({ data: mockFhirAllergyIntoleranceResponse });
+    renderAllergiesDetailedSummary();
+
+    await waitForLoadingToFinish();
+
+    expect(screen.getByRole('heading', { name: /allergies/i })).toBeInTheDocument();
+
+    const expectedNonCodedAllergy = /non-coded allergen severe non-coded allergic reaction non coded allergic note/i;
+    expect(screen.getByRole('row', { name: new RegExp(expectedNonCodedAllergy) })).toBeInTheDocument();
   });
 });
 

--- a/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
+++ b/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
@@ -53,17 +53,17 @@ export function useAllergies(patientUuid: string): UseAllergies {
 }
 
 function mapAllergyProperties(allergy: FHIRAllergy): Allergy {
-  const manifestations = allergy?.reaction[0]?.manifestation?.map((coding) => coding.coding[0]?.display);
+  const manifestations = allergy?.reaction[0]?.manifestation?.map((coding) => coding?.text);
   return {
     id: allergy?.id,
     clinicalStatus: allergy?.clinicalStatus?.coding[0]?.display,
     criticality: allergy?.criticality,
-    display: allergy?.code?.coding[0]?.display,
+    display: allergy?.code?.text,
     recordedDate: allergy?.recordedDate,
     recordedBy: allergy?.recorder?.display,
     recorderType: allergy?.recorder?.type,
     note: allergy?.note?.[0]?.text,
-    reactionToSubstance: allergy?.reaction[0]?.substance?.coding[1]?.display,
+    reactionToSubstance: allergy?.reaction[0]?.substance?.text,
     reactionManifestations: manifestations,
     reactionSeverity: allergy?.reaction[0]?.severity,
     lastUpdated: allergy?.meta?.lastUpdated,

--- a/packages/esm-patient-allergies-app/src/types/index.ts
+++ b/packages/esm-patient-allergies-app/src/types/index.ts
@@ -19,6 +19,7 @@ export interface FHIRAllergy {
   };
   code: {
     coding: Array<CodingData>;
+    text: string;
   };
   criticality: string;
   id: string;
@@ -64,10 +65,12 @@ export interface ExtensionData {
 export interface AllergicReaction {
   manifestation: Array<{
     coding: CodingData;
+    text: string;
   }>;
   severity: ReactionSeverity;
   substance: {
     coding: Array<CodingData>;
+    text: string;
   };
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
After selecting `other` and specifying the name of the non-coded allergy and saving, the allergies table in the reactions columns displays other.  It should be better if they display the actual name of the non-coded  allergy  cc @denniskigen @vasharma05 @michaelbontyes 

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/openmrs/openmrs-esm-patient-chart/assets/58003327/9b0ead16-0fef-4431-a109-b6724bf2295b


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-2888

## Other
<!-- Anything not covered above -->
