### PR TITLE
(feat) O3-2163: Add support for editing end visit data/time on current visits

### DIFF
--- a/e2e/specs/edit-existing-visit.spec.ts
+++ b/e2e/specs/edit-existing-visit.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { type Visit } from '@openmrs/esm-framework';
-import { type Patient, generateRandomPatient, deletePatient, startVisit } from '../commands';
+import { deletePatient, generateRandomPatient, type Patient, startVisit } from '../commands';
 import { test } from '../core';
 import { ChartPage, VisitsPage } from '../pages';
 
@@ -27,18 +27,24 @@ test('Edit an existing visit', async ({ page }) => {
 
   await test.step('Then I should see the `Edit Visit` form launch in the workspace', async () => {
     await expect(chartPage.page.getByText(/visit start date and time/i)).toBeVisible();
-    const datePickerInput = chartPage.page.getByPlaceholder(/dd\/mm\/yyyy/i);
-    await expect(datePickerInput).toBeVisible();
-    const dateValue = await datePickerInput.inputValue();
+
+    const startDateInput = chartPage.page.locator('input#visitStartDateInput');
+    const startTimeInput = chartPage.page.locator('input#visitStartTime');
+
+    await expect(startDateInput).toBeVisible();
+    const dateValue = await startDateInput.inputValue();
     expect(dateValue).not.toBe('');
     expect(dateValue).toMatch(/^\d{2}\/\d{2}\/\d{4}$/);
 
-    await expect(chartPage.page.getByPlaceholder(/hh\:mm/i)).toBeVisible();
+    await expect(startTimeInput).toBeVisible();
+    const timeValue = await startTimeInput.inputValue();
+    expect(timeValue).toMatch(/^(1[0-2]|0?[1-9]):([0-5][0-9])$/);
+
     await expect(chartPage.page.getByRole('combobox', { name: /select a location/i })).toBeVisible();
     await expect(chartPage.page.getByRole('combobox', { name: /select a location/i })).toHaveValue('Outpatient Clinic');
     await expect(chartPage.page.getByText(/visit type/i)).toBeVisible();
     await expect(chartPage.page.getByLabel(/facility visit/i)).toBeChecked();
-    await expect(chartPage.page.getByRole('search', { name: /search for a visit type/i })).toBeVisible();
+    await expect(chartPage.page.getByRole('search', { name: /visit type/i })).toBeVisible();
     await expect(chartPage.page.getByLabel(/facility visit/i)).toBeVisible();
     await expect(chartPage.page.getByLabel(/home visit/i)).toBeVisible();
     await expect(chartPage.page.getByLabel(/opd visit/i)).toBeVisible();

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -25,6 +25,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import {
   ExtensionSlot,
   formatDatetime,
+  type NewVisitPayload,
   openmrsFetch,
   restBaseUrl,
   saveVisit,
@@ -39,15 +40,14 @@ import {
   useSession,
   useVisit,
   useVisitTypes,
-  type NewVisitPayload,
   type Visit,
 } from '@openmrs/esm-framework';
 import {
   convertTime12to24,
   createOfflineVisitForPatient,
+  type DefaultPatientWorkspaceProps,
   time12HourFormatRegex,
   useActivePatientEnrollment,
-  type DefaultPatientWorkspaceProps,
 } from '@openmrs/esm-patient-common-lib';
 import { type ChartConfig } from '../../config-schema';
 import { type VisitFormData } from './visit-form.resource';
@@ -121,7 +121,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
   });
 
   const displayVisitStopDateTimeFields = useMemo(
-    () => Boolean(visitToEdit?.uuid || visitToEdit?.stopDatetime || showVisitEndDateTimeFields),
+    () => Boolean(visitToEdit?.uuid || showVisitEndDateTimeFields),
     [visitToEdit?.uuid, showVisitEndDateTimeFields],
   );
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -148,6 +148,8 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
       return new Date(visitStartDatetime) <= new Date();
     };
 
+    const hadPreviousStopDateTime = Boolean(visitToEdit?.stopDatetime);
+
     return z
       .object({
         visitStartDate: z.date().refine(
@@ -167,13 +169,17 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
           .string()
           .refine((value) => value.match(time12HourFormatRegex), t('invalidTimeFormat', 'Invalid time format')),
         visitStartTimeFormat: z.enum(['PM', 'AM']),
-        visitStopDate: displayVisitStopDateTimeFields ? z.date() : z.date().optional(),
-        visitStopTime: displayVisitStopDateTimeFields
-          ? z
-              .string()
-              .refine((value) => value.match(time12HourFormatRegex), t('invalidTimeFormat', 'Invalid time format'))
-          : z.string().optional(),
-        visitStopTimeFormat: displayVisitStopDateTimeFields ? z.enum(['PM', 'AM']) : z.enum(['PM', 'AM']).optional(),
+        visitStopDate: displayVisitStopDateTimeFields && hadPreviousStopDateTime ? z.date() : z.date().optional(),
+        visitStopTime:
+          displayVisitStopDateTimeFields && hadPreviousStopDateTime
+            ? z
+                .string()
+                .refine((value) => value.match(time12HourFormatRegex), t('invalidTimeFormat', 'Invalid time format'))
+            : z.string().optional(),
+        visitStopTimeFormat:
+          displayVisitStopDateTimeFields && hadPreviousStopDateTime
+            ? z.enum(['PM', 'AM'])
+            : z.enum(['PM', 'AM']).optional(),
         programType: z.string().optional(),
         visitType: z.string().refine((value) => !!value, t('visitTypeRequired', 'Visit type is required')),
         visitLocation: z.object({
@@ -186,7 +192,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
         message: t('futureStartTime', 'Visit start time cannot be in the future'),
         path: ['visitStartTime'],
       });
-  }, [t, config, displayVisitStopDateTimeFields]);
+  }, [config.visitAttributeTypes, visitToEdit?.stopDatetime, t, displayVisitStopDateTimeFields]);
 
   const defaultValues = useMemo(() => {
     const visitStartDate = visitToEdit?.startDatetime ? new Date(visitToEdit?.startDatetime) : new Date();

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -122,7 +122,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
 
   const displayVisitStopDateTimeFields = useMemo(
     () => Boolean(visitToEdit?.uuid || visitToEdit?.stopDatetime || showVisitEndDateTimeFields),
-    [visitToEdit?.stopDatetime, showVisitEndDateTimeFields],
+    [visitToEdit?.uuid, showVisitEndDateTimeFields],
   );
 
   const visitFormSchema = useMemo(() => {
@@ -283,31 +283,33 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
     const visitStopTime = getValues('visitStopTime');
     const visitStopTimeFormat = getValues('visitStopTimeFormat');
 
-    const [visitStopHours, visitStopMinutes] = convertTime12to24(visitStopTime, visitStopTimeFormat);
+    if (visitStopDate && visitStopTime && visitStopTimeFormat) {
+      const [visitStopHours, visitStopMinutes] = convertTime12to24(visitStopTime, visitStopTimeFormat);
 
-    const visitStopDatetime = visitStopDate.setHours(visitStopHours, visitStopMinutes);
+      const visitStopDatetime = visitStopDate.setHours(visitStopHours, visitStopMinutes);
 
-    if (minVisitStopDatetime && visitStopDatetime <= minVisitStopDatetime) {
-      validSubmission = false;
-      setError('visitStopDate', {
-        message: t(
-          'visitStopDateMustBeAfterMostRecentEncounter',
-          'Stop date needs to be on or after {{lastEncounterDatetime}}',
-          {
-            lastEncounterDatetime: new Date(minVisitStopDatetime).toLocaleString(),
-            interpolation: {
-              escapeValue: false,
+      if (minVisitStopDatetime && visitStopDatetime <= minVisitStopDatetime) {
+        validSubmission = false;
+        setError('visitStopDate', {
+          message: t(
+            'visitStopDateMustBeAfterMostRecentEncounter',
+            'Stop date needs to be on or after {{lastEncounterDatetime}}',
+            {
+              lastEncounterDatetime: new Date(minVisitStopDatetime).toLocaleString(),
+              interpolation: {
+                escapeValue: false,
+              },
             },
-          },
-        ),
-      });
-    }
+          ),
+        });
+      }
 
-    if (visitStartDatetime >= visitStopDatetime) {
-      validSubmission = false;
-      setError('visitStopDate', {
-        message: t('invalidVisitStopDate', 'Visit stop date time cannot be on or before visit start date time'),
-      });
+      if (visitStartDatetime >= visitStopDatetime) {
+        validSubmission = false;
+        setError('visitStopDate', {
+          message: t('invalidVisitStopDate', 'Visit stop date time cannot be on or before visit start date time'),
+        });
+      }
     }
 
     return validSubmission;
@@ -442,7 +444,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
         delete payload.patient;
       }
 
-      if (displayVisitStopDateTimeFields) {
+      if (displayVisitStopDateTimeFields && visitStopDate && visitStopTime && visitStopTimeFormat) {
         const [visitStopHours, visitStopMinutes] = convertTime12to24(visitStopTime, visitStopTimeFormat);
 
         payload.stopDatetime = toDateObjectStrict(

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -121,7 +121,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
   });
 
   const displayVisitStopDateTimeFields = useMemo(
-    () => Boolean(visitToEdit?.stopDatetime || showVisitEndDateTimeFields),
+    () => Boolean(visitToEdit?.uuid || visitToEdit?.stopDatetime || showVisitEndDateTimeFields),
     [visitToEdit?.stopDatetime, showVisitEndDateTimeFields],
   );
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -172,10 +172,11 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
         visitStopDate: displayVisitStopDateTimeFields && hadPreviousStopDateTime ? z.date() : z.date().optional(),
         visitStopTime:
           displayVisitStopDateTimeFields && hadPreviousStopDateTime
-            ? z
+            ? z.string().refine((value) => value.match(time12HourFormatRegex), t('invalidTimeFormat'))
+            : z
                 .string()
-                .refine((value) => value.match(time12HourFormatRegex), t('invalidTimeFormat', 'Invalid time format'))
-            : z.string().optional(),
+                .refine((value) => !value || value.match(time12HourFormatRegex), t('invalidTimeFormat'))
+                .optional(),
         visitStopTimeFormat:
           displayVisitStopDateTimeFields && hadPreviousStopDateTime
             ? z.enum(['PM', 'AM'])


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR provisions the adding of end date to current visits

## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/openmrs/openmrs-esm-patient-chart/assets/53287480/ab35250d-5b7c-4a17-b400-298cefcf7d87

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2163](https://openmrs.atlassian.net/browse/O3-2163)

## Other
<!-- Anything not covered above -->


[O3-2163]: https://openmrs.atlassian.net/browse/O3-2163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ