### PR TITLE
(test) Fix failing tests due to importDynamic initialization error

### DIFF
--- a/packages/esm-form-entry-app/tsconfig.json
+++ b/packages/esm-form-entry-app/tsconfig.json
@@ -18,8 +18,9 @@
       "webpack-env"
     ],
     "lib": [
+      "dom",
       "es2015",
-      "dom"
+      "es2022",
     ],
     "skipLibCheck": true,
     "useDefineForClassFields": false,

--- a/packages/esm-patient-chart-app/src/actions-buttons/start-visit.test.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/start-visit.test.tsx
@@ -17,13 +17,6 @@ const mockUseConfig = jest.mocked(useConfig<ChartConfig>);
 const mockUsePatient = jest.mocked(usePatient);
 const mockUseVisit = jest.mocked(useVisit);
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  createGlobalStore: jest.fn(),
-  createUseStore: jest.fn(),
-  getGlobalStore: jest.fn(),
-}));
-
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
 

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.test.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.test.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { screen, render } from '@testing-library/react';
-import { useExtensionSlotMeta, useExtensionStore } from '@openmrs/esm-framework';
+import {
+  type AssignedExtension,
+  type ExtensionSlotState,
+  useExtensionStore,
+  useExtensionSlotMeta,
+} from '@openmrs/esm-framework';
 import { mockPatient } from 'tools';
 import ChartReview from './chart-review.component';
 
-const mockUseExtensionStore = useExtensionStore as jest.Mock;
-const mockUseExtensionSlotMeta = useExtensionSlotMeta as jest.Mock;
+const mockUseExtensionStore = jest.mocked(useExtensionStore);
+const mockUseExtensionSlotMeta = jest.mocked(useExtensionSlotMeta);
 
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   return {
     useNavGroups: jest.fn().mockReturnValue({ navGroups: [] }),
   };
 });
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  useExtensionStore: jest.fn(),
-  useExtensionSlotMeta: jest.fn(),
-}));
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -39,7 +39,7 @@ function slotMetaFromStore(store, slotName) {
 }
 
 describe('ChartReview', () => {
-  test(`renders a grid-based layout`, () => {
+  test('renders a grid-based layout', () => {
     const mockStore = {
       slots: {
         'patient-chart-dashboard-slot': {
@@ -60,14 +60,15 @@ describe('ChartReview', () => {
                 title: 'Test Results',
               },
             },
-          ],
+          ] as unknown as AssignedExtension[],
         },
         'patient-chart-summary-dashboard-slot': {
           assignedExtensions: [],
         },
-      },
+      } as Record<string, ExtensionSlotState>,
     };
-    mockUseExtensionStore.mockReturnValue(mockStore);
+
+    mockUseExtensionStore.mockReturnValue(mockStore as unknown as ReturnType<typeof useExtensionStore>);
     mockUseExtensionSlotMeta.mockImplementation((slotName) => slotMetaFromStore(mockStore, slotName));
 
     render(

--- a/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit-header/visit-header.test.tsx
@@ -25,12 +25,6 @@ const mockUseVisit = jest.mocked(useVisit);
 const mockUseLayoutType = jest.mocked(useLayoutType);
 const mockShowModal = jest.mocked(showModal);
 const mockGetHistory = jest.mocked(getHistory);
-const mockGoBackInHistory = jest.mocked(goBackInHistory);
-
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  translateFrom: (module, key, defaultValue, options) => defaultValue,
-}));
 
 jest.mock('@openmrs/esm-patient-common-lib', () => ({
   ...jest.requireActual('@openmrs/esm-patient-common-lib'),

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -62,7 +62,6 @@ const mockUpdateVisit = jest.mocked(updateVisit);
 const mockOpenmrsFetch = jest.mocked(openmrsFetch);
 const mockUseConfig = jest.mocked(useConfig<ChartConfig>);
 const mockUseVisitAttributeType = jest.mocked(useVisitAttributeType);
-const mockGetStartedVisitGetter = jest.fn();
 const mockUseVisitTypes = jest.mocked(useVisitTypes);
 const mockUsePatient = jest.mocked(usePatient);
 
@@ -72,19 +71,6 @@ jest.mock('@openmrs/esm-patient-common-lib', () => ({
     activePatientEnrollment: [],
     isLoading: false,
   }),
-}));
-
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  get getStartedVisit() {
-    return mockGetStartedVisitGetter();
-  },
-  restBaseUrl: '/ws/rest/v1',
-  saveVisit: jest.fn(),
-  updateVisit: jest.fn(),
-  toOmrsIsoString: jest.fn(),
-  toDateObjectStrict: jest.fn(),
-  usePatient: jest.fn().mockImplementation((patientUuid) => ({ patientUuid, patient: {} })),
 }));
 
 jest.mock('../hooks/useVisitAttributeType', () => ({

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/cancel-visit-dialog.test.tsx
@@ -15,11 +15,6 @@ const mockShowSnackbar = jest.mocked(showSnackbar);
 const mockUseVisit = jest.mocked(useVisit);
 const mockUseVisitQueueEntry = jest.mocked(useVisitQueueEntry);
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  restBaseUrl: '/ws/rest/v1',
-}));
-
 jest.mock('../queue-entry/queue.resource', () => ({
   ...jest.requireActual('../queue-entry/queue.resource'),
   useVisitQueueEntry: jest.fn(),

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
@@ -19,11 +19,6 @@ const mockShowSnackbar = jest.mocked(showSnackbar);
 const mockUseVisit = jest.mocked(useVisit);
 const mockUpdateVisit = jest.mocked(updateVisit);
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  updateVisit: jest.fn(),
-}));
-
 describe('End visit dialog', () => {
   beforeEach(() => {
     mockUseVisit.mockReturnValue({

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
@@ -4,14 +4,8 @@ import { useVisit, getConfig } from '@openmrs/esm-framework';
 import { waitForLoadingToFinish } from 'tools';
 import CurrentVisitSummary from './current-visit-summary.component';
 
-const mockUseVisits = jest.mocked(useVisit);
 const mockGetConfig = jest.mocked(getConfig);
-
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework/mock'),
-  useVisits: jest.fn(),
-  getConfig: jest.fn(),
-}));
+const mockUseVisits = jest.mocked(useVisit);
 
 describe('CurrentVisitSummary', () => {
   test('renders an empty state when there is no active visit', () => {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.test.tsx
@@ -16,12 +16,6 @@ const mockShowModal = jest.mocked(showModal);
 const mockGetConfig = getConfig as jest.Mock;
 const mockUserHasAccess = userHasAccess as jest.Mock;
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  getConfig: jest.fn().mockResolvedValue({ htmlFormEntryForms: [] }),
-  userHasAccess: jest.fn().mockImplementation((privilege, _) => (privilege ? false : true)),
-}));
-
 describe('EncounterList', () => {
   it('renders an empty state when no encounters are available', async () => {
     mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -11,12 +11,6 @@ const mockGetConfig = getConfig as jest.Mock;
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockUseConfig = jest.mocked(useConfig<ChartConfig>);
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  getVisitsForPatient: jest.fn(),
-  userHasAccess: jest.fn().mockImplementation((privilege, _) => (privilege ? false : true)),
-}));
-
 mockUseConfig.mockReturnValue({
   ...getDefaultsFromConfigSchema(esmPatientChartSchema),
   numberOfVisitsToLoad: 5,

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
+import dayjs from 'dayjs';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
-import { getDefaultsFromConfigSchema, showSnackbar, useConfig, useSession, useVisit } from '@openmrs/esm-framework';
+import {
+  getDefaultsFromConfigSchema,
+  showSnackbar,
+  toDateObjectStrict,
+  toOmrsIsoString,
+  useConfig,
+  useSession,
+  useVisit,
+} from '@openmrs/esm-framework';
 import { configSchema } from '../config-schema';
 import { type ImmunizationWidgetConfigObject } from '../types/fhir-immunization-domain';
 import { immunizationFormSub } from './utils';
@@ -19,12 +28,8 @@ const mockUseConfig = jest.mocked<() => { immunizationsConfig: ImmunizationWidge
 const mockUseSession = jest.mocked(useSession);
 const mockUseVisit = jest.mocked(useVisit);
 const mockMutate = jest.fn();
-
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  toOmrsIsoString: jest.fn(),
-  toDateObjectStrict: jest.fn(),
-}));
+const mockToOmrsIsoString = jest.mocked(toOmrsIsoString);
+const mockToDateObjectStrict = jest.mocked(toDateObjectStrict);
 
 jest.mock('../hooks/useImmunizationsConceptSet', () => ({
   useImmunizationsConceptSet: jest.fn(() => ({
@@ -102,6 +107,15 @@ mockUseVisit.mockReturnValue({
 });
 
 describe('Immunizations Form', () => {
+  const dateTimeRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+  const isoFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZZ';
+  const mockVaccinationDate = new Date('2024-01-03T15:44:17');
+
+  beforeEach(() => {
+    mockToOmrsIsoString.mockReturnValue(mockVaccinationDate.toISOString());
+    mockToDateObjectStrict.mockImplementation((dateString) => dayjs(dateString, isoFormat).toDate());
+  });
+
   it('should render ImmunizationsForm component', () => {
     render(<ImmunizationsForm {...testProps} />);
 
@@ -179,14 +193,14 @@ describe('Immunizations Form', () => {
 
     expect(mockSavePatientImmunization).toHaveBeenCalledTimes(1);
     expect(mockSavePatientImmunization).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         encounter: { reference: 'Encounter/17f512b4-d264-4113-a6fe-160cb38cb46e', type: 'Encounter' },
         expirationDate: null,
         id: undefined,
         location: { reference: 'Location/b1a8b05e-3542-4037-bbd3-998ee9c40574', type: 'Location' },
         lotNumber: '',
         manufacturer: { display: 'Pfizer' },
-        occurrenceDateTime: undefined,
+        occurrenceDateTime: mockVaccinationDate,
         patient: { reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e', type: 'Patient' },
         performer: [
           { actor: { reference: 'Practitioner/b1a8b05e-3542-4037-bbd3-998ee9c4057z', type: 'Practitioner' } },
@@ -195,7 +209,7 @@ describe('Immunizations Form', () => {
         resourceType: 'Immunization',
         status: 'completed',
         vaccineCode: { coding: [{ code: '782AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Hepatitis B vaccination' }] },
-      },
+      }),
       undefined,
       new AbortController(),
     );
@@ -260,10 +274,11 @@ describe('Immunizations Form', () => {
       expect.objectContaining({
         encounter: { reference: 'Encounter/ce589c9c-2f30-42ec-b289-a153f812ea5e', type: 'Encounter' },
         id: '0a6ca2bb-a317-49d8-bd6b-dabb658840d2',
+        expirationDate: dayjs(new Date('2024-05-19T21:00:00'), isoFormat).toDate(),
         location: { reference: 'Location/b1a8b05e-3542-4037-bbd3-998ee9c40574', type: 'Location' },
         lotNumber: 'A123456',
         manufacturer: { display: 'Merck & Co., Inc.' },
-        occurrenceDateTime: undefined,
+        occurrenceDateTime: dayjs(mockVaccinationDate, isoFormat).toDate(),
         patient: { reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e', type: 'Patient' },
         performer: [
           { actor: { reference: 'Practitioner/b1a8b05e-3542-4037-bbd3-998ee9c4057z', type: 'Practitioner' } },

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -1,5 +1,6 @@
-import React, { Fragment, useEffect, useMemo, useState, useCallback } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
 import {
   Button,
   ButtonSet,
@@ -29,15 +30,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { type DefaultPatientWorkspaceProps, type amPm, convertTime12to24 } from '@openmrs/esm-patient-common-lib';
 import { savePatientImmunization } from './immunizations.resource';
-import styles from './immunizations-form.scss';
 import { useImmunizationsConceptSet } from '../hooks/useImmunizationsConceptSet';
 import { mapToFHIRImmunizationResource } from './immunization-mapper';
 import { type ConfigObject } from '../config-schema';
 import { type ImmunizationFormData } from '../types';
-import dayjs from 'dayjs';
 import { immunizationFormSub } from './utils';
 import { DoseInput } from './components/dose-input.component';
 import { useImmunizations } from '../hooks/useImmunizations';
+import styles from './immunizations-form.scss';
 
 interface ResponsiveWrapperProps {
   children: React.ReactNode;

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
@@ -7,11 +7,6 @@ import { useTestTypes } from './useTestTypes';
 
 jest.mock('swr/immutable');
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  restBaseUrl: '/ws/rest/v1',
-}));
-
 const mockOpenrsFetch = openmrsFetch as jest.Mock;
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
 const mockUseSWRImmutable = useSWRImmutable as jest.Mock;

--- a/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
-import { type FetchResponse, showSnackbar } from '@openmrs/esm-framework';
+import { type FetchResponse, showSnackbar, useLocations } from '@openmrs/esm-framework';
 import { mockCareProgramsResponse, mockEnrolledProgramsResponse, mockLocationsResponse } from '__mocks__';
 import { mockPatient } from 'tools';
 import {
@@ -17,7 +17,7 @@ const mockUseEnrollments = jest.mocked(useEnrollments);
 const mockCreateProgramEnrollment = jest.mocked(createProgramEnrollment);
 const mockUpdateProgramEnrollment = jest.mocked(updateProgramEnrollment);
 const mockShowSnackbar = jest.mocked(showSnackbar);
-
+const mockUseLocations = jest.mocked(useLocations);
 const mockCloseWorkspace = jest.fn();
 const mockCloseWorkspaceWithSavedChanges = jest.fn();
 const mockPromptBeforeClosing = jest.fn();
@@ -30,17 +30,14 @@ const testProps = {
   setTitle: jest.fn(),
 };
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  useLocations: jest.fn().mockImplementation(() => mockLocationsResponse),
-}));
-
 jest.mock('./programs.resource', () => ({
   createProgramEnrollment: jest.fn(),
   updateProgramEnrollment: jest.fn(),
   useAvailablePrograms: jest.fn(),
   useEnrollments: jest.fn(),
 }));
+
+mockUseLocations.mockReturnValue(mockLocationsResponse);
 
 mockUseAvailablePrograms.mockReturnValue({
   data: mockCareProgramsResponse,

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
@@ -10,7 +10,7 @@ import styles from './biometrics-chart.scss';
 
 enum ScaleTypes {
   LABELS = 'labels',
-  LABELS_RATIO = 'labels_ratio',
+  LABELS_RATIO = 'labels-ratio',
   LINEAR = 'linear',
   LOG = 'log',
   TIME = 'time',

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
@@ -10,7 +10,7 @@ import styles from './vitals-chart.scss';
 
 enum ScaleTypes {
   LABELS = 'labels',
-  LABELS_RATIO = 'labels_ratio',
+  LABELS_RATIO = 'labels-ratio',
   LINEAR = 'linear',
   LOG = 'log',
   TIME = 'time',

--- a/packages/esm-patient-vitals-app/translations/en.json
+++ b/packages/esm-patient-vitals-app/translations/en.json
@@ -58,7 +58,7 @@
   "vitalsAndBiometricsRecorded": "Vitals and Biometrics saved",
   "vitalsAndBiometricsSaveError": "Error saving vitals and biometrics",
   "vitalsHistory": "Vitals history",
-  "vitalSignDisplayed": "Vital Sign Displayed",
+  "vitalSignDisplayed": "Vital sign displayed",
   "vitalSigns": "Vital signs",
   "weight": "Weight"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4088,9 +4088,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-api@npm:5.7.3-pre.2157"
+"@openmrs/esm-api@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-api@npm:5.7.3-pre.2161"
   dependencies:
     "@types/fhir": "npm:0.0.31"
     lodash-es: "npm:^4.17.21"
@@ -4099,17 +4099,17 @@ __metadata:
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: 10/fb47e930fa9029ca2c1eb8f8cc4a490dadb8cfabd6b99c3f8ec721b4906f0454e0f15209b1348745d9ecb5e041b2c32e8cd98e5d71255377e01bf7f70a0a2b9b
+  checksum: 10/d6603f657df643dc39e359223d750574c7863ad5226f0c4adb02df2eb22fa20949c0e996b94957857ce406a9c51d09aecd403ebcde66a4b6bd5b914a8b091693
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-app-shell@npm:5.7.3-pre.2157"
+"@openmrs/esm-app-shell@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-app-shell@npm:5.7.3-pre.2161"
   dependencies:
     "@carbon/react": "npm:~1.37.0"
-    "@openmrs/esm-framework": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-styleguide": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-framework": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-styleguide": "npm:5.7.3-pre.2161"
     dayjs: "npm:^1.10.4"
     dexie: "npm:^3.0.3"
     html-webpack-plugin: "npm:^5.5.0"
@@ -4134,57 +4134,57 @@ __metadata:
     workbox-strategies: "npm:^6.1.5"
     workbox-webpack-plugin: "npm:^6.1.5"
     workbox-window: "npm:^6.1.5"
-  checksum: 10/897b5f3bc74e521049f202d850f3abe65b6dcc08b1d0cf03f1f02893743f9434004af20ec28fb2e099784252975d3faa4552565adb17194fee9cf67713c24507
+  checksum: 10/07d1408ada089eb9a814a02958305caf72559339d002f6aad100d68888b2835b7ee6605cc30baf59c38558c6af09b9ee9299e331316a083e7238aabca3113fa6
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-config@npm:5.7.3-pre.2157"
+"@openmrs/esm-config@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-config@npm:5.7.3-pre.2161"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 10/f591650f8b8fc4061e8668c02831804bc6ed890c44ae312223fa98ea22f1ce2c80b8b5732736c07b6e2b637fd9466e194bc97b73a4e376cd9ebf7cc35809fe32
+  checksum: 10/f650f6540cf33061d573fbc48c17317f272d768244f6416ecfbea1b27e739b4ec60d6b40196b4916a8d909092eb9281a3a9ca9eca2f4928d00c7c18aeeba792a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-context@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-context@npm:5.7.3-pre.2157"
+"@openmrs/esm-context@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-context@npm:5.7.3-pre.2161"
   dependencies:
     immer: "npm:^10.0.4"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
-  checksum: 10/a04bb335f4a7990974a5d6ab96eaeb78afa8f5396b38d05a028e20312ab222be99694fb94b23794f67357934d1be662592f0818f9a1a40edf1b7a26ae2e6f2cd
+  checksum: 10/2da63321c0820fe6509d53bcaae00320095276f1fca653919a758719ad8cf352979bbef70d2e3dd8128e95091c9672ef1acfe0ef47b548443fb7dc793af550ef
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.7.3-pre.2157"
+"@openmrs/esm-dynamic-loading@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.7.3-pre.2161"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-translations": 5.x
-  checksum: 10/7e8d18f6aeb30410bdfa24d3526556e3ffb5fa96064abc7da7966c39df209bce781d97ddf424d4d0bdfb8444109b4e3ea5219ef8adb61b755d7d1d0bbec40f07
+  checksum: 10/7eb1317d5dda0bf5211cb144f298a41113536aaa22b23bfe7f19c7083a771a64a4e35dfacf17e6720e4e692c17dddf6829977c224ee4b374b96beacd917c4b58
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-error-handling@npm:5.7.3-pre.2157"
+"@openmrs/esm-error-handling@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-error-handling@npm:5.7.3-pre.2161"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/27edb6b97ca0d095fb866e179147ddb75522313b3cca5b8e0e475eb6e480a77373314f8361495bf52bd6445c8aedb3cab1cd69d62fb2ca461490e8a0e8823a3d
+  checksum: 10/47d9266fe71e09cc1140bf064223940edf730a7c7e87a9434cd8fdefdd7375db49e687f24374020fab367b89773b703e4ff24376035b872f4d3001959675a3af
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-extensions@npm:5.7.3-pre.2157"
+"@openmrs/esm-extensions@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-extensions@npm:5.7.3-pre.2161"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -4194,20 +4194,20 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-utils": 5.x
     single-spa: 5.x
-  checksum: 10/6bcad070d9cd36bdb4023121c43239aa021b1050d4fcd5d53c113f98b1d92387ebe14cde80466667968e2ef2b8a9432153b8386333bc4f895073326d5b125e1a
+  checksum: 10/78e8b33d758bf29a3406d3eec3d78ca8f408d50331ac8fba9ef3e5a150dc713eda16c8aa51b58be5c25b65c063866f88c4da8ea8f617e7ba59c34e59acad6d51
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-feature-flags@npm:5.7.3-pre.2157"
+"@openmrs/esm-feature-flags@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-feature-flags@npm:5.7.3-pre.2161"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 10/4a10b74b62c1c721856b57ab76870be3476be0f214cc70643670d610c705e01306d988b3ccea0f6cc2437ad99986aa5183371994d1faf6d32a552eeb36f767c9
+  checksum: 10/5daea49544ebced760fa4aed1f6f24431eeddac97293cd4b277f3287368fb53434fcb23fcc81bc08d16a52188f52b2b12d89b52879352b819f76c5a04ac7efd4
   languageName: node
   linkType: hard
 
@@ -4259,7 +4259,7 @@ __metadata:
     "@carbon/styles": "npm:~1.14.0"
     "@ng-select/ng-select": "npm:^11.2.0"
     "@ngx-translate/core": "npm:^15.0.0"
-    "@openmrs/esm-framework": "npm:^5.7.3-pre.2157"
+    "@openmrs/esm-framework": "npm:next"
     "@openmrs/ngx-file-uploader": "npm:next"
     "@openmrs/ngx-formentry": "npm:next"
     "@types/jasmine": "npm:~3.6.11"
@@ -4282,7 +4282,7 @@ __metadata:
     ngx-bootstrap: "npm:^11.0.1"
     ngx-build-plus: "npm:^16.0.0"
     ngx-webcam: "npm:^0.4.1"
-    openmrs: "npm:^5.7.3-pre.2157"
+    openmrs: "npm:next"
     protractor: "npm:~7.0.0"
     reflect-metadata: "npm:^0.1.13"
     rxjs: "npm:^7.8.0"
@@ -4301,26 +4301,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-framework@npm:5.7.3-pre.2157, @openmrs/esm-framework@npm:^5.7.3-pre.2157, @openmrs/esm-framework@npm:next":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-framework@npm:5.7.3-pre.2157"
+"@openmrs/esm-framework@npm:5.7.3-pre.2161, @openmrs/esm-framework@npm:next":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-framework@npm:5.7.3-pre.2161"
   dependencies:
-    "@openmrs/esm-api": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-config": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-context": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-dynamic-loading": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-error-handling": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-extensions": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-feature-flags": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-globals": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-navigation": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-offline": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-react-utils": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-routes": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-state": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-styleguide": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-translations": "npm:5.7.3-pre.2157"
-    "@openmrs/esm-utils": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-api": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-config": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-context": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-dynamic-loading": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-error-handling": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-extensions": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-feature-flags": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-globals": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-navigation": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-offline": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-react-utils": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-routes": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-state": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-styleguide": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-translations": "npm:5.7.3-pre.2161"
+    "@openmrs/esm-utils": "npm:5.7.3-pre.2161"
     dayjs: "npm:^1.10.7"
   peerDependencies:
     dayjs: 1.x
@@ -4331,7 +4331,7 @@ __metadata:
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: 10/0e5b1a721d7fcdfc239e3a00831316ef6e155fb4822fe00a45f564c7d0d568497f99036cb62000d50dc85c19fafb2b30b237fb343ed2ab9c7d0558025cc6b7a9
+  checksum: 10/2f2d54477e6b7468ff0d574b036ec942f2f70336c2d32b9f0395b77d885dace1e6f7ab2bf17f19abfca8e57d77d5eaa16f6ea2e713c172692401f2378cd65f0a
   languageName: node
   linkType: hard
 
@@ -4357,31 +4357,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-globals@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-globals@npm:5.7.3-pre.2157"
+"@openmrs/esm-globals@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-globals@npm:5.7.3-pre.2161"
   dependencies:
     "@types/fhir": "npm:0.0.31"
   peerDependencies:
     single-spa: 5.x
-  checksum: 10/9a54835bd86e5fd5164a59231954236120ff4e32c5d008179749eef949aa20a636b1811a90179f4d48f90c037c894afc538371a02e48210986eb852a07325787
+  checksum: 10/f9f8bcf9aff7aaabb417859a3bc804741b96c15c2477508f777e21fc1b12f020299ff37b1adfd60f84936252fec84192703da59bd58072e32bc493e3a81555c7
   languageName: node
   linkType: hard
 
-"@openmrs/esm-navigation@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-navigation@npm:5.7.3-pre.2157"
+"@openmrs/esm-navigation@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-navigation@npm:5.7.3-pre.2161"
   dependencies:
     path-to-regexp: "npm:6.1.0"
   peerDependencies:
     "@openmrs/esm-state": 5.x
-  checksum: 10/f21b33d0bc967361de3dbb1b225d29c63ad1d25e760835ec27c8e443965a6a234daf9882b2a1bc939235443986fcdfa2d432f0a85a0ffc738073c5323e6c064a
+  checksum: 10/23b1b369bf0a93679bba35066c034d047e941261d1ab6e1e40632c9280c96553a5615c2131aa224d543d49b5d9b00de842f44fa3e00037949a110736f780ef98
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-offline@npm:5.7.3-pre.2157"
+"@openmrs/esm-offline@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-offline@npm:5.7.3-pre.2161"
   dependencies:
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -4392,7 +4392,7 @@ __metadata:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     rxjs: 6.x
-  checksum: 10/e2a8fd93c66c3463add879476eff975a4718243f3d4ab83da678955b4d0e0c0dd82123174472773f2e30be4195033d81cd37fd5cfbea8b2eb7480a78280ee1d6
+  checksum: 10/5997dee788f93594e668476527c05621085b491471313fe5366887760536836a6e08526312d4ded28be29e820cbbd3eea7bac246892dc86f6f81c5d540eb02ed
   languageName: node
   linkType: hard
 
@@ -4785,9 +4785,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-react-utils@npm:5.7.3-pre.2157"
+"@openmrs/esm-react-utils@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-react-utils@npm:5.7.3-pre.2161"
   dependencies:
     lodash-es: "npm:^4.17.21"
     single-spa-react: "npm:^6.0.0"
@@ -4808,13 +4808,13 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 10/aa38909094ca7176e6fc6f8ca3a00051a7d081d8f4a5d439f84d992927ea52cd349e552f8170b4cdc5e2cdb818eabab0aee5d06c9815286c0faa2fef7ea75517
+  checksum: 10/b85dc63408008b2e763b0208f8e164a7e0488e32d3a5d403ab54cd9dba512a1a9e0b412bea5d3c87486bf668cdae987e27a16439356692ec43fa9f20639b62c0
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-routes@npm:5.7.3-pre.2157"
+"@openmrs/esm-routes@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-routes@npm:5.7.3-pre.2161"
   peerDependencies:
     "@openmrs/esm-config": 5.x
     "@openmrs/esm-dynamic-loading": 5.x
@@ -4823,24 +4823,24 @@ __metadata:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-utils": 5.x
     single-spa: 6.x
-  checksum: 10/1999bdf7553a5f0679287734f608715d468cb23633de48e50e78ba9714a1fc37b473e6e3832fd2a4f45936b566da15c5225c45655028ea83c6d73de265b9b8a6
+  checksum: 10/66bf92782abecf3a73366754d856fa40c2de06b480191a8c5d795d81943eca2cbb5fa923440348997fe039c43d94650032e79dbd9102ae22df6d9636207fcc91
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-state@npm:5.7.3-pre.2157"
+"@openmrs/esm-state@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-state@npm:5.7.3-pre.2161"
   dependencies:
     zustand: "npm:^4.3.6"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/454f461e62d5fa05aae0e255301ff561c498ced3cfb17e8c95106fc37936d376391b244db0416f78ca78f4ae6918169e98cd16e8044d4bc15107273ef710b2cd
+  checksum: 10/61badf5b7344634cfe5fd3cdd504cde34d0441c634d380d6ce2b651f5a7cacd5929de26cabd08c06057f5823fbca8c844ebdeec8be3d2295c43f0471d00d9b05
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-styleguide@npm:5.7.3-pre.2157"
+"@openmrs/esm-styleguide@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-styleguide@npm:5.7.3-pre.2161"
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
     "@carbon/react": "npm:~1.37.0"
@@ -4863,24 +4863,24 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: 10/8af679b8f1504fd084fed30f2c5099a93a8642f92bee5b6b0b54da6953122c98cbda293c3d16f9ea4611c4330ee42c992c6e9be6647acefca93079b73485f43c
+  checksum: 10/bb04abe01ba726064bd7435fd31c15bf208c4bdb2191afcf35e427af654287e56b5f472ab2117a9d849af5b8b178c68af5085e8df8091edb4e5a79283e6a41c6
   languageName: node
   linkType: hard
 
-"@openmrs/esm-translations@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-translations@npm:5.7.3-pre.2157"
+"@openmrs/esm-translations@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-translations@npm:5.7.3-pre.2161"
   dependencies:
     i18next: "npm:21.10.0"
   peerDependencies:
     i18next: 21.x
-  checksum: 10/d829b5dead67142dfce376a7a691011eb79316d1133259e7fbbdfe36dd442a2604ba9f83c0048b3dfb07ac2d6249fa68ae2d559e9e85c4f8e705d4a6d062cff4
+  checksum: 10/4458cf7427925756f9165219d34dca3ebc9699857ef933517fe0ff2ab870416ff74e8ee6981b12a4e1700767dc8b1aa84e3724672c64c4f5bb0871392fccaf59
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/esm-utils@npm:5.7.3-pre.2157"
+"@openmrs/esm-utils@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/esm-utils@npm:5.7.3-pre.2161"
   dependencies:
     "@formatjs/intl-durationformat": "npm:^0.2.4"
     "@internationalized/date": "npm:^3.5.4"
@@ -4890,7 +4890,7 @@ __metadata:
     dayjs: 1.x
     i18next: 21.x
     rxjs: 6.x
-  checksum: 10/92d31ad13d267233f7bd776cc3e3df14a44405e360b4fb862242bac2513492990e11c829499a15775edfd2f6e1adc97186e204937d0b5974d9ef783686ee5a79
+  checksum: 10/755f4195bde9cf2dccd9570a6e450236db6e34ad7122db101deec1b08eaf7083809f342de4e8e3f3d3f7c5d24269383e896d52e2412ae539390bbb78e0a5624e
   languageName: node
   linkType: hard
 
@@ -4942,8 +4942,8 @@ __metadata:
   linkType: hard
 
 "@openmrs/openmrs-form-engine-lib@npm:next":
-  version: 2.1.0-pre.1313
-  resolution: "@openmrs/openmrs-form-engine-lib@npm:2.1.0-pre.1313"
+  version: 2.1.0-pre.1355
+  resolution: "@openmrs/openmrs-form-engine-lib@npm:2.1.0-pre.1355"
   dependencies:
     "@carbon/react": "npm:>1.47.0 <1.50.0"
     ace-builds: "npm:^1.33.2"
@@ -4965,13 +4965,13 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 10/036ad5aea5e7a2e6a0e18d2a9e8f035bd150376818080d12d91195fcd3c3fd40f7e47b13e6f713b8682f52156f1081043d1ce192eb95c1771fbd6418c3597f85
+  checksum: 10/f500fc610f8e88244623b9d0a9801ca6576f1284b02b50f1502293adab202ed71419ec94cdd13714f9ef445ce8ef8671ca5d767a1805d243176a0e205ec547f9
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.7.3-pre.2157":
-  version: 5.7.3-pre.2157
-  resolution: "@openmrs/webpack-config@npm:5.7.3-pre.2157"
+"@openmrs/webpack-config@npm:5.7.3-pre.2161":
+  version: 5.7.3-pre.2161
+  resolution: "@openmrs/webpack-config@npm:5.7.3-pre.2161"
   dependencies:
     "@swc/core": "npm:^1.3.58"
     clean-webpack-plugin: "npm:^4.0.0"
@@ -4989,7 +4989,7 @@ __metadata:
     webpack-stats-plugin: "npm:^1.0.3"
   peerDependencies:
     webpack: 5.x
-  checksum: 10/0d626f2437bd158c429da4ccc81765407b7266014f1040f24f96e1927bd5f986a1a268e9fae998d1b4325b8c10dd77e1f6c4a23dfd00c5feb1eb9747c233011f
+  checksum: 10/a812b16104c65cae4d3ca8e1c2db35fe36bfd64b3dd7e81641e68cf776eb38c27f9f376f5ffd081c56e7e5a2c3769d43d070ce4a66b1af49981049fde0dbc66b
   languageName: node
   linkType: hard
 
@@ -18246,12 +18246,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openmrs@npm:^5.7.3-pre.2157, openmrs@npm:next":
-  version: 5.7.3-pre.2157
-  resolution: "openmrs@npm:5.7.3-pre.2157"
+"openmrs@npm:next":
+  version: 5.7.3-pre.2161
+  resolution: "openmrs@npm:5.7.3-pre.2161"
   dependencies:
-    "@openmrs/esm-app-shell": "npm:5.7.3-pre.2157"
-    "@openmrs/webpack-config": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-app-shell": "npm:5.7.3-pre.2161"
+    "@openmrs/webpack-config": "npm:5.7.3-pre.2161"
     "@pnpm/npm-conf": "npm:^2.1.0"
     "@swc/core": "npm:^1.3.58"
     autoprefixer: "npm:^10.4.2"
@@ -18290,7 +18290,7 @@ __metadata:
     yargs: "npm:^17.6.2"
   bin:
     openmrs: ./dist/cli.js
-  checksum: 10/f912f8326e2998e6e3c75acc1260d86213a49a9d72a6e8a8f985977202ad061e9e6d5fdb6c312a63250d3af07c396b62c8e582b3b50db19ba928fccaf5237edc
+  checksum: 10/a2ffdf9d33f126308bab7dac55e4a62454471e1ddc561df9fe77b64c4d753992170188c17a5b202c130e9b77c0effc9e4df438a329e1991b341ed0df9358a74e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,6 +2885,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/ecma402-abstract@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@formatjs/ecma402-abstract@npm:2.0.0"
+  dependencies:
+    "@formatjs/intl-localematcher": "npm:0.5.4"
+    tslib: "npm:^2.4.0"
+  checksum: 10/41543ba509ea3c7d6530d57b888115f7ca242f13462a951fae4d1d1f28bae10c999f4dea28a71d2f08366d4889a3f5276cae3a16c6f6417b841a84fd314c2234
+  languageName: node
+  linkType: hard
+
 "@formatjs/fast-memoize@npm:2.2.0":
   version: 2.2.0
   resolution: "@formatjs/fast-memoize@npm:2.2.0"
@@ -2912,6 +2922,17 @@ __metadata:
     "@formatjs/ecma402-abstract": "npm:1.18.2"
     tslib: "npm:^2.4.0"
   checksum: 10/8cd96d9075d1d369e4746dfaea6e3f478d21ed0672f4b777c4ee53b2660ef8c9a081976e6a8c73bba889eddc7edc52dba6eeea5fd62a8c03aa73e266b3cd89e9
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-durationformat@npm:^0.2.4":
+  version: 0.2.4
+  resolution: "@formatjs/intl-durationformat@npm:0.2.4"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.0.0"
+    "@formatjs/intl-localematcher": "npm:0.5.4"
+    tslib: "npm:^2.4.0"
+  checksum: 10/5f500409a20d18967e17ffbc222f9b4c4bf7ef08cce20023c33f06d1989c2bc4cf700d1dd1d048748d0a36c882109d5375896a4964d6700f73ec18914c6de4ba
   languageName: node
   linkType: hard
 
@@ -4067,9 +4088,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-api@npm:5.6.1-pre.2058"
+"@openmrs/esm-api@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-api@npm:5.7.3-pre.2157"
   dependencies:
     "@types/fhir": "npm:0.0.31"
     lodash-es: "npm:^4.17.21"
@@ -4078,17 +4099,17 @@ __metadata:
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: 10/3469a543eb622ba4030126d0e05275a667f93d11915595fc9925d75381a53ee9863d7de2af4bf531eb75f32b83638d54ed5cb59a61c838f91f1f24f890ed2b22
+  checksum: 10/fb47e930fa9029ca2c1eb8f8cc4a490dadb8cfabd6b99c3f8ec721b4906f0454e0f15209b1348745d9ecb5e041b2c32e8cd98e5d71255377e01bf7f70a0a2b9b
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-app-shell@npm:5.6.1-pre.2058"
+"@openmrs/esm-app-shell@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-app-shell@npm:5.7.3-pre.2157"
   dependencies:
     "@carbon/react": "npm:~1.37.0"
-    "@openmrs/esm-framework": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-styleguide": "npm:5.6.1-pre.2058"
+    "@openmrs/esm-framework": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-styleguide": "npm:5.7.3-pre.2157"
     dayjs: "npm:^1.10.4"
     dexie: "npm:^3.0.3"
     html-webpack-plugin: "npm:^5.5.0"
@@ -4096,6 +4117,7 @@ __metadata:
     i18next-browser-languagedetector: "npm:^6.1.8"
     import-map-overrides: "npm:^3.0.0"
     lodash-es: "npm:4.17.21"
+    mini-css-extract-plugin: "npm:^2.9.0"
     react: "npm:^18.1.0"
     react-dom: "npm:^18.1.0"
     react-i18next: "npm:^11.18.6"
@@ -4105,7 +4127,6 @@ __metadata:
     single-spa: "npm:^6.0.1"
     swc-loader: "npm:^0.2.3"
     swr: "npm:^2.2.2"
-    systemjs: "npm:^6.8.3"
     webpack: "npm:^5.88.0"
     webpack-pwa-manifest: "npm:^4.3.0"
     workbox-core: "npm:^6.1.5"
@@ -4113,57 +4134,57 @@ __metadata:
     workbox-strategies: "npm:^6.1.5"
     workbox-webpack-plugin: "npm:^6.1.5"
     workbox-window: "npm:^6.1.5"
-  checksum: 10/ae67846aab0afff577641ea0e1d8fecf2aa07b075c24ac9e51ef1792a61633f976c73260dd9bda415dbb13f0b76010b9876757e58f212ba95a23ec142e51f1e3
+  checksum: 10/897b5f3bc74e521049f202d850f3abe65b6dcc08b1d0cf03f1f02893743f9434004af20ec28fb2e099784252975d3faa4552565adb17194fee9cf67713c24507
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-config@npm:5.6.1-pre.2058"
+"@openmrs/esm-config@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-config@npm:5.7.3-pre.2157"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 10/61dcbeddf685608c55d5e13cc0974c0b6481d04e99153d8eb9fcf0971a95a25c11a2847bc9dd640ed9070076df2ed09e809998b58585538437efc7260c67d278
+  checksum: 10/f591650f8b8fc4061e8668c02831804bc6ed890c44ae312223fa98ea22f1ce2c80b8b5732736c07b6e2b637fd9466e194bc97b73a4e376cd9ebf7cc35809fe32
   languageName: node
   linkType: hard
 
-"@openmrs/esm-context@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-context@npm:5.6.1-pre.2058"
+"@openmrs/esm-context@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-context@npm:5.7.3-pre.2157"
   dependencies:
     immer: "npm:^10.0.4"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
-  checksum: 10/193ff73713619843ec7edb82a3f5331636ae9b51f230fbf1652db8c8fa39bcbe0348de467195dd7332d9414e38752270bd69687154d657f66e0482e1db1fae26
+  checksum: 10/a04bb335f4a7990974a5d6ab96eaeb78afa8f5396b38d05a028e20312ab222be99694fb94b23794f67357934d1be662592f0818f9a1a40edf1b7a26ae2e6f2cd
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.6.1-pre.2058"
+"@openmrs/esm-dynamic-loading@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.7.3-pre.2157"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-translations": 5.x
-  checksum: 10/4f374ceee125048261fd3b3c696a5bbf944a9ea4649dbf3a4cf25ed8f52cc6c489371d8032f077b8a27420e2c1b9666e7636060eabd397224de81ba61adc4c65
+  checksum: 10/7e8d18f6aeb30410bdfa24d3526556e3ffb5fa96064abc7da7966c39df209bce781d97ddf424d4d0bdfb8444109b4e3ea5219ef8adb61b755d7d1d0bbec40f07
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-error-handling@npm:5.6.1-pre.2058"
+"@openmrs/esm-error-handling@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-error-handling@npm:5.7.3-pre.2157"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/0ad56135e07cf5f3d0d1098318a164d88563d700fc9342a4a9b573dfadbb00879ba3233c3439da5078d29943ade6b407b4caf404b757767eba6be7b991d08a10
+  checksum: 10/27edb6b97ca0d095fb866e179147ddb75522313b3cca5b8e0e475eb6e480a77373314f8361495bf52bd6445c8aedb3cab1cd69d62fb2ca461490e8a0e8823a3d
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-extensions@npm:5.6.1-pre.2058"
+"@openmrs/esm-extensions@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-extensions@npm:5.7.3-pre.2157"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -4173,20 +4194,20 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-utils": 5.x
     single-spa: 5.x
-  checksum: 10/e43ee4df9b15169bc55040c31cf960ab79ae7ef6cf55cc80ca0014a8b50d4054a40276e55246cdcee3892a14ad94b39854e451fa96cbd21f5f4ee311ba54fcd4
+  checksum: 10/6bcad070d9cd36bdb4023121c43239aa021b1050d4fcd5d53c113f98b1d92387ebe14cde80466667968e2ef2b8a9432153b8386333bc4f895073326d5b125e1a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-feature-flags@npm:5.6.1-pre.2058"
+"@openmrs/esm-feature-flags@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-feature-flags@npm:5.7.3-pre.2157"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 10/f473a043c66293d86e7d22de4ccd329c15bbdbc91f3036dda0dec84f1512ea1e5b466f17ba3bcae0d31cc09a45f1e7913a8309a813bce20cddfc5042896e8ec0
+  checksum: 10/4a10b74b62c1c721856b57ab76870be3476be0f214cc70643670d610c705e01306d988b3ccea0f6cc2437ad99986aa5183371994d1faf6d32a552eeb36f767c9
   languageName: node
   linkType: hard
 
@@ -4238,7 +4259,7 @@ __metadata:
     "@carbon/styles": "npm:~1.14.0"
     "@ng-select/ng-select": "npm:^11.2.0"
     "@ngx-translate/core": "npm:^15.0.0"
-    "@openmrs/esm-framework": "npm:next"
+    "@openmrs/esm-framework": "npm:^5.7.3-pre.2157"
     "@openmrs/ngx-file-uploader": "npm:next"
     "@openmrs/ngx-formentry": "npm:next"
     "@types/jasmine": "npm:~3.6.11"
@@ -4261,7 +4282,7 @@ __metadata:
     ngx-bootstrap: "npm:^11.0.1"
     ngx-build-plus: "npm:^16.0.0"
     ngx-webcam: "npm:^0.4.1"
-    openmrs: "npm:next"
+    openmrs: "npm:^5.7.3-pre.2157"
     protractor: "npm:~7.0.0"
     reflect-metadata: "npm:^0.1.13"
     rxjs: "npm:^7.8.0"
@@ -4280,26 +4301,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-framework@npm:5.6.1-pre.2058, @openmrs/esm-framework@npm:next":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-framework@npm:5.6.1-pre.2058"
+"@openmrs/esm-framework@npm:5.7.3-pre.2157, @openmrs/esm-framework@npm:^5.7.3-pre.2157, @openmrs/esm-framework@npm:next":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-framework@npm:5.7.3-pre.2157"
   dependencies:
-    "@openmrs/esm-api": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-config": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-context": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-dynamic-loading": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-error-handling": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-extensions": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-feature-flags": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-globals": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-navigation": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-offline": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-react-utils": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-routes": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-state": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-styleguide": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-translations": "npm:5.6.1-pre.2058"
-    "@openmrs/esm-utils": "npm:5.6.1-pre.2058"
+    "@openmrs/esm-api": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-config": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-context": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-dynamic-loading": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-error-handling": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-extensions": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-feature-flags": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-globals": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-navigation": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-offline": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-react-utils": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-routes": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-state": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-styleguide": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-translations": "npm:5.7.3-pre.2157"
+    "@openmrs/esm-utils": "npm:5.7.3-pre.2157"
     dayjs: "npm:^1.10.7"
   peerDependencies:
     dayjs: 1.x
@@ -4310,7 +4331,7 @@ __metadata:
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: 10/f8e41e3879aaaefe0935e29925d6e9a2924a546e5b8d3be03187f41878902aa041b9159de192d1b59d455ed0de9a04cf959f0763267a5141e7125477da5b58ec
+  checksum: 10/0e5b1a721d7fcdfc239e3a00831316ef6e155fb4822fe00a45f564c7d0d568497f99036cb62000d50dc85c19fafb2b30b237fb343ed2ab9c7d0558025cc6b7a9
   languageName: node
   linkType: hard
 
@@ -4336,31 +4357,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-globals@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-globals@npm:5.6.1-pre.2058"
+"@openmrs/esm-globals@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-globals@npm:5.7.3-pre.2157"
   dependencies:
     "@types/fhir": "npm:0.0.31"
   peerDependencies:
     single-spa: 5.x
-  checksum: 10/38e73046cbc4797c1ff98f22e61fffb0e8fd44f6733701463f9008e781720f8e85b7185255c64e2078bf380a51528bcbb259d7023398ae8680c2bb7b26d1da91
+  checksum: 10/9a54835bd86e5fd5164a59231954236120ff4e32c5d008179749eef949aa20a636b1811a90179f4d48f90c037c894afc538371a02e48210986eb852a07325787
   languageName: node
   linkType: hard
 
-"@openmrs/esm-navigation@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-navigation@npm:5.6.1-pre.2058"
+"@openmrs/esm-navigation@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-navigation@npm:5.7.3-pre.2157"
   dependencies:
     path-to-regexp: "npm:6.1.0"
   peerDependencies:
     "@openmrs/esm-state": 5.x
-  checksum: 10/0c5e055c82ebef4b21c320cff93443f6431be669b84a356757bab5784a408a123fc3d88749ea50a2479a114b7a8ab1c83072e946acb3e3a0fe9b57b8c58d3f91
+  checksum: 10/f21b33d0bc967361de3dbb1b225d29c63ad1d25e760835ec27c8e443965a6a234daf9882b2a1bc939235443986fcdfa2d432f0a85a0ffc738073c5323e6c064a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-offline@npm:5.6.1-pre.2058"
+"@openmrs/esm-offline@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-offline@npm:5.7.3-pre.2157"
   dependencies:
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -4371,7 +4392,7 @@ __metadata:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     rxjs: 6.x
-  checksum: 10/11d0ea9f30b59f1e54014931b2fc3de2c5022427f6368373595f7c654e6c604058aa6a6fc99608618f6ff45afb82eaa8341f1b10453959d0f5017a0dc988c061
+  checksum: 10/e2a8fd93c66c3463add879476eff975a4718243f3d4ab83da678955b4d0e0c0dd82123174472773f2e30be4195033d81cd37fd5cfbea8b2eb7480a78280ee1d6
   languageName: node
   linkType: hard
 
@@ -4764,9 +4785,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-react-utils@npm:5.6.1-pre.2058"
+"@openmrs/esm-react-utils@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-react-utils@npm:5.7.3-pre.2157"
   dependencies:
     lodash-es: "npm:^4.17.21"
     single-spa-react: "npm:^6.0.0"
@@ -4787,34 +4808,39 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 10/4652eb142c04a4630014bc493a7d12b0c1fdc8e8bd019316890878510562435917af324d54a2b2a2a77e652e48acd6f2f6e759778ac27600ba3db96d942a06eb
+  checksum: 10/aa38909094ca7176e6fc6f8ca3a00051a7d081d8f4a5d439f84d992927ea52cd349e552f8170b4cdc5e2cdb818eabab0aee5d06c9815286c0faa2fef7ea75517
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-routes@npm:5.6.1-pre.2058"
+"@openmrs/esm-routes@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-routes@npm:5.7.3-pre.2157"
   peerDependencies:
+    "@openmrs/esm-config": 5.x
+    "@openmrs/esm-dynamic-loading": 5.x
+    "@openmrs/esm-extensions": 5.x
+    "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-utils": 5.x
-  checksum: 10/56ce91b7ae692e434ff798acf6d80e27b0ff4f0ba39374650555bc8b9044758efacfd4aa3b1fbcf86674234855dd966eadf4cf755f9a0ee5d46a01dd9cd3bf46
+    single-spa: 6.x
+  checksum: 10/1999bdf7553a5f0679287734f608715d468cb23633de48e50e78ba9714a1fc37b473e6e3832fd2a4f45936b566da15c5225c45655028ea83c6d73de265b9b8a6
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-state@npm:5.6.1-pre.2058"
+"@openmrs/esm-state@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-state@npm:5.7.3-pre.2157"
   dependencies:
     zustand: "npm:^4.3.6"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/2263fc29da93712713441456ca5ddfbe1fa93e1ad1e02112855b4866b741934d4cb1011659cc737fd21254b9aa9352b92f85b4add37c6efe1d5f2c7981130421
+  checksum: 10/454f461e62d5fa05aae0e255301ff561c498ced3cfb17e8c95106fc37936d376391b244db0416f78ca78f4ae6918169e98cd16e8044d4bc15107273ef710b2cd
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-styleguide@npm:5.6.1-pre.2058"
+"@openmrs/esm-styleguide@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-styleguide@npm:5.7.3-pre.2157"
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
     "@carbon/react": "npm:~1.37.0"
@@ -4837,25 +4863,26 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: 10/cf0e5f7a3dee3d15add39c3c86f03234516f1366070d3d43b513eb8ebff9c54e2b00d19f91d6c19bed0adebaa845840d5f900037c62fe0b07c8433de392b5e1a
+  checksum: 10/8af679b8f1504fd084fed30f2c5099a93a8642f92bee5b6b0b54da6953122c98cbda293c3d16f9ea4611c4330ee42c992c6e9be6647acefca93079b73485f43c
   languageName: node
   linkType: hard
 
-"@openmrs/esm-translations@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-translations@npm:5.6.1-pre.2058"
+"@openmrs/esm-translations@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-translations@npm:5.7.3-pre.2157"
   dependencies:
     i18next: "npm:21.10.0"
   peerDependencies:
     i18next: 21.x
-  checksum: 10/3ca7e46e150e8ac65ff3dfed6b2bd00d037e181e92e5c9f3d85463f76db36e4195f81db02e37280029898a76ac59c97a44024ff44ba424f57d7e0bcf730e33fe
+  checksum: 10/d829b5dead67142dfce376a7a691011eb79316d1133259e7fbbdfe36dd442a2604ba9f83c0048b3dfb07ac2d6249fa68ae2d559e9e85c4f8e705d4a6d062cff4
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/esm-utils@npm:5.6.1-pre.2058"
+"@openmrs/esm-utils@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/esm-utils@npm:5.7.3-pre.2157"
   dependencies:
+    "@formatjs/intl-durationformat": "npm:^0.2.4"
     "@internationalized/date": "npm:^3.5.4"
     semver: "npm:7.3.2"
   peerDependencies:
@@ -4863,7 +4890,7 @@ __metadata:
     dayjs: 1.x
     i18next: 21.x
     rxjs: 6.x
-  checksum: 10/baadb893fe189aa94c949e06f9444f761f72181d883990386835655f024d65269c7930567647a7d4e22274ac3946708b40cd013dd981ff0a0524882bc8e0183f
+  checksum: 10/92d31ad13d267233f7bd776cc3e3df14a44405e360b4fb862242bac2513492990e11c829499a15775edfd2f6e1adc97186e204937d0b5974d9ef783686ee5a79
   languageName: node
   linkType: hard
 
@@ -4942,9 +4969,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.6.1-pre.2058":
-  version: 5.6.1-pre.2058
-  resolution: "@openmrs/webpack-config@npm:5.6.1-pre.2058"
+"@openmrs/webpack-config@npm:5.7.3-pre.2157":
+  version: 5.7.3-pre.2157
+  resolution: "@openmrs/webpack-config@npm:5.7.3-pre.2157"
   dependencies:
     "@swc/core": "npm:^1.3.58"
     clean-webpack-plugin: "npm:^4.0.0"
@@ -4952,6 +4979,7 @@ __metadata:
     css-loader: "npm:^5.2.4"
     fork-ts-checker-webpack-plugin: "npm:^6.5.0"
     lodash: "npm:^4.17.21"
+    lodash-es: "npm:^4.17.21"
     sass: "npm:>=1.45.0 <1.65.0"
     sass-loader: "npm:^12.3.0"
     style-loader: "npm:^3.3.1"
@@ -4961,7 +4989,7 @@ __metadata:
     webpack-stats-plugin: "npm:^1.0.3"
   peerDependencies:
     webpack: 5.x
-  checksum: 10/2926cc187283398d0c9233d5ff9b28f9eb9ea46d9a81f1448f2661ddb09419b1c44eaf9c88be23294b86c4b0b75b0073f4f1da1107efd74d8e371d22e44430b4
+  checksum: 10/0d626f2437bd158c429da4ccc81765407b7266014f1040f24f96e1927bd5f986a1a268e9fae998d1b4325b8c10dd77e1f6c4a23dfd00c5feb1eb9747c233011f
   languageName: node
   linkType: hard
 
@@ -17349,7 +17377,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mini-css-extract-plugin@npm:2.7.6, mini-css-extract-plugin@npm:^2.4.5":
+"mini-css-extract-plugin@npm:2.7.6":
   version: 2.7.6
   resolution: "mini-css-extract-plugin@npm:2.7.6"
   dependencies:
@@ -17357,6 +17385,18 @@ __metadata:
   peerDependencies:
     webpack: ^5.0.0
   checksum: 10/1f718bfdcb7c2bf5e4336f694e5576432149d63f9dacaf94eae38ad046534050471a712a2d1bedf95e1722a2d3b56c3361d7352849e802e4875e716885e952c3
+  languageName: node
+  linkType: hard
+
+"mini-css-extract-plugin@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "mini-css-extract-plugin@npm:2.9.0"
+  dependencies:
+    schema-utils: "npm:^4.0.0"
+    tapable: "npm:^2.2.1"
+  peerDependencies:
+    webpack: ^5.0.0
+  checksum: 10/4c9ee9c0c6160a64a4884d5a92a1a5c0b68d556cd00f975cf6c8a79b51ac90e6130a37b3832b17d377d0cb1b31c0313c8c023458d4f69e95fe3424a8b43d834f
   languageName: node
   linkType: hard
 
@@ -18206,12 +18246,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openmrs@npm:next":
-  version: 5.6.1-pre.2058
-  resolution: "openmrs@npm:5.6.1-pre.2058"
+"openmrs@npm:^5.7.3-pre.2157, openmrs@npm:next":
+  version: 5.7.3-pre.2157
+  resolution: "openmrs@npm:5.7.3-pre.2157"
   dependencies:
-    "@openmrs/esm-app-shell": "npm:5.6.1-pre.2058"
-    "@openmrs/webpack-config": "npm:5.6.1-pre.2058"
+    "@openmrs/esm-app-shell": "npm:5.7.3-pre.2157"
+    "@openmrs/webpack-config": "npm:5.7.3-pre.2157"
     "@pnpm/npm-conf": "npm:^2.1.0"
     "@swc/core": "npm:^1.3.58"
     autoprefixer: "npm:^10.4.2"
@@ -18219,31 +18259,38 @@ __metadata:
     browserslist-config-openmrs: "npm:^1.0.1"
     chalk: "npm:^4.1.2"
     copy-webpack-plugin: "npm:^11.0.0"
+    css-loader: "npm:^5.2.4"
     cssnano: "npm:^5.0.16"
     ejs: "npm:^3.1.8"
     glob: "npm:^7.1.3"
     html-webpack-plugin: "npm:^5.5.0"
     inquirer: "npm:^7.3.3"
-    mini-css-extract-plugin: "npm:^2.4.5"
+    lodash: "npm:^4.17.21"
+    lodash-es: "npm:^4.17.21"
+    mini-css-extract-plugin: "npm:^2.9.0"
     node-watch: "npm:^0.7.4"
     npm-registry-fetch: "npm:^14.0.3"
     pacote: "npm:^15.0.0"
     postcss: "npm:^8.4.6"
     postcss-loader: "npm:^6.2.1"
     rimraf: "npm:^3.0.2"
+    sass-loader: "npm:^12.3.0"
     semver: "npm:^7.3.4"
+    style-loader: "npm:^3.3.1"
     swc-loader: "npm:^0.2.3"
     tar: "npm:^6.0.5"
     typescript: "npm:^4.6.4"
     webpack: "npm:^5.88.0"
+    webpack-bundle-analyzer: "npm:^4.5.0"
     webpack-cli: "npm:^4.10.0"
     webpack-dev-server: "npm:^4.10.1"
     webpack-pwa-manifest: "npm:^4.3.0"
+    webpack-stats-plugin: "npm:^1.0.3"
     workbox-webpack-plugin: "npm:^6.4.1"
     yargs: "npm:^17.6.2"
   bin:
     openmrs: ./dist/cli.js
-  checksum: 10/7d4b13b33cdfabbc3e0362682aeb81a71a770133d81bc35ad232e6d0e0bc7e5f665fbc5472020c7bbd661c01a6aa342cd1012a64b0970dc2c7410c8a87069c14
+  checksum: 10/f912f8326e2998e6e3c75acc1260d86213a49a9d72a6e8a8f985977202ad061e9e6d5fdb6c312a63250d3af07c396b62c8e582b3b50db19ba928fccaf5237edc
   languageName: node
   linkType: hard
 
@@ -22004,13 +22051,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"systemjs@npm:^6.8.3":
-  version: 6.12.1
-  resolution: "systemjs@npm:6.12.1"
-  checksum: 10/c2ca06919f8a4e3ae14bb1eccc0f37d852fd371f908afd4537b7efe2014c02e2fac4890243a712bb7e4dbfd199292e8642070c91545a9f8796e1d2d71e300fe4
-  languageName: node
-  linkType: hard
-
 "tapable@npm:^1.0.0":
   version: 1.1.3
   resolution: "tapable@npm:1.1.3"
@@ -22018,7 +22058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tapable@npm:^2.0.0, tapable@npm:^2.1.1, tapable@npm:^2.2.0":
+"tapable@npm:^2.0.0, tapable@npm:^2.1.1, tapable@npm:^2.2.0, tapable@npm:^2.2.1":
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
   checksum: 10/1769336dd21481ae6347611ca5fca47add0962fd8e80466515032125eca0084a4f0ede11e65341b9c0018ef4e1cf1ad820adbb0fba7cc99865c6005734000b0a


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Relates to https://github.com/openmrs/openmrs-esm-patient-management/pull/1264 and https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/359.

This PR fixes an issue in the Patient Chart where tests fail because of an `importDynamic` initialization error when using partial mocks to extend the framework mock. The solution is to:

1. Extend the framework mocks with all the missing stubs that originally necessitated the use of partial mocks (done [here](https://github.com/openmrs/openmrs-esm-core/pull/1105))
2. Remove all partial mocks and extend the stubs from the framework mock as needed.

This also bumps the Core tooling and the framework. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
