### PR TITLE
(fix): remove ellipsis suffix from the "Save and Close" button

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.html
@@ -38,7 +38,7 @@
             (click)="onSubmit()"
             type="submit"
           >
-            <span *ngIf="formState !== 'submitting'">{{ 'saveAndCloseButton' | translate }}...</span>
+            <span *ngIf="formState !== 'submitting'">{{ 'saveAndCloseButton' | translate }}</span>
             <loader
               class="spinner"
               *ngIf="formState === 'submitting'"


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR remove ellipsis suffix from the `Save and close` button.

## Screenshots
<img width="677" alt="Screenshot 2024-03-08 at 09 07 14" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/28008754/7aa829bd-248b-433c-bc21-f05fa3ddf244">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
