### PR TITLE
(fix) Use optional chaining to safely access current session provider

### DIFF
--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.tsx
@@ -146,7 +146,7 @@ const TestTypeSearchResultItem: React.FC<TestTypeSearchResultItemProps> = ({ tes
 
   const createLabOrder = useCallback(
     (testType: TestType) => {
-      return createEmptyLabOrder(testType, session.currentProvider.uuid);
+      return createEmptyLabOrder(testType, session.currentProvider?.uuid);
     },
     [session.currentProvider.uuid],
   );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds an optional chaining operator to the createEmptyLabOrder function’s current session provider argument for safe access.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/57391531/c82f6f20-8a90-4387-b7e8-afcb186f9641

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3496

## Other
<!-- Anything not covered above -->
