### PR TITLE
(fix) O3-3196: Fix diagnoses tags display on tablet

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
@@ -386,45 +386,45 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
             />
           </Column>
         </Row>
+        <div className={styles.diagnosesText}>
+          {selectedPrimaryDiagnoses && selectedPrimaryDiagnoses.length ? (
+            <>
+              {selectedPrimaryDiagnoses.map((diagnosis, index) => (
+                <Tag
+                  className={styles.tag}
+                  filter
+                  key={index}
+                  onClose={() => handleRemoveDiagnosis(diagnosis, 'primaryInputSearch')}
+                  type="red"
+                >
+                  {diagnosis.display}
+                </Tag>
+              ))}
+            </>
+          ) : null}
+          {selectedSecondaryDiagnoses && selectedSecondaryDiagnoses.length ? (
+            <>
+              {selectedSecondaryDiagnoses.map((diagnosis, index) => (
+                <Tag
+                  classname={styles.tag}
+                  filter
+                  key={index}
+                  onClose={() => handleRemoveDiagnosis(diagnosis, 'secondaryInputSearch')}
+                  type="blue"
+                >
+                  {diagnosis.display}
+                </Tag>
+              ))}
+            </>
+          ) : null}
+          {selectedPrimaryDiagnoses &&
+            !selectedPrimaryDiagnoses.length &&
+            selectedSecondaryDiagnoses &&
+            !selectedSecondaryDiagnoses.length && (
+              <span>{t('emptyDiagnosisText', 'No diagnosis selected — Enter a diagnosis below')}</span>
+            )}
+        </div>
         <Row className={styles.row}>
-          <div className={styles.diagnosesText}>
-            {selectedPrimaryDiagnoses && selectedPrimaryDiagnoses.length ? (
-              <>
-                {selectedPrimaryDiagnoses.map((diagnosis, index) => (
-                  <Tag
-                    className={styles.tag}
-                    filter
-                    key={index}
-                    onClose={() => handleRemoveDiagnosis(diagnosis, 'primaryInputSearch')}
-                    type="red"
-                  >
-                    {diagnosis.display}
-                  </Tag>
-                ))}
-              </>
-            ) : null}
-            {selectedSecondaryDiagnoses && selectedSecondaryDiagnoses.length ? (
-              <>
-                {selectedSecondaryDiagnoses.map((diagnosis, index) => (
-                  <Tag
-                    classname={styles.tag}
-                    filter
-                    key={index}
-                    onClose={() => handleRemoveDiagnosis(diagnosis, 'secondaryInputSearch')}
-                    type="blue"
-                  >
-                    {diagnosis.display}
-                  </Tag>
-                ))}
-              </>
-            ) : null}
-            {selectedPrimaryDiagnoses &&
-              !selectedPrimaryDiagnoses.length &&
-              selectedSecondaryDiagnoses &&
-              !selectedSecondaryDiagnoses.length && (
-                <span>{t('emptyDiagnosisText', 'No diagnosis selected — Enter a diagnosis below')}</span>
-              )}
-          </div>
           <Column sm={1}>
             <span className={styles.columnLabel}>{t('primaryDiagnosis', 'Primary diagnosis')}</span>
           </Column>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the rendering of the diagnoses tags and the associated empty state in the Visit Note form in the tablet viewport. Presently, the parent div that houses this content is rendered inside a flex container with `flex-direction: row`. 

I've moved it outside the flex container so it always gets rendered above the `Primary diagnoses` and `Secondary diagnoses` search inputs.

## Screenshots

### Before

![CleanShot 2024-05-14 at 2  05 30@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/0dbc0ff6-818d-4148-94d1-5f80fd429f44)

### After

![CleanShot 2024-05-14 at 2  20 43@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/9764a04a-caa0-44c1-910e-fc257e3b4d7e)

#### With diagnoses selected on tablet 

![CleanShot 2024-05-14 at 2  23 11@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/2c7a1161-1b39-4610-a840-83d0ce5a24fa)

#### Desktop is unaffected

![CleanShot 2024-05-14 at 2  22 57@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/7d7ee22c-d054-4acf-b9ea-ecfa6c9819d8)

## Related Issue

https://openmrs.atlassian.net/browse/O3-3196

## Other
<!-- Anything not covered above -->
