### PR TITLE
(fix) Change the form collapse toggle color on tablet

### DIFF
--- a/packages/esm-form-engine-app/src/form-collapse-toggle/form-collapse-toggle.component.tsx
+++ b/packages/esm-form-engine-app/src/form-collapse-toggle/form-collapse-toggle.component.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Toggle } from '@carbon/react';
-import styles from './styles.scss';
+import styles from './form-collapse-toggle.scss';
 
 const FormCollapseToggle = () => {
   const { t } = useTranslation();
@@ -31,6 +31,7 @@ const FormCollapseToggle = () => {
   return (
     <div className={styles.toggleContainer}>
       <Toggle
+        className={styles.toggle}
         size="sm"
         aria-label={t('toggleCollapseOrExpand', 'Toggle collapse or expand')}
         defaultToggled

--- a/packages/esm-form-engine-app/src/form-collapse-toggle/form-collapse-toggle.scss
+++ b/packages/esm-form-engine-app/src/form-collapse-toggle/form-collapse-toggle.scss
@@ -4,3 +4,11 @@
   height: var(--workspace-header-height);
   margin-right: 0.5rem;
 }
+
+:global(.omrs-breakpoint-lt-desktop) {
+  .toggle {
+    :global(.cds--toggle__text) {
+      color: white;
+    }
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This changes the colour of the form collapse toggle text from black to white on tablet for better contrast.

## Screenshots

> Before

![CleanShot 2024-06-05 at 12  52 55@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/6f6683c6-5435-4910-9667-1e1ee1e823d8)

> After

![CleanShot 2024-06-05 at 12  51 30@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/34415849-69bf-4e30-be9d-85bdbb72b405)

![CleanShot 2024-06-05 at 12  51 47@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/85ad7c94-323d-4749-9b62-1ed45e05fe19)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
