### PR TITLE
(fix) O3-2945: Results viewer shows a loading UI infinitely while in Tree View mode

### DIFF
--- a/packages/esm-patient-labs-app/src/test-results/tree-view/index.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/tree-view/index.tsx
@@ -16,7 +16,7 @@ interface TreeViewWrapperProps {
 
 const TreeViewWrapper: React.FC<TreeViewWrapperProps> = (props) => {
   const config = useConfig();
-  const conceptUuids = config?.concepts?.map((c) => c.conceptUuid) ?? [];
+  const conceptUuids = config?.resultsViewerConcepts?.map((c) => c.conceptUuid) ?? [];
   const { roots, loading, error } = useGetManyObstreeData(conceptUuids);
   const { t } = useTranslation();
 


### PR DESCRIPTION
## Screenshots
https://github.com/openmrs/openmrs-esm-patient-chart/assets/121826239/e3a06f39-d68d-4beb-a70d-fe2fde75a4c1

## Related Issue
https://openmrs.atlassian.net/browse/O3-2945

