### PR TITLE
(feat) Only show concepts diagnoses concepts in visit notes diagnosis search

### DIFF
--- a/packages/esm-patient-notes-app/src/config-schema.ts
+++ b/packages/esm-patient-notes-app/src/config-schema.ts
@@ -8,8 +8,15 @@ export const configSchema = {
     _description: 'The number of visits to load initially in the Visits Summary tab. Defaults to 5',
     _default: 5,
   },
+  diagnosisConceptClass: {
+    _type: Type.UUID,
+    _description: 'The concept class to use for the diagnoses',
+    _default: '8d4918b0-c2cc-11de-8d13-0010c6dffd0f',
+  },
 };
 
 export interface ConfigObject {
   visitNoteConfig: VisitNoteConfigObject;
+  numberOfVisitsToLoad: number;
+  diagnosisConceptClass: string;
 }

--- a/packages/esm-patient-notes-app/src/notes/visit-note-config-schema.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-note-config-schema.ts
@@ -28,4 +28,5 @@ export interface VisitNoteConfigObject {
   encounterNoteTextConceptUuid: string;
   encounterTypeUuid: string;
   formConceptUuid: string;
+  visitDiagnosesConceptUuid: string;
 }

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -82,7 +82,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const session = useSession();
-  const config = useConfig() as ConfigObject;
+  const config = useConfig<ConfigObject>();
   const state = useMemo(() => ({ patientUuid }), [patientUuid]);
   const { clinicianEncounterRole, encounterNoteTextConceptUuid, encounterTypeUuid, formConceptUuid } =
     config.visitNoteConfig;
@@ -135,7 +135,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
           } else if (fieldName === 'secondaryDiagnosisSearch') {
             setLoadingSecondary(true);
           }
-          const sub = fetchConceptDiagnosisByName(fieldQuery).subscribe(
+          const sub = fetchConceptDiagnosisByName(fieldQuery, config.diagnosisConceptClass).subscribe(
             (matchingConceptDiagnoses: Array<Concept>) => {
               if (fieldName == 'primaryDiagnosisSearch') {
                 setSearchPrimaryResults(matchingConceptDiagnoses);

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -17,9 +17,17 @@
   border-top: 0.0625rem solid $grey-2;
 }
 
+.diagnosis:first-of-type {
+  border-top: none;
+}
+
+.diagnosis:last-of-type {
+  border-bottom: none;
+}
+
 .diagnosisList {
   background-color: $ui-02;
-  max-height: 14rem;
+  max-height: 13.5rem;
   overflow-y: auto;
   border: 1px solid $ui-03;
 }
@@ -35,7 +43,6 @@
 
 .emptyResults {
   @include type.type-style("body-compact-01");
-  margin-top: 0.25rem;
   color: $text-02;
   min-height: 1rem;
 }

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -14,10 +14,10 @@
 
 .diagnosis {
   padding: 0.75rem;
+  border-top: 0.0625rem solid $grey-2;
 }
 
 .diagnosisList {
-  margin-top: 0.25rem;
   background-color: $ui-02;
   max-height: 14rem;
   overflow-y: auto;
@@ -129,7 +129,6 @@
 .errorMessage {
   @include type.type-style("label-02");
   color: $danger;
-  margin-top: 0.5rem;
 }
 
 :global(.omrs-breakpoint-lt-desktop) {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
@@ -2,6 +2,7 @@ import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
 import { map } from 'rxjs/operators';
 import { openmrsFetch, openmrsObservableFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
+import { type ConfigObject } from '../config-schema';
 import {
   type EncountersFetchResponse,
   type RESTPatientNote,
@@ -22,7 +23,7 @@ interface UseVisitNotes {
 export function useVisitNotes(patientUuid: string): UseVisitNotes {
   const {
     visitNoteConfig: { encounterNoteTextConceptUuid, visitDiagnosesConceptUuid },
-  } = useConfig();
+  } = useConfig<ConfigObject>();
 
   const customRepresentation =
     'custom:(uuid,display,encounterDatetime,patient,obs,' +
@@ -103,9 +104,9 @@ export function useInfiniteVisits(patientUuid: string) {
   };
 }
 
-export function fetchConceptDiagnosisByName(searchTerm: string) {
+export function fetchConceptDiagnosisByName(searchTerm: string, diagnosisConceptClass: string) {
   return openmrsObservableFetch<Array<Concept>>(
-    `${restBaseUrl}/concept?name=${searchTerm}&searchType=fuzzy&class=8d4918b0-c2cc-11de-8d13-0010c6dffd0f&name=&v=custom:(uuid,display)`,
+    `${restBaseUrl}/concept?name=${searchTerm}&searchType=fuzzy&class=${diagnosisConceptClass}&name=&v=custom:(uuid,display)`,
   ).pipe(map(({ data }) => data['results']));
 }
 

--- a/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
@@ -105,7 +105,7 @@ export function useInfiniteVisits(patientUuid: string) {
 
 export function fetchConceptDiagnosisByName(searchTerm: string) {
   return openmrsObservableFetch<Array<Concept>>(
-    `${restBaseUrl}/concept?q=${searchTerm}&searchType=fuzzy&class=8d4918b0-c2cc-11de-8d13-0010c6dffd0f&q=&v=custom:(uuid,display)`,
+    `${restBaseUrl}/concept?name=${searchTerm}&searchType=fuzzy&class=8d4918b0-c2cc-11de-8d13-0010c6dffd0f&name=&v=custom:(uuid,display)`,
   ).pipe(map(({ data }) => data['results']));
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated

## Summary
<!-- Please describe what problems your PR addresses. -->
The current presentation of the diagnosis list within the visit note inaccurately includes lab tests, medications, and medical equipment instead of the intended diagnoses.
This ticket aims to rectify this issue by excluding unrelated items leaving only the patient's diagnoses.

## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/openmrs/openmrs-esm-patient-chart/assets/29108523/94eed550-85d3-4c90-870f-47c8cef7343a

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->

https://openmrs.atlassian.net/browse/O3-2844

<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
