### PR TITLE
(fix) O3-3046: Updated the interpretation keys for vital signs matching table headers

### DIFF
--- a/__mocks__/vitals-and-biometrics.mock.ts
+++ b/__mocks__/vitals-and-biometrics.mock.ts
@@ -6020,7 +6020,7 @@ export const formattedVitals = [
     diastolic: 89,
     systolic: 121,
     bmi: null,
-    bloodPressureInterpretation: 'normal',
+    bloodPressureRenderInterpretation: 'normal',
   },
   {
     id: '1',
@@ -6034,7 +6034,7 @@ export const formattedVitals = [
     temperature: 37,
     spo2: 90,
     bmi: 23,
-    bloodPressureInterpretation: 'normal',
+    bloodPressureRenderInterpretation: 'normal',
   },
   {
     id: '2',
@@ -6042,7 +6042,7 @@ export const formattedVitals = [
     diastolic: 80,
     systolic: 120,
     bmi: null,
-    bloodPressureInterpretation: 'normal',
+    bloodPressureRenderInterpretation: 'normal',
   },
   {
     id: '3',
@@ -6053,7 +6053,7 @@ export const formattedVitals = [
     pulse: 78,
     respiratoryRate: 65,
     bmi: 22.6,
-    bloodPressureInterpretation: 'normal',
+    bloodPressureRenderInterpretation: 'normal',
   },
 ];
 

--- a/packages/esm-patient-vitals-app/src/common/data.resource.ts
+++ b/packages/esm-patient-vitals-app/src/common/data.resource.ts
@@ -52,6 +52,11 @@ interface VitalsConceptMetadataResponse {
   }>;
 }
 
+function getInterpretationKey(header: string) {
+  // Reason for `Render` string is to match the column header in the table
+  return `${header}RenderInterpretation`;
+}
+
 export function useVitalsConceptMetadata() {
   const customRepresentation =
     'custom:(setMembers:(uuid,display,hiNormal,hiAbsolute,hiCritical,lowNormal,lowAbsolute,lowCritical,units))';
@@ -205,13 +210,13 @@ export function useVitalsAndBiometrics(patientUuid: string, mode: VitalsAndBiome
           vitalsHashTable.set(recordedDate, {
             ...vitalsHashTable.get(recordedDate),
             [getVitalsMapKey(vitalSign.code)]: vitalSign.value,
-            [getVitalsMapKey(vitalSign.code) + 'Interpretation']: vitalSign.interpretation,
+            [getInterpretationKey(getVitalsMapKey(vitalSign.code))]: vitalSign.interpretation,
           });
         } else {
           vitalSign.value &&
             vitalsHashTable.set(recordedDate, {
               [getVitalsMapKey(vitalSign.code)]: vitalSign.value,
-              [getVitalsMapKey(vitalSign.code) + 'Interpretation']: vitalSign.interpretation,
+              [getInterpretationKey(getVitalsMapKey(vitalSign.code))]: vitalSign.interpretation,
             });
         }
 
@@ -230,7 +235,7 @@ export function useVitalsAndBiometrics(patientUuid: string, mode: VitalsAndBiome
       }
 
       if (mode === 'both' || mode === 'vitals') {
-        result.bloodPressureInterpretation = interpretBloodPressure(
+        result.bloodPressureRenderInterpretation = interpretBloodPressure(
           vitalSigns.systolic,
           vitalSigns.diastolic,
           concepts,

--- a/packages/esm-patient-vitals-app/src/common/types.ts
+++ b/packages/esm-patient-vitals-app/src/common/types.ts
@@ -30,7 +30,7 @@ export interface PatientVitalsAndBiometrics {
   date: string;
   systolic?: number;
   diastolic?: number;
-  bloodPressureInterpretation?: ObservationInterpretation;
+  bloodPressureRenderInterpretation?: ObservationInterpretation;
   pulse?: number;
   temperature?: number;
   spo2?: number;

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
@@ -121,7 +121,7 @@ describe('VitalsHeader: ', () => {
         date: '2022-05-19T00:00:00.000Z',
         systolic: 165,
         diastolic: 150,
-        bloodPressureInterpretation: 'critically_high',
+        bloodPressureRenderInterpretation: 'critically_high',
         pulse: 76,
         spo2: undefined,
         temperature: 37,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the styling for abnormal values in vitals table.

## Screenshots

### Before
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/a78b7fb8-cf98-4ba1-8c16-00ba157c7135)

### After
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/33b44ddb-f30f-424a-9bd4-e24d009924de)


## Related Issue
Extension of https://issues.openmrs.org/browse/O3-3046

## Other
Fix to #1779 
