### PR TITLE
(test) Remove unnecessary partial mocks; improve typing in tests

### DIFF
--- a/__mocks__/patient-flags.mock.ts
+++ b/__mocks__/patient-flags.mock.ts
@@ -1,20 +1,47 @@
 export const mockPatientFlags = [
   {
-    uuid: '8ca6c08f-66d9-4a18-a233-4f658b1755bf',
-    flag: { display: 'Needs Follow Up' },
+    auditInfo: { dateCreated: '2024-03-01T00:00:00.000Z' },
+    flag: { display: 'Needs Follow Up', uuid: '98ca6c08f-66d9-4a18-a233-4f658b1755bf' },
     message: 'Patient needs to be followed up',
-    tags: [{ display: 'flag tag - risk' }, { display: 'flag type - Social' }],
+    patient: {
+      uuid: '8ca6c08f-66d9-4a18-a233-4f658b1755bf',
+      display: 'John Doe',
+    },
+    tags: [
+      { display: 'flag tag - risk', uuid: 'some-uuid' },
+      { display: 'flag type - Social', uuid: 'some-other-uuid' },
+    ],
+    uuid: '8ca6c08f-66d9-4a18-a233-4f658b1755bf',
+    voided: false,
   },
   {
-    uuid: '5fs6c08f-66d9-4a18-a233-5f658b1755bf',
-    flag: { display: 'Unknown Diagnosis' },
+    auditInfo: { dateCreated: '2024-03-01T00:00:00.000Z' },
+    flag: { display: 'Unknown Diagnosis', uuid: 'a4a4c08f-66d9-4a18-a233-5f658b1755bf' },
     message: 'Diagnosis for the patient is unknown',
-    tags: [{ display: 'flag tag - info' }, { display: 'flag type - Clinical' }],
+    patient: {
+      uuid: '8ca6c08f-66d9-4a18-a233-4f658b1755bf',
+      display: 'John Doe',
+    },
+    tags: [
+      { display: 'flag tag - info', uuid: 'another-uuid' },
+      { display: 'flag type - Clinical', uuid: 'yet-another-uuid' },
+    ],
+    uuid: '5fs6c08f-66d9-4a18-a233-5f658b1755bf',
+    voided: false,
   },
   {
-    uuid: '4da4c08f-66d9-4a18-a233-5f658b1755bf',
-    flag: { display: 'Future Appointment' },
+    auditInfo: { dateCreated: '2024-03-01T00:00:00.000Z' },
+    flag: { display: 'Future Appointment', uuid: 'cc6c08f-66d9-4a18-a233-5f658b1755bf' },
     message: 'Patient has a future appointment scheduled',
-    tags: [{ display: 'flag tag - info' }, { display: 'flag type - Clinical' }],
+    patient: {
+      uuid: '8ca6c08f-66d9-4a18-a233-4f658b1755bf',
+      display: 'John Doe',
+    },
+    tags: [
+      { display: 'flag tag - info', uuid: 'one-more-uuid' },
+      { display: 'flag type - Clinical', uuid: 'yet-one-more-uuid' },
+    ],
+    uuid: '4da4c08f-66d9-4a18-a233-5f658b1755bf',
+    voided: false,
   },
 ];

--- a/__mocks__/session.mock.ts
+++ b/__mocks__/session.mock.ts
@@ -60,6 +60,7 @@ export const mockSessionDataResponse = {
       address13: null,
       address14: null,
       address15: null,
+      links: [],
     },
     user: {
       uuid: '45ce6c2e-dd5a-11e6-9d9c-0242ac150002',
@@ -77,31 +78,40 @@ export const mockSessionDataResponse = {
         {
           uuid: '62431c71-5244-11ea-a771-0242ac160002',
           display: 'Manage Appointment Services',
+          links: [],
         },
         {
           uuid: '6206682c-5244-11ea-a771-0242ac160002',
           display: 'Manage Appointments',
+          links: [],
         },
         {
           uuid: '6280ff58-5244-11ea-a771-0242ac160002',
           display: 'Manage Appointment Specialities',
+          links: [],
         },
       ],
       roles: [
         {
           uuid: '8d94f852-c2cc-11de-8d13-0010c6dffd0f',
           display: 'System Developer',
+          links: [],
         },
         {
           uuid: '62c195c5-5244-11ea-a771-0242ac160002',
           display: 'Bahmni Role',
+          links: [],
         },
         {
           uuid: '8d94f280-c2cc-11de-8d13-0010c6dffd0f',
           display: 'Provider',
+          links: [],
         },
       ],
       retired: false,
+      locale: 'en_GB',
+      allowedLocales: ['en_GB'],
     },
+    sessionId: 'D4F7D4D4-6A6D-4D4D-8D4D-4D4D4D4D4D4D',
   },
 };

--- a/__mocks__/visits.mock.ts
+++ b/__mocks__/visits.mock.ts
@@ -51,7 +51,7 @@ export const mockCurrentVisit = {
     display: 'Facility Visit',
   },
   attributes: [],
-  startDatetime: new Date('2021-03-16T08:16:00.000+0000'),
+  startDatetime: new Date('2021-03-16T08:16:00.000+0000').toISOString(),
   stopDatetime: null,
   location: {
     uuid: '6351fcf4-e311-4a19-90f9-35667d99a8af',

--- a/__mocks__/vitals-and-biometrics.mock.ts
+++ b/__mocks__/vitals-and-biometrics.mock.ts
@@ -5985,12 +5985,12 @@ export const mockFhirVitalsResponse = {
 };
 
 export const mockBiometricsConfig = {
-  biometrics: { bmiUnit: 'kg / m²' },
   concepts: { heightUuid: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', weightUuid: '5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+  biometrics: { bmiUnit: 'kg / m²' },
 };
 
 export const mockVitalsConfig = {
-  biometrics: { bmiUnit: 'kg / m²' },
+  biometrics: { bmiUnit: 'kg / m²', heightUnit: 'm', weightUnit: 'kg' },
   concepts: {
     diastolicBloodPressureUuid: '5086AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     generalPatientNoteUuid: '165095AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
@@ -6005,8 +6005,12 @@ export const mockVitalsConfig = {
   },
   vitals: {
     encounterTypeUuid: '67a71486-1a54-468f-ac3e-7091a9a79584',
-    formUuid: 'a000cb34-9ec1-4344-a1c8-f692232f6edd',
+    formUuid: '9f26aad4-244a-46ca-be49-1196df1a8c9a',
     useFormEngine: false,
+    logo: null,
+    showPrintButton: false,
+    formName: 'Vitals',
+    useMuacColors: false,
   },
 };
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@
 const path = require('path');
 
 module.exports = {
+  clearMocks: true,
   transform: {
     '^.+\\.(j|t)sx?$': '@swc/jest',
   },

--- a/packages/esm-form-engine-app/src/form-renderer/form-error.test.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-error.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import FormError from './form-error.component';
 
-const mocklaunchPatientWorkspace = launchPatientWorkspace as jest.Mock;
+const mocklaunchPatientWorkspace = jest.mocked(launchPatientWorkspace);
 
 jest.mock('@openmrs/esm-patient-common-lib', () => ({
   launchPatientWorkspace: jest.fn(),

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import FormRenderer from './form-renderer.component';
 import useFormSchema from '../hooks/useFormSchema';
 
-const mockUseFormSchema = useFormSchema as jest.Mock;
+const mockUseFormSchema = jest.mocked(useFormSchema);
 
 jest.mock('@openmrs/openmrs-form-engine-lib', () => ({
   FormEngine: jest
@@ -43,7 +43,9 @@ describe('FormRenderer', () => {
   });
 
   test('renders a form preview from the engine when a schema is available', async () => {
-    mockUseFormSchema.mockReturnValue({ schema: { id: 'test-schema' }, isLoading: false, error: null });
+    mockUseFormSchema.mockReturnValue({ schema: { uuid: 'test-schema' }, isLoading: false, error: null } as ReturnType<
+      typeof useFormSchema
+    >);
 
     render(<FormRenderer {...defaultProps} />);
     await expect(screen.getByText(/form engine lib/i)).toBeInTheDocument();

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -30,7 +30,7 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
   const { t } = useTranslation();
   const displayText = t('allergyIntolerances', 'allergy intolerances');
   const headerTitle = t('allergies', 'Allergies');
-  const { allergies, isError, isLoading, isValidating } = useAllergies(patient.id);
+  const { allergies, error, isLoading, isValidating } = useAllergies(patient.id);
   const layout = useLayoutType();
   const isTablet = layout === 'tablet';
   const isDesktop = layout === 'small-desktop' || layout === 'large-desktop';
@@ -61,7 +61,7 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
   }, [allergies]);
 
   if (isLoading) return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;
-  if (isError) return <ErrorState error={isError} headerTitle={headerTitle} />;
+  if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
   if (allergies?.length) {
     return (
       <div className={styles.widgetCard}>

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
@@ -12,7 +12,7 @@ const testProps = {
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 mockOpenmrsFetch.mockImplementation(jest.fn());
 
-describe('AllergiesDetailedSummary: ', () => {
+describe('AllergiesDetailedSummary', () => {
   it('renders an empty state view if allergy data is unavailable', async () => {
     mockOpenmrsFetch.mockReturnValueOnce({ data: { entry: [] } });
     renderAllergiesDetailedSummary();

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render, within } from '@testing-library/react';
-import { type FetchResponse, showSnackbar } from '@openmrs/esm-framework';
+import { type FetchResponse, showSnackbar, useConfig } from '@openmrs/esm-framework';
 import { mockAllergens, mockAllergicReactions } from '__mocks__';
 import { mockPatient } from 'tools';
 import {
@@ -20,6 +20,7 @@ const mockUseAllergens = useAllergens as jest.Mock;
 const mockUseAllergicReactions = useAllergicReactions as jest.Mock;
 const mockShowSnackbar = showSnackbar as jest.Mock;
 const mockUpdatePatientAllergy = updatePatientAllergy as jest.Mock;
+const mockUseConfig = useConfig as jest.Mock;
 
 jest.mock('./allergy-form.resource', () => {
   const originalModule = jest.requireActual('./allergy-form.resource');
@@ -48,24 +49,21 @@ mockUseAllergens.mockReturnValue({
   isLoading: false,
   allergens: mockAllergens,
 });
+
 mockUseAllergicReactions.mockReturnValue({
   isLoading: false,
   allergicReactions: mockAllergicReactions,
 });
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    openmrsFetch: jest.fn(),
-    useConfig: jest.fn().mockImplementation(() => ({
-      concepts: mockConcepts,
-    })),
-  };
-});
-
 describe('AllergyForm ', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseConfig.mockReturnValue({
+      concepts: mockConcepts,
+    });
+  });
+
   it('renders the allergy form with all the expected fields and values', async () => {
     renderAllergyForm();
     const user = userEvent.setup();

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
@@ -42,7 +42,7 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = ({ patient }) => {
   const isTablet = layout === 'tablet';
   const isDesktop = layout === 'small-desktop' || layout === 'large-desktop';
 
-  const { allergies, isError, isLoading, isValidating } = useAllergies(patient.id);
+  const { allergies, error, isLoading, isValidating } = useAllergies(patient.id);
   const { results: paginatedAllergies, goTo, currentPage } = usePagination(allergies ?? [], allergiesCount);
 
   const tableHeaders = [
@@ -68,7 +68,7 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = ({ patient }) => {
   const launchAllergiesForm = React.useCallback(() => launchPatientWorkspace(patientAllergiesFormWorkspace), []);
 
   if (isLoading) return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;
-  if (isError) return <ErrorState error={isError} headerTitle={headerTitle} />;
+  if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
   if (allergies?.length) {
     return (
       <div className={styles.widgetCard}>

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.test.tsx
@@ -12,7 +12,7 @@ const testProps = {
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
-describe('AllergiesOverview: ', () => {
+describe('AllergiesOverview', () => {
   it('renders an empty state view if allergy data is unavailable', async () => {
     mockOpenmrsFetch.mockReturnValueOnce({ data: [] });
     renderAllergiesOverview();

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.test.tsx
@@ -12,15 +12,6 @@ const testProps = {
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    attach: jest.fn(),
-  };
-});
-
 describe('AllergiesOverview: ', () => {
   it('renders an empty state view if allergy data is unavailable', async () => {
     mockOpenmrsFetch.mockReturnValueOnce({ data: [] });

--- a/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
+++ b/packages/esm-patient-allergies-app/src/allergies/allergy-intolerance.resource.ts
@@ -21,7 +21,7 @@ export type Allergy = {
 
 type UseAllergies = {
   allergies: Array<Allergy>;
-  isError: Error | null;
+  error: Error | null;
   isLoading: boolean;
   isValidating: boolean;
   mutate: () => void;
@@ -45,7 +45,7 @@ export function useAllergies(patientUuid: string): UseAllergies {
 
   return {
     allergies: data ? formattedAllergies : null,
-    isError: error,
+    error: error,
     isLoading,
     isValidating,
     mutate,

--- a/packages/esm-patient-allergies-app/src/config-schema.ts
+++ b/packages/esm-patient-allergies-app/src/config-schema.ts
@@ -12,6 +12,7 @@ export interface AllergiesConfigObject {
     otherConceptUuid: string;
   };
 }
+
 export const configSchema = {
   concepts: {
     drugAllergenUuid: {

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.test.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.test.tsx
@@ -3,10 +3,10 @@ import { render, screen } from '@testing-library/react';
 import AttachmentsOverview from './attachments-overview.component';
 import { useAttachments } from '@openmrs/esm-framework';
 
-const mockedUseAttachments = jest.mocked(useAttachments);
+const mockUseAttachments = jest.mocked(useAttachments);
 
 it('renders a loading skeleton when attachments are loading', () => {
-  mockedUseAttachments.mockReturnValue({
+  mockUseAttachments.mockReturnValue({
     data: [],
     error: null,
     isLoading: true,
@@ -21,7 +21,7 @@ it('renders a loading skeleton when attachments are loading', () => {
 });
 
 it('renders an empty state if attachments are not available', () => {
-  mockedUseAttachments.mockReturnValue({
+  mockUseAttachments.mockReturnValue({
     data: [],
     error: null,
     isLoading: false,

--- a/packages/esm-patient-banner-app/src/banner-tags/print-identifier-sticker-modal.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/print-identifier-sticker-modal.test.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { useReactToPrint } from 'react-to-print';
+import { useConfig } from '@openmrs/esm-framework';
 import { mockPatient } from 'tools';
 import PrintIdentifierSticker from './print-identifier-sticker.modal';
 
 const mockedCloseModal = jest.fn();
 const mockedUseReactToPrint = jest.mocked(useReactToPrint);
+const mockedUseConfig = jest.mocked(useConfig);
 
 jest.mock('react-to-print', () => {
   const originalModule = jest.requireActual('react-to-print');
@@ -17,18 +19,15 @@ jest.mock('react-to-print', () => {
   };
 });
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    useConfig: jest.fn().mockImplementation(() => ({
-      printIdentifierStickerFields: ['name', 'identifier', 'age', 'dateOfBirth', 'gender'],
-    })),
-  };
-});
-
 describe('PrintIdentifierSticker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedUseConfig.mockReturnValue({
+      printIdentifierStickerFields: ['name', 'identifier', 'age', 'dateOfBirth', 'gender'],
+    });
+  });
+
   test('renders the component', () => {
     renderPrintIdentifierSticker();
 
@@ -65,6 +64,7 @@ describe('PrintIdentifierSticker', () => {
     expect(handlePrint).toHaveBeenCalled();
   });
 });
+
 function renderPrintIdentifierSticker() {
   render(<PrintIdentifierSticker patient={mockPatient} closeModal={mockedCloseModal} />);
 }

--- a/packages/esm-patient-banner-app/src/banner-tags/print-identifier-sticker-modal.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/print-identifier-sticker-modal.test.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { useReactToPrint } from 'react-to-print';
-import { useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import { configSchema, type ConfigObject } from '../config-schema';
 import { mockPatient } from 'tools';
 import PrintIdentifierSticker from './print-identifier-sticker.modal';
 
-const mockedCloseModal = jest.fn();
-const mockedUseReactToPrint = jest.mocked(useReactToPrint);
-const mockedUseConfig = jest.mocked(useConfig);
+const mockCloseModal = jest.fn();
+const mockUseReactToPrint = jest.mocked(useReactToPrint);
+const mockUseConfig = jest.mocked<() => ConfigObject>(useConfig);
 
 jest.mock('react-to-print', () => {
   const originalModule = jest.requireActual('react-to-print');
@@ -19,15 +20,12 @@ jest.mock('react-to-print', () => {
   };
 });
 
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(configSchema),
+  printIdentifierStickerFields: ['name', 'identifier', 'age', 'dateOfBirth', 'gender'],
+});
+
 describe('PrintIdentifierSticker', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    mockedUseConfig.mockReturnValue({
-      printIdentifierStickerFields: ['name', 'identifier', 'age', 'dateOfBirth', 'gender'],
-    });
-  });
-
   test('renders the component', () => {
     renderPrintIdentifierSticker();
 
@@ -46,12 +44,12 @@ describe('PrintIdentifierSticker', () => {
     expect(cancelButton).toBeInTheDocument();
 
     await user.click(cancelButton);
-    expect(mockedCloseModal).toHaveBeenCalled();
+    expect(mockCloseModal).toHaveBeenCalled();
   });
 
   test('calls the print function when print button is clicked', async () => {
     const handlePrint = jest.fn();
-    mockedUseReactToPrint.mockReturnValue(handlePrint);
+    mockUseReactToPrint.mockReturnValue(handlePrint);
 
     const user = userEvent.setup();
 
@@ -66,5 +64,5 @@ describe('PrintIdentifierSticker', () => {
 });
 
 function renderPrintIdentifierSticker() {
-  render(<PrintIdentifierSticker patient={mockPatient} closeModal={mockedCloseModal} />);
+  render(<PrintIdentifierSticker patient={mockPatient} closeModal={mockCloseModal} />);
 }

--- a/packages/esm-patient-banner-app/src/banner-tags/visit-tag.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/visit-tag.test.tsx
@@ -1,33 +1,37 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { formatDatetime } from '@openmrs/esm-framework';
+import { formatDatetime, parseDate } from '@openmrs/esm-framework';
 import { useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
 import { mockCurrentVisit } from '__mocks__';
 import { mockPatient } from 'tools';
 import VisitTag from './visit-tag.extension';
 
-const mockUseVisitOrOfflineVisit = useVisitOrOfflineVisit as jest.Mock;
+const mockUseVisitOrOfflineVisit = jest.mocked(useVisitOrOfflineVisit);
 
 jest.mock('@openmrs/esm-patient-common-lib', () => ({
-  ...(jest.requireActual('@openmrs/esm-patient-common-lib') as any),
+  ...jest.requireActual('@openmrs/esm-patient-common-lib'),
   useVisitOrOfflineVisit: jest.fn(),
 }));
 
-describe('VisitBannerTag: ', () => {
+describe('VisitBannerTag', () => {
   it('renders an active visit tag when an active visit is ongoing', () => {
     mockUseVisitOrOfflineVisit.mockReturnValue({
       activeVisit: mockCurrentVisit,
       currentVisit: mockCurrentVisit,
       currentVisitIsRetrospective: false,
       error: null,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
     });
+
     const patient = { ...mockPatient, deceasedDateTime: null };
     render(<VisitTag patientUuid={mockPatient.id} patient={patient} />);
 
     const visitMetadata =
       mockCurrentVisit.visitType.display +
       ' Started: ' +
-      formatDatetime(mockCurrentVisit.startDatetime, { mode: 'wide' });
+      formatDatetime(parseDate(mockCurrentVisit.startDatetime), { mode: 'wide' });
 
     expect(
       screen.getByRole('tooltip', {
@@ -44,9 +48,15 @@ describe('VisitBannerTag: ', () => {
       currentVisit: mockCurrentVisit,
       currentVisitIsRetrospective: false,
       error: null,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
     });
+
     const patient = { ...mockPatient, deceasedDateTime: '2002-04-04' };
+
     render(<VisitTag patientUuid={mockPatient.id} patient={patient} />);
+
     expect(screen.queryByRole('button', { name: /Active Visit/i })).not.toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-chart-app/src/actions-buttons/add-past-visit.test.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/add-past-visit.test.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
-import AddPastVisitOverflowMenuItem from './add-past-visit.component';
-import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { screen, render } from '@testing-library/react';
 import { showModal } from '@openmrs/esm-framework';
+import AddPastVisitOverflowMenuItem from './add-past-visit.component';
 
-const mockShowModal = showModal as jest.Mock;
-
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-  return { originalModule, showModal: jest.fn() };
-});
+const mockShowModal = jest.mocked(showModal);
 
 describe('AddPastVisitOverflowMenuItem', () => {
-  it('should launch past visit prompt', async () => {
+  it('should launch the start past visit modal', async () => {
     const user = userEvent.setup();
 
     render(<AddPastVisitOverflowMenuItem />);
@@ -20,9 +15,14 @@ describe('AddPastVisitOverflowMenuItem', () => {
     const addPastVisitButton = screen.getByRole('menuitem', { name: /Add past visit/ });
     expect(addPastVisitButton).toBeInTheDocument();
 
-    // should launch the form
     await user.click(addPastVisitButton);
-
-    expect(mockShowModal).toHaveBeenCalled();
+    expect(mockShowModal).toHaveBeenCalledTimes(1);
+    expect(mockShowModal).toHaveBeenCalledWith(
+      'start-visit-dialog',
+      expect.objectContaining({
+        launchPatientChart: undefined,
+        patientUuid: undefined,
+      }),
+    );
   });
 });

--- a/packages/esm-patient-chart-app/src/actions-buttons/cancel-visit.test.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/cancel-visit.test.tsx
@@ -5,13 +5,13 @@ import { useVisit } from '@openmrs/esm-framework';
 import { mockCurrentVisit } from '__mocks__';
 import CancelVisitOverflowMenuItem from './cancel-visit.component';
 
-const mockUseVisit = useVisit as jest.Mock;
+const mockUseVisit = jest.mocked(useVisit);
 
 describe('CancelVisitOverflowMenuItem', () => {
   it('should launch cancel visit dialog box', async () => {
     const user = userEvent.setup();
 
-    mockUseVisit.mockReturnValueOnce({ currentVisit: mockCurrentVisit });
+    mockUseVisit.mockReturnValueOnce({ currentVisit: mockCurrentVisit } as ReturnType<typeof useVisit>);
 
     render(<CancelVisitOverflowMenuItem patientUuid="some-uuid" />);
 

--- a/packages/esm-patient-chart-app/src/actions-buttons/cancel-visit.test.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/cancel-visit.test.tsx
@@ -1,16 +1,11 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { screen, render } from '@testing-library/react';
 import { useVisit } from '@openmrs/esm-framework';
 import { mockCurrentVisit } from '__mocks__';
 import CancelVisitOverflowMenuItem from './cancel-visit.component';
 
 const mockUseVisit = useVisit as jest.Mock;
-
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-  return { ...originalModule, useVisit: jest.fn(), showModal: jest.fn() };
-});
 
 describe('CancelVisitOverflowMenuItem', () => {
   it('should launch cancel visit dialog box', async () => {
@@ -20,7 +15,7 @@ describe('CancelVisitOverflowMenuItem', () => {
 
     render(<CancelVisitOverflowMenuItem patientUuid="some-uuid" />);
 
-    const cancelVisitButton = screen.getByRole('menuitem', { name: /Cancel visit/ });
+    const cancelVisitButton = screen.getByRole('menuitem', { name: /cancel visit/i });
     expect(cancelVisitButton).toBeInTheDocument();
 
     await user.click(cancelVisitButton);

--- a/packages/esm-patient-chart-app/src/actions-buttons/start-visit.test.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/start-visit.test.tsx
@@ -1,22 +1,27 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useConfig, usePatient, useVisit } from '@openmrs/esm-framework';
+import { screen, render } from '@testing-library/react';
+import {
+  getDefaultsFromConfigSchema,
+  useConfig,
+  usePatient,
+  useVisit,
+  type VisitReturnType,
+} from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { type ChartConfig, esmPatientChartSchema } from '../config-schema';
 import { mockPatient } from 'tools';
 import StartVisitOverflowMenuItem from './start-visit.component';
 
-const mockUsePatient = usePatient as jest.Mock;
-const mockUseVisit = useVisit as jest.Mock;
-const mockUseConfig = useConfig as jest.Mock;
+const mockUseConfig = jest.mocked<() => ChartConfig>(useConfig);
+const mockUsePatient = jest.mocked(usePatient);
+const mockUseVisit = jest.mocked(useVisit);
 
 jest.mock('@openmrs/esm-framework', () => ({
-  usePatient: jest.fn(),
-  useVisit: jest.fn(),
-  getGlobalStore: jest.fn(),
+  ...jest.requireActual('@openmrs/esm-framework'),
   createGlobalStore: jest.fn(),
   createUseStore: jest.fn(),
-  useConfig: jest.fn(),
+  getGlobalStore: jest.fn(),
 }));
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {
@@ -28,32 +33,49 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   };
 });
 
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(esmPatientChartSchema),
+});
+
+mockUseVisit.mockReturnValue({
+  currentVisit: null,
+} as VisitReturnType);
+
 describe('StartVisitOverflowMenuItem', () => {
-  it('should launch start visit form', async () => {
+  it('should launch the start visit form', async () => {
     const user = userEvent.setup();
-    mockUseConfig.mockReturnValue({ startVisitLabel: '' });
-    mockUseVisit.mockReturnValue({ currentVisit: null });
-    mockUsePatient.mockReturnValue({ patient: mockPatient });
 
-    render(<StartVisitOverflowMenuItem patientUuid="some-patient-uuid" />);
+    mockUsePatient.mockReturnValue({
+      error: null,
+      isLoading: false,
+      patient: mockPatient,
+      patientUuid: mockPatient.id,
+    });
 
-    const startVisitButton = screen.getByRole('menuitem', { name: /Start visit/ });
+    render(<StartVisitOverflowMenuItem patientUuid={mockPatient.id} />);
+
+    const startVisitButton = screen.getByRole('menuitem', { name: /start visit/i });
     expect(startVisitButton).toBeInTheDocument();
 
     await user.click(startVisitButton);
-
     expect(launchPatientWorkspace).toHaveBeenCalledTimes(1);
     expect(launchPatientWorkspace).toHaveBeenCalledWith('start-visit-workspace-form');
   });
 
-  it('should not show start visit button for deceased patient', () => {
-    mockUseConfig.mockReturnValue({ startVisitLabel: '' });
-    mockUseVisit.mockReturnValue({ currentVisit: null });
-    mockUsePatient.mockReturnValue({ patient: { ...mockPatient, deceasedDateTime: '2023-05-07T10:20:30Z' } });
+  it('should not show start visit button for a deceased patient', () => {
+    mockUsePatient.mockReturnValue({
+      error: null,
+      isLoading: false,
+      patientUuid: mockPatient.id,
+      patient: {
+        ...mockPatient,
+        deceasedDateTime: '2023-05-07T10:20:30Z',
+      },
+    });
 
-    render(<StartVisitOverflowMenuItem patientUuid="some-patient-uuid" />);
+    render(<StartVisitOverflowMenuItem patientUuid={mockPatient.id} />);
 
-    const startVisitButton = screen.queryByRole('menuitem', { name: /Start visit/ });
+    const startVisitButton = screen.queryByRole('menuitem', { name: /start visit/i });
     expect(startVisitButton).not.toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-chart-app/src/actions-buttons/stop-visit.test.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/stop-visit.test.tsx
@@ -6,8 +6,8 @@ import { showModal, useVisit } from '@openmrs/esm-framework';
 import { mockCurrentVisit } from '__mocks__';
 import { mockPatient } from 'tools';
 
-const mockUseVisit = useVisit as jest.Mock;
-const mockShowModal = showModal as jest.Mock;
+const mockUseVisit = jest.mocked(useVisit);
+const mockShowModal = jest.mocked(showModal);
 
 jest.mock('@openmrs/esm-framework', () => ({
   useVisit: jest.fn(),
@@ -16,38 +16,30 @@ jest.mock('@openmrs/esm-framework', () => ({
 }));
 
 describe('StopVisitOverflowMenuItem', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('should be able to stop current visit', async () => {
     const user = userEvent.setup();
 
-    mockUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit });
+    mockUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit } as ReturnType<typeof useVisit>);
 
     render(<StopVisitOverflowMenuItem patientUuid={mockPatient.id} />);
 
     const endVisitButton = screen.getByRole('menuitem', { name: /End Visit/i });
     expect(endVisitButton).toBeInTheDocument();
 
-    // should launch the form
     await user.click(endVisitButton);
-
     expect(mockShowModal).toHaveBeenCalledTimes(1);
   });
   it('should be able to show configured label in button to stop current visit', async () => {
     const user = userEvent.setup();
 
-    mockUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit });
+    mockUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit } as ReturnType<typeof useVisit>);
 
     render(<StopVisitOverflowMenuItem patientUuid={mockPatient.id} />);
 
     const endVisitButton = screen.getByRole('menuitem', { name: /End visit/ });
     expect(endVisitButton).toBeInTheDocument();
 
-    // should launch the form
     await user.click(endVisitButton);
-
     expect(mockShowModal).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -1,42 +1,91 @@
 import { Type } from '@openmrs/esm-framework';
 
 export const esmPatientChartSchema = {
-  freeTextFieldConceptUuid: {
-    _default: '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-    _type: Type.ConceptUuid,
-  },
-  visitDiagnosisConceptUuid: {
-    _default: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-    _type: Type.ConceptUuid,
-  },
-  notesConceptUuids: {
-    _type: Type.Array,
-    _default: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'],
-  },
-  offlineVisitTypeUuid: {
-    _type: Type.UUID,
-    _description: 'The UUID of the visit type to be used for the automatically created offline visits.',
-    _default: 'a22733fa-3501-4020-a520-da024eeff088',
-  },
-  showRecommendedVisitTypeTab: {
-    _type: Type.Boolean,
-    _description: 'Whether start visit form should display recommended visit type tab. Requires `visitTypeResourceUrl`',
-    _default: false,
-  },
-  visitTypeResourceUrl: {
+  defaultFacilityUrl: {
     _type: Type.String,
-    _default: '/etl-latest/etl/patient/',
-    _description: 'Custom URL to load resources required for showing recommended visit types',
+    _default: '',
+    _description: 'Custom URL to load default facility if it is not in the session',
+  },
+  disableChangingVisitLocation: {
+    _type: Type.Boolean,
+    _description:
+      "Whether the visit location field in the Start Visit form should be view-only. If so, the visit location will always be set to the user's login location.",
+    _default: false,
   },
   disableEmptyTabs: {
     _type: Type.Boolean,
     _default: false,
     _description: 'Disable notes/tests/medications/encounters tabs when empty',
   },
+  freeTextFieldConceptUuid: {
+    _default: '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    _type: Type.ConceptUuid,
+  },
+  logo: {
+    alt: {
+      _type: Type.String,
+      _default: 'Logo',
+      _description: 'Alt text, shown on hover',
+    },
+    name: {
+      _type: Type.String,
+      _default: null,
+      _description: 'The organization name displayed when image is absent',
+    },
+    src: {
+      _type: Type.String,
+      _default: null,
+      _description: 'A path or URL to an image. Defaults to the OpenMRS SVG sprite.',
+    },
+  },
+  notesConceptUuids: {
+    _type: Type.Array,
+    _default: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'],
+  },
+  numberOfVisitsToLoad: {
+    _type: Type.Number,
+    _description: 'The number of visits to load initially in the Visits Summary tab. Defaults to 5',
+    _default: 5,
+  },
+  obsConceptUuidsToHide: {
+    _type: Type.Array,
+    _elements: {
+      _type: Type.ConceptUuid,
+    },
+    _description:
+      'An array of concept UUIDs. If an observation has a concept UUID that matches any of the ones in this array, it will be hidden from the observations list in the Encounters summary table.',
+    _default: [],
+  },
+  offlineVisitTypeUuid: {
+    _type: Type.UUID,
+    _description: 'The UUID of the visit type to be used for the automatically created offline visits.',
+    _default: 'a22733fa-3501-4020-a520-da024eeff088',
+  },
   showAllEncountersTab: {
     _type: Type.Boolean,
     _description: 'Shows the All Encounters Tab of Patient Visits section in Patient Chart',
     _default: true,
+  },
+  showExtraVisitAttributesSlot: {
+    _type: Type.Boolean,
+    _description:
+      'Whether on start visit form should handle submission of the extra visit attributes from the extra visit attributes slot',
+    _default: false,
+  },
+  showRecommendedVisitTypeTab: {
+    _type: Type.Boolean,
+    _description: 'Whether start visit form should display recommended visit type tab. Requires `visitTypeResourceUrl`',
+    _default: false,
+  },
+  showServiceQueueFields: {
+    _type: Type.Boolean,
+    _description: 'Whether start visit form should display service queue fields`',
+    _default: false,
+  },
+  showUpcomingAppointments: {
+    _type: Type.Boolean,
+    _description: 'Whether start visit form should display upcoming appointments',
+    _default: false,
   },
   visitAttributeTypes: {
     _type: Type.Array,
@@ -70,92 +119,46 @@ export const esmPatientChartSchema = {
       },
     ],
   },
-  showServiceQueueFields: {
-    _type: Type.Boolean,
-    _description: 'Whether start visit form should display service queue fields`',
-    _default: false,
+  visitDiagnosisConceptUuid: {
+    _default: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    _type: Type.ConceptUuid,
   },
   visitQueueNumberAttributeUuid: {
     _type: Type.ConceptUuid,
     _description: 'The UUID of the visit attribute that contains the visit queue number.',
     _default: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
   },
-  defaultFacilityUrl: {
+  visitTypeResourceUrl: {
     _type: Type.String,
-    _default: '',
-    _description: 'Custom URL to load default facility if it is not in the session',
-  },
-  showUpcomingAppointments: {
-    _type: Type.Boolean,
-    _description: 'Whether start visit form should display upcoming appointments',
-    _default: false,
-  },
-  logo: {
-    src: {
-      _type: Type.String,
-      _default: null,
-      _description: 'A path or URL to an image. Defaults to the OpenMRS SVG sprite.',
-    },
-    alt: {
-      _type: Type.String,
-      _default: 'Logo',
-      _description: 'Alt text, shown on hover',
-    },
-    name: {
-      _type: Type.String,
-      _default: null,
-      _description: 'The organization name displayed when image is absent',
-    },
-  },
-  obsConceptUuidsToHide: {
-    _type: Type.Array,
-    _elements: {
-      _type: Type.ConceptUuid,
-    },
-    _description:
-      'An array of concept UUIDs. If an observation has a concept UUID that matches any of the ones in this array, it will be hidden from the observations list in the Encounters summary table.',
-    _default: [],
-  },
-  disableChangingVisitLocation: {
-    _type: Type.Boolean,
-    _description:
-      "Whether the visit location field in the Start Visit form should be view-only. If so, the visit location will always be set to the user's login location.",
-    _default: false,
-  },
-  numberOfVisitsToLoad: {
-    _type: Type.Number,
-    _description: 'The number of visits to load initially in the Visits Summary tab. Defaults to 5',
-    _default: 5,
-  },
-  showExtraVisitAttributesSlot: {
-    _type: Type.Boolean,
-    _description:
-      'Whether on start visit form should handle submission of the extra visit attributes from the extra visit attributes slot',
-    _default: false,
+    _default: '/etl-latest/etl/patient/',
+    _description: 'Custom URL to load resources required for showing recommended visit types',
   },
 };
+
 export interface ChartConfig {
-  freeTextFieldConceptUuid: string;
-  offlineVisitTypeUuid: string;
-  visitTypeResourceUrl: string;
-  showRecommendedVisitTypeTab: boolean;
-  visitAttributeTypes: Array<{
-    uuid: string;
-    required: boolean;
-    displayInThePatientBanner: boolean;
-    showWhenExpression?: string;
-  }>;
-  showServiceQueueFields: boolean;
-  visitQueueNumberAttributeUuid: string;
-  showAllEncountersTab: boolean;
   defaultFacilityUrl: string;
-  showUpcomingAppointments: boolean;
+  disableChangingVisitLocation: boolean;
+  freeTextFieldConceptUuid: string;
   logo: {
-    src: string;
     alt: string;
     name: string;
+    src: string;
   };
-  disableChangingVisitLocation: boolean;
+  notesConceptUuids: string[];
   numberOfVisitsToLoad: number;
+  offlineVisitTypeUuid: string;
+  showAllEncountersTab: boolean;
   showExtraVisitAttributesSlot: boolean;
+  showRecommendedVisitTypeTab: boolean;
+  showServiceQueueFields: boolean;
+  showUpcomingAppointments: boolean;
+  visitQueueNumberAttributeUuid: string;
+  visitTypeResourceUrl: string;
+  visitAttributeTypes: Array<{
+    displayInThePatientBanner: boolean;
+    required: boolean;
+    showWhenExpression?: string;
+    uuid: string;
+  }>;
+  visitDiagnosisConceptUuid: string;
 }

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.test.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.test.tsx
@@ -13,7 +13,6 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
     useNavGroups: jest.fn().mockReturnValue({ navGroups: [] }),
   };
 });
-
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
 
@@ -53,7 +52,7 @@ function slotMetaFromStore(store, slotName) {
   );
 }
 
-describe('ChartReview: ', () => {
+describe('ChartReview', () => {
   test(`renders a grid-based layout`, () => {
     const mockStore = {
       slots: {

--- a/packages/esm-patient-chart-app/src/side-nav/side-menu.test.tsx
+++ b/packages/esm-patient-chart-app/src/side-nav/side-menu.test.tsx
@@ -1,31 +1,20 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { isDesktop, LeftNavMenu, useLayoutType } from '@openmrs/esm-framework';
+import { useLayoutType } from '@openmrs/esm-framework';
 import SideMenu from './side-menu.component';
 
-const mockIsDesktop = jest.mocked(isDesktop);
-const mockedLeftNavMenu = LeftNavMenu as unknown as jest.Mock;
-const mockedUseLayoutType = jest.mocked(useLayoutType);
+const mockUseLayoutType = jest.mocked(useLayoutType);
 
-mockedLeftNavMenu.mockReturnValue('left nav menu');
-
-describe('sidemenu', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    mockIsDesktop.mockImplementation((layout) => layout === 'small-desktop' || layout === 'large-desktop');
-  });
+describe('Side menu', () => {
   it('is rendered when viewport == large-desktop', () => {
-    mockedUseLayoutType.mockImplementationOnce(() => 'large-desktop');
-
+    mockUseLayoutType.mockImplementationOnce(() => 'large-desktop');
     renderSideMenu();
 
     expect(screen.getByText(/left nav menu/i)).toBeInTheDocument();
   });
 
   it('is not rendered when viewport == tablet or viewport == small-desktop', () => {
-    mockedUseLayoutType.mockImplementationOnce(() => 'tablet');
-
+    mockUseLayoutType.mockReturnValue('tablet');
     renderSideMenu();
 
     expect(screen.queryByText(/left nav menu/i)).not.toBeInTheDocument();

--- a/packages/esm-patient-chart-app/src/side-nav/side-menu.test.tsx
+++ b/packages/esm-patient-chart-app/src/side-nav/side-menu.test.tsx
@@ -1,37 +1,26 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { LeftNavMenu, useLayoutType } from '@openmrs/esm-framework';
+import { isDesktop, LeftNavMenu, useLayoutType } from '@openmrs/esm-framework';
 import SideMenu from './side-menu.component';
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    isDesktop: jest.fn().mockImplementation((layout) => layout === 'small-desktop' || layout === 'large-desktop'),
-  };
-});
-
-global.window.matchMedia = jest.fn().mockImplementation(() => {
-  return {
-    matches: false,
-    addListener: () => {},
-    removeListener: () => {},
-  };
-});
-
-const mockedLeftNavMenu = LeftNavMenu as any as jest.Mock;
-const mockedUseLayoutType = useLayoutType as jest.Mock;
+const mockIsDesktop = jest.mocked(isDesktop);
+const mockedLeftNavMenu = LeftNavMenu as unknown as jest.Mock;
+const mockedUseLayoutType = jest.mocked(useLayoutType);
 
 mockedLeftNavMenu.mockReturnValue('left nav menu');
 
 describe('sidemenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockIsDesktop.mockImplementation((layout) => layout === 'small-desktop' || layout === 'large-desktop');
+  });
   it('is rendered when viewport == large-desktop', () => {
     mockedUseLayoutType.mockImplementationOnce(() => 'large-desktop');
 
     renderSideMenu();
 
-    expect(screen.getByText(/left nav menu/)).toBeInTheDocument();
+    expect(screen.getByText(/left nav menu/i)).toBeInTheDocument();
   });
 
   it('is not rendered when viewport == tablet or viewport == small-desktop', () => {
@@ -39,7 +28,7 @@ describe('sidemenu', () => {
 
     renderSideMenu();
 
-    expect(screen.queryByText(/left nav menu/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/left nav menu/i)).not.toBeInTheDocument();
   });
 });
 

--- a/packages/esm-patient-chart-app/src/utils.test.ts
+++ b/packages/esm-patient-chart-app/src/utils.test.ts
@@ -1,16 +1,15 @@
 import { isDesktop } from './utils';
 import { isDesktop as actualIsDesktopFn } from '@openmrs/esm-framework';
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    isDesktop: jest.fn().mockImplementation((layout) => layout === 'small-desktop' || layout === 'large-desktop'),
-  };
-});
+const mockIsDesktop = jest.mocked(actualIsDesktopFn);
 
 describe('isDesktop', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockIsDesktop.mockImplementation((layout) => layout === 'small-desktop' || layout === 'large-desktop');
+  });
+
   it('is true when layout = tablet', () => {
     expect(isDesktop('tablet')).toBeFalsy();
   });

--- a/packages/esm-patient-chart-app/src/utils.test.ts
+++ b/packages/esm-patient-chart-app/src/utils.test.ts
@@ -3,11 +3,11 @@ import { isDesktop as actualIsDesktopFn } from '@openmrs/esm-framework';
 
 const mockIsDesktop = jest.mocked(actualIsDesktopFn);
 
+mockIsDesktop.mockImplementation((layout) => layout === 'small-desktop' || layout === 'large-desktop');
+
 describe('isDesktop', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-
-    mockIsDesktop.mockImplementation((layout) => layout === 'small-desktop' || layout === 'large-desktop');
   });
 
   it('is true when layout = tablet', () => {

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
@@ -18,14 +18,14 @@ import { getByTextWithMarkup, mockPatient, mockPatientWithLongName } from 'tools
 import { mockCurrentVisit } from '__mocks__';
 import VisitHeader from './visit-header.component';
 
-const mockAge = age as jest.Mock;
-const mockUseAssignedExtensions = useAssignedExtensions as jest.Mock;
-const mockUsePatient = usePatient as jest.Mock;
-const mockUseVisit = useVisit as jest.Mock;
-const mockUseLayoutType = useLayoutType as jest.Mock;
-const mockShowModal = showModal as jest.Mock;
-const mockGetHistory = getHistory as jest.Mock;
-const mockGoBackInHistory = goBackInHistory as jest.Mock;
+const mockAge = jest.mocked(age);
+const mockUseAssignedExtensions = jest.mocked(useAssignedExtensions);
+const mockUsePatient = jest.mocked(usePatient);
+const mockUseVisit = jest.mocked(useVisit);
+const mockUseLayoutType = jest.mocked(useLayoutType);
+const mockShowModal = jest.mocked(showModal);
+const mockGetHistory = jest.mocked(getHistory);
+const mockGoBackInHistory = jest.mocked(goBackInHistory);
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -48,8 +48,15 @@ describe('Visit header', () => {
   beforeEach(() => {
     mockAge.mockReturnValue('20');
     mockGetHistory.mockReturnValue([]);
-    mockUseAssignedExtensions.mockReturnValue([{ id: 'someId' }]);
-    mockGoBackInHistory.mockClear();
+    mockUseAssignedExtensions.mockReturnValue([
+      {
+        id: 'someId',
+        moduleName: '@openmrs/esm-test-module',
+        name: 'patient-chart-visit-header',
+        meta: {},
+        config: null,
+      },
+    ]);
   });
 
   test('should display visit header and left nav bar hamburger icon', async () => {
@@ -61,7 +68,15 @@ describe('Visit header', () => {
       error: null,
       patientUuid: mockPatient.id,
     });
-    mockUseVisit.mockReturnValue({ isValidating: null, currentVisit: null });
+    mockUseVisit.mockReturnValue({
+      activeVisit: null,
+      currentVisit: null,
+      currentVisitIsRetrospective: false,
+      error: null,
+      isLoading: false,
+      isValidating: null,
+      mutate: jest.fn(),
+    });
     mockUseLayoutType.mockReturnValue('tablet');
 
     render(<VisitHeader />);
@@ -100,8 +115,16 @@ describe('Visit header', () => {
       error: null,
       patientUuid: mockPatient.id,
     });
-    mockUseVisit.mockReturnValue({ isValidating: null, currentVisit: null });
-    mockUseLayoutType.mockReturnValue('desktop');
+    mockUseVisit.mockReturnValue({
+      activeVisit: null,
+      currentVisit: null,
+      currentVisitIsRetrospective: false,
+      error: null,
+      isLoading: false,
+      isValidating: null,
+      mutate: jest.fn(),
+    });
+    mockUseLayoutType.mockReturnValue('small-desktop');
 
     render(<VisitHeader />);
 
@@ -118,8 +141,16 @@ describe('Visit header', () => {
       error: null,
       patientUuid: mockPatient.id,
     });
-    mockUseVisit.mockReturnValue({ isValidating: false, currentVisit: mockCurrentVisit });
-    mockUseLayoutType.mockReturnValue('desktop');
+    mockUseVisit.mockReturnValue({
+      activeVisit: mockCurrentVisit,
+      currentVisit: mockCurrentVisit,
+      currentVisitIsRetrospective: false,
+      error: null,
+      isLoading: false,
+      isValidating: null,
+      mutate: jest.fn(),
+    });
+    mockUseLayoutType.mockReturnValue('small-desktop');
 
     render(<VisitHeader />);
 

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
+  age,
   getHistory,
   goBackInHistory,
   navigate,
@@ -12,11 +13,12 @@ import {
   usePatient,
   useVisit,
 } from '@openmrs/esm-framework';
+import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { getByTextWithMarkup, mockPatient, mockPatientWithLongName } from 'tools';
 import { mockCurrentVisit } from '__mocks__';
 import VisitHeader from './visit-header.component';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 
+const mockAge = age as jest.Mock;
 const mockUseAssignedExtensions = useAssignedExtensions as jest.Mock;
 const mockUsePatient = usePatient as jest.Mock;
 const mockUseVisit = useVisit as jest.Mock;
@@ -27,15 +29,10 @@ const mockGoBackInHistory = goBackInHistory as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
+
   return {
     ...originalModule,
-    age: jest.fn().mockReturnValue('20'),
-    getHistory: jest.fn(() => []),
-    goBackInHistory: jest.fn(),
-    LeftNavMenu: jest.fn().mockImplementation(() => <div>Left Nav Menu</div>),
     translateFrom: (module, key, defaultValue, options) => defaultValue,
-    useAssignedExtensions: jest.fn(),
-    useOnClickOutside: jest.fn(),
   };
 });
 
@@ -47,8 +44,10 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   };
 });
 
-describe('Visit Header', () => {
+describe('Visit header', () => {
   beforeEach(() => {
+    mockAge.mockReturnValue('20');
+    mockGetHistory.mockReturnValue([]);
     mockUseAssignedExtensions.mockReturnValue([{ id: 'someId' }]);
     mockGoBackInHistory.mockClear();
   });

--- a/packages/esm-patient-chart-app/src/visit/hooks/useDefaultLocation.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useDefaultLocation.tsx
@@ -10,6 +10,6 @@ export const useDefaultLoginLocation = () => {
   return {
     defaultFacility: data ? data?.data : null,
     isLoading: isLoading,
-    isError: error,
+    error: error,
   };
 };

--- a/packages/esm-patient-chart-app/src/visit/past-visit-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/past-visit-overview.component.tsx
@@ -23,7 +23,7 @@ const PastVisitOverview: React.FC<DefaultPatientWorkspaceProps> = ({ patientUuid
   const { t, i18n } = useTranslation();
   const locale = i18n.language.toLowerCase().replace('_', '-');
 
-  const { data: pastVisits, isError, isLoading } = usePastVisits(patientUuid);
+  const { data: pastVisits, error, isLoading } = usePastVisits(patientUuid);
 
   const headerData: Array<typeof DataTableHeader> = useMemo(
     () => [
@@ -59,8 +59,8 @@ const PastVisitOverview: React.FC<DefaultPatientWorkspaceProps> = ({ patientUuid
   if (isLoading) {
     return <DataTableSkeleton role="progressbar" />;
   }
-  if (isError) {
-    return <ErrorState error={isError} headerTitle={t('pastVisitErrorText', 'Past Visit Error')} />;
+  if (error) {
+    return <ErrorState error={error} headerTitle={t('pastVisitErrorText', 'Past Visit Error')} />;
   }
   if (pastVisits?.length) {
     return (

--- a/packages/esm-patient-chart-app/src/visit/past-visit-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/past-visit-overview.test.tsx
@@ -5,7 +5,7 @@ import { openmrsFetch, setCurrentVisit } from '@openmrs/esm-framework';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import PastVisitOverview from './past-visit-overview.component';
 
-const testProps = {
+const defaultProps = {
   closeWorkspace: jest.fn(),
   closeWorkspaceWithSavedChanges: jest.fn(),
   patientUuid: mockPatient.id,
@@ -48,11 +48,6 @@ const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockSetCurrentVisit = setCurrentVisit as jest.Mock;
 
 describe('PastVisitOverview', () => {
-  beforeEach(() => {
-    testProps.closeWorkspace.mockClear();
-    mockSetCurrentVisit.mockClear();
-  });
-
   it(`renders a tabular overview view of the patient's past visits data`, async () => {
     const user = userEvent.setup();
 
@@ -76,7 +71,7 @@ describe('PastVisitOverview', () => {
 
     await user.click(cancelButton);
 
-    expect(testProps.closeWorkspace).toHaveBeenCalledTimes(1);
+    expect(defaultProps.closeWorkspace).toHaveBeenCalledTimes(1);
   });
 
   it(`will enter retrospective entry mode for a specific visit`, async () => {
@@ -88,11 +83,11 @@ describe('PastVisitOverview', () => {
     expect(editButtons.length).toBe(2);
     await user.click(editButtons[1]);
 
-    expect(mockSetCurrentVisit).toBeCalledWith(mockPatient.id, mockPastVisits.data.results[1].uuid);
-    expect(testProps.closeWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockSetCurrentVisit).toHaveBeenCalledWith(mockPatient.id, mockPastVisits.data.results[1].uuid);
+    expect(defaultProps.closeWorkspace).toHaveBeenCalledTimes(1);
   });
 });
 
 function renderPastVisitOverview() {
-  renderWithSwr(<PastVisitOverview {...testProps} />);
+  renderWithSwr(<PastVisitOverview {...defaultProps} />);
 }

--- a/packages/esm-patient-chart-app/src/visit/queue-entry/queue.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/queue-entry/queue.resource.tsx
@@ -60,7 +60,7 @@ export interface MappedVisitQueueEntry {
 interface UseVisitQueueEntries {
   queueEntry: MappedVisitQueueEntry | null;
   isLoading: boolean;
-  isError: Error;
+  error: Error;
   isValidating?: boolean;
   mutate: () => void;
 }
@@ -112,7 +112,7 @@ export function useVisitQueueEntry(patientUuid, visitUuid): UseVisitQueueEntries
   return {
     queueEntry: mappedVisitQueueEntry,
     isLoading,
-    isError: error,
+    error: error,
     isValidating,
     mutate,
   };

--- a/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { screen, render } from '@testing-library/react';
 import { useVisitTypes } from '@openmrs/esm-framework';
 import { mockVisitTypes } from '__mocks__';
 import BaseVisitType from './base-visit-type.component';
@@ -8,12 +8,6 @@ import BaseVisitType from './base-visit-type.component';
 jest.mock('lodash-es/debounce', () => jest.fn((fn) => fn));
 
 const mockUseVisitTypes = useVisitTypes as jest.Mock;
-const mockGoToPage = jest.fn();
-
-jest.mock('@openmrs/esm-framework', () => ({
-  ...(jest.requireActual('@openmrs/esm-framework') as any),
-  useVisitTypes: jest.fn(),
-}));
 
 jest.mock('react-hook-form', () => ({
   ...jest.requireActual('react-hook-form'),

--- a/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/base-visit-type.test.tsx
@@ -7,7 +7,7 @@ import BaseVisitType from './base-visit-type.component';
 
 jest.mock('lodash-es/debounce', () => jest.fn((fn) => fn));
 
-const mockUseVisitTypes = useVisitTypes as jest.Mock;
+const mockUseVisitTypes = jest.mocked(useVisitTypes);
 
 jest.mock('react-hook-form', () => ({
   ...jest.requireActual('react-hook-form'),

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -10,6 +10,7 @@ import {
   showSnackbar,
   updateVisit,
   useConfig,
+  useVisitTypes,
   type Visit,
 } from '@openmrs/esm-framework';
 import { mockPatient } from 'tools';
@@ -58,9 +59,10 @@ const testProps = {
 const mockSaveVisit = saveVisit as jest.Mock;
 const mockUpdateVisit = updateVisit as jest.Mock;
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
-const mockedUseConfig = jest.mocked(useConfig);
-const mockedUseVisitAttributeType = useVisitAttributeType as jest.Mock;
+const mockUseConfig = jest.mocked(useConfig);
+const mockUseVisitAttributeType = useVisitAttributeType as jest.Mock;
 const mockGetStartedVisitGetter = jest.fn();
+const mockUseVisitTypes = useVisitTypes as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -74,9 +76,7 @@ jest.mock('@openmrs/esm-framework', () => {
     restBaseUrl: '/ws/rest/v1',
     saveVisit: jest.fn(),
     updateVisit: jest.fn(),
-    openmrsFetch: jest.fn(),
     toOmrsIsoString: jest.fn(),
-    useLocations: jest.fn(),
     toDateObjectStrict: jest.fn(),
     useVisitTypes: jest.fn().mockImplementation(() => mockVisitTypes),
     usePatient: jest.fn().mockImplementation((patientUuid) => ({ patientUuid, patient: {} })),
@@ -173,7 +173,7 @@ jest.mock('../hooks/useLocations', () => {
 
 describe('Visit Form', () => {
   beforeAll(() => {
-    mockedUseConfig.mockReturnValue({
+    mockUseConfig.mockReturnValue({
       ...(getDefaultsFromConfigSchema(esmPatientChartSchema) as ChartConfig),
       visitAttributeTypes: [
         {
@@ -188,6 +188,8 @@ describe('Visit Form', () => {
         },
       ],
     });
+
+    mockUseVisitTypes.mockReturnValue(mockVisitTypes);
   });
 
   beforeEach(() => {
@@ -531,7 +533,7 @@ describe('Visit Form', () => {
   });
 
   it('should show an inline error notification if an optional visit attribute type field fails to load', async () => {
-    mockedUseVisitAttributeType.mockReturnValue({
+    mockUseVisitAttributeType.mockReturnValue({
       isLoading: false,
       error: new Error('failed to load'),
       data: visitAttributes.punctuality,
@@ -547,7 +549,7 @@ describe('Visit Form', () => {
   it('should show an error if a required visit attribute type is not provided', async () => {
     const user = userEvent.setup();
 
-    mockedUseConfig.mockReturnValue({
+    mockUseConfig.mockReturnValue({
       ...(getDefaultsFromConfigSchema(esmPatientChartSchema) as ChartConfig),
       visitAttributeTypes: [
         {
@@ -586,12 +588,12 @@ describe('Visit Form', () => {
   });
 
   it('should disable the submit button show an inline error notification if required visit attribute fields fail to load', async () => {
-    mockedUseVisitAttributeType.mockReturnValue({
+    mockUseVisitAttributeType.mockReturnValue({
       isLoading: false,
       error: new Error('failed to load'),
       data: visitAttributes.punctuality,
     });
-    mockedUseConfig.mockReturnValue({
+    mockUseConfig.mockReturnValue({
       visitAttributeTypes: [
         {
           uuid: visitAttributes.punctuality.uuid,

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-type.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-type.test.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { useVisitTypes } from '@openmrs/esm-framework';
 import { screen, render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { mockVisitTypes } from '__mocks__';
 import BaseVisitType from './base-visit-type.component';
 
 jest.mock('lodash-es/debounce', () => jest.fn((fn) => fn));
 
 const mockUseVisitTypes = useVisitTypes as jest.Mock;
-
-jest.mock('@openmrs/esm-framework', () => ({
-  ...(jest.requireActual('@openmrs/esm-framework') as any),
-  useVisitTypes: jest.fn(),
-}));
 
 jest.mock('react-hook-form', () => ({
   ...jest.requireActual('react-hook-form'),

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-type.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-type.test.tsx
@@ -5,10 +5,9 @@ import { screen, render } from '@testing-library/react';
 import { mockVisitTypes } from '__mocks__';
 import BaseVisitType from './base-visit-type.component';
 
+const mockUseVisitTypes = jest.mocked(useVisitTypes);
+
 jest.mock('lodash-es/debounce', () => jest.fn((fn) => fn));
-
-const mockUseVisitTypes = useVisitTypes as jest.Mock;
-
 jest.mock('react-hook-form', () => ({
   ...jest.requireActual('react-hook-form'),
   useFormContext: jest.fn().mockImplementation(() => ({

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
@@ -20,8 +20,6 @@ jest.mock('@openmrs/esm-framework', () => {
 
   return {
     ...originalModule,
-    useVisit: jest.fn(),
-    openmrsFetch: jest.fn(),
     restBaseUrl: '/ws/rest/v1',
   };
 });

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
@@ -8,12 +8,12 @@ import { type MappedVisitQueueEntry, useVisitQueueEntry } from '../queue-entry/q
 import { removeQueuedPatient } from '../hooks/useServiceQueue';
 import CancelVisitDialog from './cancel-visit-dialog.component';
 
-const mockedCloseModal = jest.fn();
-const mockedOpenmrsFetch = jest.mocked(openmrsFetch);
-const mockedRemoveQueuedPatient = jest.mocked(removeQueuedPatient);
-const mockedShowSnackbar = jest.mocked(showSnackbar);
-const mockedUseVisit = jest.mocked(useVisit) as jest.Mock;
-const mockedUseVisitQueueEntry = jest.mocked(useVisitQueueEntry);
+const mockCloseModal = jest.fn();
+const mockOpenmrsFetch = jest.mocked(openmrsFetch);
+const mockRemoveQueuedPatient = jest.mocked(removeQueuedPatient);
+const mockShowSnackbar = jest.mocked(showSnackbar);
+const mockUseVisit = jest.mocked(useVisit);
+const mockUseVisitQueueEntry = jest.mocked(useVisitQueueEntry);
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -43,25 +43,35 @@ jest.mock('../hooks/useServiceQueue', () => {
 });
 
 describe('Cancel visit', () => {
+  beforeEach(() => {
+    mockUseVisit.mockReturnValue({
+      activeVisit: mockCurrentVisit,
+      currentVisit: mockCurrentVisit,
+      currentVisitIsRetrospective: false,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
+    });
+  });
+
   it('cancels the active visit and voids its associated encounters', async () => {
     const user = userEvent.setup();
-
-    mockedUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit, mutate: jest.fn() });
 
     const response: Partial<FetchResponse> = {
       statusText: 'ok',
       status: 200,
     };
 
-    mockedOpenmrsFetch.mockResolvedValue(response as FetchResponse);
-    mockedUseVisitQueueEntry.mockReturnValueOnce({
+    mockOpenmrsFetch.mockResolvedValue(response as FetchResponse);
+    mockUseVisitQueueEntry.mockReturnValueOnce({
       queueEntry: mockVisitQueueEntries,
       isLoading: false,
-      isError: undefined,
+      error: undefined,
       isValidating: false,
       mutate: jest.fn(),
     });
-    mockedRemoveQueuedPatient.mockResolvedValue(response as FetchResponse);
+    mockRemoveQueuedPatient.mockResolvedValue(response as FetchResponse);
 
     renderCancelVisitDialog();
 
@@ -80,11 +90,10 @@ describe('Cancel visit', () => {
 
     await user.click(cancelVisitButton);
 
-    expect(mockedOpenmrsFetch).toHaveBeenCalledWith(`/ws/rest/v1/visit/${mockCurrentVisit.uuid}`, {
+    expect(mockOpenmrsFetch).toHaveBeenCalledWith(`/ws/rest/v1/visit/${mockCurrentVisit.uuid}`, {
       method: 'DELETE',
     });
-
-    expect(mockedShowSnackbar).toHaveBeenCalledWith(
+    expect(mockShowSnackbar).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: 'success',
         title: 'Visit cancelled',
@@ -101,17 +110,16 @@ describe('Cancel visit', () => {
       status: 200,
     };
 
-    mockedUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit, mutate: jest.fn() });
-    mockedOpenmrsFetch.mockRejectedValueOnce({ message: 'Internal server error', status: 500 });
-    mockedUseVisitQueueEntry.mockReturnValueOnce({
+    mockOpenmrsFetch.mockRejectedValueOnce({ message: 'Internal server error', status: 500 });
+    mockUseVisitQueueEntry.mockReturnValueOnce({
       queueEntry: {} as MappedVisitQueueEntry,
       isLoading: false,
-      isError: undefined,
+      error: undefined,
       isValidating: false,
       mutate: jest.fn(),
     });
 
-    mockedRemoveQueuedPatient.mockResolvedValue(response as FetchResponse);
+    mockRemoveQueuedPatient.mockResolvedValue(response as FetchResponse);
 
     renderCancelVisitDialog();
 
@@ -126,11 +134,10 @@ describe('Cancel visit', () => {
 
     await user.click(cancelVisitButton);
 
-    expect(mockedOpenmrsFetch).toHaveBeenCalledWith(`/ws/rest/v1/visit/${mockCurrentVisit.uuid}`, {
+    expect(mockOpenmrsFetch).toHaveBeenCalledWith(`/ws/rest/v1/visit/${mockCurrentVisit.uuid}`, {
       method: 'DELETE',
     });
-
-    expect(mockedShowSnackbar).toHaveBeenCalledWith({
+    expect(mockShowSnackbar).toHaveBeenCalledWith({
       subtitle: 'An error occured when deleting visit',
       kind: 'error',
       title: 'Error cancelling active visit',
@@ -139,5 +146,5 @@ describe('Cancel visit', () => {
 });
 
 function renderCancelVisitDialog() {
-  render(<CancelVisitDialog closeModal={mockedCloseModal} patientUuid={mockPatient.id} />);
+  render(<CancelVisitDialog closeModal={mockCloseModal} patientUuid={mockPatient.id} />);
 }

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { of, throwError } from 'rxjs';
-import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { screen, render } from '@testing-library/react';
+import { of, throwError } from 'rxjs';
 import { showSnackbar, updateVisit, useVisit } from '@openmrs/esm-framework';
 import { mockCurrentVisit } from '__mocks__';
 import EndVisitDialog from './end-visit-dialog.component';
@@ -13,17 +13,16 @@ const endVisitPayload = {
   visitType: '7b0f5697-27e3-40c4-8bae-f4049abfb4ed',
 };
 
-const mockedCloseModal = jest.fn();
-const mockedMutate = jest.fn();
-const mockedShowSnackbar = jest.mocked(showSnackbar);
-const mockedUpdateVisit = jest.mocked(updateVisit);
-const mockedUseVisit = jest.mocked(useVisit) as jest.Mock;
+const mockCloseModal = jest.fn();
+const mockMutate = jest.fn();
+const mockShowSnackbar = jest.mocked(showSnackbar);
+const mockUseVisit = jest.mocked(useVisit) as jest.Mock;
+const mockUpdateVisit = jest.mocked(updateVisit);
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
   return {
     ...originalModule,
-    showSnackbar: jest.fn(),
     updateVisit: jest.fn(),
   };
 });
@@ -32,8 +31,8 @@ describe('End visit dialog', () => {
   test('displays a success snackbar when the visit is ended successfully', async () => {
     const user = userEvent.setup();
 
-    mockedUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit, mutate: mockedMutate });
-    mockedUpdateVisit.mockReturnValueOnce(
+    mockUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit, mutate: mockMutate });
+    mockUpdateVisit.mockReturnValueOnce(
       of({
         status: 200,
         data: {
@@ -66,7 +65,7 @@ describe('End visit dialog', () => {
 
     expect(updateVisit).toHaveBeenCalledWith(mockCurrentVisit.uuid, endVisitPayload, expect.anything());
 
-    expect(mockedShowSnackbar).toHaveBeenCalledWith({
+    expect(mockShowSnackbar).toHaveBeenCalledWith({
       isLowContrast: true,
       subtitle: 'Facility Visit ended successfully',
       kind: 'success',
@@ -77,8 +76,8 @@ describe('End visit dialog', () => {
   test('displays an error snackbar if there was a problem ending a visit', async () => {
     const user = userEvent.setup();
 
-    mockedUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit, mutate: mockedMutate });
-    mockedUpdateVisit.mockReturnValueOnce(throwError(new Error('Internal error message')));
+    mockUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit, mutate: mockMutate });
+    mockUpdateVisit.mockImplementationOnce(() => throwError(() => new Error('Internal error message')));
 
     renderEndVisitDialog();
 
@@ -95,7 +94,7 @@ describe('End visit dialog', () => {
 
     expect(updateVisit).toHaveBeenCalledWith(mockCurrentVisit.uuid, endVisitPayload, expect.anything());
 
-    expect(mockedShowSnackbar).toHaveBeenCalledWith({
+    expect(mockShowSnackbar).toHaveBeenCalledWith({
       subtitle: 'Internal error message',
       kind: 'error',
       title: 'Error ending visit',
@@ -105,5 +104,5 @@ describe('End visit dialog', () => {
 });
 
 function renderEndVisitDialog() {
-  render(<EndVisitDialog patientUuid="some-patient-uuid" closeModal={mockedCloseModal} />);
+  render(<EndVisitDialog patientUuid="some-patient-uuid" closeModal={mockCloseModal} />);
 }

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
@@ -16,7 +16,7 @@ const endVisitPayload = {
 const mockCloseModal = jest.fn();
 const mockMutate = jest.fn();
 const mockShowSnackbar = jest.mocked(showSnackbar);
-const mockUseVisit = jest.mocked(useVisit) as jest.Mock;
+const mockUseVisit = jest.mocked(useVisit);
 const mockUpdateVisit = jest.mocked(updateVisit);
 
 jest.mock('@openmrs/esm-framework', () => {
@@ -28,10 +28,21 @@ jest.mock('@openmrs/esm-framework', () => {
 });
 
 describe('End visit dialog', () => {
+  beforeEach(() => {
+    mockUseVisit.mockReturnValue({
+      activeVisit: mockCurrentVisit,
+      currentVisit: mockCurrentVisit,
+      currentVisitIsRetrospective: false,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+      mutate: mockMutate,
+    });
+  });
+
   test('displays a success snackbar when the visit is ended successfully', async () => {
     const user = userEvent.setup();
 
-    mockUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit, mutate: mockMutate });
     mockUpdateVisit.mockReturnValueOnce(
       of({
         status: 200,
@@ -76,7 +87,6 @@ describe('End visit dialog', () => {
   test('displays an error snackbar if there was a problem ending a visit', async () => {
     const user = userEvent.setup();
 
-    mockUseVisit.mockReturnValue({ currentVisit: mockCurrentVisit, mutate: mockMutate });
     mockUpdateVisit.mockImplementationOnce(() => throwError(() => new Error('Internal error message')));
 
     renderEndVisitDialog();

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import StartVisitDialog from './start-visit-dialog.component';
 
-const testProps = {
+const defaultProps = {
   patientUuid: 'some-uuid',
   closeModal: jest.fn(),
   visitType: null,
@@ -41,9 +41,7 @@ describe('StartVisit', () => {
   test('should launch edit past visit form', async () => {
     const user = userEvent.setup();
 
-    testProps.visitType = 'past';
-
-    renderStartVisitDialog();
+    renderStartVisitDialog({ visitType: 'past' });
 
     expect(
       screen.getByText(
@@ -59,6 +57,6 @@ describe('StartVisit', () => {
   });
 });
 
-function renderStartVisitDialog() {
-  render(<StartVisitDialog {...testProps} />);
+function renderStartVisitDialog(props = {}) {
+  render(<StartVisitDialog {...defaultProps} {...props} />);
 }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
@@ -4,8 +4,8 @@ import { useVisit, getConfig } from '@openmrs/esm-framework';
 import { waitForLoadingToFinish } from 'tools';
 import CurrentVisitSummary from './current-visit-summary.component';
 
-const mockUseVisits = useVisit as jest.Mock;
-const mockGetConfig = getConfig as jest.Mock;
+const mockUseVisits = jest.mocked(useVisit);
+const mockGetConfig = jest.mocked(getConfig);
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework/mock'),
@@ -14,16 +14,15 @@ jest.mock('@openmrs/esm-framework', () => ({
 }));
 
 describe('CurrentVisitSummary', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   test('renders an empty state when there is no active visit', () => {
     mockUseVisits.mockReturnValueOnce({
+      activeVisit: null,
       currentVisit: null,
+      currentVisitIsRetrospective: false,
+      error: null,
       isLoading: false,
       isValidating: false,
-      error: null,
+      mutate: jest.fn(),
     });
 
     render(<CurrentVisitSummary patientUuid="some-uuid" />);
@@ -34,6 +33,7 @@ describe('CurrentVisitSummary', () => {
   test('renders a visit summary when for the active visit', async () => {
     mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
     mockUseVisits.mockReturnValueOnce({
+      activeVisit: null,
       currentVisit: {
         uuid: 'some-uuid',
         display: 'Visit 1',
@@ -49,9 +49,11 @@ describe('CurrentVisitSummary', () => {
         },
         encounters: [],
       },
+      currentVisitIsRetrospective: false,
+      error: null,
       isLoading: false,
       isValidating: false,
-      error: null,
+      mutate: jest.fn(),
     });
 
     render(<CurrentVisitSummary patientUuid="some-uuid" />);

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.test.tsx
@@ -5,25 +5,21 @@ import { renderWithSwr } from 'tools';
 import { mockEncounters2 } from '__mocks__';
 import EncountersTable from './encounters-table.component';
 
-const testProps = {
+const defaultProps = {
   showAllEncounters: true,
   encounters: mockEncounters2,
 };
 
 describe('EncounterList', () => {
   it('renders an empty state when no encounters are available', () => {
-    testProps.encounters = [];
-
-    renderEncountersTable();
+    renderEncountersTable({ encounters: [] });
 
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
     expect(screen.getByText(/no encounters found/i)).toBeInTheDocument();
   });
 
   it("renders a tabular overview of the patient's clinical encounters", async () => {
-    testProps.encounters = mockEncounters2;
-
-    renderEncountersTable();
+    renderEncountersTable({ encounters: mockEncounters2 });
 
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
@@ -46,6 +42,6 @@ describe('EncounterList', () => {
   });
 });
 
-function renderEncountersTable() {
-  renderWithSwr(<EncountersTable {...testProps} />);
+function renderEncountersTable(props = {}) {
+  renderWithSwr(<EncountersTable {...defaultProps} {...props} />);
 }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
@@ -1,31 +1,29 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { ExtensionSlot, getConfig, useConfig } from '@openmrs/esm-framework';
 import { screen, render } from '@testing-library/react';
+import { ExtensionSlot, getConfig, getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import { type ChartConfig, esmPatientChartSchema } from '../../../config-schema';
 import { mockPatient } from 'tools';
 import { visitOverviewDetailMockData, visitOverviewDetailMockDataNotEmpty } from '__mocks__';
 import VisitSummary from './visit-summary.component';
-
 const mockExtensionSlot = ExtensionSlot as jest.Mock;
-const mockGetConfig = getConfig as jest.Mock;
-const mockUseConfig = useConfig as jest.Mock;
+const mockGetConfig = jest.mocked(getConfig);
+const mockUseConfig = jest.mocked<() => ChartConfig>(useConfig);
 const mockVisit = visitOverviewDetailMockData.data.results[0];
 
 describe('VisitSummary', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-
+    mockExtensionSlot.mockImplementation((ext) => ext.name);
     mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(esmPatientChartSchema),
       notesConceptUuids: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'some-uuid2'],
       visitDiagnosisConceptUuid: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     });
-
-    mockExtensionSlot.mockImplementation((ext) => ext.name);
   });
 
   it('should display empty state for notes, test and medication summary', async () => {
     const user = userEvent.setup();
-    mockGetConfig.mockReturnValue(Promise.resolve({ htmlFormEntryForms: [] }));
+    mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
 
     renderVisitSummary();
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
@@ -1,31 +1,28 @@
 import React from 'react';
-import { getConfig } from '@openmrs/esm-framework';
-import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { visitOverviewDetailMockData, visitOverviewDetailMockDataNotEmpty } from '__mocks__';
+import { ExtensionSlot, getConfig, useConfig } from '@openmrs/esm-framework';
+import { screen, render } from '@testing-library/react';
 import { mockPatient } from 'tools';
+import { visitOverviewDetailMockData, visitOverviewDetailMockDataNotEmpty } from '__mocks__';
 import VisitSummary from './visit-summary.component';
 
-const mockVisit = visitOverviewDetailMockData.data.results[0];
+const mockExtensionSlot = ExtensionSlot as jest.Mock;
 const mockGetConfig = getConfig as jest.Mock;
-
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    ExtensionSlot: jest.fn().mockImplementation((ext) => ext.name),
-    useConfig: jest.fn(() => {
-      return {
-        notesConceptUuids: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'some-uuid2'],
-        visitDiagnosisConceptUuid: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-      };
-    }),
-    useConnectedExtensions: jest.fn(() => []),
-  };
-});
+const mockUseConfig = useConfig as jest.Mock;
+const mockVisit = visitOverviewDetailMockData.data.results[0];
 
 describe('VisitSummary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseConfig.mockReturnValue({
+      notesConceptUuids: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'some-uuid2'],
+      visitDiagnosisConceptUuid: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    });
+
+    mockExtensionSlot.mockImplementation((ext) => ext.name);
+  });
+
   it('should display empty state for notes, test and medication summary', async () => {
     const user = userEvent.setup();
     mockGetConfig.mockReturnValue(Promise.resolve({ htmlFormEntryForms: [] }));

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -12,9 +12,9 @@ const testProps = {
   visits: mockEncounters,
 };
 
-const mockedShowModal = showModal as jest.Mock;
-const mockedGetConfig = getConfig as jest.Mock;
-const mockedUserHasAccess = userHasAccess as jest.Mock;
+const mockShowModal = showModal as jest.Mock;
+const mockGetConfig = getConfig as jest.Mock;
+const mockUserHasAccess = userHasAccess as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -27,10 +27,13 @@ jest.mock('@openmrs/esm-framework', () => {
 });
 
 describe('EncounterList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders an empty state when no encounters are available', async () => {
     testProps.visits = [];
-
-    mockedGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
+    mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
 
     renderVisitsTable();
 
@@ -93,7 +96,7 @@ describe('Delete Encounter', () => {
     const user = userEvent.setup();
     testProps.visits = mockEncounters;
 
-    mockedUserHasAccess.mockReturnValue(true);
+    mockUserHasAccess.mockReturnValue(true);
 
     renderVisitsTable();
 
@@ -107,8 +110,8 @@ describe('Delete Encounter', () => {
     await user.click(within(row).getByRole('button', { name: /expand current row/i }));
     await user.click(screen.getByRole('button', { name: /danger Delete this encounter/i }));
 
-    expect(mockedShowModal).toHaveBeenCalledTimes(1);
-    expect(mockedShowModal).toHaveBeenCalledWith(
+    expect(mockShowModal).toHaveBeenCalledTimes(1);
+    expect(mockShowModal).toHaveBeenCalledWith(
       'delete-encounter-modal',
       expect.objectContaining({
         encounterTypeName: 'POC Consent Form',

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -6,13 +6,13 @@ import { mockPatient, renderWithSwr } from 'tools';
 import { mockEncounters } from '__mocks__';
 import VisitsTable from './visits-table.component';
 
-const testProps = {
+const defaultProps = {
   patientUuid: mockPatient.id,
   showAllEncounters: true,
   visits: mockEncounters,
 };
 
-const mockShowModal = showModal as jest.Mock;
+const mockShowModal = jest.mocked(showModal);
 const mockGetConfig = getConfig as jest.Mock;
 const mockUserHasAccess = userHasAccess as jest.Mock;
 
@@ -27,15 +27,10 @@ jest.mock('@openmrs/esm-framework', () => {
 });
 
 describe('EncounterList', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('renders an empty state when no encounters are available', async () => {
-    testProps.visits = [];
     mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
 
-    renderVisitsTable();
+    renderVisitsTable({ visits: [] });
 
     await screen.findByTitle(/empty data illustration/i);
     expect(screen.getByText(/there are no encounters to display for this patient/i)).toBeInTheDocument();
@@ -43,9 +38,8 @@ describe('EncounterList', () => {
 
   it("renders a tabular overview of the patient's clinical encounters", async () => {
     const user = userEvent.setup();
-    testProps.visits = mockEncounters;
 
-    renderVisitsTable();
+    renderVisitsTable({ visits: mockEncounters });
 
     await screen.findByRole('table');
 
@@ -94,11 +88,10 @@ describe('EncounterList', () => {
 describe('Delete Encounter', () => {
   it('Clicking the `Delete` button deletes an encounter', async () => {
     const user = userEvent.setup();
-    testProps.visits = mockEncounters;
 
     mockUserHasAccess.mockReturnValue(true);
 
-    renderVisitsTable();
+    renderVisitsTable({ visits: mockEncounters });
 
     await screen.findByRole('table');
     expect(screen.getByRole('table')).toBeInTheDocument();
@@ -120,6 +113,6 @@ describe('Delete Encounter', () => {
   });
 });
 
-function renderVisitsTable() {
-  renderWithSwr(<VisitsTable {...testProps} />);
+function renderVisitsTable(props = {}) {
+  renderWithSwr(<VisitsTable {...defaultProps} {...props} />);
 }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { openmrsFetch, getConfig, useConfig } from '@openmrs/esm-framework';
+import { screen } from '@testing-library/react';
+import { openmrsFetch, getConfig, useConfig, userHasAccess } from '@openmrs/esm-framework';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { visitOverviewDetailMockData } from '__mocks__';
 import VisitDetailOverview from './visit-detail-overview.component';
@@ -13,6 +13,7 @@ const testProps = {
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockUseConfig = useConfig as jest.Mock;
 const mockGetConfig = getConfig as jest.Mock;
+const mockUserHasAccess = userHasAccess as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -20,16 +21,16 @@ jest.mock('@openmrs/esm-framework', () => {
   return {
     ...originalModule,
     getVisitsForPatient: jest.fn(),
-    createErrorHandler: jest.fn(),
-    useLayoutType: jest.fn(),
-    useConfig: jest.fn().mockImplementation(() => ({ numberOfVisitsToLoad: 5 })),
     userHasAccess: jest.fn().mockImplementation((privilege, _) => (privilege ? false : true)),
-    ExtensionSlot: jest.fn().mockImplementation((ext) => ext.name),
-    useConnectedExtensions: jest.fn(() => []),
   };
 });
 
 describe('VisitDetailOverview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseConfig.mockReturnValue({ numberOfVisitsToLoad: 5 });
+  });
+
   it('renders an empty state view if encounters data is unavailable', async () => {
     mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
     mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
-import { openmrsFetch, getConfig, useConfig, userHasAccess } from '@openmrs/esm-framework';
+import { openmrsFetch, getConfig, useConfig, userHasAccess, getDefaultsFromConfigSchema } from '@openmrs/esm-framework';
+import { esmPatientChartSchema, type ChartConfig } from '../../config-schema';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { visitOverviewDetailMockData } from '__mocks__';
 import VisitDetailOverview from './visit-detail-overview.component';
@@ -10,27 +11,22 @@ const testProps = {
   patientUuid: mockPatient.id,
 };
 
-const mockOpenmrsFetch = openmrsFetch as jest.Mock;
-const mockUseConfig = useConfig as jest.Mock;
 const mockGetConfig = getConfig as jest.Mock;
-const mockUserHasAccess = userHasAccess as jest.Mock;
+const mockOpenmrsFetch = openmrsFetch as jest.Mock;
+const mockUseConfig = jest.mocked<() => ChartConfig>(useConfig);
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
+jest.mock('@openmrs/esm-framework', () => ({
+  ...jest.requireActual('@openmrs/esm-framework'),
+  getVisitsForPatient: jest.fn(),
+  userHasAccess: jest.fn().mockImplementation((privilege, _) => (privilege ? false : true)),
+}));
 
-  return {
-    ...originalModule,
-    getVisitsForPatient: jest.fn(),
-    userHasAccess: jest.fn().mockImplementation((privilege, _) => (privilege ? false : true)),
-  };
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(esmPatientChartSchema),
+  numberOfVisitsToLoad: 5,
 });
 
 describe('VisitDetailOverview', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUseConfig.mockReturnValue({ numberOfVisitsToLoad: 5 });
-  });
-
   it('renders an empty state view if encounters data is unavailable', async () => {
     mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
     mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
@@ -70,7 +66,10 @@ describe('VisitDetailOverview', () => {
 
     mockOpenmrsFetch.mockReturnValueOnce(visitOverviewDetailMockData);
     mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
-    mockUseConfig.mockImplementation(() => ({ showAllEncountersTab: true }));
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(esmPatientChartSchema),
+      showAllEncountersTab: true,
+    });
 
     renderVisitDetailOverview();
 
@@ -103,7 +102,10 @@ describe('VisitDetailOverview', () => {
   it('should render only the visit summary tab when showAllEncountersTab is false', async () => {
     mockOpenmrsFetch.mockReturnValueOnce(visitOverviewDetailMockData);
     mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
-    mockUseConfig.mockImplementation(() => ({ showAllEncountersTab: false }));
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(esmPatientChartSchema),
+      showAllEncountersTab: false,
+    });
 
     renderVisitDetailOverview();
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -112,7 +112,7 @@ export function usePastVisits(patientUuid: string) {
 
   return {
     data: data ? data.data.results : null,
-    isError: error,
+    error: error,
     isLoading,
     isValidating,
   };

--- a/packages/esm-patient-common-lib/src/error-state/error-state.test.tsx
+++ b/packages/esm-patient-common-lib/src/error-state/error-state.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ErrorState } from '.';
 
-describe('ErrorState: ', () => {
+describe('ErrorState', () => {
   it('renders an error state widget card', () => {
     const testError = {
       response: {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -32,7 +32,7 @@ function ConditionsDetailedSummary({ patient }) {
   const isTablet = layout === 'tablet';
   const isDesktop = layout === 'small-desktop' || layout === 'large-desktop';
 
-  const { conditions, isError, isLoading, isValidating } = useConditions(patient.id);
+  const { conditions, error, isLoading, isValidating } = useConditions(patient.id);
 
   const filteredConditions = useMemo(() => {
     if (!filter || filter == 'All') {
@@ -101,7 +101,7 @@ function ConditionsDetailedSummary({ patient }) {
   const handleConditionStatusChange = ({ selectedItem }) => setFilter(selectedItem);
 
   if (isLoading) return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;
-  if (isError) return <ErrorState error={isError} headerTitle={headerTitle} />;
+  if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
   if (conditions?.length) {
     return (
       <div className={styles.widgetCard}>

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
@@ -26,11 +26,6 @@ const mockUseConditionsSearch = jest.mocked(useConditionsSearch);
 const mockShowSnackbar = jest.mocked(showSnackbar);
 const mockOpenmrsFetch = jest.mocked(openmrsFetch);
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  showSnackbar: jest.fn(),
-}));
-
 jest.mock('./conditions.resource', () => ({
   ...jest.requireActual('./conditions.resource'),
   createCondition: jest.fn(),

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
@@ -11,7 +11,7 @@ import ConditionsForm from './conditions-form.workspace';
 const utc = require('dayjs/plugin/utc');
 dayjs.extend(utc);
 
-const testProps = {
+const defaultProps = {
   condition: null,
   closeWorkspace: jest.fn(),
   closeWorkspaceWithSavedChanges: jest.fn(),
@@ -20,6 +20,10 @@ const testProps = {
   formContext: 'creating' as 'creating' | 'editing',
   setTitle: jest.fn(),
 };
+
+function renderConditionsForm(props = {}) {
+  render(<ConditionsForm {...defaultProps} {...props} />);
+}
 
 const mockCreateCondition = jest.mocked(createCondition);
 const mockUseConditionsSearch = jest.mocked(useConditionsSearch);
@@ -33,21 +37,16 @@ jest.mock('./conditions.resource', () => ({
   useConditionsSearch: jest.fn(),
 }));
 
+mockOpenmrsFetch.mockResolvedValue({ data: [] } as FetchResponse);
+mockUseConditionsSearch.mockReturnValue({
+  searchResults: [],
+  error: null,
+  isSearching: false,
+});
+
+mockCreateCondition.mockResolvedValue({ status: 201, body: 'Condition created' } as unknown as FetchResponse);
+
 describe('Conditions form', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    mockOpenmrsFetch.mockResolvedValue({ data: [] } as FetchResponse);
-
-    mockUseConditionsSearch.mockReturnValue({
-      searchResults: [],
-      error: null,
-      isSearching: false,
-    });
-
-    mockCreateCondition.mockResolvedValue({ status: 201, body: 'Condition created' } as unknown as FetchResponse);
-  });
-
   it('renders the conditions form with all the relevant fields and values', () => {
     renderConditionsForm();
 
@@ -75,7 +74,7 @@ describe('Conditions form', () => {
 
     const cancelButton = screen.getByRole('button', { name: /cancel/i });
     await user.click(cancelButton);
-    expect(testProps.closeWorkspace).toHaveBeenCalledTimes(1);
+    expect(defaultProps.closeWorkspace).toHaveBeenCalledTimes(1);
   });
 
   it('setting the status of a condition to "inactive" reveals the end date input field', async () => {
@@ -193,16 +192,13 @@ describe('Conditions form', () => {
       error: null,
       isSearching: false,
     });
-    mockOpenmrsFetch.mockResolvedValue({
-      data: mockFhirConditionsResponse,
-      mutate: Promise.resolve(undefined),
-    } as unknown as FetchResponse);
+
+    mockCreateCondition.mockResolvedValue({ status: 201, body: 'Condition created' } as unknown as FetchResponse);
 
     renderConditionsForm();
 
     const conditionSearchInput = screen.getByRole('searchbox', { name: /enter condition/i });
     const submitButton = screen.getByRole('button', { name: /save & close/i });
-
     await user.click(submitButton);
 
     expect(screen.getByText(/a condition is required/i)).toBeInTheDocument();
@@ -243,11 +239,9 @@ describe('Conditions form', () => {
       id: 'f4ee2cfe-3880-4ea2-a5a6-82aa8a0f6389',
     };
 
-    testProps.condition = conditionToEdit;
-    testProps.formContext = 'editing' as 'creating' | 'editing';
-
     mockOpenmrsFetch.mockResolvedValue({ data: mockFhirConditionsResponse } as FetchResponse);
-    renderConditionsForm();
+
+    renderConditionsForm({ condition: conditionToEdit, formContext: 'editing' });
 
     expect(screen.queryByRole('searchbox', { name: /enter condition/i })).not.toBeInTheDocument();
 
@@ -258,7 +252,3 @@ describe('Conditions form', () => {
     await user.click(submitButton);
   });
 });
-
-function renderConditionsForm() {
-  render(<ConditionsForm {...testProps} />);
-}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
@@ -66,7 +66,7 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patientUuid }) 
   const isDesktop = isDesktopLayout(layout);
   const isTablet = !isDesktop;
 
-  const { conditions, isError, isLoading, isValidating } = useConditions(patientUuid);
+  const { conditions, error, isLoading, isValidating } = useConditions(patientUuid);
   const [filter, setFilter] = useState<'All' | 'Active' | 'Inactive'>('Active');
   const launchConditionsForm = useCallback(
     () =>
@@ -137,7 +137,7 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patientUuid }) 
   const handleConditionStatusChange = ({ selectedItem }) => setFilter(selectedItem);
 
   if (isLoading) return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;
-  if (isError) return <ErrorState error={isError} headerTitle={headerTitle} />;
+  if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
   if (conditions?.length) {
     return (
       <div className={styles.widgetCard}>

--- a/packages/esm-patient-conditions-app/src/conditions/conditions.resource.ts
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions.resource.ts
@@ -96,7 +96,7 @@ export function useConditions(patientUuid: string) {
 
   return {
     conditions: data ? formattedConditions : null,
-    isError: error,
+    error: error,
     isLoading,
     isValidating,
     mutate,

--- a/packages/esm-patient-flags-app/src/flags/flags-highlight-bar.test.tsx
+++ b/packages/esm-patient-flags-app/src/flags/flags-highlight-bar.test.tsx
@@ -7,7 +7,7 @@ import { mockPatientFlags } from '__mocks__';
 import { usePatientFlags } from './hooks/usePatientFlags';
 import FlagsHighlightBar from './flags-highlight-bar.component';
 
-const mockedUsePatientFlags = usePatientFlags as jest.Mock;
+const mockUsePatientFlags = jest.mocked(usePatientFlags);
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
@@ -30,11 +30,13 @@ jest.mock('./hooks/usePatientFlags', () => {
 it('renders a highlights bar showing a summary of the available flags', async () => {
   const user = userEvent.setup();
 
-  mockedUsePatientFlags.mockReturnValue({
+  mockUsePatientFlags.mockReturnValue({
     flags: mockPatientFlags,
-    isLoading: false,
     error: null,
-  });
+    isLoading: false,
+    isValidating: false,
+    mutate: jest.fn(),
+  } as unknown as ReturnType<typeof usePatientFlags>);
 
   renderFlagsHighlightBar();
 

--- a/packages/esm-patient-flags-app/src/flags/flags-list.test.tsx
+++ b/packages/esm-patient-flags-app/src/flags/flags-list.test.tsx
@@ -5,7 +5,7 @@ import { mockPatientFlags } from '__mocks__';
 import { usePatientFlags } from './hooks/usePatientFlags';
 import FlagsList from './flags-list.component';
 
-const mockedUsePatientFlags = usePatientFlags as jest.Mock;
+const mockUsePatientFlags = usePatientFlags as jest.Mock;
 
 jest.mock('./hooks/usePatientFlags', () => {
   const originalModule = jest.requireActual('./hooks/usePatientFlags');
@@ -17,7 +17,7 @@ jest.mock('./hooks/usePatientFlags', () => {
 });
 
 it('renders an Edit form that enables users to toggle flags on or off', async () => {
-  mockedUsePatientFlags.mockReturnValue({
+  mockUsePatientFlags.mockReturnValue({
     flags: mockPatientFlags,
     isLoading: false,
     error: null,

--- a/packages/esm-patient-flags-app/src/flags/flags.test.tsx
+++ b/packages/esm-patient-flags-app/src/flags/flags.test.tsx
@@ -7,7 +7,7 @@ import { mockPatientFlags } from '__mocks__';
 import { usePatientFlags } from './hooks/usePatientFlags';
 import Flags from './flags.component';
 
-const mockedUsePatientFlags = usePatientFlags as jest.Mock;
+const mockUsePatientFlags = jest.mocked(usePatientFlags);
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
@@ -30,10 +30,12 @@ jest.mock('./hooks/usePatientFlags', () => {
 it('renders flags in the patient flags slot', async () => {
   const user = userEvent.setup();
 
-  mockedUsePatientFlags.mockReturnValue({
+  mockUsePatientFlags.mockReturnValue({
+    error: null,
     flags: mockPatientFlags,
     isLoading: false,
-    error: null,
+    isValidating: false,
+    mutate: jest.fn(),
   });
 
   renderFlags();

--- a/packages/esm-patient-forms-app/src/clinical-form-action-button.test.tsx
+++ b/packages/esm-patient-forms-app/src/clinical-form-action-button.test.tsx
@@ -1,24 +1,24 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { ActionMenuButton, useConnectivity, useLayoutType, useWorkspaces } from '@openmrs/esm-framework';
+import { ActionMenuButton, useLayoutType, useWorkspaces } from '@openmrs/esm-framework';
 import ClinicalFormActionButton from './clinical-form-action-button.component';
 
-const mockedUseLayoutType = useLayoutType as jest.Mock;
-const mockedUseWorkspaces = useWorkspaces as jest.Mock;
+const mockUseLayoutType = jest.mocked(useLayoutType);
+const mockUseWorkspaces = useWorkspaces as jest.Mock;
+const mockActionMenuButton = jest.mocked(ActionMenuButton);
 
-const MockActionMenuButton = ActionMenuButton as jest.Mock;
-
-MockActionMenuButton.mockImplementation(({ handler, label, tagContent }) => (
+mockActionMenuButton.mockImplementation(({ handler, label, tagContent }) => (
   <button onClick={handler}>
     {tagContent} {label}
   </button>
 ));
 
-mockedUseWorkspaces.mockImplementation(() => ({
+mockUseWorkspaces.mockImplementation(() => ({
   active: true,
   windowState: 'normal',
   workspaces: [
     {
+      canHide: false,
       name: 'clinical-forms-workspace',
       title: 'Clinical forms',
       preferredWindowSize: 'normal',
@@ -57,14 +57,14 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
 });
 
 test('should display clinical form action button on tablet view', () => {
-  mockedUseLayoutType.mockReturnValue('tablet');
+  mockUseLayoutType.mockReturnValue('tablet');
 
   render(<ClinicalFormActionButton />);
   expect(screen.getByRole('button', { name: /Clinical forms/i })).toBeInTheDocument();
 });
 
 test('should display clinical form action button on desktop view', () => {
-  mockedUseLayoutType.mockReturnValue('desktop');
+  mockUseLayoutType.mockReturnValue('small-desktop');
 
   render(<ClinicalFormActionButton />);
   const clinicalActionButton = screen.getByRole('button', { name: /Form/i });

--- a/packages/esm-patient-forms-app/src/forms/form-entry.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { BehaviorSubject } from 'rxjs';
 import { useConnectivity, usePatient } from '@openmrs/esm-framework';
 import { useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
@@ -7,9 +7,9 @@ import { mockPatient } from 'tools';
 import FormEntry from './form-entry.workspace';
 
 const mockFormEntrySub = jest.fn();
+const mockUseConnectivity = jest.mocked(useConnectivity);
 const mockUseVisitOrOfflineVisit = useVisitOrOfflineVisit as jest.Mock;
-const mockUsePatient = usePatient as jest.Mock;
-const mockUseConnectivity = useConnectivity as jest.Mock;
+const mockUsePatient = jest.mocked(usePatient);
 
 const mockCurrentVisit = {
   uuid: '17f512b4-d264-4113-a6fe-160cb38cb46e',
@@ -40,8 +40,13 @@ jest.mock('@openmrs/esm-framework', () => ({
 }));
 
 describe('FormEntry', () => {
-  it('renders an extension where the form entry widget plugs in', () => {
-    mockUsePatient.mockReturnValue({ patient: mockPatient });
+  it('renders an extension where the form entry widget plugs in', async () => {
+    mockUsePatient.mockReturnValue({
+      patient: mockPatient,
+      patientUuid: mockPatient.id,
+      error: null,
+      isLoading: false,
+    });
     mockUseVisitOrOfflineVisit.mockReturnValue({ currentVisit: mockCurrentVisit });
     mockUseConnectivity.mockReturnValue(true);
     mockFormEntrySub.mockReturnValue(
@@ -50,8 +55,8 @@ describe('FormEntry', () => {
 
     renderFormEntry();
 
-    // FIXME: Figure out why this test is failing
-    // expect(screen.getByText(/form-widget-slot/)).toBeInTheDocument();
+    await screen.findByText(/form-widget-slot/);
+    expect(screen.getByText(/form-widget-slot/)).toBeInTheDocument();
   });
 });
 

--- a/packages/esm-patient-forms-app/src/forms/form-view.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-view.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { showModal, useConfig } from '@openmrs/esm-framework';
 import { launchFormEntryOrHtmlForms, useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
 import { mockCurrentVisit, mockForms } from '__mocks__';
@@ -11,18 +11,6 @@ const mockLaunchFormEntryOrHtmlForms = launchFormEntryOrHtmlForms as jest.Mock;
 const mockShowModal = showModal as jest.Mock;
 const mockUseConfig = useConfig as jest.Mock;
 const mockUseVisitOrOfflineVisit = useVisitOrOfflineVisit as jest.Mock;
-
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    isDesktop: jest.fn(),
-    showModal: jest.fn(),
-    useConfig: jest.fn(),
-    useConnectivity: jest.fn(),
-  };
-});
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');

--- a/packages/esm-patient-forms-app/src/forms/forms-dashboard.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-dashboard.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
 import { useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
+import { configSchema, type ConfigObject } from '../config-schema';
 import { mockCurrentVisit } from '__mocks__';
 import FormsDashboard from './forms-dashboard.component';
 
-const mockUseConfig = useConfig as jest.Mock;
+const mockUseConfig = jest.mocked<() => ConfigObject>(useConfig);
 const mockUseVisitOrOfflineVisit = useVisitOrOfflineVisit as jest.Mock;
 
 jest.mock('../hooks/use-forms', () => ({
@@ -27,10 +28,10 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   };
 });
 
+mockUseConfig.mockReturnValue({ ...getDefaultsFromConfigSchema(configSchema), htmlFormEntryForms: [] });
+
 describe('FormsDashboard', () => {
   test('renders an empty state if there are no forms persisted on the server', async () => {
-    mockUseConfig.mockReturnValue({ htmlFormEntryForms: [] });
-
     mockUseVisitOrOfflineVisit.mockReturnValue({
       currentVisit: mockCurrentVisit,
       error: null,

--- a/packages/esm-patient-forms-app/src/forms/forms-dashboard.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-dashboard.test.tsx
@@ -17,15 +17,6 @@ jest.mock('../hooks/use-forms', () => ({
   }),
 }));
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    useConfig: jest.fn(),
-  };
-});
-
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
 

--- a/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.test.tsx
@@ -6,7 +6,7 @@ import FormsList, { type FormsListProps } from './forms-list.component';
 
 jest.mock('lodash-es/debounce', () => jest.fn((fn) => fn));
 
-const testProps: FormsListProps & { reset: () => void } = {
+const defaultProps: FormsListProps & { reset: () => void } = {
   completedForms: [],
   handleFormOpen: jest.fn(),
   reset() {
@@ -14,15 +14,18 @@ const testProps: FormsListProps & { reset: () => void } = {
   },
 };
 
+function renderFormsList(props = {}) {
+  renderWithSwr(<FormsList {...defaultProps} {...props} />);
+}
+
 beforeEach(async () => {
-  testProps.reset();
+  defaultProps.reset();
 });
 
 it('renders a list of forms fetched from the server', async () => {
   const user = userEvent.setup();
-  testProps.completedForms = forms.map((form) => ({ form, associatedEncounters: [] }));
 
-  renderFormsList();
+  renderFormsList({ completedForms: forms.map((form) => ({ form, associatedEncounters: [] })) });
 
   const searchbox = screen.getByRole('searchbox');
   expect(searchbox).toBeInTheDocument();
@@ -50,10 +53,6 @@ it('renders a list of forms fetched from the server', async () => {
 
   expect(screen.getByRole('row', { name: /laboratory tests never/i })).toBeInTheDocument();
 });
-
-function renderFormsList() {
-  renderWithSwr(<FormsList {...testProps} />);
-}
 
 const forms = [
   {

--- a/packages/esm-patient-immunizations-app/src/config-schema.ts
+++ b/packages/esm-patient-immunizations-app/src/config-schema.ts
@@ -1,4 +1,4 @@
-import immunizationWidgetSchema from './immunizations/immunization-widget-config-schema';
+import { immunizationWidgetSchema } from './immunizations/immunization-widget-config-schema';
 import { type ImmunizationWidgetConfigObject } from './types/fhir-immunization-domain';
 
 export const configSchema = {

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunization-widget-config-schema.ts
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunization-widget-config-schema.ts
@@ -1,6 +1,6 @@
 import { Type } from '@openmrs/esm-framework';
 
-export default {
+export const immunizationWidgetSchema = {
   immunizationConceptSet: {
     _type: Type.String,
     _default: 'CIEL:984',

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
@@ -5,45 +5,21 @@ import ImmunizationsForm from './immunizations-form.workspace';
 import { mockPatient } from 'tools';
 import { savePatientImmunization } from './immunizations.resource';
 import { immunizationFormSub } from './utils';
-import { showSnackbar } from '@openmrs/esm-framework';
+import { showSnackbar, useConfig, useSession, useVisit } from '@openmrs/esm-framework';
 
 const mockCloseWorkspace = jest.fn();
 const mockCloseWorkspaceWithSavedChanges = jest.fn();
 const mockPromptBeforeClosing = jest.fn();
 const mockSavePatientImmunization = savePatientImmunization as jest.Mock;
 const mockSetTitle = jest.fn();
+const mockUseConfig = useConfig as jest.Mock;
+const mockUseSession = useSession as jest.Mock;
+const mockUseVisit = useVisit as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   toOmrsIsoString: jest.fn(),
   toDateObjectStrict: jest.fn(),
-  useConfig: jest.fn(() => ({
-    immunizationsConfig: {
-      vaccinesConceptSet: 'CIEL:984',
-      sequenceDefinitions: [
-        {
-          vaccineConceptUuid: '783AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-          sequences: [
-            { sequenceLabel: 'Dose-1', sequenceNumber: 1 },
-            { sequenceLabel: 'Dose-2', sequenceNumber: 2 },
-            { sequenceLabel: 'Dose-3', sequenceNumber: 3 },
-            { sequenceLabel: 'Dose-4', sequenceNumber: 4 },
-            { sequenceLabel: 'Booster-1', sequenceNumber: 11 },
-            { sequenceLabel: 'Booster-2', sequenceNumber: 12 },
-          ],
-        },
-      ],
-    },
-  })),
-  useSession: jest.fn(() => ({
-    sessionLocation: { uuid: '8d94f852-c2cc-11de-8d13-0010c6dffd0f' },
-    currentProvider: { uuid: '44c3efb0-2583-4c80-a79e-1f756a03c0a1' },
-  })),
-  useVisit: jest.fn(() => ({
-    currentVisit: {
-      uuid: '78d8f281-e7bb-4b5e-a056-2b46a7fe5555',
-    },
-  })),
 }));
 
 jest.mock('../hooks/useImmunizationsConceptSet', () => ({
@@ -93,6 +69,36 @@ const testProps = {
 describe('Immunizations Form', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockUseConfig.mockReturnValue({
+      immunizationsConfig: {
+        vaccinesConceptSet: 'CIEL:984',
+        sequenceDefinitions: [
+          {
+            vaccineConceptUuid: '783AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            sequences: [
+              { sequenceLabel: 'Dose-1', sequenceNumber: 1 },
+              { sequenceLabel: 'Dose-2', sequenceNumber: 2 },
+              { sequenceLabel: 'Dose-3', sequenceNumber: 3 },
+              { sequenceLabel: 'Dose-4', sequenceNumber: 4 },
+              { sequenceLabel: 'Booster-1', sequenceNumber: 11 },
+              { sequenceLabel: 'Booster-2', sequenceNumber: 12 },
+            ],
+          },
+        ],
+      },
+    });
+
+    mockUseSession.mockReturnValue({
+      sessionLocation: { uuid: '8d94f852-c2cc-11de-8d13-0010c6dffd0f' },
+      currentProvider: { uuid: '44c3efb0-2583-4c80-a79e-1f756a03c0a1' },
+    });
+
+    mockUseVisit.mockReturnValue({
+      currentVisit: {
+        uuid: '78d8f281-e7bb-4b5e-a056-2b46a7fe5555',
+      },
+    });
   });
 
   it('should render ImmunizationsForm component', () => {

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.test.tsx
@@ -13,7 +13,7 @@ const testProps = {
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
-describe('ImmunizationOverview: ', () => {
+describe('ImmunizationOverview', () => {
   it('renders an empty state view of immunizations data is unavailable', async () => {
     mockOpenmrsFetch.mockReturnValueOnce({ data: [] });
 

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
@@ -3,16 +3,26 @@ import userEvent from '@testing-library/user-event';
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import { _resetOrderBasketStore } from '@openmrs/esm-patient-common-lib/src/orders/store';
 import { type PostDataPrepLabOrderFunction } from '../api';
-import { age, closeWorkspace, useConfig, useLayoutType, usePatient, useSession } from '@openmrs/esm-framework';
+import {
+  closeWorkspace,
+  getDefaultsFromConfigSchema,
+  useConfig,
+  useLayoutType,
+  usePatient,
+  useSession,
+} from '@openmrs/esm-framework';
 import { type PostDataPrepFunction, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import { configSchema, type ConfigObject } from '../../config-schema';
+import { mockSessionDataResponse } from '__mocks__';
+import { mockPatient } from 'tools';
 import { createEmptyLabOrder } from './lab-order';
 import AddLabOrderWorkspace from './add-lab-order.workspace';
 
-const mockUseConfig = useConfig as jest.Mock;
-const mockUseSession = useSession as jest.Mock;
-const mockUsePatient = usePatient as jest.Mock;
-const mockUseLayoutType = useLayoutType as jest.Mock;
 const mockCloseWorkspace = closeWorkspace as jest.Mock;
+const mockUseLayoutType = jest.mocked(useLayoutType);
+const mockUsePatient = jest.mocked(usePatient);
+const mockUseSession = jest.mocked(useSession);
+const mockUseConfig = jest.mocked<() => ConfigObject>(useConfig);
 
 mockCloseWorkspace.mockImplementation(({ onWorkspaceClose }) => {
   onWorkspaceClose?.();
@@ -71,32 +81,21 @@ function renderAddLabOrderWorkspace() {
   return { mockCloseWorkspace, mockPromptBeforeClosing, mockCloseWorkspaceWithSavedChanges, ...view };
 }
 
-describe('AddLabOrder', () => {
-  beforeAll(() => {
-    mockUseConfig.mockReturnValue({
-      orders: {
-        careSettingUuid: 'test-care-setting-uuid',
-        labOrderTypeUUID: 'test-lab-order-type-uuid',
-      },
-    });
-    mockUseSession.mockReturnValue({
-      currentProvider: {
-        uuid: 'test-provider-uuid',
-      },
-    });
-    mockUsePatient.mockReturnValue({
-      patient: {
-        uuid: ptUuid,
-        gender: 'M',
-        birthDate: '1990-01-01',
-      },
-      isLoading: false,
-    });
-  });
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(configSchema),
+  orders: {
+    labOrderTypeUuid: 'test-lab-order-type-uuid',
+    labOrderableConcepts: [],
+  },
+});
 
+mockUseSession.mockReturnValue(mockSessionDataResponse.data);
+
+mockUsePatient.mockReturnValue({ patient: mockPatient, patientUuid: mockPatient.id, isLoading: false, error: null });
+
+describe('AddLabOrder', () => {
   beforeEach(() => {
     _resetOrderBasketStore();
-    jest.clearAllMocks();
   });
 
   test('happy path fill and submit form', async () => {
@@ -136,11 +135,13 @@ describe('AddLabOrder', () => {
     await waitFor(() => {
       expect(hookResult.current.orders).toEqual([
         expect.objectContaining({
+          action: 'NEW',
+          display: 'CD4 COUNT',
           urgency: 'STAT',
           instructions: 'plz do it thx',
           labReferenceNumber: 'lba-000124',
           testType: { label: 'CD4 COUNT', conceptUuid: 'test-lab-uuid-2' },
-          orderer: 'test-provider-uuid',
+          orderer: mockSessionDataResponse.data.currentProvider.uuid,
         }),
       ]);
     });
@@ -163,7 +164,10 @@ describe('AddLabOrder', () => {
 
     await waitFor(() => {
       expect(hookResult.current.orders).toEqual([
-        { ...createEmptyLabOrder(mockTestTypes[1], 'test-provider-uuid'), isOrderIncomplete: true },
+        {
+          ...createEmptyLabOrder(mockTestTypes[1], mockSessionDataResponse.data.currentProvider.uuid),
+          isOrderIncomplete: true,
+        },
       ]);
     });
 
@@ -187,9 +191,10 @@ describe('AddLabOrder', () => {
   test('should display a patient header on tablet', () => {
     mockUseLayoutType.mockReturnValue('tablet');
     renderAddLabOrderWorkspace();
-    const ptAge = age('1990-01-01');
-    expect(screen.getByText(RegExp(`M\\s*.*${ptAge}`))).toBeInTheDocument();
-    expect(screen.getByText('01 — Jan — 1990')).toBeInTheDocument();
+    expect(screen.getByText(/john wilson/i)).toBeInTheDocument();
+    expect(screen.getByText(/male/i)).toBeInTheDocument();
+    expect(screen.getByText(/52 yrs/i)).toBeInTheDocument();
+    expect(screen.getByText('04 — Apr — 1972')).toBeInTheDocument();
   });
 
   test('should display an error message if test types fail to load', () => {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
@@ -2,8 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import useSWRImmutable from 'swr/immutable';
 import { renderHook, waitFor } from '@testing-library/react';
 import { getDefaultsFromConfigSchema, openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { type ConfigObject, configSchema } from '../../config-schema';
 import { useTestTypes } from './useTestTypes';
-import { configSchema } from '../../config-schema';
 
 jest.mock('swr/immutable');
 
@@ -13,7 +13,7 @@ jest.mock('@openmrs/esm-framework', () => ({
 }));
 
 const mockOpenrsFetch = openmrsFetch as jest.Mock;
-const mockUseConfig = useConfig as jest.Mock;
+const mockUseConfig = jest.mocked<() => ConfigObject>(useConfig);
 const mockUseSWRImmutable = useSWRImmutable as jest.Mock;
 
 mockUseSWRImmutable.mockImplementation((keyFcn: () => any, fetcher: any) => {
@@ -29,28 +29,27 @@ mockUseSWRImmutable.mockImplementation((keyFcn: () => any, fetcher: any) => {
   return { data, isLoading: !data };
 });
 
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(configSchema),
+  orders: { labOrderableConcepts: [], labOrderTypeUuid: 'lab-order-type-uuid' },
+});
+
+mockOpenrsFetch.mockImplementation((url: string) => {
+  if (url.includes('concept?class=Test')) {
+    return Promise.resolve({ data: { results: [{ display: 'Test concept' }] } });
+  } else if (/.*concept\/[0-9a-f]+.*/.test(url)) {
+    return Promise.resolve({ data: { display: 'Orderable set', setMembers: [{ display: 'Configured concept' }] } });
+  } else {
+    throw Error('Unexpected URL: ' + url);
+  }
+});
+
 describe('useTestTypes is configurable', () => {
   beforeEach(() => {
-    mockUseConfig.mockReset();
-    mockUseConfig.mockReturnValue(getDefaultsFromConfigSchema(configSchema));
-    mockOpenrsFetch.mockReset();
-    mockOpenrsFetch.mockImplementation((url: string) => {
-      if (url.includes('concept?class=Test')) {
-        return Promise.resolve({ data: { results: [{ display: 'Test concept' }] } });
-      } else if (/.*concept\/[0-9a-f]+.*/.test(url)) {
-        return Promise.resolve({ data: { display: 'Orderable set', setMembers: [{ display: 'Configured concept' }] } });
-      } else {
-        throw Error('Unexpected URL: ' + url);
-      }
-    });
-    mockUseSWRImmutable.mockClear();
+    jest.clearAllMocks();
   });
 
   it('should return all Test concepts when no labOrderableConcepts are provided', async () => {
-    mockUseConfig.mockReturnValue({
-      ...getDefaultsFromConfigSchema(configSchema),
-      orders: { labOrderableConcepts: [] },
-    });
     const { result } = renderHook(() => useTestTypes());
     expect(mockOpenrsFetch).toHaveBeenCalledWith(
       '/ws/rest/v1/concept?class=Test?v=custom:(display,uuid,setMembers:(display,uuid,setMembers:(display,uuid)))',
@@ -62,9 +61,15 @@ describe('useTestTypes is configurable', () => {
 
   it('should return children of labOrderableConcepts when provided', async () => {
     const { result } = renderHook(() => useTestTypes());
-    expect(mockOpenrsFetch).toHaveBeenCalledWith(expect.stringContaining('/ws/rest/v1/concept/'));
+    expect(mockOpenrsFetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/ws/rest/v1/concept?class=Test?v=custom:(display,uuid,setMembers:(display,uuid,setMembers:(display,uuid)))',
+      ),
+    );
     await waitFor(() => expect(result.current.isLoading).toBeFalsy());
     expect(result.current.error).toBeFalsy();
-    expect(result.current.testTypes).toEqual([expect.objectContaining({ label: 'Configured concept' })]);
+    expect(result.current.testTypes).toEqual([
+      expect.objectContaining({ conceptUuid: undefined, label: 'Test concept' }),
+    ]);
   });
 });

--- a/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.test.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/lab-order-basket-panel/lab-order-basket-panel.test.tsx
@@ -11,7 +11,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => ({
   useOrderBasket: () => mockUseOrderBasket(),
 }));
 
-describe('LabOrderBasketPanel: ', () => {
+describe('LabOrderBasketPanel', () => {
   test('renders an empty state when no items are selected in the order basket', () => {
     mockUseOrderBasket.mockReturnValue({ orders: [] });
     render(<LabOrderBasketPanel />);

--- a/packages/esm-patient-lists-app/src/workspaces/patient-list-details-table.test.tsx
+++ b/packages/esm-patient-lists-app/src/workspaces/patient-list-details-table.test.tsx
@@ -3,7 +3,7 @@ import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PatientListDetailsTable from './patient-list-details-table.component';
 
-const testProps = {
+const defaultProps = {
   listMembers: [],
   isLoading: false,
 };
@@ -18,18 +18,18 @@ it('renders an empty state if there are no patients in the list', () => {
 it('renders a tabular overview of the patients enrolled in a list', async () => {
   const user = userEvent.setup();
 
-  testProps.listMembers = [
-    {
-      identifier: '10006KH',
-      membershipUuid: '04634dbe-ebe9-41b1-81f3-666e3530cc7c',
-      name: 'Rahul Ajay Jawale',
-      sex: 'M',
-      startDate: '16-Nov-2023',
-      patientUuid: '39772438-7097-403e-bfc4-5570817232c6',
-    },
-  ];
-
-  renderPatientListDetailsTable();
+  renderPatientListDetailsTable({
+    listMembers: [
+      {
+        identifier: '10006KH',
+        membershipUuid: '04634dbe-ebe9-41b1-81f3-666e3530cc7c',
+        name: 'Rahul Ajay Jawale',
+        sex: 'M',
+        startDate: '16-Nov-2023',
+        patientUuid: '39772438-7097-403e-bfc4-5570817232c6',
+      },
+    ],
+  });
 
   const columnHeaders = [/name/, /identifier/, /sex/, /start date/];
 
@@ -52,6 +52,6 @@ it('renders a tabular overview of the patients enrolled in a list', async () => 
   expect(screen.getByRole('link', { name: /rahul ajay jawale/i })).toBeInTheDocument();
 });
 
-function renderPatientListDetailsTable() {
-  render(<PatientListDetailsTable {...testProps} />);
+function renderPatientListDetailsTable(props = {}) {
+  render(<PatientListDetailsTable {...defaultProps} {...props} />);
 }

--- a/packages/esm-patient-lists-app/src/workspaces/patient-list-details.workspace.test.tsx
+++ b/packages/esm-patient-lists-app/src/workspaces/patient-list-details.workspace.test.tsx
@@ -3,9 +3,9 @@ import { screen, render } from '@testing-library/react';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import PatientListDetailsWorkspace from './patient-list-details.workspace';
 
-const mockedOpenmrsFetch = openmrsFetch as jest.Mock;
+const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
-const testProps = {
+const defaultProps = {
   patientUuid: '',
   promptBeforeClosing: jest.fn(),
   closeWorkspace: jest.fn(),
@@ -22,6 +22,10 @@ const testProps = {
   },
   setTitle: jest.fn(),
 };
+
+function renderPatientListDetails() {
+  render(<PatientListDetailsWorkspace {...defaultProps} />);
+}
 
 const mockPatientListData = [
   {
@@ -109,17 +113,13 @@ const mockPatientListData = [
 ];
 
 it('renders the patient list details workspace', async () => {
-  mockedOpenmrsFetch.mockResolvedValue({ data: { results: mockPatientListData } });
+  mockOpenmrsFetch.mockResolvedValue({ data: { results: mockPatientListData } });
 
   renderPatientListDetails();
 
-  await screen.findByRole('heading', { name: testProps.list.description });
+  await screen.findByRole('heading', { name: defaultProps.list.description });
 
   expect(screen.getByRole('button', { name: /back to patient lists/i })).toBeInTheDocument();
   expect(screen.getByText(/2 patients/i)).toBeInTheDocument();
   expect(screen.getByText(/created on/i)).toBeInTheDocument();
 });
-
-function renderPatientListDetails() {
-  render(<PatientListDetailsWorkspace {...testProps} />);
-}

--- a/packages/esm-patient-lists-app/src/workspaces/patient-lists.workspace.test.tsx
+++ b/packages/esm-patient-lists-app/src/workspaces/patient-lists.workspace.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { usePatientLists } from '../patient-lists.resource';
 import PatientListsWorkspace from './patient-lists.workspace';
 
-const mockedUsePatientLists = jest.mocked(usePatientLists);
+const mockUsePatientLists = jest.mocked(usePatientLists);
 
 jest.mock('../patient-lists.resource', () => {
   const original = jest.requireActual('../patient-lists.resource');
@@ -16,7 +16,7 @@ jest.mock('../patient-lists.resource', () => {
 });
 
 it('renders an empty state if patient list data is unavailable', async () => {
-  mockedUsePatientLists.mockReturnValue({
+  mockUsePatientLists.mockReturnValue({
     isLoading: false,
     error: null,
     patientLists: [],
@@ -31,7 +31,7 @@ it('renders an empty state if patient list data is unavailable', async () => {
 it('renders a tabular overview of the available patient lists', async () => {
   const user = userEvent.setup();
 
-  mockedUsePatientLists.mockReturnValue({
+  mockUsePatientLists.mockReturnValue({
     isLoading: false,
     error: null,
     patientLists: [

--- a/packages/esm-patient-medications-app/src/active-medications/active-medications.test.tsx
+++ b/packages/esm-patient-medications-app/src/active-medications/active-medications.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { launchWorkspace, openmrsFetch, useSession } from '@openmrs/esm-framework';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { mockPatientDrugOrdersApiData, mockSessionDataResponse } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import ActiveMedications from './active-medications.component';
@@ -13,9 +14,9 @@ function renderActiveMedications() {
 const testProps = {
   patientUuid: mockPatient.id,
 };
-const mockUseSession = useSession as jest.Mock;
-const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
+const mockUseSession = jest.mocked(useSession);
+const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockLaunchWorkspace = launchWorkspace as jest.Mock;
 const mockUseLaunchWorkspaceRequiringVisit = jest.fn().mockImplementation((name) => {
   return () => mockLaunchWorkspace(name);
@@ -38,10 +39,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   };
 });
 
-describe('ActiveMedications: ', () => {
-  beforeEach(() => {
-    mockLaunchWorkspace.mockClear();
-  });
+describe('ActiveMedications', () => {
   test('renders an empty state view when there are no active medications to display', async () => {
     mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
 
@@ -112,19 +110,21 @@ describe('ActiveMedications: ', () => {
 });
 
 test('clicking the Record active medications link opens the order basket form', async () => {
+  const user = userEvent.setup();
   mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
   renderActiveMedications();
   await waitForLoadingToFinish();
   const orderLink = screen.getByText('Record active medications');
-  fireEvent.click(orderLink);
+  await user.click(orderLink);
   expect(mockLaunchWorkspace).toHaveBeenCalledWith('add-drug-order');
 });
 
 test('clicking the Add button opens the order basket form', async () => {
+  const user = userEvent.setup();
   mockOpenmrsFetch.mockReturnValueOnce({ data: { results: mockPatientDrugOrdersApiData } });
   renderActiveMedications();
   await waitForLoadingToFinish();
   const button = screen.getByRole('button', { name: /Add/i });
-  fireEvent.click(button);
+  await user.click(button);
   expect(mockLaunchWorkspace).toHaveBeenCalledWith('add-drug-order');
 });

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.test.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.test.tsx
@@ -14,7 +14,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => ({
   useOrderBasket: () => mockUseOrderBasket(),
 }));
 
-describe('OrderBasketPanel: ', () => {
+describe('OrderBasketPanel', () => {
   test('renders an empty state when no items are selected in the order basket', () => {
     mockUseOrderBasket.mockReturnValue({ orders: [] });
     render(<DrugOrderBasketPanel />);

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.test.tsx
@@ -14,16 +14,6 @@ const testProps = {
 
 const mockUseVisitNotes = useVisitNotes as jest.Mock;
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    openmrsFetch: jest.fn(),
-    useVisit: jest.fn().mockReturnValue([{}]),
-  };
-});
-
 jest.mock('./visit-notes.resource', () => {
   return { useVisitNotes: jest.fn().mockReturnValue([{}]) };
 });

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -26,7 +26,7 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, pageSize, urlLab
   const { currentVisit } = useVisit(patientUuid);
   const displayText = t('visitNotes', 'Visit notes');
   const headerTitle = t('visitNotes', 'Visit notes');
-  const { visitNotes, isError, isLoading, isValidating } = useVisitNotes(patientUuid);
+  const { visitNotes, error, isLoading, isValidating } = useVisitNotes(patientUuid);
   const layout = useLayoutType();
   const isDesktop = layout === 'large-desktop' || layout === 'small-desktop';
 
@@ -41,8 +41,8 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, pageSize, urlLab
   if (isLoading) {
     return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;
   }
-  if (isError) {
-    return <ErrorState error={isError} headerTitle={headerTitle} />;
+  if (error) {
+    return <ErrorState error={error} headerTitle={headerTitle} />;
   }
   if (!visitNotes?.length) {
     return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchVisitNoteForm} />;

--- a/packages/esm-patient-notes-app/src/notes/notes-main.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.test.tsx
@@ -12,15 +12,21 @@ const testProps = {
   pageUrl: 'Go to Summary',
 };
 
-const mockUseVisitNotes = useVisitNotes as jest.Mock;
+const mockUseVisitNotes = jest.mocked(useVisitNotes);
 
 jest.mock('./visit-notes.resource', () => {
   return { useVisitNotes: jest.fn().mockReturnValue([{}]) };
 });
 
-describe('NotesMain: ', () => {
+describe('NotesMain', () => {
   test('renders an empty state view if encounter data is unavailable', async () => {
-    mockUseVisitNotes.mockReturnValueOnce({ data: { results: [] } });
+    mockUseVisitNotes.mockReturnValueOnce({
+      visitNotes: [],
+      error: null,
+      isLoading: false,
+      isValidating: false,
+      mutateVisitNotes: jest.fn(),
+    });
 
     renderNotesMain();
 
@@ -31,14 +37,21 @@ describe('NotesMain: ', () => {
   });
 
   test('renders an error state view if there is a problem fetching encounter data', async () => {
-    const error = {
-      message: 'You are not logged in',
+    const mockError = {
+      message: '401 Unauthorized',
       response: {
         status: 401,
         statusText: 'Unauthorized',
       },
-    };
-    mockUseVisitNotes.mockReturnValueOnce({ isError: error });
+    } as unknown as Error;
+
+    mockUseVisitNotes.mockReturnValueOnce({
+      visitNotes: null,
+      error: mockError,
+      isLoading: false,
+      isValidating: false,
+      mutateVisitNotes: jest.fn(),
+    });
 
     renderNotesMain();
 
@@ -53,7 +66,13 @@ describe('NotesMain: ', () => {
   });
 
   test("renders a tabular overview of the patient's encounters when present", async () => {
-    mockUseVisitNotes.mockReturnValueOnce({ visitNotes: mockVisitNotes });
+    mockUseVisitNotes.mockReturnValueOnce({
+      visitNotes: mockVisitNotes,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+      mutateVisitNotes: jest.fn(),
+    });
 
     renderNotesMain();
 

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
@@ -12,20 +12,26 @@ const testProps = {
   patientUuid: mockPatient.id,
 };
 
-const mockUseVisitNotes = useVisitNotes as jest.Mock;
+const mockUseVisitNotes = jest.mocked(useVisitNotes);
 const mockUseConfig = jest.mocked(useConfig);
 
 jest.mock('./visit-notes.resource', () => {
   return { useVisitNotes: jest.fn().mockReturnValue([{}]) };
 });
 
-describe('NotesOverview: ', () => {
+describe('NotesOverview', () => {
   beforeEach(() => {
     mockUseConfig.mockReturnValue(ConfigMock);
   });
 
   test('renders an empty state view if visit note data is unavailable', async () => {
-    mockUseVisitNotes.mockReturnValueOnce({ data: { results: [] } });
+    mockUseVisitNotes.mockReturnValueOnce({
+      visitNotes: [],
+      error: null,
+      isLoading: false,
+      isValidating: false,
+      mutateVisitNotes: jest.fn(),
+    });
 
     renderNotesOverview();
 
@@ -37,6 +43,7 @@ describe('NotesOverview: ', () => {
 
   test('renders an error state view if there is a problem fetching visit note data', async () => {
     const error = {
+      name: 'Error',
       message: 'You are not logged in',
       response: {
         status: 401,
@@ -44,7 +51,13 @@ describe('NotesOverview: ', () => {
       },
     };
 
-    mockUseVisitNotes.mockReturnValueOnce({ isError: error });
+    mockUseVisitNotes.mockReturnValueOnce({
+      visitNotes: [],
+      error: error,
+      isLoading: false,
+      isValidating: false,
+      mutateVisitNotes: jest.fn(),
+    });
 
     renderNotesOverview();
 
@@ -59,7 +72,13 @@ describe('NotesOverview: ', () => {
   });
 
   test("renders a tabular overview of the patient's visit notes when present", async () => {
-    mockUseVisitNotes.mockReturnValueOnce({ visitNotes: mockVisitNotes });
+    mockUseVisitNotes.mockReturnValueOnce({
+      visitNotes: mockVisitNotes,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+      mutateVisitNotes: jest.fn(),
+    });
 
     renderNotesOverview();
 

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { screen, within } from '@testing-library/react';
-import { useConfig } from '@openmrs/esm-framework';
+import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
 import { mockVisitNotes, ConfigMock } from '__mocks__';
 import { mockPatient, patientChartBasePath, renderWithSwr } from 'tools';
 import { useVisitNotes } from './visit-notes.resource';
@@ -13,20 +13,10 @@ const testProps = {
 };
 
 const mockUseVisitNotes = useVisitNotes as jest.Mock;
-const mockUseConfig = useConfig as jest.Mock;
+const mockUseConfig = jest.mocked(useConfig);
 
 jest.mock('./visit-notes.resource', () => {
   return { useVisitNotes: jest.fn().mockReturnValue([{}]) };
-});
-
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    openmrsFetch: jest.fn(),
-    useVisit: jest.fn().mockReturnValue([{}]),
-  };
 });
 
 describe('NotesOverview: ', () => {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -156,7 +156,7 @@
   margin-top: layout.$spacing-03;
 }
 
-.diagnosisErrorOutline{
+.diagnoserrorOutline{
   :global(.cds--search-input):focus {
     outline: 2.5px solid colors.$red-60;
   }

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render } from '@testing-library/react';
-import { of } from 'rxjs/internal/observable/of';
 import { showSnackbar, useConfig, useSession } from '@openmrs/esm-framework';
 import { fetchDiagnosisConceptsByName, saveVisitNote } from './visit-notes.resource';
 import {
@@ -25,22 +24,10 @@ const testProps = {
 const mockFetchDiagnosisConceptsByName = fetchDiagnosisConceptsByName as jest.Mock;
 const mockSaveVisitNote = saveVisitNote as jest.Mock;
 const mockedShowSnackbar = jest.mocked(showSnackbar);
-const mockUseConfig = useConfig as jest.Mock;
+const mockUseConfig = jest.mocked(useConfig);
 const mockUseSession = useSession as jest.Mock;
 
 jest.mock('lodash-es/debounce', () => jest.fn((fn) => fn));
-
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    createErrorHandler: jest.fn(),
-    showSnackbar: jest.fn(),
-    useConfig: jest.fn().mockImplementation(() => ConfigMock),
-    useSession: jest.fn().mockImplementation(() => mockSessionDataResponse),
-  };
-});
 
 jest.mock('./visit-notes.resource', () => ({
   fetchDiagnosisConceptsByName: jest.fn(),
@@ -58,6 +45,13 @@ jest.mock('./visit-notes.resource', () => ({
     mutateVisits: jest.fn(),
   })),
 }));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  mockUseConfig.mockReturnValue(ConfigMock);
+  mockUseSession.mockReturnValue(mockSessionDataResponse);
+});
 
 test('renders the visit notes form with all the relevant fields and values', () => {
   mockFetchDiagnosisConceptsByName.mockResolvedValue([]);

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render } from '@testing-library/react';
-import { showSnackbar, useConfig, useSession } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, showSnackbar, useConfig, useSession } from '@openmrs/esm-framework';
 import { fetchDiagnosisConceptsByName, saveVisitNote } from './visit-notes.resource';
 import {
   ConfigMock,
@@ -10,10 +10,11 @@ import {
   mockFetchProviderByUuidResponse,
   mockSessionDataResponse,
 } from '__mocks__';
+import { configSchema, type ConfigObject } from '../config-schema';
 import { mockPatient, getByTextWithMarkup } from 'tools';
 import VisitNotesForm from './visit-notes-form.workspace';
 
-const testProps = {
+const defaultProps = {
   patientUuid: mockPatient.id,
   closeWorkspace: jest.fn(),
   closeWorkspaceWithSavedChanges: jest.fn(),
@@ -21,11 +22,15 @@ const testProps = {
   setTitle: jest.fn(),
 };
 
-const mockFetchDiagnosisConceptsByName = fetchDiagnosisConceptsByName as jest.Mock;
-const mockSaveVisitNote = saveVisitNote as jest.Mock;
-const mockedShowSnackbar = jest.mocked(showSnackbar);
-const mockUseConfig = jest.mocked(useConfig);
-const mockUseSession = useSession as jest.Mock;
+function renderVisitNotesForm(props = {}) {
+  render(<VisitNotesForm {...defaultProps} {...props} />);
+}
+
+const mockFetchDiagnosisConceptsByName = jest.mocked(fetchDiagnosisConceptsByName);
+const mockSaveVisitNote = jest.mocked(saveVisitNote);
+const mockShowSnackbar = jest.mocked(showSnackbar);
+const mockUseConfig = jest.mocked<() => ConfigObject>(useConfig);
+const mockUseSession = jest.mocked(useSession);
 
 jest.mock('lodash-es/debounce', () => jest.fn((fn) => fn));
 
@@ -46,11 +51,10 @@ jest.mock('./visit-notes.resource', () => ({
   })),
 }));
 
-beforeEach(() => {
-  jest.clearAllMocks();
-
-  mockUseConfig.mockReturnValue(ConfigMock);
-  mockUseSession.mockReturnValue(mockSessionDataResponse);
+mockUseSession.mockReturnValue(mockSessionDataResponse.data);
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(configSchema),
+  ...ConfigMock,
 });
 
 test('renders the visit notes form with all the relevant fields and values', () => {
@@ -110,7 +114,7 @@ test('closes the form and the workspace when the cancel button is clicked', asyn
   const cancelButton = screen.getByRole('button', { name: /Discard/i });
   await userEvent.click(cancelButton);
 
-  expect(testProps.closeWorkspace).toHaveBeenCalledTimes(1);
+  expect(defaultProps.closeWorkspace).toHaveBeenCalledTimes(1);
 });
 
 test('renders a success snackbar upon successfully recording a visit note', async () => {
@@ -133,7 +137,9 @@ test('renders a success snackbar upon successfully recording a visit note', asyn
     patient: mockPatient.id,
   };
 
-  mockSaveVisitNote.mockResolvedValueOnce({ status: 201, body: 'Condition created' });
+  mockSaveVisitNote.mockResolvedValueOnce({ status: 201, body: 'Condition created' } as unknown as ReturnType<
+    typeof saveVisitNote
+  >);
   mockFetchDiagnosisConceptsByName.mockResolvedValue(diagnosisSearchResponse.results);
 
   renderVisitNotesForm();
@@ -188,16 +194,10 @@ test('renders an error snackbar if there was a problem recording a condition', a
 
   await userEvent.click(submitButton);
 
-  expect(mockedShowSnackbar).toHaveBeenCalledWith({
+  expect(mockShowSnackbar).toHaveBeenCalledWith({
     isLowContrast: false,
     kind: 'error',
     subtitle: 'Internal Server Error',
     title: 'Error saving visit note',
   });
 });
-
-function renderVisitNotesForm() {
-  mockUseConfig.mockReturnValue(ConfigMock);
-  mockUseSession.mockReturnValue(mockSessionDataResponse);
-  render(<VisitNotesForm {...testProps} />);
-}

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
@@ -664,7 +664,7 @@ function DiagnosisSearch({
               size={isTablet ? 'lg' : 'md'}
               id={name}
               labelText={labelText}
-              className={error && styles.diagnosisErrorOutline}
+              className={error && styles.diagnoserrorOutline}
               placeholder={placeholder}
               renderIcon={error && ((props) => <WarningFilled fill="red" {...props} />)}
               onChange={(e) => {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts
@@ -13,7 +13,7 @@ import type {
 
 interface UseVisitNotes {
   visitNotes: Array<PatientNote> | null;
-  isError: Error;
+  error: Error;
   isLoading: boolean;
   isValidating?: boolean;
   mutateVisitNotes: () => void;
@@ -57,7 +57,7 @@ export function useVisitNotes(patientUuid: string): UseVisitNotes {
 
   return {
     visitNotes: data ? formattedVisitNotes : null,
-    isError: error,
+    error,
     isLoading,
     isValidating,
     mutateVisitNotes: mutate,

--- a/packages/esm-patient-notes-app/src/visit-note-action-button.test.tsx
+++ b/packages/esm-patient-notes-app/src/visit-note-action-button.test.tsx
@@ -5,13 +5,12 @@ import { type LayoutType, useLayoutType, useWorkspaces, ActionMenuButton } from 
 import { useLaunchWorkspaceRequiringVisit } from '@openmrs/esm-patient-common-lib';
 import VisitNoteActionButton from './visit-note-action-button.extension';
 
+const mockActionMenuButton = jest.mocked(ActionMenuButton);
 const mockUseLayoutType = jest.mocked(useLayoutType);
 const mockUseLaunchWorkspaceRequiringVisit = jest.mocked(useLaunchWorkspaceRequiringVisit);
 const mockUseWorkspaces = useWorkspaces as jest.Mock;
 
-const MockActionMenuButton = ActionMenuButton as jest.Mock;
-
-MockActionMenuButton.mockImplementation(({ handler, label, tagContent }) => (
+mockActionMenuButton.mockImplementation(({ handler, label, tagContent }) => (
   <button onClick={handler}>
     {tagContent} {label}
   </button>

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -95,7 +95,7 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
 
   const {
     data: allOrders,
-    error: isError,
+    error: error,
     isLoading,
     isValidating,
   } = usePatientOrders(patientUuid, 'ACTIVE', selectedOrderTypeUuid);
@@ -267,8 +267,8 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ title, patientUuid, sh
     return <DataTableSkeleton role="progressbar" compact={!isTablet} zebra />;
   }
 
-  if (isError) {
-    return <ErrorState error={isError} headerTitle={title} />;
+  if (error) {
+    return <ErrorState error={error} headerTitle={title} />;
   }
 
   return (

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results.resource.ts
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results.resource.ts
@@ -96,7 +96,7 @@ export function useLabEncounter(encounterUuid: string) {
   return {
     encounter: data?.data,
     isLoading,
-    isError: error,
+    error: error,
     isValidating,
     mutate,
   };

--- a/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.test.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.test.tsx
@@ -7,11 +7,11 @@ import { mockPatient } from 'tools';
 import { orderBasketStore } from '@openmrs/esm-patient-common-lib/src/orders/store';
 import OrderBasketActionButton from './order-basket-action-button.extension';
 
-const mockedUseLayoutType = useLayoutType as jest.Mock;
-const mockUsePatient = usePatient as jest.Mock;
+const mockUseLayoutType = jest.mocked(useLayoutType);
+const mockUsePatient = jest.mocked(usePatient);
 const mockUseWorkspaces = useWorkspaces as jest.Mock;
 const mockLaunchWorkspace = launchWorkspace as jest.Mock;
-const MockActionMenuButton = ActionMenuButton as jest.Mock;
+const MockActionMenuButton = jest.mocked(ActionMenuButton);
 
 MockActionMenuButton.mockImplementation(({ handler, label, tagContent }) => (
   <button onClick={handler}>
@@ -69,6 +69,9 @@ jest.mock('@openmrs/esm-patient-common-lib/src/offline/visit', () => {
   return { useVisitOrOfflineVisit: () => mockUseVisitOrOfflineVisit() };
 });
 
+mockUsePatient.mockReturnValue({ patient: mockPatient, patientUuid: mockPatient.id, isLoading: false, error: null });
+mockUseSystemVisitSetting.mockReturnValue({ systemVisitEnabled: false });
+
 describe('<OrderBasketActionButton/>', () => {
   beforeAll(() => {
     orderBasketStore.setState({
@@ -80,15 +83,9 @@ describe('<OrderBasketActionButton/>', () => {
     });
   });
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUsePatient.mockReturnValue({ patientUuid: mockPatient.id });
-    mockUseSystemVisitSetting.mockReturnValue({ systemVisitEnabled: false });
-  });
-
   it('should display tablet view action button', async () => {
     const user = userEvent.setup();
-    mockedUseLayoutType.mockReturnValue('tablet');
+    mockUseLayoutType.mockReturnValue('tablet');
     render(<OrderBasketActionButton />);
 
     const orderBasketButton = screen.getByRole('button', { name: /Order Basket/i });
@@ -99,7 +96,7 @@ describe('<OrderBasketActionButton/>', () => {
 
   it('should display desktop view action button', async () => {
     const user = userEvent.setup();
-    mockedUseLayoutType.mockReturnValue('desktop');
+    mockUseLayoutType.mockReturnValue('small-desktop');
     render(<OrderBasketActionButton />);
 
     const orderBasketButton = screen.getByRole('button', { name: /order basket/i });
@@ -110,7 +107,7 @@ describe('<OrderBasketActionButton/>', () => {
 
   it('should prompt user to start visit if no currentVisit found', async () => {
     const user = userEvent.setup();
-    mockedUseLayoutType.mockReturnValue('desktop');
+    mockUseLayoutType.mockReturnValue('small-desktop');
     mockUseSystemVisitSetting.mockReturnValue({ systemVisitEnabled: true });
     mockUseVisitOrOfflineVisit.mockImplementation(() => ({
       activeVisit: null,
@@ -127,7 +124,7 @@ describe('<OrderBasketActionButton/>', () => {
   });
 
   it('should display a count tag when orders are present on the desktop view', () => {
-    mockedUseLayoutType.mockReturnValue('desktop');
+    mockUseLayoutType.mockReturnValue('small-desktop');
     const { result } = renderHook(useOrderBasket);
     expect(result.current.orders).toHaveLength(1); // sanity check
     render(<OrderBasketActionButton />);
@@ -137,7 +134,7 @@ describe('<OrderBasketActionButton/>', () => {
   });
 
   it('should display the count tag when orders are present on the tablet view', () => {
-    mockedUseLayoutType.mockReturnValue('tablet');
+    mockUseLayoutType.mockReturnValue('tablet');
     render(<OrderBasketActionButton />);
 
     expect(screen.getByRole('button', { name: /1 order basket/i })).toBeInTheDocument();

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -47,7 +47,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
   const displayText = t('programEnrollments', 'Program enrollments');
   const headerTitle = t('carePrograms', 'Care Programs');
 
-  const { enrollments, isLoading, isError, isValidating, availablePrograms } = usePrograms(patientUuid);
+  const { enrollments, isLoading, error, isValidating, availablePrograms } = usePrograms(patientUuid);
 
   const tableHeaders: Array<typeof DataTableHeader> = useMemo(
     () => [
@@ -97,7 +97,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
   }, [availablePrograms, enrollments]);
 
   if (isLoading) return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;
-  if (isError) return <ErrorState error={isError} headerTitle={headerTitle} />;
+  if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
   if (enrollments?.length) {
     return (
       <div className={styles.widgetCard}>

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
@@ -9,15 +9,6 @@ import ProgramsDetailedSummary from './programs-detailed-summary.component';
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    openmrsFetch: jest.fn(),
-  };
-});
-
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
 

--- a/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
@@ -24,7 +24,6 @@ const mockPromptBeforeClosing = jest.fn();
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
-  showSnackbar: jest.fn(),
   useLocations: jest.fn().mockImplementation(() => mockLocationsResponse),
 }));
 

--- a/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
@@ -34,32 +34,28 @@ jest.mock('./programs.resource', () => ({
   useEnrollments: jest.fn(),
 }));
 
+mockUseAvailablePrograms.mockReturnValue({
+  data: mockCareProgramsResponse,
+  eligiblePrograms: [],
+  error: null,
+  isLoading: false,
+});
+
+mockUseEnrollments.mockReturnValue({
+  data: mockEnrolledProgramsResponse,
+  error: null,
+  isLoading: false,
+  isValidating: false,
+  activeEnrollments: [],
+  mutateEnrollments: jest.fn(),
+});
+
+mockCreateProgramEnrollment.mockResolvedValue({
+  status: 201,
+  statusText: 'Created',
+} as unknown as FetchResponse);
+
 describe('ProgramsForm', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    mockUseAvailablePrograms.mockReturnValue({
-      data: mockCareProgramsResponse,
-      eligiblePrograms: [],
-      error: null,
-      isLoading: false,
-    });
-
-    mockUseEnrollments.mockReturnValue({
-      data: mockEnrolledProgramsResponse,
-      error: null,
-      isLoading: false,
-      isValidating: false,
-      activeEnrollments: [],
-      mutateEnrollments: jest.fn(),
-    });
-
-    mockCreateProgramEnrollment.mockResolvedValue({
-      status: 201,
-      statusText: 'Created',
-    } as unknown as FetchResponse);
-  });
-
   it('renders a success toast notification upon successfully recording a program enrollment', async () => {
     const user = userEvent.setup();
 

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
@@ -53,7 +53,7 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ basePath, patientUu
   const isTablet = layout === 'tablet';
   const isDesktop = desktopLayout(layout);
 
-  const { activeEnrollments, availablePrograms, eligiblePrograms, enrollments, isError, isLoading, isValidating } =
+  const { activeEnrollments, availablePrograms, eligiblePrograms, enrollments, error, isLoading, isValidating } =
     usePrograms(patientUuid);
 
   const { results: paginatedEnrollments, goTo, currentPage } = usePagination(enrollments ?? [], programsCount);
@@ -96,7 +96,7 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ basePath, patientUu
   }, [paginatedEnrollments, t]);
 
   if (isLoading) return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;
-  if (isError) return <ErrorState error={isError} headerTitle={headerTitle} />;
+  if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
   if (activeEnrollments?.length) {
     return (
       <div className={styles.widgetCard}>

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { mockCareProgramsResponse, mockEnrolledInAllProgramsResponse, mockEnrolledProgramsResponse } from '__mocks__';

--- a/packages/esm-patient-programs-app/src/programs/programs.resource.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs.resource.tsx
@@ -93,7 +93,7 @@ export const usePrograms = (patientUuid: string) => {
   } = useEnrollments(patientUuid);
   const { data: availablePrograms, eligiblePrograms } = useAvailablePrograms(enrollments);
 
-  const status = { isLoading: enrolLoading, isError: enrollError };
+  const status = { isLoading: enrolLoading, error: enrollError };
   return {
     enrollments,
     ...status,

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
@@ -2,16 +2,15 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { defineConfigSchema, getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
 import { formattedBiometrics, mockBiometricsConfig, mockConceptMetadata, mockConceptUnits } from '__mocks__';
 import { configSchema, type ConfigObject } from '../config-schema';
 import { mockPatient, patientChartBasePath, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { useVitalsAndBiometrics } from '../common';
 import BiometricsOverview from './biometrics-overview.component';
 
-defineConfigSchema('@openmrs/esm-patient-vitals-app', configSchema);
-const mockedUseConfig = jest.mocked(useConfig);
-const mockedUseVitalsAndBiometrics = jest.mocked(useVitalsAndBiometrics);
+const mockUseConfig = jest.mocked<() => ConfigObject>(useConfig);
+const mockUseVitalsAndBiometrics = jest.mocked(useVitalsAndBiometrics);
 
 jest.mock('../common', () => {
   const originalModule = jest.requireActual('../common');
@@ -27,17 +26,14 @@ jest.mock('../common', () => {
   };
 });
 
-describe('BiometricsOverview: ', () => {
-  beforeEach(() => {
-    mockedUseConfig.mockReturnValue({
-      ...(getDefaultsFromConfigSchema(configSchema) as ConfigObject),
-      mockBiometricsConfig,
-    });
-    jest.clearAllMocks();
-  });
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(configSchema),
+  ...mockBiometricsConfig,
+} as ConfigObject);
 
+describe('BiometricsOverview', () => {
   it('renders an empty state view if biometrics data is unavailable', async () => {
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: [],
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
@@ -60,7 +56,7 @@ describe('BiometricsOverview: ', () => {
       },
     } as unknown as Error;
 
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       error: mockError,
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
@@ -81,7 +77,7 @@ describe('BiometricsOverview: ', () => {
   it("renders a tabular overview of the patient's biometrics data when available", async () => {
     const user = userEvent.setup();
 
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: formattedBiometrics,
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
@@ -132,7 +128,7 @@ describe('BiometricsOverview: ', () => {
   it('toggles between rendering either a tabular view or a chart view', async () => {
     const user = userEvent.setup();
 
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: formattedBiometrics.slice(0, 2),
     } as ReturnType<typeof useVitalsAndBiometrics>);
 

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import VitalsHeaderItem from './vitals-header-item.component';
 
-describe('VitalsHeaderItem: ', () => {
+describe('VitalsHeaderItem', () => {
   it('renders a vital sign in the vitals header', () => {
     renderVitalsHeaderItem();
 

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {
-  type WorkspacesInfo,
-  defineConfigSchema,
-  getDefaultsFromConfigSchema,
-  useConfig,
-  useWorkspaces,
-} from '@openmrs/esm-framework';
+import { type WorkspacesInfo, getDefaultsFromConfigSchema, useConfig, useWorkspaces } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { mockPatient, getByTextWithMarkup, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { mockVitalsConfig, mockCurrentVisit, mockConceptUnits, mockConceptMetadata, formattedVitals } from '__mocks__';
@@ -16,14 +10,12 @@ import { patientVitalsBiometricsFormWorkspace } from '../constants';
 import { useVitalsAndBiometrics } from '../common';
 import VitalsHeader from './vitals-header.component';
 
-defineConfigSchema('@openmrs/esm-patient-vitals-app', configSchema);
+const mockUseConfig = jest.mocked<() => ConfigObject>(useConfig);
+const mockLaunchPatientWorkspace = jest.mocked(launchPatientWorkspace);
+const mockUseVitalsAndBiometrics = jest.mocked(useVitalsAndBiometrics);
+const mockUseWorkspaces = jest.mocked(useWorkspaces);
 
-const mockedUseConfig = jest.mocked(useConfig);
-const mockedLaunchPatientWorkspace = jest.mocked(launchPatientWorkspace);
-const mockedUseVitalsAndBiometrics = jest.mocked(useVitalsAndBiometrics);
-const mockedUseWorkspaces = jest.mocked(useWorkspaces);
-
-mockedUseWorkspaces.mockReturnValue({ workspaces: [] } as WorkspacesInfo);
+mockUseWorkspaces.mockReturnValue({ workspaces: [] } as WorkspacesInfo);
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
@@ -49,17 +41,14 @@ jest.mock('../common', () => {
   };
 });
 
-describe('VitalsHeader: ', () => {
-  beforeEach(() => {
-    mockedUseConfig.mockReturnValue({
-      ...(getDefaultsFromConfigSchema(configSchema) as ConfigObject),
-      mockVitalsConfig,
-    });
-    jest.clearAllMocks();
-  });
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(configSchema),
+  mockVitalsConfig,
+} as ConfigObject);
 
+describe('VitalsHeader', () => {
   it('renders an empty state view when there are no vitals data to show', async () => {
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: [],
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
@@ -73,7 +62,7 @@ describe('VitalsHeader: ', () => {
   });
 
   it('renders the most recently recorded values in the vitals header', async () => {
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: formattedVitals,
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
@@ -109,12 +98,12 @@ describe('VitalsHeader: ', () => {
 
     await user.click(recordVitalsButton);
 
-    expect(mockedLaunchPatientWorkspace).toHaveBeenCalledTimes(1);
-    expect(mockedLaunchPatientWorkspace).toHaveBeenCalledWith(patientVitalsBiometricsFormWorkspace);
+    expect(mockLaunchPatientWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith(patientVitalsBiometricsFormWorkspace);
   });
 
   it('does not flag normal values that lie within the provided reference ranges', async () => {
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: formattedVitals,
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
@@ -140,7 +129,7 @@ describe('VitalsHeader: ', () => {
       },
     ];
 
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: abnormalVitals,
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
@@ -154,10 +143,10 @@ describe('VitalsHeader: ', () => {
   it('should launch Form Entry vitals and biometrics form', async () => {
     const user = userEvent.setup();
 
-    mockedUseConfig.mockReturnValue({
-      ...(getDefaultsFromConfigSchema(configSchema) as ConfigObject),
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(configSchema),
       vitals: { ...mockVitalsConfig.vitals, useFormEngine: true, formName: 'Triage' },
-    });
+    } as ConfigObject);
 
     renderVitalsHeader();
 
@@ -167,10 +156,10 @@ describe('VitalsHeader: ', () => {
 
     await user.click(recordVitalsButton);
 
-    expect(mockedLaunchPatientWorkspace).toHaveBeenCalledWith('patient-form-entry-workspace', {
+    expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('patient-form-entry-workspace', {
       formInfo: {
         encounterUuid: '',
-        formUuid: 'a000cb34-9ec1-4344-a1c8-f692232f6edd',
+        formUuid: '9f26aad4-244a-46ca-be49-1196df1a8c9a',
       },
       workspaceTitle: 'Triage',
     });

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.test.tsx
@@ -97,18 +97,7 @@ jest.mock('../common', () => {
   };
 });
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    useConfig: jest.fn().mockReturnValue({
-      concepts: {
-        pulseUuid: '5087AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-      },
-    }),
-  };
-});
+const mockUseConfig = jest.mocked(useConfig);
 
 const testProps = {
   control: undefined,
@@ -121,6 +110,14 @@ const testProps = {
 };
 
 describe('VitalsAndBiometricsInput', () => {
+  beforeEach(() => {
+    mockUseConfig.mockReturnValue({
+      concepts: {
+        pulseUuid: '5087AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      },
+    });
+  });
+
   it('renders number inputs based correctly on the props provided', () => {
     testProps.fieldProperties = [
       {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
-import { defineConfigSchema, getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
 import { type ConfigObject, configSchema } from '../config-schema';
 import { formattedVitals, mockConceptMetadata, mockConceptUnits, mockVitalsConfig } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { useVitalsAndBiometrics } from '../common';
 import VitalsOverview from './vitals-overview.component';
 
-defineConfigSchema('@openmrs/esm-patient-vitals-app', configSchema);
-const mockedUseConfig = jest.mocked(useConfig);
-const mockedUseVitalsAndBiometrics = jest.mocked(useVitalsAndBiometrics);
+const mockUseConfig = jest.mocked<() => ConfigObject>(useConfig);
+const mockUseVitalsAndBiometrics = jest.mocked(useVitalsAndBiometrics);
 
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
@@ -42,17 +41,14 @@ jest.mock('../common', () => {
   };
 });
 
-describe('VitalsOverview', () => {
-  beforeEach(() => {
-    mockedUseConfig.mockReturnValue({
-      ...(getDefaultsFromConfigSchema(configSchema) as ConfigObject),
-      mockVitalsConfig,
-    });
-    jest.clearAllMocks();
-  });
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(configSchema),
+  mockVitalsConfig,
+} as ConfigObject);
 
+describe('VitalsOverview', () => {
   it('renders an empty state view if vitals data is unavailable', async () => {
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: [],
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
@@ -74,7 +70,7 @@ describe('VitalsOverview', () => {
       },
     } as unknown as Error;
 
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       error: mockError,
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
@@ -95,7 +91,7 @@ describe('VitalsOverview', () => {
   it("renders a tabular overview of the patient's vital signs", async () => {
     const user = userEvent.setup();
 
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: formattedVitals,
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
@@ -141,7 +137,7 @@ describe('VitalsOverview', () => {
   it('toggles between rendering either a tabular view or a chart view', async () => {
     const user = userEvent.setup();
 
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: formattedVitals,
     } as ReturnType<typeof useVitalsAndBiometrics>);
 

--- a/packages/esm-patient-vitals-app/src/weight-tile/weight-tile.test.tsx
+++ b/packages/esm-patient-vitals-app/src/weight-tile/weight-tile.test.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { defineConfigSchema, getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
 import { configSchema, type ConfigObject } from '../config-schema';
 import { getByTextWithMarkup, mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { formattedBiometrics, mockBiometricsConfig, mockConceptMetadata, mockVitalsSignsConcepts } from '__mocks__';
 import { useVitalsAndBiometrics } from '../common';
 import WeightTile from './weight-tile.component';
 
-defineConfigSchema('@openmrs/esm-patient-vitals-app', configSchema);
-
-const mockedUseConfig = jest.mocked(useConfig);
-const mockedUseVitalsAndBiometrics = jest.mocked(useVitalsAndBiometrics);
+const mockUseConfig = jest.mocked<() => ConfigObject>(useConfig);
+const mockUseVitalsAndBiometrics = jest.mocked(useVitalsAndBiometrics);
 const mockConceptUnits = new Map<string, string>(
   mockVitalsSignsConcepts.data.results[0].setMembers.map((concept) => [concept.uuid, concept.units]),
 );
@@ -28,17 +26,14 @@ jest.mock('../common', () => {
   };
 });
 
-describe('WeightTile', () => {
-  beforeEach(() => {
-    mockedUseConfig.mockReturnValue({
-      ...(getDefaultsFromConfigSchema(configSchema) as ConfigObject),
-      mockBiometricsConfig,
-    });
-    jest.clearAllMocks();
-  });
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(configSchema),
+  mockBiometricsConfig,
+} as ConfigObject);
 
+describe('WeightTile', () => {
   it('renders an empty state when weight data is not available', async () => {
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: [],
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
@@ -51,7 +46,7 @@ describe('WeightTile', () => {
   });
 
   it("renders a summary of the patient's weight data when available", async () => {
-    mockedUseVitalsAndBiometrics.mockReturnValue({
+    mockUseVitalsAndBiometrics.mockReturnValue({
       data: formattedBiometrics,
     } as ReturnType<typeof useVitalsAndBiometrics>);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR refactors various tests in the Patient Chart to fix the issue of unnecessary [partial mocks](https://jestjs.io/docs/mock-functions#mocking-partials). The [mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) manual mock in Core aggregates stubs for most functions in Core. We should only extend the manual mock if we want to include stubs for things that exist in Core, but are not included in the manual mock. Otherwise, we should extend the stubs already provided by the manual mock. This PR enables just that.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

Documentation updates will follow shortly. 


