### PR TITLE
(feat) O3-3657: Adapt vitals header styling for small screens

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
@@ -78,22 +78,20 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid }) => {
     }
 
     return (
-      <div className={styles['background']}>
-        <div className={styles['vitals-header']} role="button" tabIndex={0} onClick={toggleDetailsPanel}>
-          <span className={styles.container}>
+      <div className={styles.container}>
+        <div className={styles.vitalsHeader} role="button" tabIndex={0} onClick={toggleDetailsPanel}>
+          <div className={styles.headerItems}>
             <span className={styles.heading}>{t('vitalsAndBiometrics', 'Vitals and biometrics')}</span>
-            <span className={styles['body-text']}>
+            <span className={styles.bodyText}>
               {formatDate(parseDate(latestVitals?.date), { day: true, time: true })}
             </span>
             {vitalsOverdue ? (
-              <div className={styles.tag}>
-                <Tag type="red">
-                  <span className={styles.overdueIndicator}>
-                    <Time />
-                    {`${t('overdue', 'Overdue')}: ${overdueVitalsTagContent}`}
-                  </span>
-                </Tag>
-              </div>
+              <Tag type="red">
+                <span className={styles.overdueIndicator}>
+                  <Time />
+                  {`${t('overdue', 'Overdue')}: ${overdueVitalsTagContent}`}
+                </span>
+              </Tag>
             ) : null}
             <ConfigurableLink
               className={styles.link}
@@ -101,27 +99,27 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid }) => {
             >
               {t('vitalsHistory', 'Vitals history')}
             </ConfigurableLink>
-          </span>
+          </div>
           {isValidating ? (
             <div className={styles.backgroundDataFetchingIndicator}>
               <span>{isValidating ? <InlineLoading /> : null}</span>
             </div>
           ) : null}
-          <div className={styles['button-container']}>
+          <div className={styles.buttonContainer}>
             <Button
-              className={classNames(styles['record-vitals'], styles['arrow-up-icon'])}
               kind="ghost"
+              className={classNames(styles.recordVitals, styles.arrowUpIcon)}
               size="sm"
               onClick={launchVitalsAndBiometricsForm}
             >
               {t('recordVitals', 'Record vitals')}
-              <ArrowRight size={16} className={styles['arrow-up-button']} title={'ArrowRight'} />
+              <ArrowRight size={16} className={styles.arrowUpButton} title={'ArrowRight'} />
             </Button>
           </div>
         </div>
         <div
-          className={classNames(styles['row-container'], {
-            [styles['workspace-open']]: isWorkspaceOpen(),
+          className={classNames(styles.rowContainer, {
+            [styles.workspaceOpen]: isWorkspaceOpen(),
           })}
         >
           <div className={styles.row}>
@@ -196,21 +194,21 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid }) => {
   }
 
   return (
-    <div className={styles['vitals-header']}>
+    <div className={styles.vitalsHeader}>
       <span className={styles.container}>
         <span className={styles.heading}>{t('vitalsAndBiometrics', 'Vitals and biometrics')}</span>
-        <span className={styles['body-text']}>{t('noDataRecorded', 'No data has been recorded for this patient')}</span>
+        <span className={styles.bodyText}>{t('noDataRecorded', 'No data has been recorded for this patient')}</span>
       </span>
 
       <div className={styles.container}>
         <Button
-          className={classNames(styles['record-vitals'], styles['arrow-up-icon'])}
+          className={classNames(styles.recordVitals, styles.arrowUpIcon)}
           onClick={launchVitalsAndBiometricsForm}
           kind="ghost"
           size="sm"
         >
           {t('recordVitals', 'Record vitals')}
-          <ArrowRight size={16} className={styles['arrow-up-button']} title={'ArrowRight'} />
+          <ArrowRight size={16} className={styles.arrowUpButton} title={'ArrowRight'} />
         </Button>
       </div>
     </div>

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.scss
@@ -2,26 +2,34 @@
 @use '@carbon/type';
 @import '@openmrs/esm-styleguide/src/vars';
 
-.vitals-header {
+.container {
+  background-color: $openmrs-background-grey;
+}
+
+.vitalsHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: layout.$spacing-09;
-  margin-left: layout.$spacing-05;
+  min-height: layout.$spacing-09;
+  margin: layout.$spacing-03 0 layout.$spacing-03 layout.$spacing-05;
   outline: none;
   pointer-events: visibleFill;
 }
 
-.container {
+.headerItems {
   display: flex;
-  align-items: baseline;
+  align-items: center;
+  flex-flow: row wrap;
+  gap: layout.$spacing-02;
 }
 
-.background {
-  background-color: $openmrs-background-grey;
+.heading {
+  @include type.type-style("heading-compact-02");
+  margin-right: layout.$spacing-03;
+  color: $text-02;
 }
 
-.row-container {
+.rowContainer {
   width: 100%;
   border-bottom: 1px solid $ui-03;
   padding-bottom: 0.75rem;
@@ -35,8 +43,7 @@
   max-width: 100vw;
 }
 
-
-:global(.omrs-breakpoint-lt-desktop), .workspace-open {
+:global(.omrs-breakpoint-lt-desktop), .workspaceOpen {
   .row {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -56,10 +63,6 @@
   flex-wrap: wrap;
 }
 
-.tag {
-  margin-left: 0.25rem;
-}
-
 .overdueIndicator {
   display: flex;
   align-items: center;
@@ -70,12 +73,13 @@
   }
 }
 
-.button-container {
+.buttonContainer {
   display: flex;
   align-items: center;
+  justify-content: right;
 }
 
-.arrow-up-button {
+.arrowUpButton {
   display: flex;
   align-items: baseline;
   justify-content: center;
@@ -83,28 +87,22 @@
   margin-left: 0.5rem;
 }
 
-.arrow-up-icon:not([disabled]) svg {
+.arrowUpIcon:not([disabled]) svg {
   fill: $color-blue-60-2;
 }
 
-.heading {
-  @include type.type-style("heading-compact-02");
-  margin-right: layout.$spacing-03;
-  color: $text-02;
-}
-
-.record-vitals {
+.recordVitals {
   @include type.type-style('body-compact-01');
 }
 
-.body-text {
+.bodyText {
   @include type.type-style('label-01');
   color: $text-02;
 }
 
 .link {
   margin-left: 0.25rem;
-  @extend .body-text;
+  @extend .bodyText;
   text-decoration-line: none;
   color: $interactive-01;
 }

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.scss
@@ -1,6 +1,6 @@
 @use '@carbon/layout';
 @use '@carbon/type';
-@import '@openmrs/esm-styleguide/src/vars';
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .container {
   background-color: $openmrs-background-grey;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adapts the Vitals header styling to fix issues with the spacing of items in the Vitals header. 

## Screenshots

### Spacing constraints due to the Overdue tag on the tablet (iPad mini 8-inch)

![vitals-header](https://github.com/user-attachments/assets/918e38ba-19c0-4b2a-9a03-133f509e7931)

### Fix 

https://github.com/user-attachments/assets/b6f344fd-2c0c-4c16-8a98-c85a8c2062ef

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

https://openmrs.atlassian.net/browse/O3-3657