### PR TITLE
(fix) O3-3573: The Modify order action should take one to modify the order

### DIFF
--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -50,7 +50,6 @@ import {
   usePatient,
   PrinterIcon,
   AddIcon,
-  closeWorkspace,
 } from '@openmrs/esm-framework';
 import { buildLabOrder, buildMedicationOrder } from '../utils';
 import MedicationRecord from './medication-record.component';
@@ -475,11 +474,8 @@ function OrderBasketItemActions({
   const isTablet = useLayoutType() === 'tablet';
   const alreadyInBasket = items.some((x) => x.uuid === orderItem.uuid);
 
-  const openEditLabForm = useCallback((order: OrderBasketItem) => {
-    closeWorkspace('order-basket', {
-      ignoreChanges: true,
-      onWorkspaceClose: () => launchPatientWorkspace('add-lab-order', { order }),
-    });
+  const openLabOrderForm = useCallback((order: OrderBasketItem) => {
+    launchPatientWorkspace('add-lab-order', { order });
   }, []);
 
   const handleModifyClick = useCallback(() => {
@@ -492,9 +488,9 @@ function OrderBasketItemActions({
       });
     } else {
       const labItem = buildLabOrder(orderItem, 'REVISE');
-      openEditLabForm(labItem);
+      openLabOrderForm(labItem);
     }
-  }, [orderItem, openOrderForm, openEditLabForm, items, setOrderItems]);
+  }, [orderItem, openOrderForm, openLabOrderForm, items, setOrderItems]);
 
   const handleAddResultsClick = useCallback(() => {
     launchPatientWorkspace('test-results-form-workspace', { order: orderItem });

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -83,6 +83,9 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
   const isTablet = useLayoutType() === 'tablet';
   const launchOrderBasket = useLaunchWorkspaceRequiringVisit('order-basket');
   const launchAddDrugOrder = useLaunchWorkspaceRequiringVisit('add-drug-order');
+  const launchModifyLabOrder = useCallback((order: OrderBasketItem) => {
+    launchPatientWorkspace('add-lab-order', { order });
+  }, []);
   const contentToPrintRef = useRef(null);
   const patient = usePatient(patientUuid);
   const { excludePatientIdentifierCodeTypes } = useConfig();
@@ -106,11 +109,14 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
         case 'drugorder':
           launchAddDrugOrder();
           break;
+        case 'testorder':
+          launchModifyLabOrder(buildLabOrder(orderItem, 'REVISE'));
+          break;
         default:
           launchOrderBasket();
       }
     },
-    [launchAddDrugOrder, launchOrderBasket],
+    [launchAddDrugOrder, launchModifyLabOrder, launchOrderBasket],
   );
 
   const tableHeaders: Array<OrderHeaderProps> = [
@@ -474,10 +480,6 @@ function OrderBasketItemActions({
   const isTablet = useLayoutType() === 'tablet';
   const alreadyInBasket = items.some((x) => x.uuid === orderItem.uuid);
 
-  const openLabOrderForm = useCallback((order: OrderBasketItem) => {
-    launchPatientWorkspace('add-lab-order', { order });
-  }, []);
-
   const handleModifyClick = useCallback(() => {
     if (orderItem.type === 'drugorder') {
       getDrugOrderByUuid(orderItem.uuid).then((res) => {
@@ -488,9 +490,9 @@ function OrderBasketItemActions({
       });
     } else {
       const labItem = buildLabOrder(orderItem, 'REVISE');
-      openLabOrderForm(labItem);
+      openOrderForm({ order: labItem });
     }
-  }, [orderItem, openOrderForm, openLabOrderForm, items, setOrderItems]);
+  }, [orderItem, openOrderForm, items, setOrderItems]);
 
   const handleAddResultsClick = useCallback(() => {
     launchPatientWorkspace('test-results-form-workspace', { order: orderItem });

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -83,9 +83,7 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
   const isTablet = useLayoutType() === 'tablet';
   const launchOrderBasket = useLaunchWorkspaceRequiringVisit('order-basket');
   const launchAddDrugOrder = useLaunchWorkspaceRequiringVisit('add-drug-order');
-  const launchModifyLabOrder = useCallback((order: OrderBasketItem) => {
-    launchPatientWorkspace('add-lab-order', { order });
-  }, []);
+  const launchModifyLabOrder = useLaunchWorkspaceRequiringVisit('add-lab-order');
   const contentToPrintRef = useRef(null);
   const patient = usePatient(patientUuid);
   const { excludePatientIdentifierCodeTypes } = useConfig();
@@ -110,7 +108,7 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
           launchAddDrugOrder();
           break;
         case 'testorder':
-          launchModifyLabOrder(buildLabOrder(orderItem, 'REVISE'));
+          launchModifyLabOrder({ order: buildLabOrder(orderItem, 'REVISE') });
           break;
         default:
           launchOrderBasket();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, when, in the Orders view of the patient chart, you select “Modify order“, it takes you to the Add lab order view of the order basket with all lab tests.  Instead, it should take you to this screen, i.e., where I can actually modify the order.

## Screenshots

https://github.com/user-attachments/assets/cc909e95-66d9-472a-abf9-dad50ef4653c

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
