### PR TITLE
(feat) Update Angular form engine translations

### DIFF
--- a/packages/esm-form-entry-app/translations/en.json
+++ b/packages/esm-form-entry-app/translations/en.json
@@ -18,6 +18,7 @@
   "daysAgo": " days ago",
   "deleteEntry": "Are you sure you want to delete this item?",
   "discardButton": "Discard",
+  "disallowDecimals": "Decimals are not allowed",
   "enterMoreCharacters": "Please enter 2 or more characters",
   "errorFetchingFormData": "There was an error fetching form data. Details: {detail}",
   "errorLoadingForm": "Error loading form",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds a translation key and string pair to `@openmrs/esm-form-entry` that corresponds to this [change](https://github.com/openmrs/openmrs-ngx-formentry/pull/135) to the Angular form engine.

## Screenshots

> Fixes this:

![CleanShot 2024-04-19 at 2  24 32@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/46bc2cca-b881-47c4-a7f0-149f515d87d5)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
