### PR TITLE
(fix) O3-2975: Encounter datetime should not be sent when saving vitals and biometrics form

### DIFF
--- a/packages/esm-patient-vitals-app/src/common/data.resource.ts
+++ b/packages/esm-patient-vitals-app/src/common/data.resource.ts
@@ -304,7 +304,6 @@ export function saveVitalsAndBiometrics(
   concepts: ConfigObject['concepts'],
   patientUuid: string,
   vitals: VitalsBiometricsFormData,
-  encounterDatetime: Date,
   abortController: AbortController,
   location: string,
 ) {
@@ -316,7 +315,6 @@ export function saveVitalsAndBiometrics(
     signal: abortController.signal,
     body: {
       patient: patientUuid,
-      encounterDatetime: encounterDatetime,
       location: location,
       encounterType: encounterTypeUuid,
       form: formUuid,

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.component.tsx
@@ -187,7 +187,6 @@ const VitalsAndBiometricsForm: React.FC<DefaultWorkspaceProps> = ({
           config.concepts,
           patientUuid,
           formData,
-          new Date(),
           abortController,
           session?.sessionLocation?.uuid,
         )

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
@@ -149,7 +149,6 @@ describe('VitalsBiometricsForm', () => {
         temperature: temperatureValue,
         weight: weightValue,
       }),
-      expect.anything(),
       new AbortController(),
       undefined,
     );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the issue of not saving the vitals form if the user's computer time is ahead of the server time.

## Screenshots
Uploading soon

## Related Issue
https://openmrs.atlassian.net/browse/O3-2975

## Other
None