### PR TITLE
(feat)O3-3179: Change the styling of the Patient Header for deceased patients

### DIFF
--- a/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.scss
+++ b/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.scss
@@ -9,6 +9,6 @@
 }
 
 .tagOverride {
-  background-color: #6B1A18;
+  background-color: colors.$gray-80;
   color: colors.$gray-20;
 }

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.scss
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.scss
@@ -8,7 +8,8 @@
   background-color: $ui-01;
 }
 
-.activePatientContainer {
+.activePatientContainer, 
+.deceasedPatientContainer {
   background-color: $ui-01;
 }
 
@@ -17,22 +18,6 @@
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-end;
-}
-
-.deceasedPatientContainer {
-  background-color: colors.$gray-80;
-
-  .demographics, .row, .identifierTag, .identifier, .contactDetails .heading {
-    color: $ui-02;
-  }
-
-  .toggleContactDetailsButton, .toggleContactDetailsButton > svg, .actionsButtonText {
-    color: colors.$blue-40;
-  }
-
-  &:focus, &:hover {
-    background-color: colors.$gray-90;
-  }
 }
 
 .patientBanner {
@@ -62,16 +47,6 @@
   a {
     @include type.type-style("body-compact-01");
     text-decoration: none;
-  }
-}
-
-.deceasedContactDetails {
-  .contactDetails, .heading, .row, .row > .col {
-    color: $ui-02;
-  }
-
-  a {
-    color: $inverse-link
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The current styling for the deceased patient is too high-contrast so I had to remove all the inverted colour styling for deceased patients and append the Deceased tag to their name in the Patient Header and Visit Header.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/33891016/6513740d-7c25-43cd-b3f7-4079cbe3893e

## Related Issue

https://openmrs.atlassian.net/browse/O3-3179

## Other

[Patient header design doc](https://zeroheight.com/23a080e38/p/6663f3-patient-header)
