### PR TITLE
(feat) O3-3748: Add `data-openmrs-role` data attributes to DOM elements

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -652,7 +652,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
 
   return (
     <FormProvider {...methods}>
-      <Form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
+      <Form className={styles.form} onSubmit={handleSubmit(onSubmit)} data-openmrs-role="Start Visit Form">
         {showPatientHeader && patient && (
           <ExtensionSlot
             name="patient-header-slot"

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
@@ -108,6 +108,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid }) => {
           <div className={styles.buttonContainer}>
             <Button
               className={styles.recordVitalsButton}
+              data-openmrs-role="Record Vitals"
               kind="ghost"
               onClick={launchVitalsAndBiometricsForm}
               size="sm"

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
@@ -285,7 +285,7 @@ const VitalsAndBiometricsForm: React.FC<DefaultPatientWorkspaceProps> = ({
   }
 
   return (
-    <Form className={styles.form}>
+    <Form className={styles.form} data-openmrs-role="Vitals and Biometrics Form">
       <div className={styles.grid}>
         <Stack>
           <Column>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR defines a proper way for selectors accesability. By having this, we can query element using `data-openmrs-role` in the dom.
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-3748](https://openmrs.atlassian.net/browse/O3-3748
)

## Other
<!-- Anything not covered above -->
As per this [#comment](https://github.com/openmrs/openmrs-esm-patient-chart/pull/1946#issuecomment-2263188415)


cc : @jayasanka-sack 


[O3-3748]: https://openmrs.atlassian.net/browse/O3-3748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ