### PR TITLE
(fix) O3-2969: Vitals table doesn't display warnings for abnormal values after the first page

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -89,8 +89,8 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
                 {rows.map((row) => (
                   <TableRow key={row.id}>
                     {row.cells.map((cell) => {
-                      const vitalSignInterpretation =
-                        paginatedVitals[row.id] && paginatedVitals[row.id][cell.id.substring(2) + 'Interpretation'];
+                      const vitalsObj = paginatedVitals.find((obj) => obj.id === row.id);
+                      const vitalSignInterpretation = vitalsObj && vitalsObj[cell.id.substring(2) + 'Interpretation'];
 
                       return (
                         <StyledTableCell key={`styled-cell-${cell.id}`} interpretation={vitalSignInterpretation}>


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the issue where the Vitals table was not displaying warnings in cells with abornal values for pages other than the first page.

## Screenshots
https://github.com/openmrs/openmrs-esm-patient-chart/assets/121826239/f9c7324a-a2ee-489b-ab84-15ffc67e8e1a

## Related Issue
https://openmrs.atlassian.net/issues/?jql=project%20%3D%20%22O3%22%20AND%20component%20%3D%20%22Patient%20Chart%22
