### PR TITLE
(feat) O3-3077: Add validation to restrict users from initiating future visit

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -33,6 +33,7 @@ import {
   type Visit,
   updateVisit,
   useConnectivity,
+  formatDatetime,
 } from '@openmrs/esm-framework';
 import {
   convertTime12to24,
@@ -55,6 +56,9 @@ import { type VisitFormData } from './visit-form.resource';
 import VisitDateTimeField from './visit-date-time.component';
 import { useVisits } from '../visits-widget/visit.resource';
 import { useOfflineVisitType } from '../hooks/useOfflineVisitType';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+
+dayjs.extend(isSameOrBefore);
 
 interface StartVisitFormProps extends DefaultWorkspaceProps {
   visitToEdit?: Visit;
@@ -117,12 +121,13 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
 
     return z.object({
       visitStartDate: z.date().refine(
-        (value) =>
-          displayVisitStopDateTimeFields
-            ? true
-            : dayjs(value).isBefore(dayjs(), 'day') || dayjs(value).isSame(dayjs(), 'day'),
+        (value) => {
+          const today = dayjs();
+          const startDate = dayjs(value);
+          return displayVisitStopDateTimeFields ? true : startDate.isSameOrBefore(today, 'day');
+        },
         t('invalidVisitStartDate', 'Start date needs to be on or before {{firstEncounterDatetime}}', {
-          firstEncounterDatetime: new Date().toLocaleString(),
+          firstEncounterDatetime: formatDatetime(new Date()),
           interpolation: {
             escapeValue: false,
           },

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -116,7 +116,18 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
     );
 
     return z.object({
-      visitStartDate: z.date(),
+      visitStartDate: z.date().refine(
+        (value) =>
+          displayVisitStopDateTimeFields
+            ? true
+            : dayjs(value).isBefore(dayjs(), 'day') || dayjs(value).isSame(dayjs(), 'day'),
+        t('invalidVisitStartDate', 'Start date needs to be on or before {{firstEncounterDatetime}}', {
+          firstEncounterDatetime: new Date().toLocaleString(),
+          interpolation: {
+            escapeValue: false,
+          },
+        }),
+      ),
       visitStartTime: z
         .string()
         .refine((value) => value.match(time12HourFormatRegex), t('invalidTimeFormat', 'Invalid time format')),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds validation for start visit date time, to ensure visit aren't initiated in the future. This also maintains existing validation for editing visit start and end date time.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/28008754/dfc9103b-acfb-4557-bc8f-e0e41dfb6692

## Related Issue
See https://openmrs.atlassian.net/browse/O3-3077
cc @ojwanganto @makombe 
## Other
<!-- Anything not covered above -->
