### PR TITLE
(fix) Correctly pick the current location in the Edit visit form

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/location-selector.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/location-selector.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { useForm, FormProvider } from 'react-hook-form';
+import { getDefaultsFromConfigSchema, useConfig, useSession } from '@openmrs/esm-framework';
+import { esmPatientChartSchema, type ChartConfig } from '../../config-schema';
+import { mockLocationsResponse, mockSessionDataResponse } from '__mocks__';
+import { type VisitFormData } from './visit-form.resource';
+import { useLocations } from '../hooks/useLocations';
+import LocationSelector from './location-selector.component';
+
+const mockSession = jest.mocked(useSession);
+const mockUseLocations = jest.mocked(useLocations);
+const mockUseConfig = jest.mocked(useConfig<ChartConfig>);
+
+mockSession.mockReturnValue(mockSessionDataResponse.data);
+
+jest.mock('../hooks/useLocations.tsx', () => ({
+  useLocations: jest.fn().mockReturnValue({
+    locations: mockLocationsResponse,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+beforeEach(() => {
+  mockUseConfig.mockReturnValue({
+    ...getDefaultsFromConfigSchema(esmPatientChartSchema),
+  });
+});
+
+it('renders a paragraph with the location name if disableChangingVisitLocation is truthy', () => {
+  mockUseConfig.mockReturnValue({
+    ...getDefaultsFromConfigSchema(esmPatientChartSchema),
+    disableChangingVisitLocation: true,
+  });
+
+  renderLocationSelector();
+
+  expect(screen.getByText(/visit location/i)).toBeInTheDocument();
+  expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  expect(screen.getByRole('paragraph')).toHaveTextContent('Inpatient Ward');
+});
+
+it('renders a combobox with options to pick from if disableChangingVisitLocation is falsy', () => {
+  renderLocationSelector();
+
+  expect(screen.getByRole('combobox', { name: /select a location/i })).toBeInTheDocument();
+  expect(screen.queryByRole('paragraph')).not.toBeInTheDocument();
+});
+
+it('defaults to showing the session location as the selected location if no locations are available', () => {
+  mockUseLocations.mockReturnValue({
+    locations: [],
+    isLoading: false,
+    error: null,
+  });
+
+  renderLocationSelector();
+
+  expect(screen.getByRole('combobox')).toHaveValue('Test Location');
+});
+
+it('renders a list of locations to pick from if locations are available', async () => {
+  const user = userEvent.setup();
+
+  mockUseLocations.mockReturnValue({
+    locations: mockLocationsResponse,
+    isLoading: false,
+    error: null,
+  });
+
+  renderLocationSelector();
+
+  const locationSelector = screen.getByRole('combobox');
+  expect(locationSelector).toBeInTheDocument();
+
+  await user.click(locationSelector);
+
+  mockLocationsResponse.forEach((location) => {
+    expect(screen.getByRole('option', { name: location.display })).toBeInTheDocument();
+  });
+});
+
+function renderLocationSelector(props = {}) {
+  const visitToEdit = {
+    uuid: 'visit-uuid',
+    location: {
+      uuid: 'test-location-uuid',
+      display: 'Test Location',
+    },
+  };
+
+  const App = () => {
+    const methods = useForm<VisitFormData>({
+      mode: 'all',
+      defaultValues: {
+        visitLocation: visitToEdit?.location ?? mockSessionDataResponse.data.sessionLocation ?? {},
+      },
+    });
+
+    return (
+      <FormProvider {...methods}>
+        <LocationSelector control={methods.control} />
+      </FormProvider>
+    );
+  };
+
+  render(<App />);
+}

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -61,7 +61,7 @@ import { useVisitAttributeTypes } from '../hooks/useVisitAttributeType';
 import { useVisitQueueEntry } from '../queue-entry/queue.resource';
 import { useVisits } from '../visits-widget/visit.resource';
 import BaseVisitType from './base-visit-type.component';
-import LocationSelector from './location-selection.component';
+import LocationSelector from './location-selector.component';
 import VisitAttributeTypeFields from './visit-attribute-type.component';
 import VisitDateTimeField from './visit-date-time.component';
 import styles from './visit-form.scss';
@@ -712,7 +712,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
             )}
 
             {/* This field lets the user select a location for the visit. The location is required for the visit to be saved. Defaults to the active session location */}
-            <LocationSelector />
+            <LocationSelector control={control} />
 
             {/* Lists available program types. This feature is dependent on the `showRecommendedVisitTypeTab` config being set
           to true. */}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -13,7 +13,7 @@ import { type ChartConfig } from '../../config-schema';
 export function useInfiniteVisits(patientUuid: string) {
   const config = useConfig<ChartConfig>();
   const customRepresentation =
-    'custom:(uuid,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis),form:(uuid,display),encounterDatetime,orders:full,obs:(uuid,concept:(uuid,display,conceptClass:(uuid,display)),display,groupMembers:(uuid,concept:(uuid,display),value:(uuid,display),display),value,obsDatetime),encounterType:(uuid,display,viewPrivilege,editPrivilege),encounterProviders:(uuid,display,encounterRole:(uuid,display),provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient,attributes:(attributeType:ref,display,uuid,value)';
+    'custom:(uuid,location,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis),form:(uuid,display),encounterDatetime,orders:full,obs:(uuid,concept:(uuid,display,conceptClass:(uuid,display)),display,groupMembers:(uuid,concept:(uuid,display),value:(uuid,display),display),value,obsDatetime),encounterType:(uuid,display,viewPrivilege,editPrivilege),encounterProviders:(uuid,display,encounterRole:(uuid,display),provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient,attributes:(attributeType:ref,display,uuid,value)';
 
   const getKey = (pageIndex, previousPageData) => {
     const pageSize = config.numberOfVisitsToLoad;

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -129,6 +129,7 @@
   "record": "Record",
   "refills": "Refills",
   "refreshToTryAgain": "Please refresh to try again",
+  "required": "Required",
   "retrospectiveEntry": "Retrospective entry",
   "saveAndClose": "Save and close",
   "saving": "Saving",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR fixes a regression raised by Veronica involving the Start Visit form. More specifically, the logic that sets the `defaultValues` in the form isn't correctly setting the current location when the form is launched in Edit mode. This happens because the visit object that gets passed down into the form (as the optional `visitToEdit` prop) doesn't contain a `location` property. I've fixed that by adding a `location` property to the `useInfiniteVisit` hook that fetches visits in the Visit Summary page. Following that, the default value gets set' correctly and the form properly defaults to showing the location of the visit to edit.

Additionally, I've renamed the `LocationSelector` component and added a new `control` prop to it. This does the same thing as obtaining the control from the `useFormContext` hook, except that it makes the test setup for the `LocationSelector` component a bit more straightforward.

Ultimately, I think that this is a good candidate for an E2E test as trying to mimic the same case in a unit or integration test requires a setup that's too contrived. I'll file a ticket to address that. 

## Screenshots

### Bug
https://github.com/user-attachments/assets/246eaee7-5b1b-45af-b188-a61534ce1647

### Fix
https://github.com/user-attachments/assets/2ca8ce68-48ef-4f19-8629-868db3021716

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
