### PR TITLE
(feat) O3-2626: Visit note attach image should be able to attach multiple images

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -65,6 +65,29 @@
   object-fit: cover;
 }
 
+.imgThumbnailGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 10px;
+}
+ 
+.imgThumbnailItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+ 
+.removeButton {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
 .button {
   height: 4rem;
   display: flex;

--- a/packages/esm-patient-notes-app/translations/en.json
+++ b/packages/esm-patient-notes-app/translations/en.json
@@ -2,7 +2,6 @@
   "add": "Add",
   "addImage": "Add image",
   "addVisitNote": "Add a visit note",
-  "changeImage": "Change image",
   "clinicalNoteLabel": "Write your notes",
   "clinicalNotePlaceholder": "Write any notes here",
   "date": "Date",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I fixed the VisitNotesForm component to allow attaching multiple images without necessarily being an array by adjusting the UploadedFile type to accommodate multiple files and update the related logic.

## Screenshots



Uploading screencast 2024-05-01 5 PM-36-32.mp4…


## Related Issue
https://openmrs.atlassian.net/browse/O3-2626

## Other
<!-- Anything not covered above -->
