### PR TITLE
(fix) Revalidate visits after submitting the visit notes form

### DIFF
--- a/packages/esm-patient-notes-app/src/config-schema.ts
+++ b/packages/esm-patient-notes-app/src/config-schema.ts
@@ -1,7 +1,13 @@
+import { Type } from '@openmrs/esm-framework';
 import notesConfigSchema, { type VisitNoteConfigObject } from './notes/visit-note-config-schema';
 
 export const configSchema = {
   visitNoteConfig: notesConfigSchema,
+  numberOfVisitsToLoad: {
+    _type: Type.Number,
+    _description: 'The number of visits to load initially in the Visits Summary tab. Defaults to 5',
+    _default: 5,
+  },
 };
 
 export interface ConfigObject {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -43,6 +43,7 @@ import {
   fetchConceptDiagnosisByName,
   savePatientDiagnosis,
   saveVisitNote,
+  useInfiniteVisits,
   useVisitNotes,
 } from './visit-notes.resource';
 import styles from './visit-notes-form.scss';
@@ -111,6 +112,8 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
 
   const currentImage = watch('image');
   const { mutateVisitNotes } = useVisitNotes(patientUuid);
+  const { mutateVisits } = useInfiniteVisits(patientUuid);
+
   const mutateAttachments = () =>
     mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/attachment`));
   const locationUuid = session?.sessionLocation?.uuid;
@@ -278,6 +281,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
         })
         .then(() => {
           mutateVisitNotes();
+          mutateVisits();
           if (data.image) {
             mutateAttachments();
           }

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -56,9 +56,6 @@ jest.mock('./visit-notes.resource', () => ({
   useInfiniteVisits: jest.fn().mockImplementation(() => ({
     mutateVisits: jest.fn(),
   })),
-  use: jest.fn().mockImplementation(() => ({
-    mutateVisitNotes: jest.fn(),
-  })),
 }));
 
 test('renders the visit notes form with all the relevant fields and values', () => {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -53,6 +53,9 @@ jest.mock('./visit-notes.resource', () => ({
   useVisitNotes: jest.fn().mockImplementation(() => ({
     mutateVisitNotes: jest.fn(),
   })),
+  useInfiniteVisits: jest.fn().mockImplementation(() => ({
+    mutateVisits: jest.fn(),
+  })),
   use: jest.fn().mockImplementation(() => ({
     mutateVisitNotes: jest.fn(),
   })),

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -53,6 +53,9 @@ jest.mock('./visit-notes.resource', () => ({
   useVisitNotes: jest.fn().mockImplementation(() => ({
     mutateVisitNotes: jest.fn(),
   })),
+  use: jest.fn().mockImplementation(() => ({
+    mutateVisitNotes: jest.fn(),
+  })),
 }));
 
 test('renders the visit notes form with all the relevant fields and values', () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This pull request addresses an issue where the Visit Note was not appearing as saved if the user was on the Visits/Notes page when completing a visit note. The fix ensures that the Visit Note is  displayed in both the visit summaries and all encounters.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/openmrs/openmrs-esm-patient-chart/assets/29108523/5fad3e7f-48fa-4528-952b-185a2bf78e4d


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-1721

## Other
<!-- Anything not covered above -->
