### PR TITLE
(chore) Add generic slot to Visit Form

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -122,6 +122,11 @@ export const esmPatientChartSchema = {
     _type: Type.Number,
     _description: 'The number of visits to load initially in the Visits Summary tab. Defaults to 5',
     _default: 5,
+    showBillingSlot: {
+      _type: Type.Boolean,
+      _description: 'Whether on start visit form to show billing extension and enable billing functionality',
+      _default: false,
+    },
   },
 };
 export interface ChartConfig {
@@ -139,6 +144,7 @@ export interface ChartConfig {
   showAllEncountersTab: boolean;
   defaultFacilityUrl: string;
   showUpcomingAppointments: boolean;
+  showBillingSlot: boolean;
   logo: {
     src: string;
     alt: string;

--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -122,11 +122,6 @@ export const esmPatientChartSchema = {
     _type: Type.Number,
     _description: 'The number of visits to load initially in the Visits Summary tab. Defaults to 5',
     _default: 5,
-    showBillingSlot: {
-      _type: Type.Boolean,
-      _description: 'Whether on start visit form to show billing extension and enable billing functionality',
-      _default: false,
-    },
   },
 };
 export interface ChartConfig {
@@ -144,7 +139,6 @@ export interface ChartConfig {
   showAllEncountersTab: boolean;
   defaultFacilityUrl: string;
   showUpcomingAppointments: boolean;
-  showBillingSlot: boolean;
   logo: {
     src: string;
     alt: string;

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -91,7 +91,6 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
   const visitQueueNumberAttributeUuid = config.visitQueueNumberAttributeUuid;
   const [visitUuid, setVisitUuid] = useState('');
   const { mutate: mutateQueueEntry } = useVisitQueueEntry(patientUuid, visitUuid);
-  const [billingInfo, setBillingInfo] = useState(null);
 
   const displayVisitStopDateTimeFields = useMemo(
     () => visitToEdit?.stopDatetime || showVisitEndDateTimeFields,
@@ -317,11 +316,6 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
       }
 
       const abortController = new AbortController();
-      if (config.showBillingSlot) {
-        const { handleCreateBill, attributes } = billingInfo ?? {};
-        payload.attributes = attributes;
-        handleCreateBill && handleCreateBill();
-      }
 
       if (isOnline) {
         (visitToEdit?.uuid
@@ -648,9 +642,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
               </section>
             )}
 
-            {config.showBillingSlot && (
-              <ExtensionSlot state={{ patientUuid, setBillingInfo }} name="extra-visit-attribute-slot" />
-            )}
+            <ExtensionSlot state={{ patientUuid }} name="extra-visit-attribute-slot" />
 
             {/* Visit type attribute fields. These get shown when visit attribute types are configured */}
             <section>

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -91,6 +91,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
   const visitQueueNumberAttributeUuid = config.visitQueueNumberAttributeUuid;
   const [visitUuid, setVisitUuid] = useState('');
   const { mutate: mutateQueueEntry } = useVisitQueueEntry(patientUuid, visitUuid);
+  const [billingInfo, setBillingInfo] = useState(null);
 
   const displayVisitStopDateTimeFields = useMemo(
     () => visitToEdit?.stopDatetime || showVisitEndDateTimeFields,
@@ -316,6 +317,11 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
       }
 
       const abortController = new AbortController();
+      if (config.showBillingSlot) {
+        const { handleCreateBill, attributes } = billingInfo ?? {};
+        payload.attributes = attributes;
+        handleCreateBill && handleCreateBill();
+      }
 
       if (isOnline) {
         (visitToEdit?.uuid
@@ -640,6 +646,10 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
                   />
                 </div>
               </section>
+            )}
+
+            {config.showBillingSlot && (
+              <ExtensionSlot state={{ patientUuid, setBillingInfo }} name="extra-visit-attribute-slot" />
             )}
 
             {/* Visit type attribute fields. These get shown when visit attribute types are configured */}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This change adds an extension to the start visit form in order to enable dynamic mounting for custom implementations. This should facilitates a scalable approach allowing for any modifications without the need for reconfiguration or redevelopment of the existing form structure. 

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/43242517/e89ce752-92e5-490a-ba9f-a8913802ba4f)
## Related Issue
[Link to ticket](https://openmrs.atlassian.net/browse/O3-2871)

## Other
<!-- Anything not covered above -->
