### PR TITLE
(fix) O3-3473: Fix results viewer print modal date range selection

### DIFF
--- a/packages/esm-patient-labs-app/src/test-results/print-modal/print-modal.extension.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/print-modal/print-modal.extension.tsx
@@ -19,6 +19,9 @@ import {
   Tile,
 } from '@carbon/react';
 import { useReactToPrint } from 'react-to-print';
+import dayjs from 'dayjs';
+import isBetween from 'dayjs/plugin/isBetween';
+dayjs.extend(isBetween);
 import {
   age,
   getPatientName,
@@ -96,14 +99,17 @@ function PrintModal({ patientUuid, closeDialog }) {
 
   const testResults = useMemo(() => {
     if (selectedFromDate && selectedToDate) {
+      const fromDate = dayjs(selectedFromDate).startOf('day');
+      const toDate = dayjs(selectedToDate).startOf('day');
+
       return panels
         .filter((panel) => {
-          const panelDate = new Date(panel.effectiveDateTime);
-          return panelDate >= new Date(selectedFromDate) && panelDate <= new Date(selectedToDate);
+          const panelDate = dayjs(panel.effectiveDateTime).startOf('day');
+          return panelDate.isBetween(fromDate, toDate, null, '[]');
         })
         .map((panel) => formatPanelForDisplay(panel));
     }
-    return panels.map((panel) => formatPanelForDisplay(panel));
+    return [];
   }, [panels, selectedFromDate, selectedToDate]);
 
   return (
@@ -130,6 +136,7 @@ function PrintModal({ patientUuid, closeDialog }) {
               className={styles.datePicker}
               dateFormat={datePickerFormat}
               datePickerType="single"
+              minDate={selectedFromDate}
               maxDate={new Date().toISOString()}
               onChange={([date]) => setSelectedToDate(date)}
               value={selectedToDate}
@@ -228,16 +235,14 @@ function PrintModal({ patientUuid, closeDialog }) {
           )}
         </div>
       </ModalBody>
-      {testResults?.length ? (
-        <ModalFooter>
-          <Button kind="secondary" onClick={closeDialog}>
-            {t('cancel', 'Cancel')}
-          </Button>
-          <Button kind="primary" onClick={handlePrint}>
-            {t('print', 'Print')}
-          </Button>
-        </ModalFooter>
-      ) : null}
+      <ModalFooter>
+        <Button kind="secondary" onClick={closeDialog}>
+          {t('cancel', 'Cancel')}
+        </Button>
+        <Button disabled={!testResults?.length} kind="primary" onClick={handlePrint}>
+          {t('print', 'Print')}
+        </Button>
+      </ModalFooter>
     </>
   );
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR is a follow-up to https://github.com/openmrs/openmrs-esm-patient-chart/pull/1878. It amends the date comparison logic determining which test results to show for the selected date range. Currently, this logic doesn't consider the timestamps associated with the dates. I've added logic that considers the associated timestamps and validates that the End date cannot be earlier than the Start date. I'm also disabling the print modal's Print action button only if there are no test results to print.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/de1ff3ae-ee60-41c8-a1e5-6ef1b998ba2a

## Related Issue
https://openmrs.atlassian.net/browse/O3-3473

## Other
<!-- Anything not covered above -->
