### PR TITLE
(fix) O3-3571: Use `issued` property to determine when test results were issued

### DIFF
--- a/packages/esm-patient-labs-app/src/test-results/panel-timeline/index.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/panel-timeline/index.tsx
@@ -14,7 +14,7 @@ const PanelTimelineComponent: React.FC<PanelTimelineComponentProps> = ({ activeP
   const rows: Array<ObsRecord> = activePanel ? [activePanel, ...activePanel?.relatedObs] : [];
   const mappedObservations = Object.fromEntries(rows.map((obs) => [obs.name, groupedObservations[obs.conceptUuid]]));
   const allTimes = []
-    .concat(...Object.values(mappedObservations).map((obsRecords) => obsRecords.map((obs) => obs.effectiveDateTime)))
+    .concat(...Object.values(mappedObservations).map((obsRecords) => obsRecords.map((obs) => obs.issued)))
     .sort((time1, time2) => Date.parse(time2) - Date.parse(time1));
 
   const parsedTime = parseTime(allTimes);
@@ -22,7 +22,7 @@ const PanelTimelineComponent: React.FC<PanelTimelineComponentProps> = ({ activeP
   const timelineData: Record<string, Array<ObsRecord>> = Object.fromEntries(
     Object.entries(mappedObservations).map(([title, observations]) => [
       title,
-      allTimes.map((time) => observations.find((obs) => obs.effectiveDateTime === time)),
+      allTimes.map((time) => observations.find((obs) => obs.issued === time)),
     ]),
   );
   if (!activePanel) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This pull request updates the `PanelTimelineComponent` to use the `issued` property instead of `effectiveDateTime` for handling timestamps of observations, necessitated by the fact that the `issued` property is a more accurate reflector of the date and time in which the order results were submitted.

## Screenshots
<!-- Required if you are making UI changes. -->
Before: 
<img width="1722" alt="Screenshot 2024-07-11 at 13 11 14" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/51090527/b8dc8f8d-265f-4d34-b007-18c332735d31">

After:
<img width="1722" alt="Screenshot 2024-07-11 at 13 02 02" src="https://github.com/openmrs/openmrs-esm-patient-chart/assets/51090527/9dff8fff-73ae-49b9-b782-fbc4bf5daca2">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3571
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
