### PR TITLE
(chore) Update E2E tests to use .env file instead of example.env

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
 import { devices, type PlaywrightTestConfig } from '@playwright/test';
 import { config as dotenvConfig } from 'dotenv';
 import { resolve } from 'node:path';
-dotenvConfig({ path: resolve(process.cwd(), 'example.env') });
+dotenvConfig({ path: resolve(process.cwd(), '.env') });
 dotenvConfig();
 
 // See https://playwright.dev/docs/test-configuration.


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
It was mistakenly configured to use the `example.env` file instead of the `.env` file. Fixing it with this PR. Thanks @usamaidrsk for reporting the issue.
