### PR TITLE
(fix) Fix feature flag for the patient flags app

### DIFF
--- a/packages/esm-patient-flags-app/src/index.ts
+++ b/packages/esm-patient-flags-app/src/index.ts
@@ -9,12 +9,6 @@ export const importTranslation = require.context('../translations', false, /.jso
 
 export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
-
-  registerFeatureFlag(
-    'patientFlags',
-    'Patient Flags',
-    'Visual components that enable healthcare providers to see relevant patient information with a glance in the Patient chart. Flags are displayed in the Patient Summary, just below the patient banner, and can link users to other areas of the chart to perform relevant actions during a visit.',
-  );
 }
 
 export const flagTags = getSyncLifecycle(flagTagsComponent, {

--- a/packages/esm-patient-flags-app/src/routes.json
+++ b/packages/esm-patient-flags-app/src/routes.json
@@ -10,7 +10,7 @@
       "meta": {
         "title": {
           "key": "editPatientFlags",
-          "default":"Edit patient flags"
+          "default": "Edit patient flags"
         }
       },
       "featureFlag": "patientFlags"
@@ -33,5 +33,11 @@
       }
     }
   ],
-  "pages": []
+  "featureFlags": [
+    {
+      "flagName": "patientFlags",
+      "label": "Patient Flags",
+      "description": "Visual components that enable healthcare providers to see relevant patient information with a glance in the Patient chart. Flags are displayed in the Patient Summary, just below the patient banner, and can link users to other areas of the chart to perform relevant actions during a visit."
+    }
+  ]
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

The Patient Flags app's feature flag isn't working correctly because of the approach used to register it. https://github.com/openmrs/openmrs-esm-core/pull/1104 made it possible to register feature flags by declaring static metadata in the routes registry file. This PR moves the registration logic for the flags app feature flag into the `routes.json` file and makes it so that admins can toggle it on or off via the implementer tools.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
