### PR TITLE
(fix) O3-3158: Follow-up commit fixing patientUuid sometimes undefined

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -47,6 +47,7 @@ jest.mock('@openmrs/esm-framework', () => {
     useLocations: jest.fn(),
     toDateObjectStrict: jest.fn(),
     useVisitTypes: jest.fn().mockImplementation(() => mockVisitTypes),
+    usePatient: jest.fn().mockImplementation((patientUuid) => ({ patientUuid, patient: {} })),
   };
 });
 
@@ -215,7 +216,7 @@ describe('Visit Form', () => {
         patient: mockPatient.id,
         visitType: 'some-uuid1',
       }),
-      new AbortController(),
+      expect.any(Function),
     );
 
     expect(showSnackbar).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Prior to this change, because of the addition of the `usePatient()` hook, the `patientUuid` prop had been being set to `undefined` when initially loaded. This patches around that by taking the `patientUuid` from the hook, so it will always be the initial value. Also contains some other minor fixes.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
