### PR TITLE
(test) Amend E2E test for retained inputs in clinical forms workspace

### DIFF
--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -176,7 +176,7 @@ test('Form state is retained when minimizing a form in the workspace', async ({ 
     await page.getByLabel(/clinical forms/i, { exact: true }).click();
   });
 
-  await test.step('Then I should see `Laboratory Test Results` listed in the clinical forms workspace', async () => {
+  await test.step('Then I should see the `Laboratory Test Results` form listed in the clinical forms workspace', async () => {
     await expect(page.getByRole('cell', { name: /laboratory test results/i, exact: true })).toBeVisible();
   });
 
@@ -192,19 +192,13 @@ test('Form state is retained when minimizing a form in the workspace', async ({ 
     await page.getByLabel('maximize').click();
   });
 
-  await test.step('And I fill the `White Blood Cells (WBC)` result as `5000', async () => {
-    await page.locator('#ManualInputWhiteBloodCells').fill('5000');
+  await test.step('And I fill in values for the `White Blood Cells (WBC)`, `Platelets`, and `Neutrophils` questions', async () => {
+    await page.getByRole('spinbutton', { name: /white blood cells/i }).fill('5000');
+    await page.getByRole('spinbutton', { name: /platelets/i }).fill('180000');
+    await page.getByRole('spinbutton', { name: /neutrophils/i }).fill('35');
   });
 
-  await test.step('And I fill the `Platelets` result as `180000`', async () => {
-    await page.locator('#ManualEntryPlatelets').fill('180000');
-  });
-
-  await test.step('And I fill the `Neutrophils` result as `35`', async () => {
-    await page.locator('#ManualEntryNeutrophilsMicroscopic').fill('35');
-  });
-
-  await test.step('When I minimize the form in the workspace', async () => {
+  await test.step('Then I minimize the form in the workspace', async () => {
     await page.getByLabel('Minimize').click();
   });
 
@@ -213,14 +207,9 @@ test('Form state is retained when minimizing a form in the workspace', async ({ 
   });
 
   await test.step('Then I should see the entered data retained in the form', async () => {
-    const whiteBloodCells = await page.locator('#ManualInputWhiteBloodCells');
-    await expect(whiteBloodCells).toHaveValue('5000');
-
-    const platelets = await page.locator('#ManualEntryPlatelets');
-    await expect(platelets).toHaveValue('180000');
-
-    const neutrophils = page.locator('#ManualEntryNeutrophilsMicroscopic');
-    await expect(neutrophils).toHaveValue('35');
+    await expect(page.getByRole('spinbutton', { name: /white blood cells/i })).toHaveValue('5000');
+    await expect(page.getByRole('spinbutton', { name: /platelets/i })).toHaveValue('180000');
+    await expect(page.getByRole('spinbutton', { name: /neutrophils/i })).toHaveValue('35');
   });
 
   await test.step('When I click on the `Save` button', async () => {

--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -207,6 +207,8 @@ test('Form state is retained when minimizing a form in the workspace', async ({ 
   });
 
   await test.step('Then I should see the entered data retained in the form', async () => {
+    await page.locator('#ManualInputWhiteBloodCells').waitFor();
+    await expect(page.getByRole('spinbutton', { name: /white blood cells/i })).toHaveValue('5000');
     await expect(page.getByRole('spinbutton', { name: /white blood cells/i })).toHaveValue('5000');
     await expect(page.getByRole('spinbutton', { name: /platelets/i })).toHaveValue('180000');
     await expect(page.getByRole('spinbutton', { name: /neutrophils/i })).toHaveValue('35');

--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -189,7 +189,7 @@ test('Form state is retained when minimizing a form in the workspace', async ({ 
   });
 
   await test.step('And I maximize the form', async () => {
-    await page.getByLabel('maximize').click();
+    await page.getByRole('button', { name: /maximize/i }).click();
   });
 
   await test.step('And I fill in values for the `White Blood Cells (WBC)`, `Platelets`, and `Neutrophils` questions', async () => {
@@ -199,19 +199,18 @@ test('Form state is retained when minimizing a form in the workspace', async ({ 
   });
 
   await test.step('Then I minimize the form in the workspace', async () => {
-    await page.getByLabel('Minimize').click();
+    await page.getByRole('button', { name: /minimize/i }).click();
   });
 
-  await test.step('And then maximize the form in the workspace', async () => {
-    await page.getByLabel('Maximize').click();
+  await test.step('And then I maximize the form in the workspace', async () => {
+    await page.getByRole('button', { name: /maximize/i }).click();
   });
 
-  await test.step('Then I should see the entered data retained in the form', async () => {
-    await page.locator('#ManualInputWhiteBloodCells').waitFor();
-    await expect(page.getByRole('spinbutton', { name: /white blood cells/i })).toHaveValue('5000');
-    await expect(page.getByRole('spinbutton', { name: /white blood cells/i })).toHaveValue('5000');
-    await expect(page.getByRole('spinbutton', { name: /platelets/i })).toHaveValue('180000');
-    await expect(page.getByRole('spinbutton', { name: /neutrophils/i })).toHaveValue('35');
+  await test.step('And I should see the original form state retained', async () => {
+    await expect(page.getByText(/loading/i)).not.toBeVisible();
+    await expect(page.getByLabel(/white blood cells/i)).toHaveValue('5000');
+    await expect(page.getByLabel(/platelets/i)).toHaveValue('180000');
+    await expect(page.getByLabel(/neutrophils/i)).toHaveValue('35');
   });
 
   await test.step('When I click on the `Save` button', async () => {

--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -208,7 +208,6 @@ test('Form state is retained when minimizing a form in the workspace', async ({ 
   });
 
   await test.step('And I should see the original form state retained', async () => {
-    // await expect(page.getByText(/loading/i)).not.toBeVisible();
     await expect(page.getByLabel(/white blood cells/i)).toHaveValue('5000');
     await expect(page.getByLabel(/platelets/i)).toHaveValue('180000');
     await expect(page.getByLabel(/neutrophils/i)).toHaveValue('35');

--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -193,6 +193,7 @@ test('Form state is retained when minimizing a form in the workspace', async ({ 
   });
 
   await test.step('And I fill in values for the `White Blood Cells (WBC)`, `Platelets`, and `Neutrophils` questions', async () => {
+    await page.locator('#ManualInputWhiteBloodCells').waitFor();
     await page.getByRole('spinbutton', { name: /white blood cells/i }).fill('5000');
     await page.getByRole('spinbutton', { name: /platelets/i }).fill('180000');
     await page.getByRole('spinbutton', { name: /neutrophils/i }).fill('35');
@@ -207,7 +208,7 @@ test('Form state is retained when minimizing a form in the workspace', async ({ 
   });
 
   await test.step('And I should see the original form state retained', async () => {
-    await expect(page.getByText(/loading/i)).not.toBeVisible();
+    // await expect(page.getByText(/loading/i)).not.toBeVisible();
     await expect(page.getByLabel(/white blood cells/i)).toHaveValue('5000');
     await expect(page.getByLabel(/platelets/i)).toHaveValue('180000');
     await expect(page.getByLabel(/neutrophils/i)).toHaveValue('35');


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR amends the Clinical Forms E2E test to fix a flaky spec that tests whether form input values are retained when maximizing and minimizing the forms workspace. Here's [an example](https://github.com/openmrs/openmrs-esm-patient-chart/actions/runs/10279602708/job/28445274257) of a test failure with the flaky test. Here's a video showing the test failure from the run:

[video(2).webm](https://github.com/user-attachments/assets/1f38b787-6253-4cd0-b1ee-52aafd501ff4)

It appears that the `White blood cells` input gets cleared for whatever reason. I've tweaked the locators we're using to access and fill the inputs to use more robust matchers in the hope that that reduces the flakiness of the test. We'll find out soon enough whether this works. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
