### PR TITLE
(feat) Minor style tweak to order details table status pills

### DIFF
--- a/packages/esm-patient-orders-app/src/components/order-details-table.scss
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.scss
@@ -51,6 +51,7 @@
   background-color: colors.$gray-20;
   border-radius: spacing.$spacing-05;
   padding: spacing.$spacing-01;
+  padding-inline: spacing.$spacing-03;
   text-align: center;
 
   white-space: nowrap;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR introduces the `padding-inline` property to the `statusPill` class, enhancing the appearance of status pills in the order details table by adding padding to both the left and right sides. This also gets the custom status pills closer in terms of look and feel to the Carbon [Tag](https://react.carbondesignsystem.com/?path=/story/components-tag) component.

## Screenshots

### Before

![CleanShot 2024-07-09 at 8  26 32@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/c968f9ed-46c1-4c25-974f-0439d90de271)

### After

![CleanShot 2024-07-09 at 8  23 45@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/68958e3a-19d2-4da4-bcc6-0a892d83de9d)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
