### PR TITLE
(fix) O3-2995: Allow empty quantity to dispense and prescription refills in Drug Order Form

### DIFF
--- a/e2e/specs/drug-orders.spec.ts
+++ b/e2e/specs/drug-orders.spec.ts
@@ -72,6 +72,16 @@ test('Record, edit and discontinue a drug order', async ({ page }) => {
     await form.getByLabel(/^duration$/i).fill('3');
   });
 
+  await test.step('And I set the quantity to dispense to 3', async () => {
+    await form.getByLabel(/^quantity to dispense$/i).clear();
+    await form.getByLabel(/^quantity to dispense$/i).fill('3');
+  });
+
+  await test.step('And I set the prescription refills to 1', async () => {
+    await form.getByLabel(/^prescription refills$/i).clear();
+    await form.getByLabel(/^prescription refills$/i).fill('1');
+  });
+
   await test.step('And I set the indication to `Headache`', async () => {
     await form.getByLabel(/indication/i).clear();
     await form.getByLabel(/indication/i).fill('Headache');

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -57,9 +57,9 @@ export interface DrugOrderFormProps {
 
 const createMedicationOrderFormSchema = (requireOutpatientQuantity: boolean, t: TFunction) => {
   const comboSchema = {
+    default: z.boolean().optional(),
     value: z.string(),
     valueCoded: z.string(),
-    default: z.boolean().optional(),
   };
 
   const baseSchemaFields = {
@@ -813,8 +813,12 @@ const ControlledFieldInput = ({
 }: ControlledFieldInputProps) => {
   const {
     field: { onBlur, onChange, value, ref },
-    fieldState,
+    fieldState: { error },
   } = useController<MedicationOrderFormData>({ name: name, control });
+
+  const fieldErrorStyles = classNames({
+    [styles.fieldError]: error?.message,
+  });
 
   const handleChange = useCallback(
     (newValue: MedicationOrderFormData[keyof MedicationOrderFormData]) => {
@@ -842,14 +846,14 @@ const ControlledFieldInput = ({
     if (type === 'number')
       return (
         <NumberInput
-          value={!!value ? value : 0}
+          className={fieldErrorStyles}
+          onBlur={onBlur}
           onChange={(e, { value }) => {
             const number = parseFloat(value);
             handleChange(isNaN(number) ? null : number);
           }}
-          className={fieldState?.error?.message && styles.fieldError}
-          onBlur={onBlur}
           ref={ref}
+          value={!!value ? value : 0}
           {...restProps}
         />
       );
@@ -857,11 +861,11 @@ const ControlledFieldInput = ({
     if (type === 'textArea')
       return (
         <TextArea
-          value={value}
-          onChange={(e) => handleChange(e.target.value)}
+          className={fieldErrorStyles}
           onBlur={onBlur}
+          onChange={(e) => handleChange(e.target.value)}
           ref={ref}
-          className={fieldState?.error?.message && styles.fieldError}
+          value={value}
           {...restProps}
         />
       );
@@ -869,11 +873,11 @@ const ControlledFieldInput = ({
     if (type === 'textInput')
       return (
         <TextInput
-          value={value}
+          className={fieldErrorStyles}
           onChange={(e) => handleChange(e.target.value)}
-          ref={ref}
           onBlur={onBlur}
-          className={fieldState?.error?.message && styles.fieldError}
+          ref={ref}
+          value={value}
           {...restProps}
         />
       );
@@ -881,22 +885,22 @@ const ControlledFieldInput = ({
     if (type === 'comboBox')
       return (
         <ComboBox
-          selectedItem={value}
-          onChange={({ selectedItem }) => handleChange(selectedItem)}
+          className={fieldErrorStyles}
           onBlur={onBlur}
+          onChange={({ selectedItem }) => handleChange(selectedItem)}
           ref={ref}
-          className={fieldState?.error?.message && styles.fieldError}
+          selectedItem={value}
           {...restProps}
         />
       );
 
     return null;
-  }, [fieldState?.error?.message, onBlur, ref, restProps, type, value, handleChange]);
+  }, [type, value, restProps, fieldErrorStyles, onBlur, ref, handleChange]);
 
   return (
     <>
       {component}
-      <FormLabel className={styles.errorLabel}>{fieldState?.error?.message}</FormLabel>
+      <FormLabel className={styles.errorLabel}>{error?.message}</FormLabel>
     </>
   );
 };

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
@@ -240,5 +240,6 @@
 
 .errorLabel {
   color: colors.$red-60;
+  margin-top: layout.$spacing-02;
 }
 

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -137,7 +137,8 @@ export function prepMedicationOrderPostData(
  * and number of refills for outpatient drug orders.
  *
  * @returns {Object} An object containing:
- * - requireOutpatientQuantity: A boolean indicating if outpatient quantity is required.
+ * - requireOutpatientQuantity: A boolean indicating whether to require quantity, quantity units,
+ * and number of refills for outpatient drug orders.
  * - error: Any error encountered during the fetch operation.
  * - isLoading: A boolean indicating if the fetch operation is in progress.
  */

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -1,9 +1,10 @@
-import useSWR, { mutate } from 'swr';
-import { type FetchResponse, openmrsFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
-import { type ConfigObject } from '../config-schema';
 import { useCallback, useMemo } from 'react';
+import useSWR, { mutate } from 'swr';
+import { type ConfigObject } from '../config-schema';
+import { type FetchResponse, openmrsFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import { type OrderPost, type PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';
 import { type DrugOrderBasketItem } from '../types';
+import useSWRImmutable from 'swr/immutable';
 
 export const careSettingUuid = '6f0c9a92-6f24-11e3-af88-005056821db0';
 
@@ -129,4 +130,30 @@ export function prepMedicationOrderPostData(
   } else {
     throw new Error(`Unknown order action ${order.action}. This is a development error.`);
   }
+}
+
+/**
+ * Hook to fetch the system setting for whether to require quantity, quantity units,
+ * and number of refills for outpatient drug orders.
+ *
+ * @returns {Object} An object containing:
+ * - requireOutpatientQuantity: A boolean indicating if outpatient quantity is required.
+ * - error: Any error encountered during the fetch operation.
+ * - isLoading: A boolean indicating if the fetch operation is in progress.
+ */
+export function useRequireOutpatientQuantity() {
+  const url = `${restBaseUrl}/systemsetting/drugOrder.requireOutpatientQuantity?v=custom:(value)`;
+
+  const { data, error, isLoading } = useSWRImmutable<{ data: { value: 'true' | 'false' } }, Error>(url, openmrsFetch);
+
+  const results = useMemo(
+    () => ({
+      requireOutpatientQuantity: data?.data?.value && data.data.value === 'true',
+      error,
+      isLoading,
+    }),
+    [data?.data?.value, error, isLoading],
+  );
+
+  return results;
 }

--- a/packages/esm-patient-medications-app/translations/en.json
+++ b/packages/esm-patient-medications-app/translations/en.json
@@ -47,6 +47,7 @@
   "modify": "Modify",
   "none": "None",
   "noResultsForDrugSearch": "No results to display for \"{{searchTerm}}\"",
+  "numRefillsErrorMessage": "The number of refills is required",
   "onDate": "on",
   "orderActionDiscontinue": "Discontinue",
   "orderActionIncomplete": "Incomplete",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The suggested solution is two fold:
1.Adding the {allowEmpty=true} prop so that Carbon allows the field to be empty without adding a warning icon to the input field that suggests that the field should have a value
2.Previously, leaving the field empty returned NaN due to how parseFloat() deals with invalid values i.e parseFloat('') returns NaN. Now we first check for that and if NaN is returned the field value becomes 0 otherwise we proceed as before.

## Screenshots
https://github.com/openmrs/openmrs-esm-patient-chart/assets/121826239/ad419724-15a2-45c4-9c4f-76c43a8ab711


## Related Issue
https://openmrs.atlassian.net/browse/O3-2995