### PR TITLE
(feat) O3-3657: Tweak styling of abnormal results in the vitals header and data tiles

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.scss
@@ -1,7 +1,7 @@
+@use '@carbon/colors';
 @use '@carbon/type';
 @use '@carbon/layout';
-@use '@carbon/colors';
-@import '@openmrs/esm-styleguide/src/vars';
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .container {
   display: flex;
@@ -24,7 +24,7 @@
 
 .critical-value {
   @extend .abnormal-value;
-  border: solid 1px colors.$red-60;
+  border: 1px solid colors.$red-60;
   background-color: colors.$red-20;
 }
 

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.scss
@@ -1,4 +1,5 @@
 @use '@carbon/type';
+@use '@carbon/layout';
 @import '@openmrs/esm-styleguide/src/vars';
 
 .container {
@@ -10,24 +11,30 @@
 }
 
 .abnormal-value {
-  border: 1px solid $ui-05;
-  background-color: white;
+  border: solid 1px #ffc69e;
+  background-color: #fff2e8;
   display: flex;
   flex-direction: column;
   justify-content: center;
   width: fit-content;
-  padding: 0rem 0.25rem;
+  gap: layout.$spacing-02;
+  padding: layout.$spacing-02;
 }
 
 .critical-value {
   @extend .abnormal-value;
-  border: 2px solid $danger;
+  border: solid 1px #da1e28;
+  background-color: #ffd7d9;
 }
 
 .label-container {
+  flex-grow: 0;
+  flex-direction: row;
+  justify-content: flex-start;
   align-items: center;
   display: flex;
-  justify-content: space-between;
+  gap: layout.$spacing-02;
+  padding: 0;
 }
 
 .value-container {

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.scss
@@ -1,5 +1,6 @@
 @use '@carbon/type';
 @use '@carbon/layout';
+@use '@carbon/colors';
 @import '@openmrs/esm-styleguide/src/vars';
 
 .container {
@@ -11,8 +12,8 @@
 }
 
 .abnormal-value {
-  border: solid 1px #ffc69e;
-  background-color: #fff2e8;
+  border: solid 1px colors.$orange-20-hover;
+  background-color: colors.$orange-10;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -23,8 +24,8 @@
 
 .critical-value {
   @extend .abnormal-value;
-  border: solid 1px #da1e28;
-  background-color: #ffd7d9;
+  border: solid 1px colors.$red-60;
+  background-color: colors.$red-20;
 }
 
 .label-container {

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.scss
@@ -11,7 +11,7 @@
   justify-content: space-between;
   align-items: center;
   min-height: layout.$spacing-09;
-  margin: layout.$spacing-03 0 layout.$spacing-03 layout.$spacing-05;
+  margin: layout.$spacing-03 0 0 layout.$spacing-05;
   outline: none;
   pointer-events: visibleFill;
 }

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -39,35 +39,15 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
   const StyledTableCell = ({ interpretation, children }: { interpretation: string; children: React.ReactNode }) => {
     switch (interpretation) {
       case 'critically_high':
-        return (
-          <TableCell className={styles.criticallyHigh}>
-            <span>{children}</span>
-          </TableCell>
-        );
+        return <TableCell className={styles.criticallyHigh}>{children}</TableCell>;
       case 'critically_low':
-        return (
-          <TableCell className={styles.criticallyLow}>
-            <span>{children}</span>
-          </TableCell>
-        );
+        return <TableCell className={styles.criticallyLow}>{children}</TableCell>;
       case 'high':
-        return (
-          <TableCell className={styles.high}>
-            <span>{children}</span>
-          </TableCell>
-        );
+        return <TableCell className={styles.high}>{children}</TableCell>;
       case 'low':
-        return (
-          <TableCell className={styles.low}>
-            <span>{children}</span>
-          </TableCell>
-        );
+        return <TableCell className={styles.low}>{children}</TableCell>;
       default:
-        return (
-          <TableCell className={styles.normal}>
-            <span>{children}</span>
-          </TableCell>
-        );
+        return <TableCell>{children}</TableCell>;
     }
   };
 

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
@@ -10,7 +10,7 @@
   td {
     white-space: nowrap;
     border-bottom: none !important;
-    border-top: 1px solid #e0e0e0;
+    border-top: 1px solid colors.$gray-20;
   }
 }
 
@@ -21,13 +21,13 @@
 }
 
 .criticallyHigh, .criticallyLow {
-  border-top: 1px solid #ffc2c5 !important;
-  background-color: #ffd7d9 !important;
+  border-top: 1px solid colors.$red-20-hover !important;
+  background-color: colors.$red-20 !important;
 }
 
 .high, .low {
-  border-top: 1px solid #ffd9be !important;
-  background-color: #fff2e8 !important;
+  border-top: 1px solid colors.$orange-20 !important;
+  background-color: colors.$orange-10 !important;
 
 }
 

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
@@ -9,12 +9,8 @@
 .table {
   td {
     white-space: nowrap;
-    padding: layout.$spacing-02;
-    > span {
-      width: 100%;
-      height: 100%;
-      display: inline-block;
-    }
+    border-bottom: none !important;
+    border-top: 1px solid #e0e0e0;
   }
 }
 
@@ -24,18 +20,15 @@
   }
 }
 
-.criticallyHigh > span, .criticallyLow > span {
-  border: 2px solid colors.$red-60 !important;
-  padding: layout.$spacing-02 layout.$spacing-02 layout.$spacing-02 layout.$spacing-05;
+.criticallyHigh, .criticallyLow {
+  border-top: 1px solid #ffc2c5 !important;
+  background-color: #ffd7d9 !important;
 }
 
-.high > span, .low > span {
-  border: 1.5px solid colors.$black-100 !important;
-  padding: layout.$spacing-02 layout.$spacing-02 layout.$spacing-02 layout.$spacing-05;
-}
+.high, .low {
+  border-top: 1px solid #ffd9be !important;
+  background-color: #fff2e8 !important;
 
-.normal > span {
-  padding-left: layout.$spacing-05;
 }
 
 .criticallyLow {
@@ -83,18 +76,18 @@
   @include type.type-style('heading-compact-01');
 }
 
-.criticallyLow > span::after {
+.criticallyLow::after {
   content: " ↓↓";
 }
 
-.criticallyHigh > span::after {
+.criticallyHigh::after {
   content: " ↑↑";
 }
 
-.low > span::after {
+.low::after {
   content: " ↓";
 }
 
-.high > span::after {
+.high::after {
   content: " ↑";
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
With this PR, we are styling the abnormal and dangerous vital signs within vitals header and widget to have the designs [here](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/66a3a096224b02670493337d) instead of displaying with a black and red border respectively. 

## Screenshots
<!-- Required if you are making UI changes. -->

### Before:
<img width="1180" alt="vitals-before" src="https://github.com/user-attachments/assets/616943b2-595c-4061-8237-bcbee08a3b34">


### After:
![vitals-redesined](https://github.com/user-attachments/assets/e25bd411-e82f-44c2-a193-6fa136487651)



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[https://openmrs.atlassian.net/browse/O3-3657](https://openmrs.atlassian.net/browse/O3-3657)

## Other
<!-- Anything not covered above -->
