### PR TITLE
(refactor) Remove duplicate type from SingleSpaProps type annotation

### DIFF
--- a/packages/esm-form-entry-app/src/single-spa-props.ts
+++ b/packages/esm-form-entry-app/src/single-spa-props.ts
@@ -49,7 +49,6 @@ export type SingleSpaProps = AppProps &
   VisitProperties &
   EncounterProperties &
   PatientProperties &
-  UIBehavior &
   PreFilledQuestions &
   ApplicationStatus & {
     additionalProps?: any;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes a duplicate `UIBehavior` union type from the [SingleSpaProps](https://github.com/openmrs/openmrs-esm-patient-chart/tree/main/packages/esm-form-entry-app/src/single-spa-props.ts#L46) type annotation.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
