### PR TITLE
(fix) 03-2959: Update E2E tests for clinical forms workspace

### DIFF
--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -36,7 +36,6 @@ test('Fill a clinical form', async ({ page, api }) => {
     await expect(headerRow).toContainText(/form name \(a-z\)/i);
     await expect(headerRow).toContainText(/last completed/i);
 
-    await expect(chartPage.page.getByRole('cell', { name: /ampath_poc_adult_return_visit_form/i })).toBeVisible();
     await expect(chartPage.page.getByRole('cell', { name: /covid 19/i })).toBeVisible();
     await expect(chartPage.page.getByRole('cell', { name: /laboratory test orders/i })).toBeVisible();
     await expect(chartPage.page.getByRole('cell', { name: /laboratory test results/i })).toBeVisible();


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This is a fix to e2e test due to reference to `ampath_poc_adult_return_visit_form` as part of expected forms within `clinical_forms.spec.ts` file.

The clinical form `ampath_poc_adult_return_visit_form` doesn't come with a fresh install and tests targeting the presence of such form will fail for fresh installs. 

This has been resolved by deleting the reference 

## Related Issue
https://openmrs.atlassian.net/browse/O3-2959