### PR TITLE
(test) Fix flaky drug and lab E2E tests

### DIFF
--- a/e2e/specs/drug-orders.spec.ts
+++ b/e2e/specs/drug-orders.spec.ts
@@ -14,6 +14,8 @@ test.beforeEach(async ({ api }) => {
 
 test('Record, edit and discontinue a drug order', async ({ page }) => {
   const medicationsPage = new MedicationsPage(page);
+  const form = page.locator('#drugOrderForm');
+  const orderBasket = page.locator('[data-extension-slot-name="order-basket-slot"]');
 
   await test.step('When I visit the medications page', async () => {
     await medicationsPage.goTo(patient.uuid);
@@ -51,37 +53,37 @@ test('Record, edit and discontinue a drug order', async ({ page }) => {
   });
 
   await test.step('When I set the dose to `1` tablet', async () => {
-    await page.getByLabel(/^dose$/i).clear();
-    await page.getByLabel(/^dose$/i).fill('1');
+    await form.getByLabel(/^dose$/i).clear();
+    await form.getByLabel(/^dose$/i).fill('1');
   });
 
   await test.step('And I set the route to `Oral`', async () => {
-    await page.getByPlaceholder(/route/i).click();
-    await page.getByText('Oral', { exact: true }).click();
+    await form.getByPlaceholder(/route/i).click();
+    await form.getByText('Oral', { exact: true }).click();
   });
 
   await test.step('And I set the frequency to `Once daily`', async () => {
-    await page.getByPlaceholder(/frequency/i).click();
-    await page.getByText('Once daily', { exact: true }).click();
+    await form.getByPlaceholder(/frequency/i).click();
+    await form.getByText('Once daily', { exact: true }).click();
   });
 
   await test.step('And I set duration to `3` days', async () => {
-    await page.getByLabel(/^duration$/i).clear();
-    await page.getByLabel(/^duration$/i).fill('3');
+    await form.getByLabel(/^duration$/i).clear();
+    await form.getByLabel(/^duration$/i).fill('3');
   });
 
   await test.step('And I set the indication to `Headache`', async () => {
-    await page.getByLabel(/indication/i).clear();
-    await page.getByLabel(/indication/i).fill('Headache');
+    await form.getByLabel(/indication/i).clear();
+    await form.getByLabel(/indication/i).fill('Headache');
   });
 
   await test.step('And I click on the "Save Order" button', async () => {
-    await page.getByRole('button', { name: /save order/i }).click();
+    await form.getByRole('button', { name: /save order/i }).click();
   });
 
   await test.step('Then the order status should be changed to `New`', async () => {
-    await expect(page.getByText(/incomplete/i)).not.toBeVisible();
-    await expect(page.getByText(/new/i)).toBeVisible();
+    await expect(orderBasket.getByText(/incomplete/i)).not.toBeVisible();
+    await expect(orderBasket.getByText(/new/i)).toBeVisible();
   });
 
   await test.step('When I click on the `Sign and close` button', async () => {
@@ -118,59 +120,59 @@ test('Record, edit and discontinue a drug order', async ({ page }) => {
   });
 
   await test.step('Then I should see the medication launch in the workspace in edit mode', async () => {
-    await expect(page.getByText('Aspirin 81mg (81mg)')).toBeVisible();
+    await expect(form.getByText('Aspirin 81mg (81mg)')).toBeVisible();
   });
 
   await test.step('When I change the dose to `2` tablets', async () => {
-    await page.getByLabel(/^dose$/i).clear();
-    await page.getByLabel(/^dose$/i).fill('2');
+    await form.getByLabel(/^dose$/i).clear();
+    await form.getByLabel(/^dose$/i).fill('2');
   });
 
   await test.step('And I change the duration to `5` days', async () => {
-    await page.getByLabel(/^duration$/i).clear();
-    await page.getByLabel(/^duration$/i).fill('5');
+    await form.getByLabel(/^duration$/i).clear();
+    await form.getByLabel(/^duration$/i).fill('5');
   });
 
   await test.step('And I change the route to `Inhalation`', async () => {
-    await page.getByPlaceholder(/route/i).click();
-    await page.getByText('Inhalation', { exact: true }).click();
+    await form.getByPlaceholder(/route/i).click();
+    await form.getByText('Inhalation', { exact: true }).click();
   });
 
   await test.step('And I change the frequency to `Twice daily`', async () => {
-    await page.getByPlaceholder(/frequency/i).clear();
-    await page.getByText('Twice daily', { exact: true }).click();
+    await form.getByPlaceholder(/frequency/i).clear();
+    await form.getByText('Twice daily', { exact: true }).click();
   });
 
   await test.step('And I set the frequency to `q12`', async () => {
-    await page.getByPlaceholder(/frequency/i).clear();
-    await page.getByPlaceholder(/frequency/i).fill('q12');
-    await page.getByText('Every twelve hours', { exact: true }).click();
+    await form.getByPlaceholder(/frequency/i).clear();
+    await form.getByPlaceholder(/frequency/i).fill('q12');
+    await form.getByText('Every twelve hours', { exact: true }).click();
   });
 
   await test.step('And I set the frequency to `od`', async () => {
-    await page.getByPlaceholder(/frequency/i).clear();
-    await page.getByPlaceholder(/frequency/i).fill('od');
-    await page.getByText('Once daily', { exact: true }).click();
+    await form.getByPlaceholder(/frequency/i).clear();
+    await form.getByPlaceholder(/frequency/i).fill('od');
+    await form.getByText('Once daily', { exact: true }).click();
   });
 
   await test.step('And I set the frequency to `bd`', async () => {
-    await page.getByPlaceholder(/frequency/i).clear();
-    await page.getByPlaceholder(/frequency/i).fill('bd');
-    await page.getByText('Twice daily', { exact: true }).click();
+    await form.getByPlaceholder(/frequency/i).clear();
+    await form.getByPlaceholder(/frequency/i).fill('bd');
+    await form.getByText('Twice daily', { exact: true }).click();
   });
 
   await test.step('And I change the indication to `Hypertension`', async () => {
-    await page.getByLabel(/indication/i).clear();
-    await page.getByLabel(/indication/i).fill('Hypertension');
+    await form.getByLabel(/indication/i).clear();
+    await form.getByLabel(/indication/i).fill('Hypertension');
   });
 
   await test.step('And I click on the `Save Order` button', async () => {
-    await page.getByRole('button', { name: /save order/i }).click();
+    await form.getByRole('button', { name: /save order/i }).click();
   });
 
   await test.step('Then the order status should be changed to `Modify`', async () => {
-    await expect(page.getByText(/new/i)).not.toBeVisible();
-    await expect(page.getByText(/modify/i)).toBeVisible();
+    await expect(orderBasket.getByText(/new/i)).not.toBeVisible();
+    await expect(orderBasket.getByText(/modify/i)).toBeVisible();
   });
 
   await test.step('When I click on the `Sign and close` button', async () => {
@@ -212,7 +214,7 @@ test('Record, edit and discontinue a drug order', async ({ page }) => {
   });
 
   await test.step('Then the order status should be changed to `Discontinue`', async () => {
-    await expect(page.getByText(/discontinue/i)).toBeVisible();
+    await expect(orderBasket.getByText(/discontinue/i)).toBeVisible();
   });
 
   await test.step('And I click on the `Sign and close` button', async () => {

--- a/e2e/specs/results-viewer.spec.ts
+++ b/e2e/specs/results-viewer.spec.ts
@@ -273,13 +273,15 @@ test('Record and edit test results', async ({ page }) => {
     for (const { resultsPageReference, value } of completeBloodCountData) {
       await test.step(resultsPageReference, async () => {
         const row = page.locator(`tr:has-text("${resultsPageReference}")`);
-        await expect(row).toContainText(value);
+        const valueCell = row.locator('td:nth-child(2)');
+        await expect(valueCell).toContainText(value);
       });
     }
     for (const { resultsPageReference, value } of chemistryResultsData) {
       await test.step(resultsPageReference, async () => {
         const row = page.locator(`tr:has-text("${resultsPageReference}")`);
-        await expect(row).toContainText(value);
+        const valueCell = row.locator('td:nth-child(2)');
+        await expect(valueCell).toContainText(value);
       });
     }
   });
@@ -346,13 +348,15 @@ test('Record and edit test results', async ({ page }) => {
     for (const { resultsPageReference, updatedValue } of completeBloodCountData) {
       await test.step(resultsPageReference, async () => {
         const row = page.locator(`tr:has-text("${resultsPageReference}")`);
-        await expect(row).toContainText(updatedValue);
+        const valueCell = row.locator('td:nth-child(2)');
+        await expect(valueCell).toContainText(updatedValue);
       });
     }
     for (const { resultsPageReference, updatedValue } of chemistryResultsData) {
       await test.step(resultsPageReference, async () => {
         const row = page.locator(`tr:has-text("${resultsPageReference}")`);
-        await expect(row).toContainText(updatedValue);
+        const valueCell = row.locator('td:nth-child(2)');
+        await expect(valueCell).toContainText(updatedValue);
       });
     }
   });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR addresses the flakiness in the following two E2E tests:

### Lab Results:

Issue: The test compared values from table rows instead of individual cells. This caused random test failures based on rendering differences and could produce false positives as rows include reference values.
Fix: Updated the test to compare values within specific cells, ensuring accurate and consistent validation.

### Drug Orders:

Issue: The test asserted values to be present anywhere on the page, leading to failures due to word duplication. For instance, the drug name appears twice on the modify drug order form if the user scrolls, causing the test to fail when the view is slightly scrolled.
Fix: Modified the test to assert values within specific sub-elements, preventing false failures due to duplicate display of drug names.

This update ensures more reliable and accurate E2E tests by refining the assertions to target precise elements.
