### PR TITLE
(feat) O3-3365: Make freeTextFieldConceptUuid configurable

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -1,6 +1,10 @@
 import { Type } from '@openmrs/esm-framework';
 
 export const esmPatientChartSchema = {
+  freeTextFieldConceptUuid: {
+    _default: '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    _type: Type.ConceptUuid,
+  },
   visitDiagnosisConceptUuid: {
     _default: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     _type: Type.ConceptUuid,
@@ -131,6 +135,7 @@ export const esmPatientChartSchema = {
   },
 };
 export interface ChartConfig {
+  freeTextFieldConceptUuid: string;
   offlineVisitTypeUuid: string;
   visitTypeResourceUrl: string;
   showRecommendedVisitTypeTab: boolean;

--- a/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
@@ -22,18 +22,19 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { WarningFilled } from '@carbon/react/icons';
 import { EmptyState, type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
-import { ExtensionSlot, useLayoutType, showSnackbar, ResponsiveWrapper } from '@openmrs/esm-framework';
+import { ExtensionSlot, useLayoutType, showSnackbar, ResponsiveWrapper, useConfig } from '@openmrs/esm-framework';
 import { markPatientDeceased, useCausesOfDeath } from '../data.resource';
+import { type ChartConfig } from '../config-schema';
 import styles from './mark-patient-deceased-form.scss';
 
 const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ closeWorkspace, patientUuid }) => {
-  const freetextCauseOfDeathUuid = '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
-  const isTablet = useLayoutType() === 'tablet';
   const { t } = useTranslation();
+  const isTablet = useLayoutType() === 'tablet';
   const memoizedPatientUuid = useMemo(() => ({ patientUuid }), [patientUuid]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const { causesOfDeath, isLoading: isLoadingCausesOfDeath } = useCausesOfDeath();
+  const { freeTextFieldConceptUuid } = useConfig<ChartConfig>();
 
   const filteredCausesOfDeath = useMemo(() => {
     if (!searchTerm) {
@@ -59,7 +60,7 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
       }),
       nonCodedCauseOfDeath: z.string().optional(),
     })
-    .refine((data) => !(data.causeOfDeath === freetextCauseOfDeathUuid && !data.nonCodedCauseOfDeath), {
+    .refine((data) => !(data.causeOfDeath === freeTextFieldConceptUuid && !data.nonCodedCauseOfDeath), {
       message: t('nonCodedCauseOfDeathRequired', 'Please enter the non-coded cause of death'),
       path: ['nonCodedCauseOfDeath'],
     });
@@ -210,7 +211,7 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
             {errors?.causeOfDeath && <p className={styles.errorMessage}>{errors?.causeOfDeath?.message}</p>}
           </section>
         </div>
-        {causeOfDeathValue === freetextCauseOfDeathUuid && (
+        {causeOfDeathValue === freeTextFieldConceptUuid && (
           <div className={styles.nonCodedCauseOfDeath}>
             <Controller
               name="nonCodedCauseOfDeath"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Follow up to #1876. Makes the `freeTextFieldConceptUuid` configurable.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
