### PR TITLE
(fix) O3-3195: Fix rendering logic for the weight tile

### DIFF
--- a/packages/esm-patient-vitals-app/src/weight-tile/weight-tile.component.tsx
+++ b/packages/esm-patient-vitals-app/src/weight-tile/weight-tile.component.tsx
@@ -20,7 +20,7 @@ const WeightTile: React.FC<WeightTileInterface> = ({ patientUuid }) => {
   if (isLoading) {
     return <InlineLoading role="progressbar" description={`${t('loading', 'Loading')} ...`} />;
   }
-  if (biometrics?.length) {
+  if (weightData?.length) {
     return (
       <div>
         <p className={styles.label}>{t('weight', 'Weight')}</p>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
We show a weight tile above the form UI in the tablet viewport. The logic that determines what content to show in it is currently incorrect. Instead of checking whether the entire biometrics array is empty, it should check whether weight values exist in the array instead. The rest of the logic should continue to work as expected.

TL;dr: Changed the check in the WeightTile component that renders the weight data to check the length of weightData instead of biometrics.

## Screenshots
<!-- Required if you are making UI changes. -->
https://openmrs.atlassian.net/browse/O3-3195

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
