### PR TITLE
(chore) Add Eslint Rule to validate exhaustive deps on React hooks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,8 +4,9 @@
   },
   "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "react-hooks"],
   "rules": {
+    "react-hooks/exhaustive-deps": "warn",
     // Disabling these rules for now just to keep the diff small. I'll enable them in a future PR that fixes lint issues.
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-vars": "off",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dotenv": "^16.3.1",
     "eslint": "^8.50.0",
     "eslint-plugin-playwright": "^0.16.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.3",
     "i18next": "^21.10.0",
     "i18next-parser": "^6.6.0",

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.component.tsx
@@ -160,7 +160,7 @@ function AllergyForm(props: AllergyFormProps) {
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
-  }, [isDirty]);
+  }, [isDirty, promptBeforeClosing]);
 
   const selectedAllergen = watch('allergen');
   const selectedAllergicReactions = watch('allergicReactions');
@@ -268,7 +268,7 @@ function AllergyForm(props: AllergyFormProps) {
             )
             .finally(() => abortController.abort());
     },
-    [otherConceptUuid, patientUuid, closeWorkspaceWithSavedChanges, t, mutate],
+    [otherConceptUuid, patientUuid, t, mutate, allergy?.id, closeWorkspace, formContext],
   );
 
   return (

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.resource.ts
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.resource.ts
@@ -113,7 +113,7 @@ export function useAllergens() {
       allergens,
       isLoading: !drugAllergenData || !environmentalAllergenData || !foodAllergenData,
     };
-  }, [drugAllergenData, environmentalAllergenData, foodAllergenData]);
+  }, [drugAllergenData, environmentalAllergenData, foodAllergenData, otherConceptUuid]);
 }
 
 export function useAllergenSearch(allergenToLookup: string) {

--- a/packages/esm-patient-allergies-app/src/allergies/delete-allergy-modal.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/delete-allergy-modal.component.tsx
@@ -40,7 +40,7 @@ const DeleteAllergyModal: React.FC<DeleteAllergyModalProps> = ({ closeDeleteModa
           subtitle: error?.message,
         });
       });
-  }, [closeDeleteModal, allergyId, mutate, t]);
+  }, [closeDeleteModal, allergyId, mutate, t, patientUuid]);
 
   return (
     <div>

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-table-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-table-overview.component.tsx
@@ -53,7 +53,7 @@ const AttachmentsTableOverview: React.FC<AttachmentsTableOverviewProps> = ({
         type: attachment.bytesContentFamily,
         dateUploaded: attachment.dateTime,
       })),
-    [attachments, onOpenAttachment],
+    [attachments, onOpenAttachment, responsiveSize],
   );
 
   const headers = useMemo(

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/media-uploader.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/media-uploader.component.tsx
@@ -62,7 +62,7 @@ const MediaUploaderComponent = () => {
         }
       });
     },
-    [setFilesToUpload, maxFileSize, t],
+    [setFilesToUpload, maxFileSize, t, allowedExtensions],
   );
 
   const isFileExtensionAllowed = (fileName: string, allowedExtensions: string[]): boolean => {

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -63,7 +63,7 @@ const PatientInfo: React.FC<PatientInfoProps> = ({ patient }) => {
     } else {
       return '';
     }
-  }, [queueEntry]);
+  }, [queueEntry, t]);
 
   const getTagType = (priority: string) => {
     switch (priority as MappedQueuePriority) {

--- a/packages/esm-patient-chart-app/src/visit/hooks/useOfflineVisitType.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useOfflineVisitType.tsx
@@ -12,7 +12,7 @@ export const useOfflineVisitType = () => {
     setVisitTypes([
       { uuid: config.offlineVisitTypeUuid, name: 'Offline Visit', display: t('offlineVisit', 'Offline Visit') },
     ]);
-  }, []);
+  }, [t, config.offlineVisitTypeUuid]);
 
   return visitTypes;
 };

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
@@ -240,6 +240,7 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
     errorFetchingVisitAttributeAnswers,
     fieldProps,
     errors.visitAttributes,
+    id,
   ]);
 
   if (isLoading) {

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -166,7 +166,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
     }
 
     return defaultValues;
-  }, [visitToEdit]);
+  }, [visitToEdit, sessionLocation]);
 
   const methods = useForm<VisitFormData>({
     mode: 'all',
@@ -184,7 +184,20 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
-  }, [isDirty]);
+  }, [isDirty, promptBeforeClosing]);
+
+  let [maxVisitStartDatetime, minVisitStopDatetime] = useMemo(() => {
+    if (!visitToEdit?.encounters?.length) {
+      return [null, null];
+    }
+
+    const allEncountersDateTime = visitToEdit?.encounters?.map(({ encounterDatetime }) =>
+      Date.parse(encounterDatetime),
+    );
+    const maxVisitStartDatetime = Math.min(...allEncountersDateTime);
+    const minVisitStopDatetime = Math.max(...allEncountersDateTime);
+    return [maxVisitStartDatetime, minVisitStopDatetime];
+  }, [visitToEdit]);
 
   const validateVisitStartStopDatetime = useCallback(() => {
     let visitStartDate = getValues('visitStartDate');
@@ -245,7 +258,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
     }
 
     return validSubmission;
-  }, [setError]);
+  }, [setError, displayVisitStopDateTimeFields, getValues, t, maxVisitStartDatetime, minVisitStopDatetime]);
 
   const onSubmit = useCallback(
     (data: VisitFormData, event) => {
@@ -471,21 +484,15 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
       t,
       visitToEdit,
       displayVisitStopDateTimeFields,
+      config.offlineVisitTypeUuid,
+      config.showExtraVisitAttributesSlot,
+      extraVisitInfo,
+      isOnline,
+      mutate,
+      mutateQueueEntry,
+      validateVisitStartStopDatetime,
     ],
   );
-
-  let [maxVisitStartDatetime, minVisitStopDatetime] = useMemo(() => {
-    if (!visitToEdit?.encounters?.length) {
-      return [null, null];
-    }
-
-    const allEncountersDateTime = visitToEdit?.encounters?.map(({ encounterDatetime }) =>
-      Date.parse(encounterDatetime),
-    );
-    const maxVisitStartDatetime = Math.min(...allEncountersDateTime);
-    const minVisitStopDatetime = Math.max(...allEncountersDateTime);
-    return [maxVisitStartDatetime, minVisitStopDatetime];
-  }, [visitToEdit]);
 
   const visitStartDate = getValues('visitStartDate') ?? new Date();
   minVisitStopDatetime = minVisitStopDatetime ?? Date.parse(visitStartDate.toLocaleString());

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.component.tsx
@@ -23,7 +23,7 @@ const CancelVisitDialog: React.FC<CancelVisitDialogProps> = ({ patientUuid, clos
       removeQueuedPatient(queueEntry.queue.uuid, queueEntry.queueEntryUuid, new AbortController());
     }
     closeModal();
-  }, []);
+  }, [visitQueryEntry?.queueEntry, closeModal]);
 
   const { initiateDeletingVisit, isDeletingVisit } = useDeleteVisit(patientUuid, currentVisit, onDeleteVisit);
 

--- a/packages/esm-patient-common-lib/src/orders/useOrders.ts
+++ b/packages/esm-patient-common-lib/src/orders/useOrders.ts
@@ -28,7 +28,7 @@ export function usePatientOrders(patientUuid: string, status?: 'ACTIVE' | 'any',
       mutate((key) => {
         return typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?patient=${patientUuid}`);
       }, data),
-    [patientUuid],
+    [patientUuid, data, mutate],
   );
 
   const orders = useMemo(

--- a/packages/esm-patient-common-lib/src/pagination/usePaginationInfo.ts
+++ b/packages/esm-patient-common-lib/src/pagination/usePaginationInfo.ts
@@ -26,7 +26,7 @@ export function usePaginationInfo(pageSize: number, totalItems: number, pageNumb
     }
 
     return t('paginationItemsCount', `{{pageItemsCount}} / {{count}} items`, { count: totalItems, pageItemsCount });
-  }, [pageSize, totalItems, pageNumber, currentItems]);
+  }, [pageSize, totalItems, pageNumber, currentItems, t]);
 
   return {
     pageSizes,

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.component.tsx
@@ -69,7 +69,7 @@ const ConditionsForm: React.FC<ConditionFormProps> = ({
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
-  }, [isDirty]);
+  }, [isDirty, promptBeforeClosing]);
 
   const onSubmit: SubmitHandler<ConditionSchema> = (payload) => {
     setIsSubmittingForm(true);

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -188,6 +188,7 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
     setErrorUpdating,
     setIsSubmittingForm,
     t,
+    editableAbatementDateTime,
   ]);
 
   const focusOnSearchInput = () => {

--- a/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
@@ -57,6 +57,7 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({
       isOnline,
       mutateForm,
       closeWorkspaceWithSavedChanges,
+      additionalProps,
     ],
   );
 

--- a/packages/esm-patient-forms-app/src/forms/forms-dashboard.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-dashboard.component.tsx
@@ -37,7 +37,7 @@ const FormsDashboard: React.FC<DefaultWorkspaceProps> = () => {
         mutateForms,
       );
     },
-    [currentVisit, htmlFormEntryForms, patient, mutateForms],
+    [currentVisit, htmlFormEntryForms, mutateForms, patientUuid],
   );
 
   const sections = useMemo(() => {

--- a/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
@@ -45,7 +45,7 @@ const FormsList: React.FC<FormsListProps> = ({ completedForms, error, sectionNam
       .filter(searchTerm, completedForms, { extract: (formInfo) => formInfo.form.display ?? formInfo.form.name })
       .sort((r1, r2) => r1.score - r2.score)
       .map((result) => result.original);
-  }, [completedForms, searchTerm, locale]);
+  }, [completedForms, searchTerm]);
 
   const tableHeaders = useMemo(() => {
     return [

--- a/packages/esm-patient-immunizations-app/src/immunizations/components/immunizations-sequence-table.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/components/immunizations-sequence-table.component.tsx
@@ -34,7 +34,7 @@ const SequenceTable: React.FC<SequenceTableProps> = ({ immunizationsByVaccine, l
       { key: 'expirationDate', header: t('expirationDate', 'Expiration Date') },
       { key: 'edit', header: '' },
     ],
-    [t],
+    [t, sequences.length],
   );
 
   const tableRows = existingDoses?.map((dose) => {

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
@@ -62,7 +62,7 @@ const ImmunizationsDetailedSummary: React.FC<ImmunizationsDetailedSummaryProps> 
       return;
     }
     launchPatientWorkspace('immunization-form-workspace');
-  }, [currentVisit]);
+  }, [currentVisit, launchStartVisitPrompt]);
 
   const sortedImmunizations = orderBy(
     consolidatedImmunizations,

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.component.tsx
@@ -81,7 +81,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
       lotNumber: z.string().nullable(),
       manufacturer: z.string().nullable(),
     });
-  }, []);
+  }, [t]);
 
   type ImmunizationFormInputData = z.infer<typeof immunizationFormSchema>;
   const formProps = useForm<ImmunizationFormInputData>({
@@ -109,7 +109,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
-  }, [isDirty]);
+  }, [isDirty, promptBeforeClosing]);
 
   const vaccineUuid = watch('vaccineUuid');
 
@@ -136,7 +136,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
       sub.unsubscribe();
       immunizationFormSub.next(null);
     };
-  }, []);
+  }, [reset]);
 
   const onSubmit = useCallback(
     (data: ImmunizationFormInputData) => {
@@ -218,6 +218,7 @@ const ImmunizationsForm: React.FC<DefaultWorkspaceProps> = ({
       immunizationsConceptSet,
       closeWorkspaceWithSavedChanges,
       t,
+      mutate,
     ],
   );
 

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
@@ -121,7 +121,7 @@ export function LabOrderForm({
         onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
       });
     },
-    [orders, setOrders, session?.currentProvider?.uuid, defaultValues, closeWorkspaceWithSavedChanges],
+    [orders, setOrders, session?.currentProvider?.uuid, closeWorkspaceWithSavedChanges, initialOrder],
   );
 
   const cancelOrder = useCallback(() => {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
@@ -121,7 +121,7 @@ export function LabOrderForm({
         onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
       });
     },
-    [orders, setOrders, closeWorkspace, session?.currentProvider?.uuid, defaultValues],
+    [orders, setOrders, session?.currentProvider?.uuid, defaultValues, closeWorkspaceWithSavedChanges],
   );
 
   const cancelOrder = useCallback(() => {
@@ -139,7 +139,7 @@ export function LabOrderForm({
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
-  }, [isDirty]);
+  }, [isDirty, promptBeforeClosing]);
 
   return (
     <>

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
@@ -45,7 +45,7 @@ function useTestConceptsSWR(labOrderableConcepts?: Array<string>) {
     return labOrderableConcepts
       ? (data as Array<ConceptResult>)?.flatMap((d) => d.data.setMembers)
       : (data as ConceptResults)?.data.results ?? ([] as Concept[]);
-  }, [data, isLoading, error]);
+  }, [data, isLoading, error, labOrderableConcepts]);
 
   return {
     data: results,
@@ -76,7 +76,7 @@ export function useTestTypes(searchTerm: string = ''): UseTestType {
     return searchTerm && !isLoading && !error
       ? fuzzy.filter(searchTerm, testConcepts, { extract: (c) => c.label }).map((result) => result.original)
       : testConcepts;
-  }, [testConcepts, searchTerm]);
+  }, [testConcepts, searchTerm, error, isLoading]);
 
   return {
     testTypes: filteredTestTypes,

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
@@ -27,7 +27,7 @@ export default function AddDrugOrderWorkspace({
     closeWorkspace({
       onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
     });
-  }, [closeWorkspace, currentOrder, orders, setOrders]);
+  }, [closeWorkspace]);
 
   const openOrderForm = useCallback(
     (searchResult: DrugOrderBasketItem) => {

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -229,7 +229,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
-  }, [isDirty]);
+  }, [isDirty, promptBeforeClosing]);
 
   const handleUnitAfterChange = useCallback(
     (newValue: MedicationOrderFormData['unit'], prevValue: MedicationOrderFormData['unit']) => {
@@ -237,7 +237,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
         setValue('quantityUnits', newValue, { shouldValidate: true });
       }
     },
-    [setValue],
+    [setValue, getValues],
   );
 
   const routeValue = watch('route')?.value;
@@ -780,7 +780,7 @@ const ControlledFieldInput = ({
       onChange(newValue);
       handleAfterChange?.(newValue, prevValue);
     },
-    [getValues, onChange, handleAfterChange],
+    [getValues, onChange, handleAfterChange, name],
   );
 
   const component = useMemo(() => {
@@ -846,7 +846,7 @@ const ControlledFieldInput = ({
       );
 
     return null;
-  }, [fieldState?.error?.message, onBlur, onChange, ref, restProps, type, value]);
+  }, [fieldState?.error?.message, onBlur, ref, restProps, type, value, handleChange]);
 
   return (
     <>

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -122,7 +122,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
-  }, [isDirty]);
+  }, [isDirty, promptBeforeClosing]);
 
   const currentImage = watch('image');
   const { mutateVisitNotes } = useVisitNotes(patientUuid);
@@ -167,7 +167,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
             });
         }
       }, searchTimeoutInMs),
-    [],
+    [config.diagnosisConceptClass],
   );
 
   const handleAddDiagnosis = (conceptDiagnosisToAdd: Concept, searchInputField: string) => {
@@ -239,7 +239,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
       multipleFiles: false,
       collectDescription: false,
     });
-  }, [patientUuid]);
+  }, [setValue]);
 
   const onSubmit = useCallback(
     (data: VisitNotesFormData, event: SyntheticEvent) => {
@@ -337,6 +337,7 @@ const VisitNotesForm: React.FC<DefaultWorkspaceProps> = ({
       mutateVisitNotes,
       closeWorkspaceWithSavedChanges,
       t,
+      mutateVisits,
     ],
   );
 

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -93,18 +93,21 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
   } = usePatientOrders(patientUuid, 'ACTIVE', selectedOrderTypeUuid);
 
   // launch respective order basket based on order type
-  const openOrderForm = useCallback((orderItem) => {
-    switch (orderItem.type) {
-      case 'drugorder':
-        launchAddDrugOrder();
-        break;
-      case 'testorder':
-        launchAddLabsOrder();
-        break;
-      default:
-        launchOrderBasket();
-    }
-  }, []);
+  const openOrderForm = useCallback(
+    (orderItem) => {
+      switch (orderItem.type) {
+        case 'drugorder':
+          launchAddDrugOrder();
+          break;
+        case 'testorder':
+          launchAddLabsOrder();
+          break;
+        default:
+          launchOrderBasket();
+      }
+    },
+    [launchAddDrugOrder, launchAddLabsOrder, launchOrderBasket],
+  );
 
   const tableHeaders: Array<OrderHeaderProps> = [
     {
@@ -179,7 +182,7 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
         />
       ),
     }));
-  }, [allOrders, isPrinting, launchOrderBasket, orders, setOrders]);
+  }, [allOrders, isPrinting, launchOrderBasket, orders, setOrders, openOrderForm]);
 
   const sortRow = (cellA, cellB, { sortDirection, sortStates }) => {
     return sortDirection === sortStates.DESC

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -179,7 +179,7 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
         />
       ),
     }));
-  }, [allOrders]);
+  }, [allOrders, isPrinting, launchOrderBasket, orders, setOrders]);
 
   const sortRow = (cellA, cellB, { sortDirection, sortStates }) => {
     return sortDirection === sortStates.DESC
@@ -461,7 +461,7 @@ function OrderBasketItemActions({
       setOrderItems(labsOrderBasket, [...items, labItem]);
       openOrderForm({ order: labItem });
     }
-  }, [orderItem, openOrderForm]);
+  }, [orderItem, openOrderForm, items, setOrderItems]);
 
   const handleAddResultsClick = useCallback(() => {
     launchPatientWorkspace('test-results-form-workspace', { order: orderItem });

--- a/packages/esm-patient-orders-app/src/components/test-order.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/test-order.component.tsx
@@ -46,7 +46,7 @@ const TestOrder: React.FC<TestOrderProps> = ({ testOrder }) => {
     if (encounter && concept) {
       return encounter.obs?.find((obs) => obs.concept.uuid === concept.uuid);
     }
-  }, [concept]);
+  }, [concept, encounter]);
 
   const testRows = useMemo(() => {
     if (concept && concept.setMembers.length > 0) {
@@ -75,7 +75,7 @@ const TestOrder: React.FC<TestOrderProps> = ({ testOrder }) => {
     } else {
       return [];
     }
-  }, [concept]);
+  }, [concept, isLoadingResult, testResultObs?.groupMembers, testResultObs?.value?.display]);
 
   return (
     <div className={styles.testOrder}>

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
@@ -56,7 +56,7 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
-  }, [isDirty]);
+  }, [isDirty, promptBeforeClosing]);
 
   if (isLoadingConcepts) {
     return (

--- a/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
@@ -39,7 +39,7 @@ const OrderBasket: React.FC<DefaultWorkspaceProps> = ({
 
   useEffect(() => {
     promptBeforeClosing(() => !!orders.length);
-  }, [orders]);
+  }, [orders, promptBeforeClosing]);
 
   const openStartVisitDialog = useCallback(() => {
     const dispose = showModal('start-visit-dialog', {

--- a/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
@@ -50,7 +50,7 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
         required_error: t('reasonForCancellationRequired', 'Reason for cancellation is required'),
       }),
     });
-  }, []);
+  }, [t]);
 
   type CancelOrderFormData = z.infer<typeof cancelOrderSchema>;
 
@@ -71,43 +71,46 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
-  }, [isDirty]);
+  }, [isDirty, promptBeforeClosing]);
 
-  const cancelOrderRequest = useCallback((data: CancelOrderFormData) => {
-    const formData = data;
-    setShowErrorNotification(false);
-    setIsSubmitting(true);
+  const cancelOrderRequest = useCallback(
+    (data: CancelOrderFormData) => {
+      const formData = data;
+      setShowErrorNotification(false);
+      setIsSubmitting(true);
 
-    const payload = {
-      fulfillerStatus: 'DECLINED',
-      fulfillerComment: formData.reasonForCancellation,
-    };
+      const payload = {
+        fulfillerStatus: 'DECLINED',
+        fulfillerComment: formData.reasonForCancellation,
+      };
 
-    cancelOrder(order, payload).then(
-      (res) => {
-        setIsSubmitting(false);
-        closeWorkspace();
-        mutate();
+      cancelOrder(order, payload).then(
+        (res) => {
+          setIsSubmitting(false);
+          closeWorkspace();
+          mutate();
 
-        showSnackbar({
-          title: t('orderCancelled', 'Order cancelled'),
-          kind: 'success',
-          subtitle: t('successfullyCancelledOrder', 'Order {{orderNumber}} has been cancelled successfully', {
-            orderNumber: order?.orderNumber,
-          }),
-        });
-      },
-      (err) => {
-        setIsSubmitting(false);
-        showSnackbar({
-          isLowContrast: true,
-          title: t('errorCancellingOrder', 'Error cancelling order'),
-          kind: 'error',
-          subtitle: err?.message,
-        });
-      },
-    );
-  }, []);
+          showSnackbar({
+            title: t('orderCancelled', 'Order cancelled'),
+            kind: 'success',
+            subtitle: t('successfullyCancelledOrder', 'Order {{orderNumber}} has been cancelled successfully', {
+              orderNumber: order?.orderNumber,
+            }),
+          });
+        },
+        (err) => {
+          setIsSubmitting(false);
+          showSnackbar({
+            isLowContrast: true,
+            title: t('errorCancellingOrder', 'Error cancelling order'),
+            kind: 'error',
+            subtitle: err?.message,
+          });
+        },
+      );
+    },
+    [closeWorkspace, mutate, order, t],
+  );
 
   return (
     <Form className={styles.form}>

--- a/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.component.tsx
@@ -101,7 +101,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
-  }, [isDirty]);
+  }, [isDirty, promptBeforeClosing]);
 
   const onSubmit = React.useCallback(
     (data: ProgramsFormData) => {

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
@@ -90,7 +90,7 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
       },
       height: '400px',
     };
-  }, [selectedBiometrics]);
+  }, [selectedBiometrics, t]);
 
   return (
     <div className={styles.biometricChartContainer}>

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -106,7 +106,7 @@ const VitalsAndBiometricsForm: React.FC<DefaultWorkspaceProps> = ({
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
-  }, [isDirty]);
+  }, [isDirty, promptBeforeClosing]);
 
   const encounterUuid = currentVisit?.encounters?.find((encounter) => encounter?.form?.uuid === config.vitals.formUuid)
     ?.uuid;
@@ -164,61 +164,76 @@ const VitalsAndBiometricsForm: React.FC<DefaultWorkspaceProps> = ({
     ],
   );
 
-  const savePatientVitalsAndBiometrics = useCallback((data: VitalsBiometricsFormData) => {
-    const formData = data;
-    setShowErrorMessage(true);
-    setShowErrorNotification(false);
+  const savePatientVitalsAndBiometrics = useCallback(
+    (data: VitalsBiometricsFormData) => {
+      const formData = data;
+      setShowErrorMessage(true);
+      setShowErrorNotification(false);
 
-    data?.computedBodyMassIndex && delete data.computedBodyMassIndex;
+      data?.computedBodyMassIndex && delete data.computedBodyMassIndex;
 
-    const allFieldsAreValid = Object.entries(formData)
-      .filter(([, value]) => Boolean(value))
-      .every(([key, value]) => isValueWithinReferenceRange(conceptMetadata, config.concepts[`${key}Uuid`], value));
+      const allFieldsAreValid = Object.entries(formData)
+        .filter(([, value]) => Boolean(value))
+        .every(([key, value]) => isValueWithinReferenceRange(conceptMetadata, config.concepts[`${key}Uuid`], value));
 
-    if (allFieldsAreValid) {
-      setIsSubmitting(true);
-      setShowErrorMessage(false);
-      const abortController = new AbortController();
+      if (allFieldsAreValid) {
+        setIsSubmitting(true);
+        setShowErrorMessage(false);
+        const abortController = new AbortController();
 
-      savePatientVitals(
-        config.vitals.encounterTypeUuid,
-        config.vitals.formUuid,
-        config.concepts,
-        patientUuid,
-        formData,
-        new Date(),
-        abortController,
-        session?.sessionLocation?.uuid,
-      )
-        .then((response) => {
-          if (response.status === 201) {
-            invalidateCachedVitalsAndBiometrics();
-            closeWorkspaceWithSavedChanges();
+        savePatientVitals(
+          config.vitals.encounterTypeUuid,
+          config.vitals.formUuid,
+          config.concepts,
+          patientUuid,
+          formData,
+          new Date(),
+          abortController,
+          session?.sessionLocation?.uuid,
+        )
+          .then((response) => {
+            if (response.status === 201) {
+              invalidateCachedVitalsAndBiometrics();
+              closeWorkspaceWithSavedChanges();
+              showSnackbar({
+                isLowContrast: true,
+                kind: 'success',
+                title: t('vitalsAndBiometricsRecorded', 'Vitals and Biometrics saved'),
+                subtitle: t(
+                  'vitalsAndBiometricsNowAvailable',
+                  'They are now visible on the Vitals and Biometrics page',
+                ),
+              });
+            }
+          })
+          .catch((err) => {
+            setIsSubmitting(false);
+            createErrorHandler();
             showSnackbar({
-              isLowContrast: true,
-              kind: 'success',
-              title: t('vitalsAndBiometricsRecorded', 'Vitals and Biometrics saved'),
-              subtitle: t('vitalsAndBiometricsNowAvailable', 'They are now visible on the Vitals and Biometrics page'),
+              title: t('vitalsAndBiometricsSaveError', 'Error saving vitals and biometrics'),
+              kind: 'error',
+              isLowContrast: false,
+              subtitle: t('checkForValidity', 'Some of the values entered are invalid'),
             });
-          }
-        })
-        .catch((err) => {
-          setIsSubmitting(false);
-          createErrorHandler();
-          showSnackbar({
-            title: t('vitalsAndBiometricsSaveError', 'Error saving vitals and biometrics'),
-            kind: 'error',
-            isLowContrast: false,
-            subtitle: t('checkForValidity', 'Some of the values entered are invalid'),
+          })
+          .finally(() => {
+            abortController.abort();
           });
-        })
-        .finally(() => {
-          abortController.abort();
-        });
-    } else {
-      setHasInvalidVitals(true);
-    }
-  }, []);
+      } else {
+        setHasInvalidVitals(true);
+      }
+    },
+    [
+      closeWorkspaceWithSavedChanges,
+      conceptMetadata,
+      config.concepts,
+      config.vitals.encounterTypeUuid,
+      config.vitals.formUuid,
+      patientUuid,
+      session?.sessionLocation?.uuid,
+      t,
+    ],
+  );
 
   if (config.vitals.useFormEngine) {
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4484,6 +4484,7 @@ __metadata:
     dotenv: "npm:^16.3.1"
     eslint: "npm:^8.50.0"
     eslint-plugin-playwright: "npm:^0.16.0"
+    eslint-plugin-react-hooks: "npm:^4.6.0"
     husky: "npm:^8.0.3"
     i18next: "npm:^21.10.0"
     i18next-parser: "npm:^6.6.0"
@@ -12040,6 +12041,15 @@ __metadata:
     eslint-plugin-jest:
       optional: true
   checksum: 10/d44bfc78cbe216261f2afd3620a6aefa30bfbdc038f0ae269c6f93b2f77bd5167ae469ff7cfcb1c56b156806697ca533aabeda34893e4e2945ffa3a795958a90
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-react-hooks@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "eslint-plugin-react-hooks@npm:4.6.0"
+  peerDependencies:
+    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+  checksum: 10/3c63134e056a6d98d66e2c475c81f904169db817e89316d14e36269919e31f4876a2588aa0e466ec8ef160465169c627fe823bfdaae7e213946584e4a165a3ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This adds a rule for exhaustive deps in react-hooks

## Screenshots
- Common-lib react-hook warnings
<img width="1211" alt="Screenshot 2024-04-03 at 15 01 29" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/30952856/d22ade2a-1de5-4e5a-b65f-10c1b2dce065">

- patient-chart react-hooks warnings
<img width="1245" alt="Screenshot 2024-04-03 at 15 06 50" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/30952856/97db003e-2f02-4547-91b5-43fed1ee280e">



## Related Issue
https://openmrs.atlassian.net/browse/O3-3028
