### PR TITLE
(feat) O3-3683: Add aria-labels to Start and End visit buttons in the visit header

### DIFF
--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.component.tsx
@@ -182,12 +182,21 @@ const VisitHeader: React.FC = () => {
           <>
             <ExtensionSlot name="visit-header-right-slot" />
             {!isLoading && !currentVisit && !isDeceased && (
-              <Button className={styles.startVisitButton} onClick={launchStartVisitForm} size="lg">
+              <Button
+                className={styles.startVisitButton}
+                onClick={launchStartVisitForm}
+                size="lg"
+                aria-label={t('startAVisit', 'Start a visit')}
+              >
                 {t('startAVisit', 'Start a visit')}
               </Button>
             )}
             {!isLoading && !!currentVisit && (
-              <Button onClick={() => openModal(patient?.id)} className={styles.startVisitButton}>
+              <Button
+                onClick={() => openModal(patient?.id)}
+                className={styles.startVisitButton}
+                aria-label={t('endVisit', 'End visit')}
+              >
                 {t('endVisit', 'End visit')}
               </Button>
             )}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds aria-label property for the easy **accessibility** of Start a Visit and End visit button in the Navbar.


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-3683](https://openmrs.atlassian.net/browse/O3-3683)

## Other
<!-- Anything not covered above -->
cc : @jayasanka-sack 

[O3-3683]: https://openmrs.atlassian.net/browse/O3-3683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ