### PR TITLE
(fix) O3-3547: Handle possibly undefined encounter.obs in LabResultsForm

### DIFF
--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
@@ -39,20 +39,27 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
     defaultValues: {},
   });
 
-  if (!isLoadingEncounter && encounter?.obs.length > 0 && !isEditing) {
-    setObsUuid(encounter.obs.find((obs) => obs.order?.uuid === order.uuid).uuid);
-    setIsEditing(true);
-  }
-
-  if (isEditing && !obsUuid) {
-    setIsLoadingInitialValues(true);
-    fetchObservation(obsUuid).then((data) => {
-      if (data) {
-        setInitialValues(data);
+  useEffect(() => {
+    if (!isLoadingEncounter && encounter?.obs && encounter.obs.length > 0 && !isEditing) {
+      const matchingObs = encounter.obs.find((obs) => obs.order?.uuid === order.uuid);
+      if (matchingObs) {
+        setObsUuid(matchingObs.uuid);
+        setIsEditing(true);
       }
-      setIsLoadingInitialValues(false);
-    });
-  }
+    }
+  }, [isLoadingEncounter, encounter, order.uuid, isEditing]);
+
+  useEffect(() => {
+    if (isEditing && obsUuid) {
+      setIsLoadingInitialValues(true);
+      fetchObservation(obsUuid).then((data) => {
+        if (data) {
+          setInitialValues(data);
+        }
+        setIsLoadingInitialValues(false);
+      });
+    }
+  }, [isEditing, obsUuid]);
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue in the `LabResultsForm` component where clicking the `Add results` button from the `OrderDetails` table overflow menu would sometimes fail to successfully launch the form. 

To remedy this, I've tweaked the logic so that the code that sets `obsUuid` and `isEditing` is in a useEffect hook. This ensures that we only try to access `encounter.obs`when it is available and not undefined. I've also moved the logic for fetching initial values into a separate useEffect hook that depends on `isEditing` and `obsUuid`.

## Screenshots

- This is a recording of the issue
[patient-orders-result-error.webm](https://github.com/openmrs/openmrs-esm-patient-chart/assets/39379012/a4301643-28a4-4dc3-8914-297d9df55cab)

- This is the recording after the fix
[fix-add-results.webm](https://github.com/openmrs/openmrs-esm-patient-chart/assets/39379012/2e0aafbc-7832-4119-83c7-6af3893b7ea6)

## Related Issue
[LINK TO JIRA TICKET](https://openmrs.atlassian.net/browse/O3-3547)

## Other
