### PR TITLE
(fix) UI fixes for vitals and biometrics form fields

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.scss
@@ -25,6 +25,7 @@
 }
 
 .tablet {
+  margin: 0.5rem 0;
   padding: 1.5rem 1rem;
   background-color: $ui-02;
 }
@@ -56,7 +57,7 @@
   margin: 0.5rem 0rem 0rem;
   display: flex;
   flex-flow: row wrap;
-  gap: 1rem;
+  gap: 1rem 0.75rem;
 }
 
 .spacer {

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.component.tsx
@@ -25,11 +25,6 @@ type fieldId =
 type AbnormalValue = 'critically_low' | 'critically_high' | 'high' | 'low';
 type FieldTypes = 'number' | 'textarea';
 
-interface ResponsiveWrapperProps {
-  children: React.ReactNode;
-  isTablet: boolean;
-}
-
 interface VitalsAndBiometricsInputProps {
   control: Control<VitalsBiometricsFormData>;
   fieldStyles?: React.CSSProperties;
@@ -77,7 +72,6 @@ const VitalsAndBiometricsInput: React.FC<VitalsAndBiometricsInputProps> = ({
   const [isFocused, setIsFocused] = useState(false);
 
   const abnormalValues: Array<AbnormalValue> = ['critically_low', 'critically_high', 'high', 'low'];
-
   const hasAbnormalValue = !isFocused && interpretation && abnormalValues.includes(interpretation as AbnormalValue);
 
   function checkValidity(value, onChange) {
@@ -126,7 +120,11 @@ const VitalsAndBiometricsInput: React.FC<VitalsAndBiometricsInputProps> = ({
           ) : null}
         </section>
         <section className={inputClasses} style={{ ...fieldStyles }}>
-          <div className={styles.centered}>
+          <div
+            className={classNames({
+              [styles.centered]: !isTablet || unitSymbol === 'mmHg',
+            })}
+          >
             {fieldProperties.map((fieldProperty) => {
               if (fieldProperty.type === 'number') {
                 const numberInputClasses = classNames(styles.numberInput, fieldProperty.className);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the following issues with the styling of inputs in the Vitals and biometrics form:

- Placeholder content is not center-aligned on tablet.
- The inputs do not take up the entire width of the workspace on desktop.

## Screenshots

### Before

![CleanShot 2024-06-27 at 2  26 44@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/7f988c78-d321-444a-b7ef-c7bc6b89ee51)

![CleanShot 2024-06-27 at 2  28 45@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/00801374-6c21-4994-bb66-40b88da5e176)

### After

![CleanShot 2024-06-27 at 2  32 04@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/df1b1af4-96e9-48bd-850c-d43955710d88)

![CleanShot 2024-06-27 at 2  32 35@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/12c72f67-698d-4272-8fff-123a525d908d)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

