### PR TITLE
(test) O3-3361: E2E test that data isn't lost when opening a workspace from another workspace

### DIFF
--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -66,11 +66,11 @@ test('Fill a clinical form', async ({ page }) => {
     await page.getByLabel(/plan/i).fill(plan);
   });
 
-  await test.step('If I click the `Order basket` button on the siderail', async () => {
+  await test.step('And I click the `Order basket` button on the siderail', async () => {
     await page.getByRole('button', { name: /order basket/i, exact: true }).click();
   });
 
-  await test.step('And I click the `Add +` button to order drugs ', async () => {
+  await test.step('And I click the `Add +` button to order drugs', async () => {
     await page.getByRole('button', { name: /add/i }).nth(1).click();
   });
 
@@ -78,7 +78,7 @@ test('Fill a clinical form', async ({ page }) => {
     await page.getByLabel(/clinical forms/i, { exact: true }).click();
   });
 
-  await test.step('Then I should see retained SOAP form inputs', async () => {
+  await test.step('Then I should see retained inputs in `Soap note template` form', async () => {
     await expect(page.getByText(subjectiveFindings)).toBeVisible();
     await expect(page.getByText(objectiveFindings)).toBeVisible();
     await expect(page.getByText(assessment)).toBeVisible();

--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -121,7 +121,6 @@ test('Fill a clinical form', async ({ page }) => {
 
 test('Form state is retained when moving between forms in the workspace', async ({ page }) => {
   const chartPage = new ChartPage(page);
-  const visitsPage = new VisitsPage(page);
 
   await test.step('When I visit the chart summary page', async () => {
     await chartPage.goTo(patient.uuid);

--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -66,25 +66,6 @@ test('Fill a clinical form', async ({ page }) => {
     await page.getByLabel(/plan/i).fill(plan);
   });
 
-  await test.step('And I click the `Order basket` button on the siderail', async () => {
-    await page.getByRole('button', { name: /order basket/i, exact: true }).click();
-  });
-
-  await test.step('And I click the `Add +` button to order drugs', async () => {
-    await page.getByRole('button', { name: /add/i }).nth(1).click();
-  });
-
-  await test.step('And I click the `Clinical forms` button on the siderail', async () => {
-    await page.getByLabel(/clinical forms/i, { exact: true }).click();
-  });
-
-  await test.step('Then I should see retained inputs in `Soap note template` form', async () => {
-    await expect(page.getByText(subjectiveFindings)).toBeVisible();
-    await expect(page.getByText(objectiveFindings)).toBeVisible();
-    await expect(page.getByText(assessment)).toBeVisible();
-    await expect(page.getByText(plan)).toBeVisible();
-  });
-
   await test.step('And I click on the `Save and close` button', async () => {
     await page.getByRole('button', { name: /save/i }).click();
   });

--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -100,6 +100,53 @@ test('Fill a clinical form', async ({ page }) => {
   });
 });
 
+test('Form state is retained when moving between forms in the workspace', async ({ page }) => {
+  const chartPage = new ChartPage(page);
+  const visitsPage = new VisitsPage(page);
+
+  await test.step('When I visit the chart summary page', async () => {
+    await chartPage.goTo(patient.uuid);
+  });
+
+  await test.step('And I click the `Clinical forms` button on the siderail', async () => {
+    await page.getByLabel(/clinical forms/i, { exact: true }).click();
+  });
+
+  await test.step('Then I should see `Soap note template` listed in the clinical forms workspace', async () => {
+    await expect(page.getByRole('cell', { name: /soap note template/i, exact: true })).toBeVisible();
+  });
+
+  await test.step('When I click the `Soap note template` link to launch the form', async () => {
+    await page.getByText(/soap note template/i).click();
+  });
+
+  await test.step('Then I should see the `Soap note template` form launch in the workspace', async () => {
+    await expect(page.getByText(/soap note template/i)).toBeVisible();
+  });
+
+  await test.step('When I fill the `Subjective findings` and `Objective findings` questions', async () => {
+    await page.getByLabel(/subjective Findings/i).fill(subjectiveFindings);
+    await page.getByLabel(/objective findings/i).fill(objectiveFindings);
+  });
+
+  await test.step('And I click the `Order basket` button on the siderail', async () => {
+    await page.getByRole('button', { name: /order basket/i, exact: true }).click();
+  });
+
+  await test.step('And I click the `Add +` button to order drugs', async () => {
+    await page.getByRole('button', { name: /add/i }).nth(1).click();
+  });
+
+  await test.step('And I click the `Clinical forms` button on the siderail', async () => {
+    await page.getByLabel(/clinical forms/i, { exact: true }).click();
+  });
+
+  await test.step('Then I should see retained inputs in `Soap note template` form', async () => {
+    await expect(page.getByText(subjectiveFindings)).toBeVisible();
+    await expect(page.getByText(objectiveFindings)).toBeVisible();
+  });
+});
+
 test.afterEach(async ({ api }) => {
   await endVisit(api, visit.uuid);
   await deletePatient(api, patient.uuid);

--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -66,6 +66,25 @@ test('Fill a clinical form', async ({ page }) => {
     await page.getByLabel(/plan/i).fill(plan);
   });
 
+  await test.step('If I click the `Order basket` button on the siderail', async () => {
+    await page.getByRole('button', { name: /order basket/i, exact: true }).click();
+  });
+
+  await test.step('And I click the `Add +` button to order drugs ', async () => {
+    await page.getByRole('button', { name: /add/i }).nth(1).click();
+  });
+
+  await test.step('And I click the `Clinical forms` button on the siderail', async () => {
+    await page.getByLabel(/clinical forms/i, { exact: true }).click();
+  });
+
+  await test.step('Then I should see retained SOAP form inputs', async () => {
+    await expect(page.getByText(subjectiveFindings)).toBeVisible();
+    await expect(page.getByText(objectiveFindings)).toBeVisible();
+    await expect(page.getByText(assessment)).toBeVisible();
+    await expect(page.getByText(plan)).toBeVisible();
+  });
+
   await test.step('And I click on the `Save and close` button', async () => {
     await page.getByRole('button', { name: /save/i }).click();
   });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR is an additional test steps in `clinical-forms.spec` to ensure form inputs are retained when navigating in and out of different workspaces.


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-3361