### PR TITLE
(feat) O3-3375: Align visit form queue fields to work in visit start form on patient chart

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/hooks/useServiceQueue.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useServiceQueue.tsx
@@ -56,14 +56,19 @@ export async function generateVisitQueueNumber(
   );
 }
 
-export function removeQueuedPatient(queueUuid: string, queueEntryUuid: string, abortController: AbortController) {
+export function removeQueuedPatient(
+  queueUuid: string,
+  queueEntryUuid: string,
+  abortController: AbortController,
+  endedAt?: Date,
+) {
   return openmrsFetch(`${restBaseUrl}/queue/${queueUuid}/entry/${queueEntryUuid}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
     body: {
-      endedAt: toDateObjectStrict(toOmrsIsoString(new Date())),
+      endedAt: toDateObjectStrict(toOmrsIsoString(endedAt) ?? toOmrsIsoString(new Date())),
     },
     signal: abortController.signal,
   });

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -111,6 +111,13 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
   const { mutate: mutateQueueEntry } = useVisitQueueEntry(patientUuid, visitUuid);
   const { visitAttributeTypes } = useVisitAttributeTypes();
   const [extraVisitInfo, setExtraVisitInfo] = useState(null);
+  const [{ service, priority, status, sortWeight, queueLocation }, setVisitFormFields] = useState({
+    service: null,
+    priority: null,
+    status: null,
+    sortWeight: null,
+    queueLocation: null,
+  });
 
   const displayVisitStopDateTimeFields = useMemo(
     () => visitToEdit?.stopDatetime || showVisitEndDateTimeFields,
@@ -459,15 +466,10 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
                 if (config.showServiceQueueFields) {
                   // retrieve values from the queue extension
                   setVisitUuid(response.data.uuid);
-                  const queueLocation = event.target['queueLocation']?.value;
-                  const serviceUuid = event.target['service']?.value;
-                  const priority = event.target['priority']?.value;
-                  const status = event.target['status']?.value;
-                  const sortWeight = event.target['sortWeight']?.value;
 
                   saveQueueEntry(
                     response.data.uuid,
-                    serviceUuid,
+                    service,
                     patientUuid,
                     priority,
                     status,
@@ -622,6 +624,11 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
       mutateQueueEntry,
       mutateVisits,
       patientUuid,
+      priority,
+      queueLocation,
+      service,
+      sortWeight,
+      status,
       t,
       upcomingAppointment,
       validateVisitStartStopDatetime,
@@ -804,7 +811,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
               <section>
                 <div className={styles.sectionTitle}></div>
                 <div className={styles.sectionField}>
-                  <ExtensionSlot name="add-queue-entry-slot" />
+                  <ExtensionSlot name="visit-form-queue-slot" state={{ setFormFields: setVisitFormFields }} />
                 </div>
               </section>
             )}

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
@@ -36,7 +36,12 @@ const EndVisitDialog: React.FC<EndVisitDialogProps> = ({ patientUuid, closeModal
           (response) => {
             if (response.status === 200) {
               if (queueEntry) {
-                removeQueuedPatient(queueEntry.queue.uuid, queueEntry.queueEntryUuid, abortController);
+                removeQueuedPatient(
+                  queueEntry.queue.uuid,
+                  queueEntry.queueEntryUuid,
+                  abortController,
+                  response?.data.stopDatetime,
+                );
               }
               mutate();
               closeModal();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR updates `visit-queue-form-slot` to work with `VisitFormQueueField` component for the existing workflow where we add patients to queue while starting a visit. We might also want to re-design visit-form to support additional workflows e.g billing and services queues.

In addition fixed an error that occurs while ending a queue
See error 👇🏽 

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/28008754/6045cc3b-479b-47aa-9e5f-0e6a5d8b97cf


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
