### PR TITLE
(chore) Relocate Load More button in visits section

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -78,20 +78,6 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
                     <VisitSummary visit={visit} patientUuid={patientUuid} />
                   </div>
                 ))}
-
-                {hasMore ? (
-                  <Button
-                    className={styles.loadMoreButton}
-                    disabled={isValidating && shouldLoadMore}
-                    onClick={() => setSize(size + 1)}
-                  >
-                    {isValidating && shouldLoadMore ? (
-                      <InlineLoading description={`${t('loading', 'Loading')} ...`} role="progressbar" />
-                    ) : (
-                      t('loadMore', 'Load more')
-                    )}
-                  </Button>
-                ) : null}
               </>
             ) : (
               <EmptyState headerTitle={t('visits', 'visits')} displayText={t('Visits', 'Visits')} />
@@ -117,6 +103,20 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
           )}
         </TabPanels>
       </Tabs>
+
+      {hasMore ? (
+        <Button
+          className={styles.loadMoreButton}
+          disabled={isValidating && shouldLoadMore}
+          onClick={() => setSize(size + 1)}
+        >
+          {isValidating && shouldLoadMore ? (
+            <InlineLoading description={`${t('loading', 'Loading')} ...`} role="progressbar" />
+          ) : (
+            t('loadMore', 'Load more')
+          )}
+        </Button>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
In this pull request, I've relocated the "Load More" button within the visits section to ensure it remains visible across all tabs. Previously, encountering a scenario where patients had numerous encounters led to some encounters not appearing until users navigated to the visit summary tab, scrolled down, and clicked on "Load More."

By moving the "Load More" button, users can seamlessly access additional encounters without the need to navigate between tabs. This enhancement improves the user experience and ensures all encounters are readily accessible.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="988" alt="image" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/94977371/0faa48f3-7bc2-4410-bd05-51b1289f1027">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
Thanks,
CC: @ibacher 
<!-- Anything not covered above -->
