### PR TITLE
in the OTZ Discontinuation form, does not save the correct data when …

### DIFF
--- a/packages/esm-patient-chart-app/src/constants.ts
+++ b/packages/esm-patient-chart-app/src/constants.ts
@@ -6,3 +6,5 @@ export const moduleName = '@openmrs/esm-patient-chart-app';
 export const patientChartWorkspaceSlot = 'patient-chart-workspace-slot';
 export const patientChartWorkspaceHeaderSlot = 'patient-chart-workspace-header-slot';
 export const omrsDateFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZZ';
+export const otzUuid = '159836AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+export const otzOutPut = 'Opt out of OTZ';


### PR DESCRIPTION
in the OTZ Discontinuation form, does not save the correct data when saved in the database upon successful submission. For instance, Opt out of OTZ in the form will display discontinue

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->
This is the image of the error.
![otz_discontinuation](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8075969/bd21680c-2a12-4364-a113-328d7257584a)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
