### PR TITLE
(fix) O3-2977: Make end date field editable for inactive conditions

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -19,9 +19,9 @@ import {
 import { Add } from '@carbon/react/icons';
 import { formatDate, parseDate, useLayoutType } from '@openmrs/esm-framework';
 import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { useConditions } from './conditions.resource';
 import { ConditionsActionMenu } from './conditions-action-menu.component';
 import { compare } from './utils';
+import { useConditions } from './conditions.resource';
 import styles from './conditions-detailed-summary.scss';
 
 function ConditionsDetailedSummary({ patient }) {
@@ -71,6 +71,7 @@ function ConditionsDetailedSummary({ patient }) {
         ...condition,
         id: condition.id,
         condition: condition.display,
+        abatementDateTime: condition.abatementDateTime,
         onsetDateTime: {
           sortKey: condition.onsetDateTime ?? '',
           content: condition.onsetDateTime
@@ -88,7 +89,10 @@ function ConditionsDetailedSummary({ patient }) {
       : compare(cellA.sortKey, cellB.sortKey);
   };
 
-  const launchConditionsForm = useCallback(() => launchPatientWorkspace('conditions-form-workspace'), []);
+  const launchConditionsForm = useCallback(
+    () => launchPatientWorkspace('conditions-form-workspace', { formContext: 'creating' }),
+    [],
+  );
 
   const handleConditionStatusChange = ({ selectedItem }) => setFilter(selectedItem);
 

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
@@ -92,7 +92,7 @@ it('clicking the Add button or Record Conditions link launches the conditions fo
   await user.click(recordConditionsLink);
 
   expect(launchPatientWorkspace).toHaveBeenCalledTimes(1);
-  expect(launchPatientWorkspace).toHaveBeenCalledWith('conditions-form-workspace');
+  expect(launchPatientWorkspace).toHaveBeenCalledWith('conditions-form-workspace', { formContext: 'creating' });
 });
 
 function renderConditionsDetailedSummary() {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
@@ -16,10 +16,10 @@ interface ConditionFormProps extends DefaultWorkspaceProps {
 }
 
 const conditionSchema = z.object({
+  abatementDateTime: z.date().optional().nullable(),
   clinicalStatus: z.string(),
-  endDate: z.date().optional(),
+  conditionName: z.string({ required_error: 'A condition is required' }),
   onsetDateTime: z.date().nullable(),
-  search: z.string({ required_error: 'A condition is required' }),
 });
 
 export type ConditionFormData = z.infer<typeof conditionSchema>;
@@ -45,14 +45,20 @@ const ConditionsForm: React.FC<ConditionFormProps> = ({
     mode: 'all',
     resolver: zodResolver(conditionSchema),
     defaultValues: {
+      abatementDateTime:
+        formContext == 'editing'
+          ? matchingCondition?.abatementDateTime
+            ? new Date(matchingCondition?.abatementDateTime)
+            : null
+          : null,
+      conditionName: '',
+      clinicalStatus: condition?.cells?.find((cell) => cell?.info?.header === 'clinicalStatus')?.value ?? 'Active',
       onsetDateTime:
         formContext == 'editing'
           ? matchingCondition?.onsetDateTime
             ? new Date(matchingCondition?.onsetDateTime)
             : null
           : null,
-      clinicalStatus: condition?.cells?.find((cell) => cell?.info?.header === 'clinicalStatus')?.value ?? 'Active',
-      search: '',
     },
   });
 
@@ -67,8 +73,8 @@ const ConditionsForm: React.FC<ConditionFormProps> = ({
 
   const onSubmit: SubmitHandler<ConditionFormData> = (data) => {
     setIsSubmittingForm(true);
-    if (formContext === 'creating' && !data.search.trim()) {
-      setError('search', {
+    if (formContext === 'creating' && !data.conditionName.trim()) {
+      setError('conditionName', {
         type: 'manual',
         message: t('conditionRequired', 'A condition is required'),
       });

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
@@ -3,7 +3,16 @@
 @import '@openmrs/esm-styleguide/src/vars';
 
 .condition {
-  padding: 1rem 0.75rem;
+  padding: 0.75rem;
+  border-top: 0.0625rem solid $grey-2;
+
+  &:first-of-type {
+    border-top: none;
+  }
+
+  &:last-of-type {
+    border-bottom: none;
+  }
 }
 
 .conditionsList {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
@@ -54,7 +54,13 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patientUuid }) 
 
   const { conditions, isError, isLoading, isValidating } = useConditions(patientUuid);
   const [filter, setFilter] = useState<'All' | 'Active' | 'Inactive'>('Active');
-  const launchConditionsForm = useCallback(() => launchPatientWorkspace('conditions-form-workspace'), []);
+  const launchConditionsForm = useCallback(
+    () =>
+      launchPatientWorkspace('conditions-form-workspace', {
+        formContext: 'creating',
+      }),
+    [],
+  );
 
   const filteredConditions = useMemo(() => {
     if (!filter || filter == 'All') {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
@@ -117,7 +117,7 @@ describe('ConditionsOverview: ', () => {
     await user.click(recordConditionsLink);
 
     expect(launchPatientWorkspace).toHaveBeenCalledTimes(1);
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('conditions-form-workspace');
+    expect(launchPatientWorkspace).toHaveBeenCalledWith('conditions-form-workspace', { formContext: 'creating' });
   });
 });
 

--- a/packages/esm-patient-conditions-app/src/conditions/conditions.resource.ts
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions.resource.ts
@@ -9,6 +9,7 @@ export type Condition = {
   onsetDateTime: string;
   recordedDate: string;
   id: string;
+  abatementDateTime?: string;
 };
 
 export interface ConditionDataTableRow {
@@ -51,7 +52,6 @@ type CreatePayload = {
       },
     ];
   };
-  endDate: string;
   onsetDateTime: string;
   recorder: {
     reference: string;
@@ -61,6 +61,7 @@ type CreatePayload = {
   subject: {
     reference: string;
   };
+  abatementDateTime?: string;
 };
 
 type EditPayload = CreatePayload & {
@@ -71,7 +72,7 @@ export type FormFields = {
   clinicalStatus: string;
   conceptId: string;
   display: string;
-  endDate: string;
+  abatementDateTime: string;
   onsetDateTime: string;
   patientId: string;
   userId: string;
@@ -79,7 +80,6 @@ export type FormFields = {
 
 export function useConditions(patientUuid: string) {
   const conditionsUrl = `${fhirBaseUrl}/Condition?patient=${patientUuid}&_count=100`;
-
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: FHIRConditionResponse }, Error>(
     patientUuid ? conditionsUrl : null,
     openmrsFetch,
@@ -105,9 +105,7 @@ export function useConditions(patientUuid: string) {
 export function useConditionsSearch(conditionToLookup: string) {
   const config = useConfig();
   const conditionConceptClassUuid = config?.conditionConceptClassUuid;
-
   const conditionsSearchUrl = `${restBaseUrl}/conceptsearch?conceptClasses=${conditionConceptClassUuid}&q=${conditionToLookup}`;
-
   const { data, error, isLoading } = useSWR<{ data: { results: Array<CodedCondition> } }, Error>(
     conditionToLookup ? conditionsSearchUrl : null,
     openmrsFetch,
@@ -126,6 +124,7 @@ function mapConditionProperties(condition: FHIRCondition): Condition {
     clinicalStatus: status ? status.charAt(0).toUpperCase() + status.slice(1).toLowerCase() : '',
     conceptId: condition?.code?.coding[0]?.code,
     display: condition?.code?.coding[0]?.display,
+    abatementDateTime: condition?.abatementDateTime,
     onsetDateTime: condition?.onsetDateTime,
     recordedDate: condition?.recordedDate,
     id: condition?.id,
@@ -153,7 +152,7 @@ export async function createCondition(payload: FormFields) {
         },
       ],
     },
-    endDate: payload.endDate,
+    abatementDateTime: payload.abatementDateTime,
     onsetDateTime: payload.onsetDateTime,
     recorder: {
       reference: `Practitioner/${payload.userId}`,
@@ -198,7 +197,7 @@ export async function updateCondition(conditionId, payload: FormFields) {
         },
       ],
     },
-    endDate: payload.endDate,
+    abatementDateTime: payload.abatementDateTime,
     id: conditionId,
     onsetDateTime: payload.onsetDateTime,
     recorder: {

--- a/packages/esm-patient-conditions-app/src/types/index.ts
+++ b/packages/esm-patient-conditions-app/src/types/index.ts
@@ -10,6 +10,7 @@ export interface FHIRConditionResponse {
   total: number;
   type: string;
 }
+
 export interface FHIRCondition {
   clinicalStatus: {
     coding: Array<CodingData>;
@@ -36,6 +37,7 @@ export interface FHIRCondition {
     div: string;
     status: string;
   };
+  abatementDateTime?: string;
 }
 
 export interface CodingData {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR makes it possible to modify the end date property of an existing condition when specified. Currently, the end date property in the update payload maps to an end date property in the FHIR Conditions resource. This property does not exist, however. The closest matching element is [abatementDateTime](https://hl7.org/fhir/condition-definitions.html#Condition.abatement_x_), which is described as:

> 	The date or estimated date the condition resolved or went into remission. This is called "abatement" because of the many overloaded connotations associated with "remission" or "resolution" - Some conditions, such as chronic conditions, are never really resolved, but they can abate.

This PR renames the end date property in the Conditions payload to abatementDatetime, which gets things working as expected. 

I've also made the following useful fixes:

- Ensuring that the `launchConditionsForm` callback is invoked with an extra parameter, `{ formContext: 'creating' }`. This is required to get the condition name validation to work [here](https://github.com/openmrs/openmrs-esm-patient-chart/blob/94738af458ebadd96291da55d6b8b7949dffd10f/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx#L70). I've made this change in both the ConditionsOverview and ConditionsDetailedSummary components.
- Renaming the `search` property in the conditions form schema to `conditionName` to reflect its purpose more accurately.
- Adding a top and bottom border to search results in the Condition name search box to separate them visually.
- Renaming the `current status` field to `clinical status` to get it in conformance with the FHIR Conditions spec.

## Screenshots

### Before

- Validation doesn't kick in when I save the form without providing a condition.
- When I mark a condition as inactive and enter an end date, I don't see that value when I subsequently go to edit the condition. What's not shown here is the response from the backend, which doesn't contain an `endDate` property.

https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/c12055d6-a3d7-4a28-8688-2f7469e15448

### After

- Validation now kicks in when a condition is not provided.
- The end date field is now shown for conditions marked as inactive.

https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/a512335c-d380-4a65-ae4e-923b7cfb0cf5

## Related Issue

[O3-2977](https://openmrs.atlassian.net/browse/O3-2977)

## Other
<!-- Anything not covered above -->
