### PR TITLE
Revert "(fix) O3-3571: Use `issued` property to determine when test results were issued"

### DIFF
--- a/packages/esm-patient-labs-app/src/test-results/panel-timeline/index.tsx
+++ b/packages/esm-patient-labs-app/src/test-results/panel-timeline/index.tsx
@@ -14,7 +14,7 @@ const PanelTimelineComponent: React.FC<PanelTimelineComponentProps> = ({ activeP
   const rows: Array<ObsRecord> = activePanel ? [activePanel, ...activePanel?.relatedObs] : [];
   const mappedObservations = Object.fromEntries(rows.map((obs) => [obs.name, groupedObservations[obs.conceptUuid]]));
   const allTimes = []
-    .concat(...Object.values(mappedObservations).map((obsRecords) => obsRecords.map((obs) => obs.issued)))
+    .concat(...Object.values(mappedObservations).map((obsRecords) => obsRecords.map((obs) => obs.effectiveDateTime)))
     .sort((time1, time2) => Date.parse(time2) - Date.parse(time1));
 
   const parsedTime = parseTime(allTimes);
@@ -22,7 +22,7 @@ const PanelTimelineComponent: React.FC<PanelTimelineComponentProps> = ({ activeP
   const timelineData: Record<string, Array<ObsRecord>> = Object.fromEntries(
     Object.entries(mappedObservations).map(([title, observations]) => [
       title,
-      allTimes.map((time) => observations.find((obs) => obs.issued === time)),
+      allTimes.map((time) => observations.find((obs) => obs.effectiveDateTime === time)),
     ]),
   );
   if (!activePanel) {


### PR DESCRIPTION
Reverts openmrs/openmrs-esm-patient-chart#1907

Per https://github.com/openmrs/openmrs-esm-patient-chart/pull/1907#issuecomment-2233821634

Thanks for catching that, @ibacher 