### PR TITLE
(feat) O3-2760 (v2): Added new function 'closeWorkspaceWithSavedChanges' to close workspace after form is saved

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -21,6 +21,7 @@ const FormRenderer: React.FC<FormRendererProps> = ({
   patientUuid,
   visit,
   closeWorkspace,
+  closeWorkspaceWithSavedChanges,
   encounterUuid,
   mode,
 }) => {
@@ -52,7 +53,7 @@ const FormRenderer: React.FC<FormRendererProps> = ({
           visit={visit}
           formJson={schema}
           handleClose={closeWorkspace}
-          onSubmit={() => closeWorkspace({ ignoreChanges: true })}
+          onSubmit={closeWorkspaceWithSavedChanges}
           mode={mode}
         />
       )}

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
@@ -21,6 +21,7 @@ describe('FormRenderer', () => {
     formUuid: 'test-form-uuid',
     patientUuid: 'test-patient-uuid',
     closeWorkspace: jest.fn(),
+    closeWorkspaceWithSavedChanges: jest.fn(),
     promptBeforeClosing: jest.fn(),
   };
 

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
@@ -67,7 +67,7 @@ type AllergyFormData = {
 };
 
 function AllergyForm(props: DefaultWorkspaceProps) {
-  const { closeWorkspace, patientUuid, promptBeforeClosing } = props;
+  const { closeWorkspace, patientUuid, promptBeforeClosing, closeWorkspaceWithSavedChanges } = props;
   const { t } = useTranslation();
   const { concepts } = useConfig();
   const isTablet = useLayoutType() === 'tablet';
@@ -166,7 +166,7 @@ function AllergyForm(props: DefaultWorkspaceProps) {
           (response: FetchResponse) => {
             if (response.status === 201) {
               mutate();
-              closeWorkspace({ ignoreChanges: true });
+              closeWorkspaceWithSavedChanges();
               showSnackbar({
                 isLowContrast: true,
                 kind: 'success',
@@ -186,7 +186,7 @@ function AllergyForm(props: DefaultWorkspaceProps) {
         )
         .finally(() => abortController.abort());
     },
-    [otherConceptUuid, patientUuid, closeWorkspace, t, mutate],
+    [otherConceptUuid, patientUuid, closeWorkspaceWithSavedChanges, t, mutate],
   );
 
   return (

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.test.tsx
@@ -274,6 +274,7 @@ describe('AllergyForm ', () => {
 function renderAllergyForm() {
   const testProps = {
     closeWorkspace: () => {},
+    closeWorkspaceWithSavedChanges: () => {},
     promptBeforeClosing: () => {},
     patient: mockPatient,
     patientUuid: mockPatient.id,

--- a/packages/esm-patient-chart-app/src/visit/past-visit-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/past-visit-overview.test.tsx
@@ -7,6 +7,7 @@ import PastVisitOverview from './past-visit-overview.component';
 
 const testProps = {
   closeWorkspace: jest.fn(),
+  closeWorkspaceWithSavedChanges: jest.fn(),
   patientUuid: mockPatient.id,
   promptBeforeClosing: jest.fn(),
 };

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -57,7 +57,7 @@ import { useVisits } from '../visits-widget/visit.resource';
 import { useOfflineVisitType } from '../hooks/useOfflineVisitType';
 
 interface StartVisitFormProps extends DefaultWorkspaceProps {
-  visitToEdit: Visit;
+  visitToEdit?: Visit;
   showVisitEndDateTimeFields: boolean;
 }
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -14,8 +14,8 @@ const mockPromptBeforeClosing = jest.fn();
 const testProps = {
   patientUuid: mockPatient.id,
   closeWorkspace: mockCloseWorkspace,
+  closeWorkspaceWithSavedChanges: mockCloseWorkspace,
   promptBeforeClosing: mockPromptBeforeClosing,
-  visitToEdit: undefined,
   showVisitEndDateTimeFields: false,
 };
 

--- a/packages/esm-patient-common-lib/src/types/workspace.ts
+++ b/packages/esm-patient-common-lib/src/types/workspace.ts
@@ -1,5 +1,3 @@
-import { closeWorkspace } from '../workspaces';
-
 /* The possible states a workspace window can be opened in. */
 export type WorkspaceWindowState = 'maximized' | 'hidden' | 'normal';
 
@@ -35,6 +33,11 @@ export interface DefaultWorkspaceProps {
    * this workspace is closed; e.g. if there is unsaved data.
    */
   promptBeforeClosing(testFcn: () => boolean): void;
+  /**
+   * Call this function to close the workspace after the form is saved. This function
+   * will directly close the workspace without any prompt
+   */
+  closeWorkspaceWithSavedChanges(closeWorkspaceOptions?: CloseWorkspaceOptions): void;
   patientUuid: string;
   handlePostResponse?(): void;
 }

--- a/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces/workspaces.ts
@@ -163,6 +163,9 @@ export function launchPatientWorkspace(name: string, additionalProps?: object) {
   const newWorkspace = {
     ...workspace,
     closeWorkspace: (options: CloseWorkspaceOptions = {}) => closeWorkspace(name, options),
+    closeWorkspaceWithSavedChanges: (options: CloseWorkspaceOptions) => {
+      closeWorkspace(name, { ignoreChanges: true, ...options });
+    },
     promptBeforeClosing: (testFcn) => promptBeforeClosing(name, testFcn),
     additionalProps,
   };

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
@@ -26,6 +26,7 @@ export type ConditionFormData = z.infer<typeof conditionSchema>;
 
 const ConditionsForm: React.FC<ConditionFormProps> = ({
   closeWorkspace,
+  closeWorkspaceWithSavedChanges,
   condition,
   formContext,
   patientUuid,
@@ -77,7 +78,7 @@ const ConditionsForm: React.FC<ConditionFormProps> = ({
       <Form className={styles.form} onSubmit={methods.handleSubmit(onSubmit, onError)}>
         <ConditionsWidget
           patientUuid={patientUuid}
-          closeWorkspace={closeWorkspace}
+          closeWorkspaceWithSavedChanges={closeWorkspaceWithSavedChanges}
           conditionToEdit={condition}
           editing={formContext === 'editing'}
           setErrorCreating={setErrorCreating}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
@@ -30,6 +30,7 @@ dayjs.extend(utc);
 
 const testProps = {
   closeWorkspace: jest.fn(),
+  closeWorkspaceWithSavedChanges: jest.fn(),
   patientUuid: mockPatient.id,
   formContext: 'creating' as const,
 };

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -32,7 +32,7 @@ import styles from './conditions-form.scss';
 import { type DefaultWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 
 interface ConditionsWidgetProps {
-  closeWorkspace?: DefaultWorkspaceProps['closeWorkspace'];
+  closeWorkspaceWithSavedChanges?: DefaultWorkspaceProps['closeWorkspaceWithSavedChanges'];
   conditionToEdit?: ConditionDataTableRow;
   editing?: boolean;
   patientUuid: string;
@@ -44,7 +44,7 @@ interface ConditionsWidgetProps {
 }
 
 const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
-  closeWorkspace,
+  closeWorkspaceWithSavedChanges,
   conditionToEdit,
   editing,
   patientUuid,
@@ -115,14 +115,14 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
           title: t('conditionSaved', 'Condition saved'),
         });
 
-        closeWorkspace?.({ ignoreChanges: true });
+        closeWorkspaceWithSavedChanges();
       }
     } catch (error) {
       setIsSubmittingForm(false);
       setErrorCreating(error);
     }
   }, [
-    closeWorkspace,
+    closeWorkspaceWithSavedChanges,
     getValues,
     mutate,
     patientUuid,
@@ -157,14 +157,14 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
           title: t('conditionUpdated', 'Condition updated'),
         });
 
-        closeWorkspace({ ignoreChanges: true });
+        closeWorkspaceWithSavedChanges();
       }
     } catch (error) {
       setIsSubmittingForm(false);
       setErrorUpdating(error);
     }
   }, [
-    closeWorkspace,
+    closeWorkspaceWithSavedChanges,
     conditionToEdit?.id,
     displayName,
     editableClinicalStatus,

--- a/packages/esm-patient-flags-app/src/flags/flags-list.component.tsx
+++ b/packages/esm-patient-flags-app/src/flags/flags-list.component.tsx
@@ -12,7 +12,11 @@ import styles from './flags-list.scss';
 
 type dropdownFilter = 'A - Z' | 'Active first' | 'Retired first';
 
-const FlagsList: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWorkspace }) => {
+const FlagsList: React.FC<DefaultWorkspaceProps> = ({
+  patientUuid,
+  closeWorkspace,
+  closeWorkspaceWithSavedChanges,
+}) => {
   const { t } = useTranslation();
   const { flags, isLoading, error, mutate } = usePatientFlags(patientUuid);
   const isTablet = useLayoutType() === 'tablet';
@@ -198,7 +202,7 @@ const FlagsList: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWorkspac
         </Stack>
       </div>
       <ButtonSet className={isTablet ? styles.tabletButtonSet : styles.desktopButtonSet}>
-        <Button className={styles.button} kind="secondary" onClick={() => closeWorkspace()}>
+        <Button className={styles.button} kind="secondary" onClick={closeWorkspace}>
           {t('discard', 'Discard')}
         </Button>
         <Button
@@ -206,7 +210,7 @@ const FlagsList: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWorkspac
           disabled={isEnabling || isDisabling}
           kind="primary"
           type="submit"
-          onClick={() => closeWorkspace()}
+          onClick={closeWorkspaceWithSavedChanges}
         >
           {(() => {
             if (isEnabling) return t('enablingFlag', 'Enabling flag...');

--- a/packages/esm-patient-flags-app/src/flags/flags-list.test.tsx
+++ b/packages/esm-patient-flags-app/src/flags/flags-list.test.tsx
@@ -40,5 +40,12 @@ it('renders an Edit form that enables users to toggle flags on or off', async ()
 });
 
 function renderFlagsList() {
-  return render(<FlagsList closeWorkspace={jest.fn()} patientUuid={mockPatient.id} promptBeforeClosing={jest.fn()} />);
+  return render(
+    <FlagsList
+      closeWorkspace={jest.fn()}
+      closeWorkspaceWithSavedChanges={jest.fn()}
+      patientUuid={mockPatient.id}
+      promptBeforeClosing={jest.fn()}
+    />,
+  );
 }

--- a/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
@@ -11,7 +11,12 @@ interface FormEntryComponentProps extends DefaultWorkspaceProps {
   formInfo: FormEntryProps;
 }
 
-const FormEntry: React.FC<FormEntryComponentProps> = ({ patientUuid, closeWorkspace, mutateForm, formInfo }) => {
+const FormEntry: React.FC<FormEntryComponentProps> = ({
+  patientUuid,
+  closeWorkspaceWithSavedChanges,
+  mutateForm,
+  formInfo,
+}) => {
   const { encounterUuid, formUuid, visitStartDatetime, visitStopDatetime, visitTypeUuid, visitUuid, additionalProps } =
     formInfo || {};
   const { patient } = usePatient(patientUuid);
@@ -32,7 +37,7 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({ patientUuid, closeWorksp
       encounterUuid: encounterUuid ?? null,
       closeWorkspace: () => {
         typeof mutateForm === 'function' && mutateForm();
-        closeWorkspace({ ignoreChanges: true });
+        closeWorkspaceWithSavedChanges();
       },
       additionalProps,
     }),
@@ -51,7 +56,7 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({ patientUuid, closeWorksp
       patient,
       isOnline,
       mutateForm,
-      closeWorkspace,
+      closeWorkspaceWithSavedChanges,
     ],
   );
 

--- a/packages/esm-patient-forms-app/src/forms/form-entry.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.test.tsx
@@ -58,6 +58,7 @@ describe('FormEntry', () => {
 function renderFormEntry() {
   const testProps = {
     closeWorkspace: jest.fn(),
+    closeWorkspaceWithSavedChanges: jest.fn(),
     promptBeforeClosing: jest.fn(),
     patientUuid: mockPatient.id,
     formInfo: { formUuid: 'some-form-uuid' },

--- a/packages/esm-patient-forms-app/src/forms/forms-dashboard.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-dashboard.component.tsx
@@ -13,7 +13,7 @@ import styles from './forms-dashboard.scss';
 import { useForms } from '../hooks/use-forms';
 import { useTranslation } from 'react-i18next';
 
-const FormsDashboard: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace }) => {
+const FormsDashboard: React.FC<DefaultWorkspaceProps> = () => {
   const { t } = useTranslation();
   const config = useConfig<ConfigObject>();
   const isOnline = useConnectivity();

--- a/packages/esm-patient-forms-app/src/forms/forms-dashboard.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-dashboard.test.tsx
@@ -52,5 +52,12 @@ describe('FormsDashboard', () => {
 });
 
 function renderFormDashboard() {
-  render(<FormsDashboard promptBeforeClosing={jest.fn()} closeWorkspace={jest.fn()} patientUuid="" />);
+  render(
+    <FormsDashboard
+      promptBeforeClosing={jest.fn()}
+      closeWorkspace={jest.fn()}
+      closeWorkspaceWithSavedChanges={jest.fn()}
+      patientUuid=""
+    />,
+  );
 }

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
@@ -46,7 +46,12 @@ interface ResponsiveWrapperProps {
 
 const datePickerFormat = 'd/m/Y';
 
-const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWorkspace, promptBeforeClosing }) => {
+const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
+  patientUuid,
+  closeWorkspace,
+  closeWorkspaceWithSavedChanges,
+  promptBeforeClosing,
+}) => {
   const { t } = useTranslation();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { immunizationsConfig } = useConfig() as ConfigObject;
@@ -184,7 +189,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, close
       ).then(
         () => {
           setIsSubmitting(false);
-          closeWorkspace({ ignoreChanges: true });
+          closeWorkspaceWithSavedChanges();
           mutate();
           showSnackbar({
             kind: 'success',
@@ -211,7 +216,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({ patientUuid, close
       currentVisit?.uuid,
       immunizationToEditMeta,
       immunizationsConceptSet,
-      closeWorkspace,
+      closeWorkspaceWithSavedChanges,
       t,
     ],
   );

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
@@ -8,7 +8,7 @@ import { immunizationFormSub } from './utils';
 import { showSnackbar } from '@openmrs/esm-framework';
 
 const mockCloseWorkspace = jest.fn();
-const mockDiscardAndCloseWorkspace = jest.fn();
+const mockCloseWorkspaceWithSavedChanges = jest.fn();
 const mockPromptBeforeClosing = jest.fn();
 const mockSavePatientImmunization = savePatientImmunization as jest.Mock;
 
@@ -84,6 +84,7 @@ jest.mock('./immunizations.resource', () => ({
 const testProps = {
   patientUuid: mockPatient.id,
   closeWorkspace: mockCloseWorkspace,
+  closeWorkspaceWithSavedChanges: mockCloseWorkspaceWithSavedChanges,
   promptBeforeClosing: mockPromptBeforeClosing,
 };
 

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
@@ -53,15 +53,19 @@ function renderAddLabOrderWorkspace() {
   const mockCloseWorkspace = jest.fn().mockImplementation(({ onWorkspaceClose }) => {
     onWorkspaceClose();
   });
+  const mockCloseWorkspaceWithSavedChanges = jest.fn().mockImplementation(({ onWorkspaceClose }) => {
+    onWorkspaceClose();
+  });
   const mockPromptBeforeClosing = jest.fn();
   const renderResult = render(
     <AddLabOrderWorkspace
       closeWorkspace={mockCloseWorkspace}
+      closeWorkspaceWithSavedChanges={mockCloseWorkspaceWithSavedChanges}
       promptBeforeClosing={mockPromptBeforeClosing}
       patientUuid={ptUuid}
     />,
   );
-  return { mockCloseWorkspace, mockPromptBeforeClosing, ...renderResult };
+  return { mockCloseWorkspace, mockPromptBeforeClosing, mockCloseWorkspaceWithSavedChanges, ...renderResult };
 }
 
 describe('AddLabOrder', () => {
@@ -96,7 +100,7 @@ describe('AddLabOrder', () => {
     const { result: hookResult } = renderHook(() =>
       useOrderBasket('labs', ((x) => x) as unknown as PostDataPrepLabOrderFunction),
     );
-    const { mockCloseWorkspace } = renderAddLabOrderWorkspace();
+    const { mockCloseWorkspaceWithSavedChanges } = renderAddLabOrderWorkspace();
     await user.type(screen.getByRole('searchbox'), 'cd4');
     const cd4 = screen.getByText('CD4 COUNT');
     expect(cd4).toBeInTheDocument();
@@ -137,7 +141,7 @@ describe('AddLabOrder', () => {
       ]);
     });
 
-    expect(mockCloseWorkspace).toHaveBeenCalled();
+    expect(mockCloseWorkspaceWithSavedChanges).toHaveBeenCalled();
     expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('order-basket');
   });
 

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
@@ -25,6 +25,7 @@ export interface AddLabOrderWorkspace extends DefaultWorkspaceProps, AddLabOrder
 export default function AddLabOrderWorkspace({
   order: initialOrder,
   closeWorkspace,
+  closeWorkspaceWithSavedChanges,
   promptBeforeClosing,
 }: AddLabOrderWorkspace) {
   const { t } = useTranslation();
@@ -73,6 +74,7 @@ export default function AddLabOrderWorkspace({
         <LabOrderForm
           initialOrder={currentLabOrder}
           closeWorkspace={closeWorkspace}
+          closeWorkspaceWithSavedChanges={closeWorkspaceWithSavedChanges}
           promptBeforeClosing={promptBeforeClosing}
         />
       )}

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
@@ -28,6 +28,7 @@ import styles from './lab-order-form.scss';
 export interface LabOrderFormProps {
   initialOrder: LabOrderBasketItem;
   closeWorkspace: DefaultWorkspaceProps['closeWorkspace'];
+  closeWorkspaceWithSavedChanges: DefaultWorkspaceProps['closeWorkspaceWithSavedChanges'];
   promptBeforeClosing: DefaultWorkspaceProps['promptBeforeClosing'];
 }
 
@@ -52,7 +53,12 @@ const labOrderFormSchema = z.object({
 // Designs:
 //   https://app.zeplin.io/project/60d5947dd636aebbd63dce4c/screen/640b06c440ee3f7af8747620
 //   https://app.zeplin.io/project/60d5947dd636aebbd63dce4c/screen/640b06d286e0aa7b0316db4a
-export function LabOrderForm({ initialOrder, closeWorkspace, promptBeforeClosing }: LabOrderFormProps) {
+export function LabOrderForm({
+  initialOrder,
+  closeWorkspace,
+  closeWorkspaceWithSavedChanges,
+  promptBeforeClosing,
+}: LabOrderFormProps) {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const session = useSession();
@@ -88,8 +94,7 @@ export function LabOrderForm({ initialOrder, closeWorkspace, promptBeforeClosing
       const orderIndex = existingOrder ? orders.indexOf(existingOrder) : orders.length;
       newOrders[orderIndex] = data;
       setOrders(newOrders);
-      closeWorkspace({
-        ignoreChanges: true,
+      closeWorkspaceWithSavedChanges({
         onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
       });
     },

--- a/packages/esm-patient-lists-app/src/workspaces/patient-list-details.workspace.test.tsx
+++ b/packages/esm-patient-lists-app/src/workspaces/patient-list-details.workspace.test.tsx
@@ -9,6 +9,7 @@ const testProps = {
   patientUuid: '',
   promptBeforeClosing: jest.fn(),
   closeWorkspace: jest.fn(),
+  closeWorkspaceWithSavedChanges: jest.fn(),
   list: {
     attributes: [],
     description:

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
@@ -49,6 +49,7 @@ function renderDrugSearch() {
     <AddDrugOrderWorkspace
       order={undefined as any}
       closeWorkspace={jest.fn()}
+      closeWorkspaceWithSavedChanges={jest.fn()}
       promptBeforeClosing={() => false}
       patientUuid={'mock-patient-uuid'}
     />,

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
@@ -16,6 +16,7 @@ export interface AddDrugOrderWorkspace extends DefaultWorkspaceProps, AddDrugOrd
 export default function AddDrugOrderWorkspace({
   order: initialOrder,
   closeWorkspace,
+  closeWorkspaceWithSavedChanges,
   promptBeforeClosing,
 }: AddDrugOrderWorkspace) {
   const { orders, setOrders } = useOrderBasket<DrugOrderBasketItem>('medications', prepMedicationOrderPostData);
@@ -56,12 +57,11 @@ export default function AddDrugOrderWorkspace({
         newOrders.push(finalizedOrder);
       }
       setOrders(newOrders);
-      closeWorkspace({
-        ignoreChanges: true,
+      closeWorkspaceWithSavedChanges({
         onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
       });
     },
-    [orders, setOrders, closeWorkspace, session.currentProvider.uuid],
+    [orders, setOrders, closeWorkspaceWithSavedChanges, session.currentProvider.uuid],
   );
 
   if (!currentOrder) {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -69,7 +69,12 @@ interface DiagnosisSearchProps {
   error?: Object;
 }
 
-const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, patientUuid, promptBeforeClosing }) => {
+const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
+  closeWorkspace,
+  closeWorkspaceWithSavedChanges,
+  patientUuid,
+  promptBeforeClosing,
+}) => {
   const searchTimeoutInMs = 500;
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
@@ -273,7 +278,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, patie
           if (data.image) {
             mutateAttachments();
           }
-          closeWorkspace();
+          closeWorkspaceWithSavedChanges();
 
           showSnackbar({
             isLowContrast: true,
@@ -308,7 +313,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({ closeWorkspace, patie
       encounterNoteTextConceptUuid,
       combinedDiagnoses,
       mutateVisitNotes,
-      closeWorkspace,
+      closeWorkspaceWithSavedChanges,
       t,
     ],
   );

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -17,6 +17,7 @@ import VisitNotesForm from './visit-notes-form.component';
 const testProps = {
   patientUuid: mockPatient.id,
   closeWorkspace: jest.fn(),
+  closeWorkspaceWithSavedChanges: jest.fn(),
   promptBeforeClosing: jest.fn(),
 };
 

--- a/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
@@ -14,7 +14,12 @@ import { type ConfigObject } from '../config-schema';
 import { createEmptyEncounter, useOrderEncounter, useMutatePatientOrders } from '../api/api';
 import styles from './order-basket.scss';
 
-const OrderBasket: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWorkspace, promptBeforeClosing }) => {
+const OrderBasket: React.FC<DefaultWorkspaceProps> = ({
+  patientUuid,
+  closeWorkspace,
+  closeWorkspaceWithSavedChanges,
+  promptBeforeClosing,
+}) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const config = useConfig<ConfigObject>();
@@ -68,7 +73,7 @@ const OrderBasket: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWorksp
     clearOrders({ exceptThoseMatching: (item) => erroredItems.map((e) => e.display).includes(item.display) });
     mutateOrders();
     if (erroredItems.length == 0) {
-      closeWorkspace({ ignoreChanges: true });
+      closeWorkspaceWithSavedChanges();
       showOrderSuccessToast(t, orders);
     } else {
       showOrderFailureToast(t);
@@ -79,7 +84,7 @@ const OrderBasket: React.FC<DefaultWorkspaceProps> = ({ patientUuid, closeWorksp
     activeVisit,
     activeVisitRequired,
     clearOrders,
-    closeWorkspace,
+    closeWorkspaceWithSavedChanges,
     config,
     encounterUuid,
     mutateEncounterUuid,

--- a/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
@@ -52,6 +52,7 @@ export type ProgramsFormData = z.infer<typeof programsFormSchema>;
 
 const ProgramsForm: React.FC<ProgramsFormProps> = ({
   closeWorkspace,
+  closeWorkspaceWithSavedChanges,
   patientUuid,
   programEnrollmentId,
   promptBeforeClosing,
@@ -120,7 +121,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
             (response) => {
               if (response.status === 200) {
                 mutateEnrollments();
-                closeWorkspace();
+                closeWorkspaceWithSavedChanges();
 
                 showSnackbar({
                   isLowContrast: true,
@@ -148,7 +149,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
             (response) => {
               if (response.status === 201) {
                 mutateEnrollments();
-                closeWorkspace();
+                closeWorkspaceWithSavedChanges();
 
                 showSnackbar({
                   isLowContrast: true,
@@ -173,7 +174,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
         sub.unsubscribe();
       };
     },
-    [patientUuid, currentEnrollment, mutateEnrollments, closeWorkspace, t],
+    [patientUuid, currentEnrollment, mutateEnrollments, closeWorkspaceWithSavedChanges, t],
   );
 
   const programSelect = (
@@ -312,7 +313,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
         ))}
       </Stack>
       <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
-        <Button className={styles.button} kind="secondary" onClick={() => closeWorkspace()}>
+        <Button className={styles.button} kind="secondary" onClick={closeWorkspace}>
           {t('cancel', 'Cancel')}
         </Button>
         <Button className={styles.button} kind="primary" type="submit">

--- a/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
@@ -11,6 +11,7 @@ import ProgramsForm from './programs-form.component';
 
 const testProps = {
   closeWorkspace: jest.fn(),
+  closeWorkspaceWithSavedChanges: jest.fn(),
   patientUuid: mockPatient.id,
   promptBeforeClosing: jest.fn(),
 };

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -73,6 +73,7 @@ export type VitalsBiometricsFormData = z.infer<typeof VitalsAndBiometricFormSche
 const VitalsAndBiometricsForm: React.FC<DefaultWorkspaceProps> = ({
   patientUuid,
   closeWorkspace,
+  closeWorkspaceWithSavedChanges,
   promptBeforeClosing,
 }) => {
   const { t } = useTranslation();
@@ -191,7 +192,7 @@ const VitalsAndBiometricsForm: React.FC<DefaultWorkspaceProps> = ({
         .then((response) => {
           if (response.status === 201) {
             invalidateCachedVitalsAndBiometrics();
-            closeWorkspace();
+            closeWorkspaceWithSavedChanges();
             showSnackbar({
               isLowContrast: true,
               kind: 'success',
@@ -230,7 +231,7 @@ const VitalsAndBiometricsForm: React.FC<DefaultWorkspaceProps> = ({
           patientUuid: patientUuid ?? null,
           patient,
           encounterUuid,
-          closeWorkspace,
+          closeWorkspaceWithSavedChanges,
         }}
       />
     );
@@ -581,7 +582,7 @@ const VitalsAndBiometricsForm: React.FC<DefaultWorkspaceProps> = ({
       )}
 
       <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
-        <Button className={styles.button} kind="secondary" onClick={() => closeWorkspace()}>
+        <Button className={styles.button} kind="secondary" onClick={closeWorkspace}>
           {t('discard', 'Discard')}
         </Button>
         <Button

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
@@ -9,6 +9,7 @@ import VitalsAndBiometricsForm from './vitals-biometrics-form.component';
 
 const testProps = {
   closeWorkspace: () => {},
+  closeWorkspaceWithSavedChanges: jest.fn(),
   patientUuid: mockPatient.id,
   promptBeforeClosing: () => {},
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4388,9 +4388,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-api@npm:5.3.3-pre.1477"
+"@openmrs/esm-api@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-api@npm:5.4.1-pre.1567"
   dependencies:
     "@types/fhir": 0.0.31
     lodash-es: ^4.17.21
@@ -4399,17 +4399,17 @@ __metadata:
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: 825c3f856e953ca977eaafe1b1ef62fc739eb567ba92e217f17c1a76b3ca2c46e8d79be54fdf018d7115c8fef9db238f1cb4a87da46792a815536e625f17fc0c
+  checksum: cc99c640c0a710efa865d5d36738caf708f58d4278a63f108f7265b38fb6e2a0c98da76401a0673bb41152a924d5c7b2e39a0809bb5bfd65d6feaaaff2e3c23c
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-app-shell@npm:5.3.3-pre.1477"
+"@openmrs/esm-app-shell@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-app-shell@npm:5.4.1-pre.1567"
   dependencies:
     "@carbon/react": ~1.37.0
-    "@openmrs/esm-framework": 5.3.3-pre.1477
-    "@openmrs/esm-styleguide": 5.3.3-pre.1477
+    "@openmrs/esm-framework": 5.4.1-pre.1567
+    "@openmrs/esm-styleguide": 5.4.1-pre.1567
     dayjs: ^1.10.4
     dexie: ^3.0.3
     html-webpack-plugin: ^5.5.0
@@ -4434,44 +4434,44 @@ __metadata:
     workbox-strategies: ^6.1.5
     workbox-webpack-plugin: ^6.1.5
     workbox-window: ^6.1.5
-  checksum: e4e4d4fef178c5f5e22fdcbc1074c622054b26cc9dca72952ebc3c8317569fe9f8de065b4c6bda353f723b581676e7de538ce0e3dd43b2ff982ee862f598a5ed
+  checksum: 8686a32fb375d960dca8691b2d148f286cd668fc74b548c5bc5dc69473e147c2992d5c3cdc039cdd91d470c361b207a11fa85bd13aaf6e9400b0ed0d9b501473
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-config@npm:5.3.3-pre.1477"
+"@openmrs/esm-config@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-config@npm:5.4.1-pre.1567"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: ffa9ccd19decacbde26350b2f62868dc4b37ff2e7146264bb43e4b83842a4e967036a506e60ef6dbd2d3d3a45d347f0784a57fb70e4f643d3a7ef4a231855d95
+  checksum: 4e1a93b06a683d0fc7f0925c832e26da1deb32fc6c0c92384a304d562134232ebae0784f2d28cf81c25aebe518d698342c4f291bc8e221be0ee53ac7293acfe5
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1477"
+"@openmrs/esm-dynamic-loading@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.4.1-pre.1567"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 0c0e0729124ea802df6e9af0d505949f2551ff1bfbdbfa9e6d89a3ea6a04881dcba8f59618b303a28fa4316f713e91935c904b2f7c4a948931e2bba65f1809a9
+  checksum: fe1595d833a91184dd6d23048d39b8445826256bf821a2099c382a2b79f12461403bd19d7741e6694863c5166a8f20d05b451b803fc66ba40c7cf2cc7fd533cd
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-error-handling@npm:5.3.3-pre.1477"
+"@openmrs/esm-error-handling@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-error-handling@npm:5.4.1-pre.1567"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 0e6f9f54984ae1b60b9a18680c23b3fa29d0cf1a9f257be8794e476f7d6124e8a70e1c246ff16ae5815715153577dd7cca70fa63c6fd801d59855fa90213d5e6
+  checksum: 9748aec555c72120d9ba25a41a29ed0a480f2491e086a62d399e3ba78ccec372d15af3c09bcf82a0d80692799cf6faaa4d5eaf28f4ebdfb7857a6b74cd693ccd
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-extensions@npm:5.3.3-pre.1477"
+"@openmrs/esm-extensions@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-extensions@npm:5.4.1-pre.1567"
   dependencies:
     lodash-es: ^4.17.21
   peerDependencies:
@@ -4480,20 +4480,20 @@ __metadata:
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 6d6781e5c003f03562dff2657e1fe50e4d1296ace1e4e1892fca5c94b9c20e5c416fcb74c743a6fe4763e6e9ed5880443aec8603d8d3c3bd0b726a07da4b3b20
+  checksum: df23a48c3abe27eb55624c0b78564c2b72c60c2160d9e83f11197cf3abd45c23df18a7e6203030452a975925404ab7adf9be43ec1bd261f533541f42818c936f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-feature-flags@npm:5.3.3-pre.1477"
+"@openmrs/esm-feature-flags@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-feature-flags@npm:5.4.1-pre.1567"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 64253a5def6771926511b6a34768984380955468ee47f3c09fbc2a2629ed3ad16e8e1a5fc5fb817ae9322bba2e1f5ad9b1cba61ac597a66da33d6fce8b669f8e
+  checksum: f530ca2f344ae668db2951d5132fe1737d35d240277caf514a49b024c6f285dce0bbe5a3d28c05e35f3ff84b61eef97c460a1ddbcef6cae8ad1a39bd49d7b2fb
   languageName: node
   linkType: hard
 
@@ -4587,24 +4587,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-framework@npm:5.3.3-pre.1477, @openmrs/esm-framework@npm:next":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-framework@npm:5.3.3-pre.1477"
+"@openmrs/esm-framework@npm:5.4.1-pre.1567, @openmrs/esm-framework@npm:next":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-framework@npm:5.4.1-pre.1567"
   dependencies:
-    "@openmrs/esm-api": 5.3.3-pre.1477
-    "@openmrs/esm-config": 5.3.3-pre.1477
-    "@openmrs/esm-dynamic-loading": 5.3.3-pre.1477
-    "@openmrs/esm-error-handling": 5.3.3-pre.1477
-    "@openmrs/esm-extensions": 5.3.3-pre.1477
-    "@openmrs/esm-feature-flags": 5.3.3-pre.1477
-    "@openmrs/esm-globals": 5.3.3-pre.1477
-    "@openmrs/esm-navigation": 5.3.3-pre.1477
-    "@openmrs/esm-offline": 5.3.3-pre.1477
-    "@openmrs/esm-react-utils": 5.3.3-pre.1477
-    "@openmrs/esm-routes": 5.3.3-pre.1477
-    "@openmrs/esm-state": 5.3.3-pre.1477
-    "@openmrs/esm-styleguide": 5.3.3-pre.1477
-    "@openmrs/esm-utils": 5.3.3-pre.1477
+    "@openmrs/esm-api": 5.4.1-pre.1567
+    "@openmrs/esm-config": 5.4.1-pre.1567
+    "@openmrs/esm-dynamic-loading": 5.4.1-pre.1567
+    "@openmrs/esm-error-handling": 5.4.1-pre.1567
+    "@openmrs/esm-extensions": 5.4.1-pre.1567
+    "@openmrs/esm-feature-flags": 5.4.1-pre.1567
+    "@openmrs/esm-globals": 5.4.1-pre.1567
+    "@openmrs/esm-navigation": 5.4.1-pre.1567
+    "@openmrs/esm-offline": 5.4.1-pre.1567
+    "@openmrs/esm-react-utils": 5.4.1-pre.1567
+    "@openmrs/esm-routes": 5.4.1-pre.1567
+    "@openmrs/esm-state": 5.4.1-pre.1567
+    "@openmrs/esm-styleguide": 5.4.1-pre.1567
+    "@openmrs/esm-utils": 5.4.1-pre.1567
     dayjs: ^1.10.7
   peerDependencies:
     dayjs: 1.x
@@ -4615,7 +4615,7 @@ __metadata:
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: 7da04ea81b9b906ec69f7730b5399a6901e4bb0c2b6f73601016a90dbdae08fe5f471ff12a44945a90cb750f9f121332721901960a249b9d502e965b8ad9ec97
+  checksum: b7c58d27dc22589ec873b2b7a12cc10bf3764feec78172a46271824430de8bbfb14a4292c8c916a36f0146183f9d44b0fef67fc36f8aca60f412a3f18470653a
   languageName: node
   linkType: hard
 
@@ -4641,29 +4641,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-globals@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-globals@npm:5.3.3-pre.1477"
+"@openmrs/esm-globals@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-globals@npm:5.4.1-pre.1567"
   peerDependencies:
     single-spa: 5.x
-  checksum: ac8f961b5de0b86b7c9b71b72b31b1af99cd2988169292993303be61a99ed131f0d72d192ee284af01b803a7d2911a019abeeaf8c29abb5241e23b97fd4e1917
+  checksum: f88dc1a28469851c6aabf2390a353ef255d86930a44ed4f44d6e628241b5c8d920354e69d89703d877008e580271640ea8fc6b5da1caebcbe2a6552b82b7d630
   languageName: node
   linkType: hard
 
-"@openmrs/esm-navigation@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-navigation@npm:5.3.3-pre.1477"
+"@openmrs/esm-navigation@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-navigation@npm:5.4.1-pre.1567"
   dependencies:
     path-to-regexp: 6.1.0
   peerDependencies:
     "@openmrs/esm-state": 5.x
-  checksum: 1d60cf050e3424e72cb064efdb3ea02a1fb01d544c937e0c1f045a4f0d075e0e225187c3847c709b4719acee47accc254c552717f29fe5af8ed18d084eec75be
+  checksum: 24b144363aab84bd9c79b3d05e0a5058e7bdcbe1a4e5a15af28f6d67bc89ff5ec99f4e484534e89bb30eadb8284bc845b749f617014e8d58f7fd4f6240e055a7
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-offline@npm:5.3.3-pre.1477"
+"@openmrs/esm-offline@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-offline@npm:5.4.1-pre.1567"
   dependencies:
     dexie: ^3.0.3
     lodash-es: ^4.17.21
@@ -4675,7 +4675,7 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
-  checksum: 3e6d89475697c0749df09341fac00e4307d88dc86337530491640b91446de4ff0d3346a5c43676736b9b053e211daf5450fc690bd1ce061a343bf273096073f5
+  checksum: ec7b0dbfcab6d1b3a24caac0cbd3f0e2ee0658791a152d6421e66bacfa7681d6c41710a5673d79070c8d66e01d29bb5eb1cbc1e6c4b7ec4f1df92b7363ea7404
   languageName: node
   linkType: hard
 
@@ -5088,9 +5088,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-react-utils@npm:5.3.3-pre.1477"
+"@openmrs/esm-react-utils@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-react-utils@npm:5.4.1-pre.1567"
   dependencies:
     lodash-es: ^4.17.21
     single-spa-react: ^6.0.0
@@ -5108,34 +5108,34 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 7e31fa6fd9b2073680f971e2bcb54361e3d424def0e4e9761beff0f203e8bc45b25e9f14ffd5c4958f481e1a277540b35c518a6a91a96b0db157ee95f4ab0c6b
+  checksum: ec49b7add5b6755cdf48c7670a87078fcdca0095d546972b5fb24144e3db07be69b4c9146fed02606803d1d521a545e11e5e9deef3fafc4b66c0f0e65fcb086e
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-routes@npm:5.3.3-pre.1477"
+"@openmrs/esm-routes@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-routes@npm:5.4.1-pre.1567"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-utils": 5.x
-  checksum: 419ee274eb79f60ff134855c235ec434d61b847b767b6a792edcfd932ffa7b829cd3480da893f28ab537647b6b0ed200ae6b6624853588563ea76ffec99ce771
+  checksum: ea7d28eafe12b2ddfaf4f3530c02b417f2d3be2138d4e88b0a4f5038e10a257187709c9330d60b3e97592569d3c033fbfb6433f0799864bc82152ca7ff8bfccf
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-state@npm:5.3.3-pre.1477"
+"@openmrs/esm-state@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-state@npm:5.4.1-pre.1567"
   dependencies:
     zustand: ^4.3.6
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 1d74ed2706f8977d9e9c957afd195a2dc28e334d387222edc72432f68a47d5190b633a80ed2e9aebc8c2f6e587be51f5c2c06004a870df443f25acd39b0dbb76
+  checksum: 003ae94b96c1c315400790e1ff0b83f68b41e80348e803dfe84e560e9c52cfa24a76817f6b91d3a5c39895bedf3b0539e83e2a58fc2114fe8d84ecf8de1fdf24
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-styleguide@npm:5.3.3-pre.1477"
+"@openmrs/esm-styleguide@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-styleguide@npm:5.4.1-pre.1567"
   dependencies:
     "@carbon/charts": ^1.12.0
     "@carbon/react": ~1.37.0
@@ -5154,20 +5154,20 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: d02cd848c0da55ea65567e3ed1f48001154bcc1be09df9f5cc82d3ba33794e712ffe29732a7d32287899eb3baa1877984bd1793ef980e255c4b1763576de99f9
+  checksum: 3544249a2c06b3678b56a028e6b825d977156a9358f389ded31b8721588e00373369f4420a18b92e05f1862161eebdef5cf11d82c8df7f273c3069459cbb22ec
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/esm-utils@npm:5.3.3-pre.1477"
+"@openmrs/esm-utils@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-utils@npm:5.4.1-pre.1567"
   dependencies:
     semver: 7.3.2
   peerDependencies:
     dayjs: 1.x
     i18next: 19.x
     rxjs: 6.x
-  checksum: fd5652dd432a5cedd746bef0eed0440d4622c023c33c524421d7a856b321ed0ee949668269014137156153a5748ca2a3a1a0d2710316b73ca788cf8364b59762
+  checksum: caba881df6a5b3bcd39fe35fe7e03b24f8ec66f7643b19d4482ac4e5c2e43f309ea06ff0e3ef59b38e861e440109d51ed6d2bf731a8bc251d724a34724edb380
   languageName: node
   linkType: hard
 
@@ -5247,9 +5247,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.3.3-pre.1477":
-  version: 5.3.3-pre.1477
-  resolution: "@openmrs/webpack-config@npm:5.3.3-pre.1477"
+"@openmrs/webpack-config@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/webpack-config@npm:5.4.1-pre.1567"
   dependencies:
     "@swc/core": ^1.3.58
     clean-webpack-plugin: ^4.0.0
@@ -5266,7 +5266,7 @@ __metadata:
     webpack-stats-plugin: ^1.0.3
   peerDependencies:
     webpack: 5.x
-  checksum: 80d5d2e70481fa8722ac389bd2c7bce5f3fa02c891088050b8fa30b8f3b4fde497f002ca914f8f6c5fcebd8d51368d4dd30ac0f086da6aefe23a6f16bf6993bd
+  checksum: 747fbddf68265f1b6bb3963a81ce553a38dcaf02d9e2e315c26a1ea8286557b6ec7d15c01ce0cfa3e9b32e9e0a1ceb3ebde35f7dead7eea35dca98d10d4dcae5
   languageName: node
   linkType: hard
 
@@ -19413,12 +19413,12 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 5.3.3-pre.1477
-  resolution: "openmrs@npm:5.3.3-pre.1477"
+  version: 5.4.1-pre.1567
+  resolution: "openmrs@npm:5.4.1-pre.1567"
   dependencies:
     "@carbon/icons-react": 11.26.0
-    "@openmrs/esm-app-shell": 5.3.3-pre.1477
-    "@openmrs/webpack-config": 5.3.3-pre.1477
+    "@openmrs/esm-app-shell": 5.4.1-pre.1567
+    "@openmrs/webpack-config": 5.4.1-pre.1567
     "@pnpm/npm-conf": ^2.1.0
     "@swc/core": ^1.3.58
     autoprefixer: ^10.4.2
@@ -19449,7 +19449,7 @@ __metadata:
     yargs: ^17.6.2
   bin:
     openmrs: ./dist/cli.js
-  checksum: 891007b1952052501e5b002b964961ad5446c9d53ecf7adc8af8e92d6844a60b630e0c03e23c4ea424616e1fd963ce13af201216e853805a2a7e8a6f04766c9d
+  checksum: 1e74fc78d4fdda625702cafc622465cdebfdec976cc8e986b9c945135084d3102879317e105d1ae4c5c7c6a0ff42430cf6784cb668c3408de00edd7269a1c0b1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR adds a new function to the workspace props, which **should** be called after the form is successfully saved.

New function added: `closeWorkspaceWithSavedChanges`.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-2760

## Other
None
