### PR TITLE
(feat) O3-3133: Adapt cancel logic in the react form engine workspace

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -34,8 +34,8 @@ const FormRenderer: React.FC<FormRendererProps> = ({
 
   const handleCloseForm = useCallback(() => {
     closeWorkspace();
-    launchPatientWorkspace('clinical-forms-workspace');
-  }, [closeWorkspace]);
+    !encounterUuid && launchPatientWorkspace('clinical-forms-workspace');
+  }, [closeWorkspace, encounterUuid]);
 
   const handleMarkFormAsDirty = useCallback(
     (isDirty: boolean) => promptBeforeClosing(() => isDirty),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This is a follow-up to #1815 that implements the suggestions @ibacher made in [this comment](https://github.com/openmrs/openmrs-esm-patient-chart/pull/1815#issuecomment-2083131036). 

When editing a form, clicking `Cancel` will close the form and the workspace. When not in edit mode and after launching a form from the forms list workspace, clicking `Cancel` will send the user back to the forms list workspace. 

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/364f062c-2d7d-410c-a4ad-e834b6aa6a2d

## Related Issue

https://openmrs.atlassian.net/browse/O3-3133?atlOrigin=eyJpIjoiMTc0MjA2OTdkNWM0NGM4M2I1MmEyYWU1ZmNlMGZkNWEiLCJwIjoiaiJ9

## Other
<!-- Anything not covered above -->
