### PR TITLE
(feat) O3-3253: Move the details panel button below the Patient Header in the workspace

### DIFF
--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -43,6 +43,9 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
   }, []);
 
   const isDeceased = Boolean(patient?.deceasedDateTime);
+  // render details button below patient details for workspaces
+  // 520px is the maximum width a workspace occupies
+  const renderDetailsButtonBelow = patientBannerRef.current?.scrollWidth <= 520;
 
   return (
     <header
@@ -65,7 +68,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
               isDeceased={patient.deceasedBoolean}
             />
           ) : null}
-          {!isTabletViewport ? (
+          {!renderDetailsButtonBelow ? (
             <PatientBannerToggleContactDetailsButton
               className={styles.toggleContactDetailsButton}
               toggleContactDetails={toggleContactDetails}
@@ -74,7 +77,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
           ) : null}
         </div>
       </div>
-      {isTabletViewport ? (
+      {renderDetailsButtonBelow ? (
         <PatientBannerToggleContactDetailsButton
           className={styles.toggleContactDetailsButton}
           toggleContactDetails={toggleContactDetails}

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -43,10 +43,8 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
   }, []);
 
   const isDeceased = Boolean(patient?.deceasedDateTime);
-  // render details button below patient details for workspaces
-  // 520px is the maximum width a workspace occupies
-  const workspaceWidth = 520;
-  const showDetailsButtonBelowHeader = patientBannerRef.current?.scrollWidth <= workspaceWidth;
+  const maxDesktopWorkspaceWidthInPx = 520;
+  const showDetailsButtonBelowHeader = patientBannerRef.current?.scrollWidth <= maxDesktopWorkspaceWidthInPx;
 
   return (
     <header
@@ -64,9 +62,9 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
         <div className={styles.buttonCol}>
           {!hideActionsOverflow ? (
             <PatientBannerActionsMenu
-              patientUuid={patientUuid}
-              actionsSlotName={'patient-actions-slot'}
+              actionsSlotName="patient-actions-slot"
               isDeceased={patient.deceasedBoolean}
+              patientUuid={patientUuid}
             />
           ) : null}
           {!showDetailsButtonBelowHeader ? (
@@ -87,9 +85,10 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
       ) : null}
       {showContactDetails && (
         <div
-          className={`${styles.contactDetails} ${styles[patient.deceasedBoolean && 'deceasedContactDetails']} ${
-            styles[isTabletViewport && 'tabletContactDetails']
-          }`}
+          className={classNames(styles.contactDetails, {
+            [styles.deceasedContactDetails]: patient.deceasedBoolean,
+            [styles.tabletContactDetails]: isTabletViewport,
+          })}
         >
           <PatientBannerContactDetails patientId={patient?.id} deceased={isDeceased} />
         </div>

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import {
+  displayName,
   PatientBannerActionsMenu,
   PatientBannerContactDetails,
   PatientBannerPatientInfo,
   PatientBannerToggleContactDetailsButton,
   PatientPhoto,
-  displayName,
 } from '@openmrs/esm-framework';
 import styles from './patient-banner.scss';
 
@@ -45,7 +45,8 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
   const isDeceased = Boolean(patient?.deceasedDateTime);
   // render details button below patient details for workspaces
   // 520px is the maximum width a workspace occupies
-  const showDetailsButtonBelowHeader = patientBannerRef.current?.scrollWidth <= 520;
+  const workspaceWidth = 520;
+  const showDetailsButtonBelowHeader = patientBannerRef.current?.scrollWidth <= workspaceWidth;
 
   return (
     <header

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -45,7 +45,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
   const isDeceased = Boolean(patient?.deceasedDateTime);
   // render details button below patient details for workspaces
   // 520px is the maximum width a workspace occupies
-  const renderDetailsButtonBelow = patientBannerRef.current?.scrollWidth <= 520;
+  const showDetailsButtonBelowHeader = patientBannerRef.current?.scrollWidth <= 520;
 
   return (
     <header
@@ -68,7 +68,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
               isDeceased={patient.deceasedBoolean}
             />
           ) : null}
-          {!renderDetailsButtonBelow ? (
+          {!showDetailsButtonBelowHeader ? (
             <PatientBannerToggleContactDetailsButton
               className={styles.toggleContactDetailsButton}
               toggleContactDetails={toggleContactDetails}
@@ -77,7 +77,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
           ) : null}
         </div>
       </div>
-      {renderDetailsButtonBelow ? (
+      {showDetailsButtonBelowHeader ? (
         <PatientBannerToggleContactDetailsButton
           className={styles.toggleContactDetailsButton}
           toggleContactDetails={toggleContactDetails}

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -65,13 +65,22 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
               isDeceased={patient.deceasedBoolean}
             />
           ) : null}
+          {!isTabletViewport ? (
+            <PatientBannerToggleContactDetailsButton
+              className={styles.toggleContactDetailsButton}
+              toggleContactDetails={toggleContactDetails}
+              showContactDetails={showContactDetails}
+            />
+          ) : null}
         </div>
       </div>
-      <PatientBannerToggleContactDetailsButton
-        className={styles.toggleContactDetailsButton}
-        toggleContactDetails={toggleContactDetails}
-        showContactDetails={showContactDetails}
-      />
+      {isTabletViewport ? (
+        <PatientBannerToggleContactDetailsButton
+          className={styles.toggleContactDetailsButton}
+          toggleContactDetails={toggleContactDetails}
+          showContactDetails={showContactDetails}
+        />
+      ) : null}
       {showContactDetails && (
         <div
           className={`${styles.contactDetails} ${styles[patient.deceasedBoolean && 'deceasedContactDetails']} ${

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -65,13 +65,13 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
               isDeceased={patient.deceasedBoolean}
             />
           ) : null}
-          <PatientBannerToggleContactDetailsButton
-            className={styles.toggleContactDetailsButton}
-            toggleContactDetails={toggleContactDetails}
-            showContactDetails={showContactDetails}
-          />
         </div>
       </div>
+      <PatientBannerToggleContactDetailsButton
+        className={styles.toggleContactDetailsButton}
+        toggleContactDetails={toggleContactDetails}
+        showContactDetails={showContactDetails}
+      />
       {showContactDetails && (
         <div
           className={`${styles.contactDetails} ${styles[patient.deceasedBoolean && 'deceasedContactDetails']} ${

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.scss
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.scss
@@ -15,7 +15,7 @@
 .buttonCol {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: flex-end;
 }
 
@@ -80,7 +80,7 @@
 
   .row {
     &:first-child {
-    border-bottom: 1px solid $ui-03;
+      border-bottom: 1px solid $ui-03;
     }
   }
 

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.scss
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.scss
@@ -15,7 +15,7 @@
 .buttonCol {
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: space-between;
   align-items: flex-end;
 }
 

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
@@ -75,7 +75,7 @@ describe('Visit Header', () => {
     const homeLink = screen.getByRole('link');
     expect(hamburgerButton).toBeInTheDocument();
     expect(homeLink).toBeInTheDocument();
-    expect(homeLink).toHaveAttribute('href', '${openmrsSpaBase}/home');
+    expect(homeLink).toHaveAttribute('href', '/openmrs/spa/home');
 
     // Should display the leftNavMenu
     await user.click(hamburgerButton);

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
@@ -2,17 +2,17 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
+  getHistory,
+  goBackInHistory,
+  navigate,
+  showModal,
   useAssignedExtensions,
   useLayoutType,
   useOnClickOutside,
   usePatient,
   useVisit,
-  navigate,
-  showModal,
-  getHistory,
-  goBackInHistory,
 } from '@openmrs/esm-framework';
-import { mockPatient, mockPatientWithLongName, getByTextWithMarkup } from 'tools';
+import { getByTextWithMarkup, mockPatient, mockPatientWithLongName } from 'tools';
 import { mockCurrentVisit } from '__mocks__';
 import VisitHeader from './visit-header.component';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
@@ -75,7 +75,7 @@ describe('Visit Header', () => {
     const homeLink = screen.getByRole('link');
     expect(hamburgerButton).toBeInTheDocument();
     expect(homeLink).toBeInTheDocument();
-    expect(homeLink).toHaveAttribute('href', '/openmrs/spa/home');
+    expect(homeLink).toHaveAttribute('href', '${openmrsSpaBase}/home');
 
     // Should display the leftNavMenu
     await user.click(hamburgerButton);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
 This PR moves the show details button below the patient details.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/openmrs/openmrs-esm-patient-chart/assets/53287480/e4376600-fff4-439c-b98b-78868c93beef


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-3253](https://openmrs.atlassian.net/browse/O3-3253)

## Other
<!-- Anything not covered above -->


[O3-3253]: https://openmrs.atlassian.net/browse/O3-3253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ