### PR TITLE
(fix) Fix spacing around address empty state in patient banner

### DIFF
--- a/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
+++ b/packages/esm-patient-banner-app/src/contact-details/contact-details.component.tsx
@@ -104,7 +104,7 @@ const Address: React.FC<{ address?: fhir.Address }> = ({ address }) => {
               )}
           </React.Fragment>
         ) : (
-          '--'
+          <li>--</li>
         )}
       </ul>
     </>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds spacing around the empty state shown in the patient banner when a patient has no addresses recorded.

## Screenshots

### Before

![CleanShot 2024-03-11 at 11  27 38@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/b9b01776-db68-4f3e-9047-2c09a88689dd)

### After

![CleanShot 2024-03-11 at 11  24 37@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/de01d357-867b-486c-beb4-27ee9fca0996)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
