### PR TITLE
(feat) O3-3084: Sort fetched tests alphabetically in the lab order search inside order basket

### DIFF
--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
@@ -85,15 +85,15 @@ describe('useTestTypes filters by text', () => {
     await waitFor(() => expect(result.current.isLoading).toBeFalsy());
     expect(result.current.error).toBeFalsy();
     expect(result.current.testTypes).toEqual([
-      expect.objectContaining({ label: 'Sodium Chloride' }),
-      expect.objectContaining({ label: 'Sodium Bicarbonate' }),
       expect.objectContaining({ label: 'Potassium' }),
+      expect.objectContaining({ label: 'Sodium Bicarbonate' }),
+      expect.objectContaining({ label: 'Sodium Chloride' }),
     ]);
     rerender('sodium');
     await waitFor(() => expect(result.current.isLoading).toBeFalsy());
     expect(result.current.testTypes).toEqual([
-      expect.objectContaining({ label: 'Sodium Chloride' }),
       expect.objectContaining({ label: 'Sodium Bicarbonate' }),
+      expect.objectContaining({ label: 'Sodium Chloride' }),
     ]);
     rerender('pt');
     await waitFor(() => expect(result.current.isLoading).toBeFalsy());

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
@@ -66,10 +66,12 @@ export function useTestTypes(searchTerm: string = ''): UseTestType {
   }, [error]);
 
   const testConcepts = useMemo(() => {
-    return data?.map((concept) => ({
-      label: concept.display,
-      conceptUuid: concept.uuid,
-    }));
+    return data
+      ?.map((concept) => ({
+        label: concept.display,
+        conceptUuid: concept.uuid,
+      }))
+      ?.sort((testConcept1, testConcept2) => testConcept1.label.localeCompare(testConcept2.label));
   }, [data]);
 
   const filteredTestTypes = useMemo(() => {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR sorts the fetched test concepts alphabetically inside the lab order basket.

## Screenshots
### Before
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/a7988f1d-a1b2-4eca-90ef-5f1ee9d78c28)


### After
![image](https://github.com/openmrs/openmrs-esm-patient-chart/assets/51502471/f684c8d4-2088-4065-b95a-363cb1ac28c6)


## Related Issue

https://issues.openmrs.org/browse/O3-3084

## Other
<!-- Anything not covered above -->
