### PR TITLE
(fix) O3-3158: Restore abortControllers

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/hooks/useServiceQueue.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useServiceQueue.tsx
@@ -7,12 +7,12 @@ export async function saveQueueEntry(
   priority: string,
   status: string,
   sortWeight: number,
-  abortController: AbortController,
   locationUuid: string,
   visitQueueNumberAttributeUuid: string,
+  abortController?: AbortController,
 ) {
   await Promise.all([
-    generateVisitQueueNumber(locationUuid, visitUuid, queueUuid, abortController, visitQueueNumberAttributeUuid),
+    generateVisitQueueNumber(locationUuid, visitUuid, queueUuid, visitQueueNumberAttributeUuid, abortController),
   ]);
 
   return openmrsFetch(`${restBaseUrl}/visit-queue-entry`, {
@@ -20,7 +20,6 @@ export async function saveQueueEntry(
     headers: {
       'Content-Type': 'application/json',
     },
-    signal: abortController.signal,
     body: {
       visit: { uuid: visitUuid },
       queueEntry: {
@@ -40,6 +39,7 @@ export async function saveQueueEntry(
         sortWeight: sortWeight,
       },
     },
+    signal: abortController?.signal,
   });
 }
 
@@ -47,18 +47,12 @@ export async function generateVisitQueueNumber(
   location: string,
   visitUuid: string,
   queueUuid: string,
-  abortController: AbortController,
   visitQueueNumberAttributeUuid: string,
+  abortController?: AbortController,
 ) {
   await openmrsFetch(
     `${restBaseUrl}/queue-entry-number?location=${location}&queue=${queueUuid}&visit=${visitUuid}&visitAttributeType=${visitQueueNumberAttributeUuid}`,
-    {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      signal: abortController.signal,
-    },
+    { signal: abortController?.signal },
   );
 }
 

--- a/packages/esm-patient-chart-app/src/visit/hooks/useUpcomingAppointments.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useUpcomingAppointments.tsx
@@ -21,7 +21,7 @@ export interface AppointmentPayload {
 export const updateAppointmentStatus = async (
   toStatus: string,
   appointmentUuid: string,
-  abortController: AbortController,
+  abortController?: AbortController,
 ) => {
   const statusChangeTime = dayjs().format(omrsDateFormat);
   const url = `${restBaseUrl}/appointments/${appointmentUuid}/status-change`;
@@ -29,6 +29,6 @@ export const updateAppointmentStatus = async (
     body: { toStatus, onDate: statusChangeTime },
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    signal: abortController.signal,
+    signal: abortController?.signal,
   });
 };

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -15,7 +15,7 @@ import {
 } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import { useForm, Controller, FormProvider } from 'react-hook-form';
-import { first } from 'rxjs';
+import { first } from 'rxjs/operators';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.scss
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.scss
@@ -12,12 +12,12 @@
 }
 
 .heading {
-  @include type.type-style("heading-03");
+  @include type.type-style('heading-03');
   margin: spacing.$spacing-05;
 }
 
 .sectionTitle {
-  @include type.type-style("heading-compact-02");
+  @include type.type-style('heading-compact-02');
   color: $text-02;
   margin: 0 0 spacing.$spacing-03 0;
 }
@@ -44,8 +44,13 @@
 .form {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: start;
   height: var(--desktop-workspace-window-height);
+}
+
+.buttonSet {
+  margin-top: auto;
+  justify-self: end;
 }
 
 .button {
@@ -82,7 +87,7 @@
 }
 
 .label {
-  @include type.type-style("label-01");
+  @include type.type-style('label-01');
   color: $text-02;
 }
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -216,7 +216,7 @@ describe('Visit Form', () => {
         patient: mockPatient.id,
         visitType: 'some-uuid1',
       }),
-      expect.any(Function),
+      expect.any(Object),
     );
 
     expect(showSnackbar).toHaveBeenCalledTimes(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3935,9 +3935,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-api@npm:5.5.1-pre.1737"
+"@openmrs/esm-api@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-api@npm:5.6.1-pre.1801"
   dependencies:
     "@types/fhir": "npm:0.0.31"
     lodash-es: "npm:^4.17.21"
@@ -3946,17 +3946,17 @@ __metadata:
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: 10/a9b9fe489160112551e570a4722b1e1d56f50c728f46b34e31252df085822ef3a3fae7ab18f9a17b3baeeed7ec00dac30dfe5dfb750262c2388548c0942de776
+  checksum: 10/ceb26af13aa7006f113c9fb36c81e0a0599a7ffd1c4cf78160b2d0483c9ae3a284c97fa87b10fa0912983bc769a0df88d026c00abacc5111e6c06ab908695bfd
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-app-shell@npm:5.5.1-pre.1737"
+"@openmrs/esm-app-shell@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-app-shell@npm:5.6.1-pre.1801"
   dependencies:
     "@carbon/react": "npm:~1.37.0"
-    "@openmrs/esm-framework": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-styleguide": "npm:5.5.1-pre.1737"
+    "@openmrs/esm-framework": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-styleguide": "npm:5.6.1-pre.1801"
     dayjs: "npm:^1.10.4"
     dexie: "npm:^3.0.3"
     html-webpack-plugin: "npm:^5.5.0"
@@ -3981,44 +3981,56 @@ __metadata:
     workbox-strategies: "npm:^6.1.5"
     workbox-webpack-plugin: "npm:^6.1.5"
     workbox-window: "npm:^6.1.5"
-  checksum: 10/ad1dddcd585b72497a4b9d4f1b21412fec31a80fe8266339c62c13e2bbde76471b897710f6769e3d9480ae637b86652ff566c8d0f5669cf4fcdee79afe294602
+  checksum: 10/7d3bb02aca31fbff18fb8691d4fb77acd3edb9d3e8c35c01b44185efb661a03191691b4e8b04f3153f47f6e1b2f065c038400550d85877f1f2d92c94535fa35a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-config@npm:5.5.1-pre.1737"
+"@openmrs/esm-config@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-config@npm:5.6.1-pre.1801"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 10/deb14309cf68ccaddd2dea98b5b10a4062b8b8c23f1fa1311d821ecb32306b8f416355a4dac944de85b0f158efd432638b2b86990e255d9d846a49cf854b61ed
+  checksum: 10/64d6a9b317a8232df84f2b0d2ff03efada7365b4ad4ccdcd3d8d8f53f9de32b08a16ca4b6b6c4c8229fcc061896d766d97795d6a7ebf0b33c191d97a5a2c5bd5
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.5.1-pre.1737"
+"@openmrs/esm-context@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-context@npm:5.6.1-pre.1801"
+  dependencies:
+    immer: "npm:^10.0.4"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/b8a7e69e5e65f29749555e5cd18ce7dcb6bb13025efbadbb5cf2dec3d928ea33b74d20c5dce8cc1e2ced78e24cbb51a7264e296e80e36654ddc0499ea5f87857
+    "@openmrs/esm-state": 5.x
+  checksum: 10/f630bb54d835597ac14121b2a2e39b964dd48e97f6d2583a1f5ebd46e6a5487d64fed7f12b2069e3d66d9cb0dacda0378e7e37cbec7dd1499b85d9ca0fab274b
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-error-handling@npm:5.5.1-pre.1737"
+"@openmrs/esm-dynamic-loading@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.6.1-pre.1801"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/8265857eb5f5b93b228682a268bed639b00fb11ccd98a7ae181832aab7129d4aac475ab81a0551ba7ee624847659ec7134d8dfc99ab5c5153b7a06812b286896
+  checksum: 10/dda8172cf872247f2d59bbe74e308d602d24eefe2ca4817ee4a5942d91ef3c7febeaeaac700418cceda4f4f076b5674f534c8a641983c8cb4a5ddcfc334d18f7
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-extensions@npm:5.5.1-pre.1737"
+"@openmrs/esm-error-handling@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-error-handling@npm:5.6.1-pre.1801"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+  checksum: 10/21c93f483680e604dccae897c15f736f8916624729fd02eb26c4a594d396d41ab74ca01e98529fd9deff6b16022a52d89295df9e1c231755e49e483ae600eb06
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-extensions@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-extensions@npm:5.6.1-pre.1801"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -4026,21 +4038,22 @@ __metadata:
     "@openmrs/esm-config": 5.x
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-state": 5.x
+    "@openmrs/esm-utils": 5.x
     single-spa: 5.x
-  checksum: 10/c71265809df580825ef62bd49f82fcb71d9fa1f43e25bfeca0e593300625729db3b9e0469a1cc3d09afefd5443bcee04ad29b60a0ed3a4da65deff1b625c95c8
+  checksum: 10/5a3cb6799a1a6918d3a32d6d319b40ef7c6e40cfa638e577d99e58d01ac90c587f639d4a5c57bb275db16e2a03570dc357d7985c3cd499c17b2e261fc21eaed9
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-feature-flags@npm:5.5.1-pre.1737"
+"@openmrs/esm-feature-flags@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-feature-flags@npm:5.6.1-pre.1801"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 10/a1592d9a07b9cc9d6d73bf1c73c84ff42e73324738bbc7511ad7014eb580d51a719f64f67854bba327534577a694d8e06195fca70d244270d34fd8fe6720c481
+  checksum: 10/deea45403ea5f5564b9ab1f1f92615eef46cbcf471ea8016b8becf5fc18e78f5b6d2c9504bfc45b7e96ba987473bb821e3b293c74109cac9506f77b28c79da5e
   languageName: node
   linkType: hard
 
@@ -4134,25 +4147,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-framework@npm:5.5.1-pre.1737, @openmrs/esm-framework@npm:next":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-framework@npm:5.5.1-pre.1737"
+"@openmrs/esm-framework@npm:5.6.1-pre.1801, @openmrs/esm-framework@npm:next":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-framework@npm:5.6.1-pre.1801"
   dependencies:
-    "@openmrs/esm-api": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-config": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-dynamic-loading": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-error-handling": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-extensions": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-feature-flags": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-globals": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-navigation": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-offline": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-react-utils": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-routes": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-state": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-styleguide": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-translations": "npm:5.5.1-pre.1737"
-    "@openmrs/esm-utils": "npm:5.5.1-pre.1737"
+    "@openmrs/esm-api": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-config": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-context": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-dynamic-loading": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-error-handling": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-extensions": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-feature-flags": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-globals": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-navigation": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-offline": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-react-utils": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-routes": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-state": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-styleguide": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-translations": "npm:5.6.1-pre.1801"
+    "@openmrs/esm-utils": "npm:5.6.1-pre.1801"
     dayjs: "npm:^1.10.7"
   peerDependencies:
     dayjs: 1.x
@@ -4163,7 +4177,7 @@ __metadata:
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: 10/5ff73967ee41928fc24db574180b2843ee779af23c922709f01ac75383cb36eec57c088eac1f699f14427c47026630dd1518d85b50822bc52a5794d426da4b79
+  checksum: 10/a63f2c2fae69ba093722a21114baf416ce39aef57b8fcc00fc92e26daba5224dadadec76a10f984f2364f5af0806c3e474433793c1c7e351d3ac0e58ea6697f6
   languageName: node
   linkType: hard
 
@@ -4189,29 +4203,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-globals@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-globals@npm:5.5.1-pre.1737"
+"@openmrs/esm-globals@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-globals@npm:5.6.1-pre.1801"
   peerDependencies:
     single-spa: 5.x
-  checksum: 10/385d07d1b54ab101278f8edc240bd8b042ace296880b8b7f903a09643ef6b792f7299fe1267526fca5b082c899966892ace1c4240f716a82864f6fede93d6c4e
+  checksum: 10/d70c7681a2531f41db20cd05eb1254a610dc2b07125e90dbaf54fb36edb7adf0abefe8dfbac28bdceffa703132bf80110ee1b4ca0c19dae57e0a0ac282cdb38f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-navigation@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-navigation@npm:5.5.1-pre.1737"
+"@openmrs/esm-navigation@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-navigation@npm:5.6.1-pre.1801"
   dependencies:
     path-to-regexp: "npm:6.1.0"
   peerDependencies:
     "@openmrs/esm-state": 5.x
-  checksum: 10/b35e891d429afb3bbc79cfb84cc9866a59b6a7499fce1c5a8d992b67e677478fd7339fce3731d09b1c3acb822d8610d80022101d17dd2c35eda5da4e45e60b71
+  checksum: 10/a9b1f4e8b3278bc5f96f0b3c88c95b5fd3923c0a9325f5f566a63d1c80fa65a4c4bbbc5288387eb43c2ec9eb5a3befca856783710761a2a752e7dfb563a65a75
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-offline@npm:5.5.1-pre.1737"
+"@openmrs/esm-offline@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-offline@npm:5.6.1-pre.1801"
   dependencies:
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -4221,9 +4235,8 @@ __metadata:
     "@openmrs/esm-api": 5.x
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
-    "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
-  checksum: 10/733f1a5f0db0cb6453f1cce7ac0f1708fa8d58da9567b31a90112b7dbd6091e45c32c820c8d19db2c0c02936efde174b60902cc5026ee43522603b5feb7e1891
+  checksum: 10/44fa61976e59c07e666e79044159bb37527d5c6c3d1c9489244c24418852e2557fe9164726595e566fd0a9249b11b7fb319ff9725140bbdfdd950720cee24095
   languageName: node
   linkType: hard
 
@@ -4614,20 +4627,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-react-utils@npm:5.5.1-pre.1737"
+"@openmrs/esm-react-utils@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-react-utils@npm:5.6.1-pre.1801"
   dependencies:
     lodash-es: "npm:^4.17.21"
     single-spa-react: "npm:^6.0.0"
   peerDependencies:
     "@openmrs/esm-api": 5.x
     "@openmrs/esm-config": 5.x
+    "@openmrs/esm-context": 5.x
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-extensions": 5.x
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-navigation": 5.x
+    "@openmrs/esm-utils": 5.x
     dayjs: 1.x
     i18next: 21.x
     react: 18.x
@@ -4635,34 +4650,34 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 10/def7b817fbe7486454ad773e383255e093535cff74ace26e96a6c59df229f45d73531fc61f4dca3297c36ccf20117880d3ff32d8105191ef53d58a6778f3efe3
+  checksum: 10/0645cd4525b2dbf1f5f32da5b4727f7cd0ad7612e06c6503975618a01e7b62997b7d174f4321b0c605a53cfc8b27cafba0df7bbdb4e1775a9e0b1572cfc94042
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-routes@npm:5.5.1-pre.1737"
+"@openmrs/esm-routes@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-routes@npm:5.6.1-pre.1801"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-utils": 5.x
-  checksum: 10/e153461feac994f05077add8cfaed43d7701534eb9cff7a49e4a3abbf0802f1f7bf78f177aebf9689394c65c98042f86161954805f0248cc12bce703c32ddab2
+  checksum: 10/5d614ad4666ccf064ae7f047ed6e545d2c7126b0933a9ef3a49085a77834ea74c861b0a586c5324b2b286454445a2598c13dea626652ea14191023951c0a1775
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-state@npm:5.5.1-pre.1737"
+"@openmrs/esm-state@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-state@npm:5.6.1-pre.1801"
   dependencies:
     zustand: "npm:^4.3.6"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/dc7fee19fc7bd5b1e431bca56489ee883212ed198af9cdaffcbed1ae0a69d6dadbceb77fbdbc07b93afc8621e3bdc8e28f57d9f47615ef58a1d447277ee978d0
+  checksum: 10/608af61eb22cf97610ee662064f9ab677661b1d80281104b1622a2dfad785883db5d3d6777346777cf88856f086fffd0a4dfb6935199d165b54cbd1d4a3389fe
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-styleguide@npm:5.5.1-pre.1737"
+"@openmrs/esm-styleguide@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-styleguide@npm:5.6.1-pre.1801"
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
     "@carbon/react": "npm:~1.37.0"
@@ -4676,7 +4691,9 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     react-avatar: "npm:^5.0.3"
   peerDependencies:
+    "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-extensions": 5.x
+    "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-react-utils": 5.x
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-translations": 5.x
@@ -4685,31 +4702,33 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: 10/514d642326a1a6addac89d61bb0c8ccfd728e6ac4ee79e2be8d42a51bef58187750444224c516d0fd07233893a7f6014fee2b1c54007dfcc92f73e5bb86fa3bf
+  checksum: 10/4921ea7880044e346c1f024200a8e8455b138c94b2885021003dcf63f7bebe138084ad78a0c10e2bd4a5f28e1dd00c0d973f5eed33e87d2850ed1f0fb128553c
   languageName: node
   linkType: hard
 
-"@openmrs/esm-translations@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-translations@npm:5.5.1-pre.1737"
+"@openmrs/esm-translations@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-translations@npm:5.6.1-pre.1801"
   dependencies:
     i18next: "npm:21.10.0"
   peerDependencies:
     i18next: 21.x
-  checksum: 10/4c46b5963b283884ca93b19840e99e106de782f5971bcd6cf09784fe9c6fab845f01a81fcd05588b916ddc540adf2f3a7ed2f881caba829c501f1687c4aaff38
+  checksum: 10/7fdf000a4e2cecbf91df2f44498c1df4dc687bb603d7e93cfa4403d887f5c0965afae200042dc84dabde58b0881b1b79f52d6d699b322f60103b36ef230e6f68
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/esm-utils@npm:5.5.1-pre.1737"
+"@openmrs/esm-utils@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/esm-utils@npm:5.6.1-pre.1801"
   dependencies:
+    "@internationalized/date": "npm:^3.5.0"
     semver: "npm:7.3.2"
   peerDependencies:
+    "@openmrs/esm-globals": 5.x
     dayjs: 1.x
     i18next: 21.x
     rxjs: 6.x
-  checksum: 10/464549f29ed5a8ebb643d4f9437d96c678e01cc3065e413228b7e597e134096b81e9cd4e94dfa8bed79b9e6469644c26bdb07d86b8267d133c9cf1897352024b
+  checksum: 10/83f23add3016b555412c66cca44a03d3a6e511896d7562193946407720bdae3b15f82470d1aec776341939f64e38ff2994443cb9cd3ba22cc409a90211a762d7
   languageName: node
   linkType: hard
 
@@ -4788,9 +4807,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.5.1-pre.1737":
-  version: 5.5.1-pre.1737
-  resolution: "@openmrs/webpack-config@npm:5.5.1-pre.1737"
+"@openmrs/webpack-config@npm:5.6.1-pre.1801":
+  version: 5.6.1-pre.1801
+  resolution: "@openmrs/webpack-config@npm:5.6.1-pre.1801"
   dependencies:
     "@swc/core": "npm:^1.3.58"
     clean-webpack-plugin: "npm:^4.0.0"
@@ -4807,7 +4826,7 @@ __metadata:
     webpack-stats-plugin: "npm:^1.0.3"
   peerDependencies:
     webpack: 5.x
-  checksum: 10/4268fca585342e5baa563ddab93291694ca4554a276a7821d80361b4fe04368a3dad60a64da29a2ccd39aa28e2253868699bdbdfb732b3c2a8d74f1ef7573634
+  checksum: 10/989edd2efabf527cd47cf89c278ddc4741a0c8ffa39905aafe0bf2a8b427ba04f4bc6a2d1717f405ac94a5ccb0489ed7ca1288b25d35cf47ca82fc8c5a8f6095
   languageName: node
   linkType: hard
 
@@ -13701,6 +13720,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immer@npm:^10.0.4":
+  version: 10.1.1
+  resolution: "immer@npm:10.1.1"
+  checksum: 10/9dacf1e8c201d69191ccd88dc5d733bafe166cd45a5a360c5d7c88f1de0dff974a94114d72b35f3106adfe587fcfb131c545856184a2247d89d735ad25589863
+  languageName: node
+  linkType: hard
+
 "immutable@npm:^4.0.0":
   version: 4.1.0
   resolution: "immutable@npm:4.1.0"
@@ -17418,12 +17444,12 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 5.5.1-pre.1737
-  resolution: "openmrs@npm:5.5.1-pre.1737"
+  version: 5.6.1-pre.1801
+  resolution: "openmrs@npm:5.6.1-pre.1801"
   dependencies:
     "@carbon/icons-react": "npm:11.26.0"
-    "@openmrs/esm-app-shell": "npm:5.5.1-pre.1737"
-    "@openmrs/webpack-config": "npm:5.5.1-pre.1737"
+    "@openmrs/esm-app-shell": "npm:5.6.1-pre.1801"
+    "@openmrs/webpack-config": "npm:5.6.1-pre.1801"
     "@pnpm/npm-conf": "npm:^2.1.0"
     "@swc/core": "npm:^1.3.58"
     autoprefixer: "npm:^10.4.2"
@@ -17443,6 +17469,7 @@ __metadata:
     postcss: "npm:^8.4.6"
     postcss-loader: "npm:^6.2.1"
     rimraf: "npm:^3.0.2"
+    semver: "npm:^7.3.4"
     swc-loader: "npm:^0.2.3"
     tar: "npm:^6.0.5"
     typescript: "npm:^4.6.4"
@@ -17454,7 +17481,7 @@ __metadata:
     yargs: "npm:^17.6.2"
   bin:
     openmrs: ./dist/cli.js
-  checksum: 10/ba58dfd39d8ec2937c4ae9c130957f88709f0fc2f39cb35b7438881485efe6760bf06d2d885e8c02a5feabc3439f4257cba00b965094e318829b3a276afbd282
+  checksum: 10/a455a93100d7076f5e8652cecfe576913882ddaa4644ba8831b5ab45a57ff0bdebd44e7e0b941cfaf1c1d1e4725d1a07921425f1c01a49b12bd507665eb94055
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Fixes some boneheaded issues I accidentally introduced in #1831 by keeping the abort controller local to the function. For most places, I've still removed the abort controller since we never used it.

While working on this, I also noticed an issue with how the contents are justified on very "long" screens. See the attached screen shots.

## Screenshots
<!-- Required if you are making UI changes. -->

**Before**

![Screenshot showing contents far apart](https://github.com/openmrs/openmrs-esm-patient-chart/assets/52504170/852d79b2-8d68-46fe-a62a-44ccdb6af108)

**After**

![Screenshot showing contents closer together](https://github.com/openmrs/openmrs-esm-patient-chart/assets/52504170/64947d15-4e06-471f-8b0d-b57b7c3619ee)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
