### PR TITLE
(fix) O3-3609: Fix program enrollment eligibility logic

### DIFF
--- a/packages/esm-patient-programs-app/src/config-schema.ts
+++ b/packages/esm-patient-programs-app/src/config-schema.ts
@@ -8,6 +8,5 @@ export const configSchema = {
 };
 
 export interface ConfigObject {
-  customUrl: string;
   hideAddProgramButton: boolean;
 }

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -105,6 +105,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
           <span>{isValidating ? <InlineLoading /> : null}</span>
           {hideAddProgramButton ? null : (
             <Button
+              disabled={isEnrolledInAllPrograms}
               kind="ghost"
               renderIcon={(props) => <Add size={16} {...props} />}
               iconDescription={t('addPrograms', 'Add programs')}

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.scss
@@ -1,4 +1,4 @@
-@import '@openmrs/esm-styleguide/src/vars';
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .widgetCard {
   border: 1px solid $ui-03;

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
@@ -88,6 +88,7 @@ describe('ProgramsDetailedSummary', () => {
     expect(editButton).toBeInTheDocument();
 
     // Clicking "Add" launches the programs form in a workspace
+    expect(addButton).toBeEnabled();
     await user.click(addButton);
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace');
@@ -111,6 +112,7 @@ describe('ProgramsDetailedSummary', () => {
     expect(screen.getByRole('row', { name: /hiv care and treatment/i })).toBeInTheDocument();
     expect(screen.getByRole('row', { name: /hiv differentiated care/i })).toBeInTheDocument();
     expect(screen.getByRole('row', { name: /oncology screening and diagnosis/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add/i })).toBeDisabled();
     expect(screen.getByText(/enrolled in all programs/i)).toBeInTheDocument();
     expect(screen.getByText(/there are no more programs left to enroll this patient in/i)).toBeInTheDocument();
   });

--- a/packages/esm-patient-programs-app/src/programs/programs-form.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.scss
@@ -1,5 +1,5 @@
-@use '@carbon/styles/scss/type';
-@use '@carbon/styles/scss/spacing';
+@use '@carbon/type';
+@use '@carbon/layout';
 @import '@openmrs/esm-styleguide/src/vars';
 
 .loading {
@@ -42,6 +42,12 @@
 
 .errorMessage {
   @include type.type-style("label-02");
-  margin-top: spacing.$spacing-03;
+  margin-top: layout.$spacing-03;
   color: $danger;
+}
+
+.notification {
+  margin: 0;
+  min-width: 100%;
+  padding: 0;
 }

--- a/packages/esm-patient-programs-app/src/programs/programs-form.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.scss
@@ -1,6 +1,6 @@
 @use '@carbon/type';
 @use '@carbon/layout';
-@import '@openmrs/esm-styleguide/src/vars';
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .loading {
   margin-left: 1rem;

--- a/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
@@ -74,15 +74,6 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
         return !enrollment || enrollment.dateCompleted !== null;
       });
 
-  const isEnrolledInAllPrograms = useMemo(() => {
-    if (!availablePrograms?.length || !enrollments?.length) {
-      return false;
-    }
-
-    const activeEnrollments = enrollments.filter((enrollment) => !enrollment.dateCompleted);
-    return activeEnrollments.length === availablePrograms.length;
-  }, [availablePrograms, enrollments]);
-
   const getLocationUuid = () => {
     if (!currentEnrollment?.location.uuid && session?.sessionLocation?.uuid) {
       return session?.sessionLocation?.uuid;
@@ -276,14 +267,6 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
   return (
     <Form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
       <Stack className={styles.formContainer} gap={7}>
-        {isEnrolledInAllPrograms && (
-          <InlineNotification
-            className={styles.notification}
-            lowContrast
-            subtitle={t('noEligibleEnrollments', 'There are no more programs left to enroll this patient in')}
-            title={t('fullyEnrolled', 'Enrolled in all programs')}
-          />
-        )}
         {!availablePrograms.length && (
           <InlineNotification
             className={styles.notification}

--- a/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { type TFunction, useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
-import filter from 'lodash-es/filter';
-import includes from 'lodash-es/includes';
-import map from 'lodash-es/map';
 import {
   Button,
   ButtonSet,
@@ -72,7 +69,19 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
 
   const eligiblePrograms = currentProgram
     ? [currentProgram]
-    : filter(availablePrograms, (program) => !includes(map(enrollments, 'program.uuid'), program.uuid));
+    : availablePrograms.filter((program) => {
+        const enrollment = enrollments.find((e) => e.program.uuid === program.uuid);
+        return !enrollment || enrollment.dateCompleted !== null;
+      });
+
+  const isEnrolledInAllPrograms = useMemo(() => {
+    if (!availablePrograms?.length || !enrollments?.length) {
+      return false;
+    }
+
+    const activeEnrollments = enrollments.filter((enrollment) => !enrollment.dateCompleted);
+    return activeEnrollments.length === availablePrograms.length;
+  }, [availablePrograms, enrollments]);
 
   const getLocationUuid = () => {
     if (!currentEnrollment?.location.uuid && session?.sessionLocation?.uuid) {
@@ -243,7 +252,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
 
   const formGroups = [
     {
-      style: { maxWidth: isTablet ? '50%' : 'fit-content' },
+      style: { maxWidth: isTablet && '50%' },
       legendText: '',
       value: programSelect,
     },
@@ -267,10 +276,18 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
   return (
     <Form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
       <Stack className={styles.formContainer} gap={7}>
-        {!eligiblePrograms.length && (
+        {isEnrolledInAllPrograms && (
           <InlineNotification
-            style={{ minWidth: '100%', margin: '0rem', padding: '0rem' }}
-            kind={'error'}
+            className={styles.notification}
+            lowContrast
+            subtitle={t('noEligibleEnrollments', 'There are no more programs left to enroll this patient in')}
+            title={t('fullyEnrolled', 'Enrolled in all programs')}
+          />
+        )}
+        {!availablePrograms.length && (
+          <InlineNotification
+            className={styles.notification}
+            kind="error"
             lowContrast
             subtitle={t('configurePrograms', 'Please configure programs to continue.')}
             title={t('noProgramsConfigured', 'No programs configured')}

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.scss
@@ -1,4 +1,4 @@
-@import '@openmrs/esm-styleguide/src/vars';
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .widgetCard {
   border: 1px solid $ui-03;

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
@@ -3,8 +3,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { mockEnrolledProgramsResponse } from '__mocks__';
-
+import { mockCareProgramsResponse, mockEnrolledInAllProgramsResponse, mockEnrolledProgramsResponse } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import ProgramsOverview from './programs-overview.component';
 
@@ -81,9 +80,26 @@ describe('ProgramsOverview', () => {
     expect(screen.getByRole('row', { name: /HIV Care and Treatment/i })).toBeInTheDocument();
 
     // Clicking "Add" launches the programs form in a workspace
+    expect(addButton).toBeEnabled();
     await user.click(addButton);
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace');
+  });
+
+  it('renders a notification when the patient is enrolled in all available programs', async () => {
+    mockOpenmrsFetch.mockReturnValueOnce({ data: { results: mockEnrolledInAllProgramsResponse } });
+    mockOpenmrsFetch.mockReturnValueOnce({ data: { results: mockCareProgramsResponse } });
+
+    renderProgramsOverview();
+
+    await waitForLoadingToFinish();
+
+    expect(screen.getByRole('row', { name: /hiv care and treatment/i })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: /hiv differentiated care/i })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: /oncology screening and diagnosis/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add/i })).toBeDisabled();
+    expect(screen.getByText(/enrolled in all programs/i)).toBeInTheDocument();
+    expect(screen.getByText(/there are no more programs left to enroll this patient in/i)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

The logic determining patient eligibility for program enrollment needs refinement. This PR addresses the following adjustments:

1. **Enrollment Warning:**

   - Display a warning at the top of the form when attempting to enroll a patient already enrolled in all available programs by clicking the "Add" button.
   - Ensure the warning clearly indicates that the patient is already enrolled in all available programs.

2. **No Programs Configured Warning:**

   - Ensure the "No programs configured" warning is shown only when no programs are found after requesting available programs from the backend.
   - Ensure the patient’s enrollment status does not affect this warning.

### Changes Implemented

- Updated the logic to display a clear warning message when a patient is enrolled in all available programs.
- Modified the condition to display the "No programs configured" warning based solely on the backend response, irrespective of the patient's current enrollments.

## Screenshots

### Current behaviour

https://github.com/user-attachments/assets/8d6d57a5-29ad-417b-9684-78ce4d44f922

### After the fix

https://github.com/user-attachments/assets/8a6521e0-7f3e-4679-8b6b-0eed5ed01d0e

## Related Issue

https://openmrs.atlassian.net/browse/O3-3609

## Other
<!-- Anything not covered above -->
