### PR TITLE
(feat) Hide bottom navigation on tablets and phones when workspace is active

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/action-menu/action-menu.component.tsx
@@ -10,7 +10,10 @@ export const ActionMenu: React.FC<ActionMenuInterface> = () => {
   const { active, workspaceWindowState } = useWorkspaces();
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const initialHeight = useRef(window.innerHeight);
+
   const isTablet = useLayoutType() === 'tablet';
+  const isPhone = useLayoutType() === 'phone';
+
   useEffect(() => {
     const handleKeyboardVisibilityChange = () => {
       setKeyboardVisible(initialHeight.current > window.innerHeight);
@@ -22,7 +25,7 @@ export const ActionMenu: React.FC<ActionMenuInterface> = () => {
     return () => window.removeEventListener('resize', handleKeyboardVisibilityChange);
   }, [initialHeight]);
 
-  if (active && workspaceWindowState !== 'hidden' && isTablet) {
+  if (active && workspaceWindowState !== 'hidden' && (isTablet || isPhone)) {
     return null;
   }
 

--- a/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.component.tsx
+++ b/packages/esm-patient-common-lib/src/siderail-nav-button/siderail-nav-button.component.tsx
@@ -6,13 +6,12 @@ import { useWorkspaces } from '../workspaces';
 import styles from './siderail-nav-button.scss';
 
 interface TagsProps {
-  isTablet: boolean;
   getIcon: (props: object) => JSX.Element;
   formOpenInTheBackground: boolean;
   tagContent?: string | React.ReactNode;
 }
 
-function Tags({ isTablet, getIcon, formOpenInTheBackground, tagContent }: TagsProps) {
+function Tags({ getIcon, formOpenInTheBackground, tagContent }: TagsProps) {
   return (
     <>
       {getIcon({ size: 16 })}
@@ -51,7 +50,7 @@ export const SiderailNavButton: React.FC<SiderailNavButtonProps> = ({
   const isWorkspaceActive = workspaceWindowState !== 'hidden' && workspaceIndex === 0;
   const formOpenInTheBackground = workspaceIndex > 0 || (workspaceIndex === 0 && workspaceWindowState === 'hidden');
 
-  if (layout === 'tablet') {
+  if (layout === 'tablet' || layout === 'phone') {
     return (
       <Button
         className={classNames(styles.container, { [styles.active]: isWorkspaceActive })}
@@ -62,7 +61,7 @@ export const SiderailNavButton: React.FC<SiderailNavButtonProps> = ({
         tabIndex={0}
       >
         <span className={styles.elementContainer}>
-          <Tags isTablet formOpenInTheBackground={formOpenInTheBackground} getIcon={getIcon} tagContent={tagContent} />
+          <Tags formOpenInTheBackground={formOpenInTheBackground} getIcon={getIcon} tagContent={tagContent} />
         </span>
         <span>{label}</span>
       </Button>
@@ -83,12 +82,7 @@ export const SiderailNavButton: React.FC<SiderailNavButtonProps> = ({
       size="md"
     >
       <div className={styles.elementContainer}>
-        <Tags
-          isTablet={false}
-          formOpenInTheBackground={formOpenInTheBackground}
-          getIcon={getIcon}
-          tagContent={tagContent}
-        />
+        <Tags formOpenInTheBackground={formOpenInTheBackground} getIcon={getIcon} tagContent={tagContent} />
       </div>
     </IconButton>
   );


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR enhances functionality to dynamically conceal the bottom navigation when the application is accessed on a Tablet or Phone. Furthermore, it ensures that the side rail maintains its styling for both tablet and phone views.

## Screenshots
### Tablet responsive issue
![WhatsApp Image 2024-02-26 at 21 33 36](https://github.com/openmrs/openmrs-esm-patient-chart/assets/28008754/92e579c0-ea6f-48b7-92d7-5089fe86e0eb)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
