### PR TITLE
(fix) return encounter type uuid from encounter type object

### DIFF
--- a/packages/esm-form-engine-app/src/hooks/useFormSchema.tsx
+++ b/packages/esm-form-engine-app/src/hooks/useFormSchema.tsx
@@ -14,7 +14,9 @@ const useFormSchema = (formUuid: string) => {
 
   const { data, error, isLoading } = useSWR<{ data: FormSchema }>(url, openmrsFetch);
 
-  return { schema: data?.data, error, isLoading };
+  const schema = { ...data?.data, encounterType: data?.data.encounterType['uuid'] };
+
+  return { schema, error, isLoading };
 };
 
 export default useFormSchema;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR addresses an issue where the `encounterTypeUuid` was inaccessible within the form engine since it was being returned as an object in the schema from the `useFormSchema` hook. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
