### PR TITLE
(feat) O3-3079: Add ability to utilize concept answers when `setMembers` are missing on lab orderable concepts

### DIFF
--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
@@ -43,7 +43,9 @@ function useTestConceptsSWR(labOrderableConcepts?: Array<string>) {
   const results = useMemo(() => {
     if (isLoading || error) return null;
     return labOrderableConcepts
-      ? (data as Array<ConceptResult>)?.flatMap((d) => d.data.setMembers)
+      ? (data as Array<ConceptResult>)?.flatMap((d) => {
+          return d.data.setMembers?.length > 0 ? d.data?.setMembers : d.data?.answers;
+        })
       : (data as ConceptResults)?.data.results ?? ([] as Concept[]);
   }, [data, isLoading, error, labOrderableConcepts]);
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
See https://openmrs.atlassian.net/browse/O3-3079
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
