### PR TITLE
(chore) Add remote caching to E2E workflow using turborepo-gh-artifacts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+env:
+  TURBO_API: 'http://127.0.0.1:9080'
+  TURBO_TOKEN: ${{ secrets.TURBO_SERVER_TOKEN }}
+  TURBO_TEAM: ${{ github.repository_owner }}
+
 jobs:
   run_e2e_tests:
     runs-on: ubuntu-latest
@@ -37,6 +42,12 @@ jobs:
 
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps
+
+      - name: Setup local cache server for Turborepo
+        uses: felixmosh/turborepo-gh-artifacts@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: ${{ env.TURBO_TOKEN }}
 
       - name: Build apps
         run: yarn turbo run build --color --concurrency=5


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR integrates [remote caching](https://turbo.build/repo/docs/core-concepts/remote-caching) into the E2E workflow using the [turborepo-gh-artifacts](https://github.com/felixmosh/turborepo-gh-artifacts/tree/v3/) GitHub Action. Presently, the [build job](https://github.com/openmrs/openmrs-esm-patient-chart/blob/70290b7a1a9198abdf1cefcce1bcc223b1bf6ca9/.github/workflows/e2e.yml#L52) takes approximately [7 minutes](https://github.com/openmrs/openmrs-esm-patient-chart/actions/workflows/e2e.yml) to run. With this addition, subsequent build jobs will be faster as GitHub Actions can cache and reuse artifacts from previous runs. 

This update brings the E2E workflow in line with our other [workflows](https://github.com/openmrs/openmrs-esm-patient-chart/tree/main/.github/workflows) that already utilize remote caching for incrementally faster builds.

## Screenshots

First run with remote caching enabled (7 seconds)

![CleanShot 2024-07-02 at 12  30 03@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/8ec800c1-fac2-4f5a-87bf-8a7586b7278b)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
