### PR TITLE
(fix) O3-3187: Fix borders used to highlight abnormal vitals

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -39,15 +39,35 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
   const StyledTableCell = ({ interpretation, children }: { interpretation: string; children: React.ReactNode }) => {
     switch (interpretation) {
       case 'critically_high':
-        return <TableCell className={styles.criticallyHigh}>{children}</TableCell>;
+        return (
+          <TableCell className={styles.criticallyHigh}>
+            <span>{children}</span>
+          </TableCell>
+        );
       case 'critically_low':
-        return <TableCell className={styles.criticallyLow}>{children}</TableCell>;
+        return (
+          <TableCell className={styles.criticallyLow}>
+            <span>{children}</span>
+          </TableCell>
+        );
       case 'high':
-        return <TableCell className={styles.high}>{children}</TableCell>;
+        return (
+          <TableCell className={styles.high}>
+            <span>{children}</span>
+          </TableCell>
+        );
       case 'low':
-        return <TableCell className={styles.low}>{children}</TableCell>;
+        return (
+          <TableCell className={styles.low}>
+            <span>{children}</span>
+          </TableCell>
+        );
       default:
-        return <TableCell>{children}</TableCell>;
+        return (
+          <TableCell className={styles.normal}>
+            <span>{children}</span>
+          </TableCell>
+        );
     }
   };
 

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
@@ -1,10 +1,11 @@
 @use '@carbon/colors';
 @use '@carbon/type';
+@use '@carbon/layout';
 
 .table {
   td {
     white-space: nowrap;
-    padding: 0.25rem;
+    padding: layout.$spacing-02;
     > span {
       width: 100%;
       height: 100%;
@@ -19,22 +20,18 @@
   }
 }
 
-.criticallyHigh span, .criticallyLow span {
+.criticallyHigh > span, .criticallyLow > span {
   border: 2px solid colors.$red-60 !important;
-  padding-left: 1rem;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-}
+  padding: layout.$spacing-02 layout.$spacing-02 layout.$spacing-02 layout.$spacing-05;
+} 
 
-.high span, .low span {
+.high > span, .low > span {
   border: 1.5px solid colors.$black-100 !important;
-  padding-left: 1rem;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
+  padding: layout.$spacing-02 layout.$spacing-02 layout.$spacing-02 layout.$spacing-05;
 }
 
-.normal span {
-  padding-left: 1rem;
+.normal > span {
+  padding-left: layout.$spacing-05;
 }
 
 .criticallyLow {
@@ -82,18 +79,18 @@
   @include type.type-style('heading-compact-01');
 }
 
-.criticallyLow span::after {
+.criticallyLow > span::after {
   content: " ↓↓";
 }
 
-.criticallyHigh span::after {
+.criticallyHigh > span::after {
   content: " ↑↑";
 }
 
-.low span::after {
+.low > span::after {
   content: " ↓";
 }
 
-.high span::after {
+.high > span::after {
   content: " ↑";
 }

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
@@ -4,6 +4,12 @@
 .table {
   td {
     white-space: nowrap;
+    padding: 0.25rem;
+    > span {
+      width: 100%;
+      height: 100%;
+      display: inline-block;
+    }
   }
 }
 
@@ -13,12 +19,22 @@
   }
 }
 
-.criticallyLow, .criticallyHigh {
+.criticallyHigh span, .criticallyLow span {
   border: 2px solid colors.$red-60 !important;
+  padding-left: 1rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
 }
 
-.low, .high {
+.high span, .low span {
   border: 1.5px solid colors.$black-100 !important;
+  padding-left: 1rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.normal span {
+  padding-left: 1rem;
 }
 
 .criticallyLow {
@@ -66,18 +82,18 @@
   @include type.type-style('heading-compact-01');
 }
 
-.criticallyLow::after {
+.criticallyLow span::after {
   content: " ↓↓";
 }
 
-.criticallyHigh::after {
+.criticallyHigh span::after {
   content: " ↑↑";
 }
 
-.low::after {
+.low span::after {
   content: " ↓";
 }
 
-.high::after {
+.high span::after {
   content: " ↑";
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes the inconsistent borders in the vitals table.
A discussion has been going synchronously in this [ticket](https://openmrs.atlassian.net/browse/O3-3187)
and on slack.

## Screenshots
<!-- Required if you are making UI changes. -->

previously the UI looked like this
![vitals-dev3](https://github.com/openmrs/openmrs-esm-patient-chart/assets/122885804/81887b6c-d76c-43e8-8bfe-00be38531d0c)

The UI looks like this with the implementation in this PR
![vitals-fix](https://github.com/openmrs/openmrs-esm-patient-chart/assets/122885804/ca101e6f-4379-42bb-bba3-8d523d5a1626)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[Vitals table border issues - O3-3187](https://openmrs.atlassian.net/browse/O3-3187)

## Other
<!-- Anything not covered above -->
