### PR TITLE
(fix) O3-2907: Always show order type filters in the order details table

### DIFF
--- a/packages/esm-patient-orders-app/src/components/medication-record.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/medication-record.component.tsx
@@ -20,34 +20,32 @@ const MedicationRecord: React.FC<MedicationRecordProps> = ({ medication }) => {
         <InfoTooltip orderer={medication.orderer?.display ?? '--'} />
       </div>
       <div className={styles.medicationRecord}>
-        <div>
-          <p className={styles.bodyLong01}>
-            <strong>{capitalize(medication.drug?.display)}</strong>{' '}
-            {medication.drug?.strength && <>&mdash; {medication.drug?.strength.toLowerCase()}</>}{' '}
-            {medication.drug?.dosageForm?.display && <>&mdash; {medication.drug.dosageForm.display.toLowerCase()}</>}
-          </p>
-          <p className={styles.bodyLong01}>
-            <span className={styles.label01}>{t('dose', 'Dose').toUpperCase()}</span>{' '}
-            <span className={styles.dosage}>
-              {medication.dose} {medication.doseUnits?.display.toLowerCase()}
-            </span>{' '}
-            {medication.route?.display && <>&mdash; {medication.route?.display.toLowerCase()}</>}{' '}
-            {medication.frequency?.display && <>&mdash; {medication.frequency?.display.toLowerCase()}</>} &mdash;{' '}
-            {!medication.duration
-              ? t('medicationIndefiniteDuration', 'Indefinite duration').toLowerCase()
-              : t('medicationDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
-                  duration: medication.duration,
-                  durationUnit: medication.durationUnits?.display.toLowerCase(),
-                })}{' '}
-            {medication.numRefills !== 0 && (
-              <span>
-                <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
-                {medication.numRefills}
-              </span>
-            )}
-            {medication.dosingInstructions && <span> &mdash; {medication.dosingInstructions.toLocaleLowerCase()}</span>}
-          </p>
-        </div>
+        <p className={styles.bodyLong01}>
+          <strong>{capitalize(medication.drug?.display)}</strong>{' '}
+          {medication.drug?.strength && <>&mdash; {medication.drug?.strength.toLowerCase()}</>}{' '}
+          {medication.drug?.dosageForm?.display && <>&mdash; {medication.drug.dosageForm.display.toLowerCase()}</>}
+        </p>
+        <p className={styles.bodyLong01}>
+          <span className={styles.label01}>{t('dose', 'Dose').toUpperCase()}</span>{' '}
+          <span className={styles.dosage}>
+            {medication.dose} {medication.doseUnits?.display.toLowerCase()}
+          </span>{' '}
+          {medication.route?.display && <>&mdash; {medication.route?.display.toLowerCase()}</>}{' '}
+          {medication.frequency?.display && <>&mdash; {medication.frequency?.display.toLowerCase()}</>} &mdash;{' '}
+          {!medication.duration
+            ? t('medicationIndefiniteDuration', 'Indefinite duration').toLowerCase()
+            : t('medicationDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
+                duration: medication.duration,
+                durationUnit: medication.durationUnits?.display.toLowerCase(),
+              })}{' '}
+          {medication.numRefills !== 0 && (
+            <span>
+              <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
+              {medication.numRefills}
+            </span>
+          )}
+          {medication.dosingInstructions && <span> &mdash; {medication.dosingInstructions.toLocaleLowerCase()}</span>}
+        </p>
         <p className={styles.bodyLong01}>
           {medication.orderReasonNonCoded ? (
             <span>
@@ -73,7 +71,7 @@ const MedicationRecord: React.FC<MedicationRecordProps> = ({ medication }) => {
   );
 };
 
-function InfoTooltip({ orderer }: { orderer: any }) {
+function InfoTooltip({ orderer }: { orderer: string }) {
   const { t } = useTranslation();
   return (
     <Toggletip align="top-left">

--- a/packages/esm-patient-orders-app/src/components/medication-record.scss
+++ b/packages/esm-patient-orders-app/src/components/medication-record.scss
@@ -7,7 +7,7 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
-  padding: spacing.$spacing-05;
+  padding: spacing.$spacing-03;
   border-bottom: none;
 }
 
@@ -30,6 +30,10 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+
+  p:not(:first-of-type, :last-of-type) {
+    padding: spacing.$spacing-02 0;
+  }
 }
 
 .startDateColumn {

--- a/packages/esm-patient-orders-app/src/components/order-details-table.scss
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.scss
@@ -45,3 +45,9 @@
     color: $text-02;
   }
 }
+
+.table {
+  td:after {
+    display: none;
+  }
+}

--- a/packages/esm-patient-orders-app/src/components/order-details-table.scss
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.scss
@@ -35,3 +35,13 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.tile {
+  text-align: center;
+  border-bottom: 1px solid $ui-03;
+
+  .message {
+    @include type.type-style("heading-compact-01");
+    color: $text-02;
+  }
+}

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -9,6 +9,7 @@ import {
   DataTable,
   DataTableSkeleton,
   Dropdown,
+  Layer,
   IconButton,
   InlineLoading,
   OverflowMenu,
@@ -24,6 +25,7 @@ import {
   TableHeader,
   TableRow,
   Tag,
+  Tile,
   Tooltip,
 } from '@carbon/react';
 import {
@@ -41,6 +43,7 @@ import {
   type DrugOrderBasketItem,
   type LabOrderBasketItem,
   getDrugOrderByUuid,
+  EmptyDataIllustration,
 } from '@openmrs/esm-patient-common-lib';
 import { Add, User, Printer } from '@carbon/react/icons';
 import { age, formatDate, useConfig, useLayoutType, usePagination, usePatient } from '@openmrs/esm-framework';
@@ -245,10 +248,6 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
     return <ErrorState error={isError} headerTitle={title} />;
   }
 
-  if (!tableRows?.length) {
-    return <EmptyState displayText={headerTitle} headerTitle={headerTitle} launchForm={launchOrderBasket} />;
-  }
-
   return (
     <div className={styles.widgetCard}>
       <CardHeader title={title}>
@@ -302,69 +301,85 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
       </CardHeader>
       <div ref={contentToPrintRef}>
         <PrintComponent subheader={title} patientDetails={patientDetails} />
-        <DataTable
-          data-floating-menu-container
-          size="sm"
-          headers={tableHeaders}
-          rows={paginatedOrders}
-          isSortable
-          sortRow={sortRow}
-          overflowMenuOnHover={false}
-          useZebraStyles
-        >
-          {({
-            rows,
-            headers,
-            getTableProps,
-            getHeaderProps,
-            getRowProps,
-            getExpandedRowProps,
-            getTableContainerProps,
-          }) => (
-            <TableContainer {...getTableContainerProps}>
-              <Table {...getTableProps()}>
-                <TableHead>
-                  <TableRow>
-                    <TableExpandHeader />
-                    {headers.map((header) => (
-                      <TableHeader {...getHeaderProps({ header })}>{header.header}</TableHeader>
-                    ))}
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {rows.map((row) => (
-                    <React.Fragment key={row.id}>
-                      <TableExpandRow className={styles.row} {...getRowProps({ row })}>
-                        {row.cells.map((cell) => (
-                          <TableCell className={styles.tableCell} key={cell.id}>
-                            <FormatCellDisplay rowDisplay={cell.value?.content ?? cell.value} />
-                          </TableCell>
+        {!tableRows?.length ? (
+          <Layer>
+            <Tile className={styles.tile}>
+              <EmptyDataIllustration />
+              <p className={styles.message}>There are no orders to display for this patient</p>
+              <p className={styles.action}>
+                <Button onClick={launchOrderBasket} kind="ghost" size={isTablet ? 'lg' : 'sm'}>
+                  Record Orders
+                </Button>
+              </p>
+            </Tile>
+          </Layer>
+        ) : (
+          <>
+            <DataTable
+              data-floating-menu-container
+              size="sm"
+              headers={tableHeaders}
+              rows={paginatedOrders}
+              isSortable
+              sortRow={sortRow}
+              overflowMenuOnHover={false}
+              useZebraStyles
+            >
+              {({
+                rows,
+                headers,
+                getTableProps,
+                getHeaderProps,
+                getRowProps,
+                getExpandedRowProps,
+                getTableContainerProps,
+              }) => (
+                <TableContainer {...getTableContainerProps}>
+                  <Table {...getTableProps()}>
+                    <TableHead>
+                      <TableRow>
+                        <TableExpandHeader />
+                        {headers.map((header) => (
+                          <TableHeader {...getHeaderProps({ header })}>{header.header}</TableHeader>
                         ))}
-                      </TableExpandRow>
-                      <TableExpandedRow
-                        colSpan={headers.length + 1}
-                        className="demo-expanded-td"
-                        {...getExpandedRowProps({
-                          row,
-                        })}
-                      >
-                        <ExpandedRowView row={row} />
-                      </TableExpandedRow>
-                    </React.Fragment>
-                  ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
-        </DataTable>
-        {!isPrinting && (
-          <PatientChartPagination
-            pageNumber={currentPage}
-            totalItems={tableRows?.length}
-            currentItems={paginatedOrders?.length}
-            pageSize={defaultPageSize}
-            onPageNumberChange={({ page }) => goTo(page)}
-          />
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {rows.map((row) => (
+                        <React.Fragment key={row.id}>
+                          <TableExpandRow className={styles.row} {...getRowProps({ row })}>
+                            {row.cells.map((cell) => (
+                              <TableCell className={styles.tableCell} key={cell.id}>
+                                <FormatCellDisplay rowDisplay={cell.value?.content ?? cell.value} />
+                              </TableCell>
+                            ))}
+                          </TableExpandRow>
+                          <TableExpandedRow
+                            colSpan={headers.length + 1}
+                            className="demo-expanded-td"
+                            {...getExpandedRowProps({
+                              row,
+                            })}
+                          >
+                            <ExpandedRowView row={row} />
+                          </TableExpandedRow>
+                        </React.Fragment>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              )}
+            </DataTable>
+            {!isPrinting && (
+              <PatientChartPagination
+                pageNumber={currentPage}
+                totalItems={tableRows?.length}
+                currentItems={paginatedOrders?.length}
+                pageSize={defaultPageSize}
+                onPageNumberChange={({ page }) => goTo(page)}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -9,7 +9,6 @@ import {
   DataTable,
   DataTableSkeleton,
   Dropdown,
-  Layer,
   IconButton,
   InlineLoading,
   OverflowMenu,
@@ -25,7 +24,6 @@ import {
   TableHeader,
   TableRow,
   Tag,
-  Tile,
   Tooltip,
 } from '@carbon/react';
 import {
@@ -43,7 +41,6 @@ import {
   type DrugOrderBasketItem,
   type LabOrderBasketItem,
   getDrugOrderByUuid,
-  EmptyDataIllustration,
 } from '@openmrs/esm-patient-common-lib';
 import { Add, User, Printer } from '@carbon/react/icons';
 import { age, formatDate, useConfig, useLayoutType, usePagination, usePatient } from '@openmrs/esm-framework';

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -249,72 +249,61 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
   }
 
   return (
-    <div className={styles.widgetCard}>
-      <CardHeader title={title}>
-        {isValidating ? (
-          <span>
-            <InlineLoading />
-          </span>
-        ) : null}
-        <div className={styles.buttons}>
-          {orderTypes && orderTypes?.length > 0 && (
-            <Dropdown
-              id="orderTypeDropdown"
-              titleText={t('selectOrderType', 'Select order type')}
-              label={t('all', 'All')}
-              type="inline"
-              items={[...[{ display: 'All' }], ...orderTypes]}
-              selectedItem={orderTypes.find((x) => x.uuid === selectedOrderTypeUuid)}
-              itemToString={(orderType: OrderType) => (orderType ? capitalize(orderType.display) : '')}
-              onChange={(e) => {
-                if (e.selectedItem.display === 'All') {
-                  setSelectedOrderTypeUuid(null);
-                  return;
-                }
-                setSelectedOrderTypeUuid(e.selectedItem.uuid);
-              }}
-            />
-          )}
-
-          {showPrintButton && (
-            <Button
-              kind="ghost"
-              renderIcon={(props) => <Printer size={16} {...props} />}
-              iconDescription={t('print', 'Print')}
-              className={styles.printButton}
-              onClick={handlePrint}
-            >
-              {t('print', 'Print')}
-            </Button>
-          )}
-          {showAddButton ?? true ? (
-            <Button
-              kind="ghost"
-              renderIcon={(props) => <Add size={16} {...props} />}
-              iconDescription={t('launchOrderBasket', 'Launch order basket')}
-              onClick={launchOrderBasket}
-            >
-              {t('add', 'Add')}
-            </Button>
-          ) : null}
-        </div>
-      </CardHeader>
-      <div ref={contentToPrintRef}>
-        <PrintComponent subheader={title} patientDetails={patientDetails} />
-        {!tableRows?.length ? (
-          <Layer>
-            <Tile className={styles.tile}>
-              <EmptyDataIllustration />
-              <p className={styles.message}>There are no orders to display for this patient</p>
-              <p className={styles.action}>
-                <Button onClick={launchOrderBasket} kind="ghost" size={isTablet ? 'lg' : 'sm'}>
-                  Record Orders
+    <>
+      {orderTypes && orderTypes?.length > 0 && (
+        <Dropdown
+          id="orderTypeDropdown"
+          titleText={t('selectOrderType', 'Select order type')}
+          label={t('all', 'All')}
+          type="inline"
+          items={[...[{ display: 'All' }], ...orderTypes]}
+          selectedItem={orderTypes.find((x) => x.uuid === selectedOrderTypeUuid)}
+          itemToString={(orderType: OrderType) => (orderType ? capitalize(orderType.display) : '')}
+          onChange={(e) => {
+            if (e.selectedItem.display === 'All') {
+              setSelectedOrderTypeUuid(null);
+              return;
+            }
+            setSelectedOrderTypeUuid(e.selectedItem.uuid);
+          }}
+        />
+      )}
+      {!tableRows.length ? (
+        <EmptyState headerTitle={headerTitle} displayText={headerTitle} />
+      ) : (
+        <div className={styles.widgetCard}>
+          <CardHeader title={title}>
+            {isValidating ? (
+              <span>
+                <InlineLoading />
+              </span>
+            ) : null}
+            <div className={styles.buttons}>
+              {showPrintButton && (
+                <Button
+                  kind="ghost"
+                  renderIcon={(props) => <Printer size={16} {...props} />}
+                  iconDescription={t('print', 'Print')}
+                  className={styles.printButton}
+                  onClick={handlePrint}
+                >
+                  {t('print', 'Print')}
                 </Button>
-              </p>
-            </Tile>
-          </Layer>
-        ) : (
-          <>
+              )}
+              {showAddButton ?? true ? (
+                <Button
+                  kind="ghost"
+                  renderIcon={(props) => <Add size={16} {...props} />}
+                  iconDescription={t('launchOrderBasket', 'Launch order basket')}
+                  onClick={launchOrderBasket}
+                >
+                  {t('add', 'Add')}
+                </Button>
+              ) : null}
+            </div>
+          </CardHeader>
+          <div ref={contentToPrintRef}>
+            <PrintComponent subheader={title} patientDetails={patientDetails} />
             <DataTable
               data-floating-menu-container
               size="sm"
@@ -379,10 +368,10 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
                 onPageNumberChange={({ page }) => goTo(page)}
               />
             )}
-          </>
-        )}
-      </div>
-    </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import dayjs from 'dayjs';
 import capitalize from 'lodash-es/capitalize';
 import orderBy from 'lodash-es/orderBy';
 import { useTranslation } from 'react-i18next';
@@ -9,7 +8,6 @@ import {
   DataTable,
   DataTableSkeleton,
   Dropdown,
-  IconButton,
   InlineLoading,
   OverflowMenu,
   OverflowMenuItem,
@@ -17,9 +15,9 @@ import {
   TableBody,
   TableCell,
   TableContainer,
+  TableExpandedRow,
   TableExpandHeader,
   TableExpandRow,
-  TableExpandedRow,
   TableHead,
   TableHeader,
   TableRow,
@@ -27,6 +25,8 @@ import {
   Tooltip,
 } from '@carbon/react';
 import {
+  type DrugOrderBasketItem,
+  type LabOrderBasketItem,
   type Order,
   type OrderBasketItem,
   type OrderType,
@@ -38,18 +38,16 @@ import {
   useOrderBasket,
   useOrderTypes,
   usePatientOrders,
-  type DrugOrderBasketItem,
-  type LabOrderBasketItem,
   getDrugOrderByUuid,
 } from '@openmrs/esm-patient-common-lib';
-import { Add, User, Printer } from '@carbon/react/icons';
+import { Add, Printer } from '@carbon/react/icons';
 import { age, formatDate, useConfig, useLayoutType, usePagination, usePatient } from '@openmrs/esm-framework';
-import styles from './order-details-table.scss';
-import PrintComponent from '../print/print.component';
 import { buildLabOrder, buildMedicationOrder, compare, orderPriorityToColor, orderStatusColor } from '../utils/utils';
 import { labsOrderBasket, medicationsOrderBasket } from '../constants';
 import MedicationRecord from './medication-record.component';
+import PrintComponent from '../print/print.component';
 import TestOrder from './test-order.component';
+import styles from './order-details-table.scss';
 
 interface OrderDetailsProps {
   title?: string;
@@ -145,10 +143,12 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
         </div>
       ),
       orderedBy: order.orderer?.display,
-      status: (
+      status: order.fulfillerStatus ? (
         <Tag type={orderStatusColor(order.fulfillerStatus)} className={styles.singleLineText}>
-          {order.fulfillerStatus ?? '--'}
+          {order.fulfillerStatus}
         </Tag>
+      ) : (
+        '--'
       ),
       actions: !isPrinting && (
         <OrderBasketItemActions
@@ -319,19 +319,20 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
               useZebraStyles
             >
               {({
-                rows,
-                headers,
-                getTableProps,
+                getExpandedRowProps,
+                getExpandHeaderProps,
                 getHeaderProps,
                 getRowProps,
-                getExpandedRowProps,
                 getTableContainerProps,
+                getTableProps,
+                headers,
+                rows,
               }) => (
                 <TableContainer {...getTableContainerProps}>
-                  <Table {...getTableProps()}>
+                  <Table className={styles.table} {...getTableProps()}>
                     <TableHead>
                       <TableRow>
-                        <TableExpandHeader />
+                        <TableExpandHeader enableToggle {...getExpandHeaderProps()} />
                         {headers.map((header) => (
                           <TableHeader {...getHeaderProps({ header })}>{header.header}</TableHeader>
                         ))}
@@ -390,21 +391,6 @@ function FormatCellDisplay({ rowDisplay }: { rowDisplay: string }) {
         rowDisplay
       )}
     </>
-  );
-}
-
-function InfoTooltip({ orderer }: { orderer: string }) {
-  return (
-    <IconButton
-      className={styles.tooltip}
-      align="top-left"
-      direction="top"
-      label={orderer}
-      renderIcon={(props) => <User size={16} {...props} />}
-      iconDescription={orderer}
-      kind="ghost"
-      size="sm"
-    />
   );
 }
 

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -269,7 +269,14 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
         />
       )}
       {!tableRows.length ? (
-        <EmptyState headerTitle={headerTitle} displayText={headerTitle} />
+        <EmptyState
+          headerTitle={headerTitle}
+          displayText={
+            selectedOrderTypeUuid === null
+              ? t('orders', 'Orders')
+              : (orderTypes?.find((x) => x.uuid === selectedOrderTypeUuid)).display + 's'
+          }
+        />
       ) : (
         <div className={styles.widgetCard}>
           <CardHeader title={title}>


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Issue: When the user selects a filter(All, Drug Order, Test Order) and there are no entries to display for the given the filter, the `<EmptyState/>` component is rendered which does not provide an option for the user to undo the filter and select another one.

Suggested solution: Display the <CardHeader> component that includes the filter in both cases i.e when there are entries to display and zero entries. With entries to display, show the <DataTable> and with zero entries display a UI that resembles the <EmptyState> component but without the header part of it.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/121826239/bacd8ed4-d26a-4090-b133-bbc635dddaf1



## Related Issue
https://openmrs.atlassian.net/browse/O3-2907

