### PR TITLE
(feat) O3-2626: Add useAllowedFileExtensions hook to Common Lib

### DIFF
--- a/packages/esm-patient-common-lib/src/index.ts
+++ b/packages/esm-patient-common-lib/src/index.ts
@@ -19,3 +19,4 @@ export * from './types';
 export * from './useSystemVisitSetting';
 export * from './workspaces';
 export * from './form-entry-interop';
+export * from './use-allowed-file-extensions';

--- a/packages/esm-patient-common-lib/src/use-allowed-file-extensions.ts
+++ b/packages/esm-patient-common-lib/src/use-allowed-file-extensions.ts
@@ -1,0 +1,25 @@
+import useSWRImmutable from 'swr/immutable';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+
+export interface GlobalProperty {
+  property: string;
+  uuid: string;
+  value: string;
+}
+
+export function useAllowedFileExtensions() {
+  const allowedFileExtensionsGlobalProperty = 'attachments.allowedFileExtensions';
+  const customRepresentation = 'custom:(value)';
+  const url = `${restBaseUrl}/systemsetting?&v=${customRepresentation}&q=${allowedFileExtensionsGlobalProperty}`;
+
+  const { data, error, isLoading } = useSWRImmutable<{ data: { results: Array<GlobalProperty> } }>(url, openmrsFetch);
+
+  const allowedFileExtensions =
+    data?.data?.results?.length > 0 ? data?.data?.results[0].value?.toLowerCase().split(',') || undefined : undefined;
+
+  return {
+    allowedFileExtensions,
+    error,
+    isLoading,
+  };
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds the `useAllowedFileExtensions` hook to the Common Lib. This is because it's soon going to be required in more than one place: the [attachments widget](https://github.com/openmrs/openmrs-esm-patient-chart/blob/main/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx#L41) and the Visit Notes form (following @jwnasambu's work in #1798). Adding it to Common Lib makes it easier to reuse the hook.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
