### PR TITLE
(Bugfix) O3-2629: Submit button on Allergy Form remains disabled when filling allergen and severity before reactions

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
@@ -24,7 +24,6 @@ import {
   ExtensionSlot,
   type FetchResponse,
   showSnackbar,
-  showToast,
   useConfig,
   useLayoutType,
   ResponsiveWrapper,
@@ -87,7 +86,6 @@ function AllergyForm(props: DefaultWorkspaceProps) {
     control,
     handleSubmit,
     watch,
-    getValues,
     setValue,
     formState: { isDirty },
   } = useForm<AllergyFormData>({
@@ -113,8 +111,8 @@ function AllergyForm(props: DefaultWorkspaceProps) {
   const selectednonCodedAllergen = watch('nonCodedAllergen');
   const selectedNonCodedAllergicReaction = watch('nonCodedAllergicReaction');
 
+  const reactionsValidation = selectedAllergicReactions.some((item) => item !== '');
   useEffect(() => {
-    const reactionsValidation = selectedAllergicReactions.some((item) => item !== '');
     if (!!selectedAllergen && reactionsValidation && !!selectedSeverityOfWorstReaction) setIsDisabled(false);
     else setIsDisabled(true);
   }, [
@@ -124,6 +122,7 @@ function AllergyForm(props: DefaultWorkspaceProps) {
     selectedSeverityOfWorstReaction,
     otherConceptUuid,
     selectednonCodedAllergen,
+    reactionsValidation,
   ]);
 
   const onSubmit = useCallback(


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
- This PR fixes the issue of the Allerg form submit button remaining disabled when severity and allergies are checked before the reactions, it adds a dependency to the useEffect which affects the disabled state when it changes.

## Screenshots
Bug

https://github.com/openmrs/openmrs-esm-patient-chart/assets/30952856/fc81a7c3-2e54-4aa9-84da-364208c62613

Fixed

https://github.com/openmrs/openmrs-esm-patient-chart/assets/30952856/98038a60-3286-4564-8953-305b28d5749f


## Related Issue
- https://openmrs.atlassian.net/browse/O3-2629

