### PR TITLE
O3-1695: Record Immunizations workspace should be restorable

### DIFF
--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -223,199 +223,210 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
   );
 
   return (
-    <FormProvider {...formProps}>
-      <Form className={styles.form} onSubmit={handleSubmit(onSubmit)} data-testid="immunization-form">
-        <Stack gap={1} className={styles.container}>
-          <section className={` ${styles.row}`}>
-            <div className={styles.dateTimeSection}>
-              <ResponsiveWrapper>
-                <Controller
-                  name="vaccinationDate"
-                  control={control}
-                  render={({ field: { onChange, value } }) => (
-                    <DatePicker
-                      id="vaccinationDate"
-                      maxDate={new Date().toISOString()}
-                      dateFormat={datePickerFormat}
-                      datePickerType="single"
-                      value={value}
-                      onChange={([date]) => onChange(date)}
-                      style={{ paddingBottom: '1rem' }}
-                    >
-                      <DatePickerInput
-                        id="vaccinationDateInput"
-                        placeholder="dd/mm/yyyy"
-                        labelText={t('vaccinationDate', 'Vaccination Date')}
-                        type="text"
-                        invalid={!!errors['vaccinationDate']}
-                        invalidText={errors['vaccinationDate']?.message}
-                        style={{ width: '100%' }}
-                      />
-                    </DatePicker>
-                  )}
-                />
-              </ResponsiveWrapper>
-              <ResponsiveWrapper>
-                <Controller
-                  name="vaccinationTime"
-                  control={control}
-                  render={({ field: { onBlur, onChange, value } }) => (
-                    <TimePicker
-                      id="vaccinationTime"
-                      labelText={t('time', 'Time')}
-                      onChange={(event) => onChange(event.target.value as amPm)}
-                      pattern="^(1[0-2]|0?[1-9]):([0-5]?[0-9])$"
-                      style={{ marginLeft: '0.125rem', flex: 'none' }}
-                      value={value}
-                      onBlur={onBlur}
-                    >
-                      <Controller
-                        name="timeFormat"
-                        control={control}
-                        render={({ field: { onChange, value } }) => (
-                          <TimePickerSelect
-                            id="timeFormatSelect"
-                            onChange={(event) => onChange(event.target.value as amPm)}
-                            value={value}
-                            aria-label={t('timeFormat ', 'Time Format')}
-                          >
-                            <SelectItem value="AM" text="AM" />
-                            <SelectItem value="PM" text="PM" />
-                          </TimePickerSelect>
-                        )}
-                      />
-                    </TimePicker>
-                  )}
-                />
-              </ResponsiveWrapper>
-            </div>
-          </section>
-          <section>
-            <ResponsiveWrapper>
-              <Controller
-                name="vaccineUuid"
-                control={control}
-                render={({ field: { onChange, value } }) => (
-                  <div className={styles.row}>
-                    <Dropdown
-                      id="immunization"
-                      label={t('pleaseSelect', 'Please select')}
-                      titleText={t('immunization', 'Immunization')}
-                      items={immunizationsConceptSet?.answers?.map((item) => item.uuid) || []}
-                      itemToString={(item) =>
-                        immunizationsConceptSet?.answers.find((candidate) => candidate.uuid == item)?.display
-                      }
-                      onChange={(val) => onChange(val.selectedItem)}
-                      selectedItem={value}
-                      invalid={!!errors?.vaccineUuid}
-                    />
-                  </div>
-                )}
-              />
-            </ResponsiveWrapper>
-          </section>
-          {errors?.vaccineUuid && (
-            <section>
-              <div className={styles.row}>
-                <InlineNotification
-                  role="alert"
-                  style={{ margin: '0', minWidth: '100%' }}
-                  kind="error"
-                  lowContrast
-                  title={t('error', 'Error')}
-                  subtitle={errors.vaccineUuid.message}
-                />
+    <>
+      <FormProvider {...formProps}>
+        <Form className={styles.form} onSubmit={handleSubmit(onSubmit)} data-testid="immunization-form">
+          <Stack gap={1} className={styles.container}>
+            <section className={` ${styles.row}`}>
+              <div className={styles.dateTimeSection}>
+                <ResponsiveWrapper>
+                  <Controller
+                    name="vaccinationDate"
+                    control={control}
+                    render={({ field: { onChange, value } }) => (
+                      <DatePicker
+                        id="vaccinationDate"
+                        maxDate={new Date().toISOString()}
+                        dateFormat={datePickerFormat}
+                        datePickerType="single"
+                        value={value}
+                        onChange={([date]) => onChange(date)}
+                        style={{ paddingBottom: '1rem' }}
+                      >
+                        <DatePickerInput
+                          id="vaccinationDateInput"
+                          placeholder="dd/mm/yyyy"
+                          labelText={t('vaccinationDate', 'Vaccination Date')}
+                          type="text"
+                          invalid={!!errors['vaccinationDate']}
+                          invalidText={errors['vaccinationDate']?.message}
+                          style={{ width: '100%' }}
+                        />
+                      </DatePicker>
+                    )}
+                  />
+                </ResponsiveWrapper>
+                <ResponsiveWrapper>
+                  <Controller
+                    name="vaccinationTime"
+                    control={control}
+                    render={({ field: { onBlur, onChange, value } }) => (
+                      <TimePicker
+                        id="vaccinationTime"
+                        labelText={t('time', 'Time')}
+                        onChange={(event) => onChange(event.target.value as amPm)}
+                        pattern="^(1[0-2]|0?[1-9]):([0-5]?[0-9])$"
+                        style={{ marginLeft: '0.125rem', flex: 'none' }}
+                        value={value}
+                        onBlur={onBlur}
+                      >
+                        <Controller
+                          name="timeFormat"
+                          control={control}
+                          render={({ field: { onChange, value } }) => (
+                            <TimePickerSelect
+                              id="timeFormatSelect"
+                              onChange={(event) => onChange(event.target.value as amPm)}
+                              value={value}
+                              aria-label={t('timeFormat ', 'Time Format')}
+                            >
+                              <SelectItem value="AM" text="AM" />
+                              <SelectItem value="PM" text="PM" />
+                            </TimePickerSelect>
+                          )}
+                        />
+                      </TimePicker>
+                    )}
+                  />
+                </ResponsiveWrapper>
               </div>
             </section>
-          )}
-          {vaccineUuid && (
+            {isDirty && (
+              <section>
+                <div className={styles.backButton}>
+                  <Button kind="ghost" iconDescription="Return to Record Immunizations" size="sm" onClick={() => {}}>
+                    <span>{t('backToRecordImmunizations', 'Back To Record Immunizations')}</span>
+                  </Button>
+                </div>
+              </section>
+            )}
             <section>
               <ResponsiveWrapper>
-                <DoseInput
-                  vaccine={vaccineUuid}
-                  sequences={immunizationsConfig.sequenceDefinitions}
+                <Controller
+                  name="vaccineUuid"
                   control={control}
+                  render={({ field: { onChange, value } }) => (
+                    <div className={styles.row}>
+                      <Dropdown
+                        id="immunization"
+                        label={t('pleaseSelect', 'Please select')}
+                        titleText={t('immunization', 'Immunization')}
+                        items={immunizationsConceptSet?.answers?.map((item) => item.uuid) || []}
+                        itemToString={(item) =>
+                          immunizationsConceptSet?.answers.find((candidate) => candidate.uuid == item)?.display
+                        }
+                        onChange={(val) => onChange(val.selectedItem)}
+                        selectedItem={value}
+                        invalid={!!errors?.vaccineUuid}
+                      />
+                    </div>
+                  )}
                 />
               </ResponsiveWrapper>
             </section>
-          )}
-          <section>
-            <ResponsiveWrapper>
-              <Controller
-                name="manufacturer"
-                control={control}
-                render={({ field: { onChange, value } }) => (
-                  <div className={styles.row}>
-                    <TextInput
-                      type="text"
-                      id="manufacturer"
-                      labelText={t('manufacturer', 'Manufacturer')}
-                      value={value}
-                      onChange={(evt) => onChange(evt.target.value)}
-                    />
-                  </div>
-                )}
-              />
-            </ResponsiveWrapper>
-          </section>
-          <section>
-            <ResponsiveWrapper>
-              <Controller
-                name="lotNumber"
-                control={control}
-                render={({ field: { onChange, value } }) => (
-                  <div className={styles.row}>
-                    <TextInput
-                      type="text"
-                      id="lotNumber"
-                      labelText={t('lotNumber', 'Lot Number')}
-                      value={value}
-                      onChange={(evt) => onChange(evt.target.value)}
-                    />
-                  </div>
-                )}
-              />
-            </ResponsiveWrapper>
-          </section>
-          <section>
-            <ResponsiveWrapper>
-              <Controller
-                name="expirationDate"
-                control={control}
-                render={({ field: { onChange, value } }) => (
-                  <div className={styles.row}>
-                    <DatePicker
-                      id="vaccinationExpiration"
-                      className="vaccinationExpiration"
-                      minDate={immunizationToEditMeta ? null : new Date().toISOString()}
-                      dateFormat={datePickerFormat}
-                      datePickerType="single"
-                      value={value}
-                      onChange={([date]) => onChange(date)}
-                    >
-                      <DatePickerInput
-                        id="date-picker-calendar-id"
-                        placeholder="dd/mm/yyyy"
-                        labelText={t('expirationDate', 'Expiration Date')}
+            {errors?.vaccineUuid && (
+              <section>
+                <div className={styles.row}>
+                  <InlineNotification
+                    role="alert"
+                    style={{ margin: '0', minWidth: '100%' }}
+                    kind="error"
+                    lowContrast
+                    title={t('error', 'Error')}
+                    subtitle={errors.vaccineUuid.message}
+                  />
+                </div>
+              </section>
+            )}
+            {vaccineUuid && (
+              <section>
+                <ResponsiveWrapper>
+                  <DoseInput
+                    vaccine={vaccineUuid}
+                    sequences={immunizationsConfig.sequenceDefinitions}
+                    control={control}
+                  />
+                </ResponsiveWrapper>
+              </section>
+            )}
+            <section>
+              <ResponsiveWrapper>
+                <Controller
+                  name="manufacturer"
+                  control={control}
+                  render={({ field: { onChange, value } }) => (
+                    <div className={styles.row}>
+                      <TextInput
                         type="text"
+                        id="manufacturer"
+                        labelText={t('manufacturer', 'Manufacturer')}
+                        value={value}
+                        onChange={(evt) => onChange(evt.target.value)}
                       />
-                    </DatePicker>
-                  </div>
-                )}
-              />
-            </ResponsiveWrapper>
-          </section>
-        </Stack>
-        <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
-          <Button className={styles.button} kind="secondary" onClick={closeWorkspace}>
-            {t('cancel', 'Cancel')}
-          </Button>
-          <Button className={styles.button} kind="primary" disabled={isSubmitting} type="submit">
-            {t('save', 'Save')}
-          </Button>
-        </ButtonSet>
-      </Form>
-    </FormProvider>
+                    </div>
+                  )}
+                />
+              </ResponsiveWrapper>
+            </section>
+            <section>
+              <ResponsiveWrapper>
+                <Controller
+                  name="lotNumber"
+                  control={control}
+                  render={({ field: { onChange, value } }) => (
+                    <div className={styles.row}>
+                      <TextInput
+                        type="text"
+                        id="lotNumber"
+                        labelText={t('lotNumber', 'Lot Number')}
+                        value={value}
+                        onChange={(evt) => onChange(evt.target.value)}
+                      />
+                    </div>
+                  )}
+                />
+              </ResponsiveWrapper>
+            </section>
+            <section>
+              <ResponsiveWrapper>
+                <Controller
+                  name="expirationDate"
+                  control={control}
+                  render={({ field: { onChange, value } }) => (
+                    <div className={styles.row}>
+                      <DatePicker
+                        id="vaccinationExpiration"
+                        className="vaccinationExpiration"
+                        minDate={immunizationToEditMeta ? null : new Date().toISOString()}
+                        dateFormat={datePickerFormat}
+                        datePickerType="single"
+                        value={value}
+                        onChange={([date]) => onChange(date)}
+                      >
+                        <DatePickerInput
+                          id="date-picker-calendar-id"
+                          placeholder="dd/mm/yyyy"
+                          labelText={t('expirationDate', 'Expiration Date')}
+                          type="text"
+                        />
+                      </DatePicker>
+                    </div>
+                  )}
+                />
+              </ResponsiveWrapper>
+            </section>
+          </Stack>
+          <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
+            <Button className={styles.button} kind="secondary" onClick={closeWorkspace}>
+              {t('cancel', 'Cancel')}
+            </Button>
+            <Button className={styles.button} kind="primary" disabled={isSubmitting} type="submit">
+              {t('save', 'Save')}
+            </Button>
+          </ButtonSet>
+        </Form>
+      </FormProvider>
+    </>
   );
 };
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
On the "Record Immunizations" form I added a button on the right gutter that is to allows a user to switch back to the "Record Immunizations" workspace. The back button is only displayed if the user starts filling the form and it's hidden once the immunization has been hidden.


## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/c7056d94-ef45-47fe-9f4e-121b87ebc61b



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
