### PR TITLE
(test) Fix flaky Lab order E2E test

### DIFF
--- a/e2e/specs/lab-orders.spec.ts
+++ b/e2e/specs/lab-orders.spec.ts
@@ -14,6 +14,7 @@ test.beforeEach(async ({ api }) => {
 
 test('Record a lab order', async ({ page }) => {
   const ordersPage = new OrdersPage(page);
+  const orderBasket = page.locator('[data-extension-slot-name="order-basket-slot"]');
 
   await test.step('When I visit the orders page', async () => {
     await ordersPage.goTo(patient.uuid);
@@ -24,7 +25,7 @@ test('Record a lab order', async ({ page }) => {
   });
 
   await test.step('And I click the `Add +` button on the Lab orders tile', async () => {
-    await page.getByRole('button', { name: /add/i }).nth(1).click();
+    await orderBasket.getByRole('button', { name: /add/i }).nth(1).click();
   });
 
   await test.step('Then I type `Blood urea nitrogen` into the search bar', async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The lab order sometimes fails because it often confused because it counts the "Add patient" button as a valid button [here](https://github.com/openmrs/openmrs-esm-patient-chart/blob/9c85e0cb55a8c571ec581fed016500c962f39eff/e2e/specs/lab-orders.spec.ts#L27)
<img width="402" alt="image" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/33048395/0898f7f7-5951-4a7b-92ab-4a6dd78501ff">

ex: https://github.com/openmrs/openmrs-distro-referenceapplication/actions/runs/9764028376/job/26952668158

The scope for looking at buttons is narrowed down with this PR. 
