### PR TITLE
(feat) O3-3794 Opening of clinical-forms-workspace on form close should be conditional

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -29,9 +29,7 @@ const FormRenderer: React.FC<FormRendererProps> = ({
 }) => {
   const { t } = useTranslation();
   const { schema, error, isLoading } = useFormSchema(formUuid);
-  const openClinicalFormsWorkspaceOnFormClose = additionalProps?.openClinicalFormsWorkspaceOnFormClose
-    ? additionalProps?.openClinicalFormsWorkspaceOnFormClose
-    : true;
+  const openClinicalFormsWorkspaceOnFormClose = additionalProps?.openClinicalFormsWorkspaceOnFormClose ?? true;
 
   const handleCloseForm = useCallback(() => {
     closeWorkspace();

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -29,11 +29,14 @@ const FormRenderer: React.FC<FormRendererProps> = ({
 }) => {
   const { t } = useTranslation();
   const { schema, error, isLoading } = useFormSchema(formUuid);
+  const openClinicalFormsWorkspaceOnFormClose = additionalProps?.openClinicalFormsWorkspaceOnFormClose
+    ? additionalProps?.openClinicalFormsWorkspaceOnFormClose
+    : true;
 
   const handleCloseForm = useCallback(() => {
     closeWorkspace();
-    !encounterUuid && launchPatientWorkspace('clinical-forms-workspace');
-  }, [closeWorkspace, encounterUuid]);
+    !encounterUuid && openClinicalFormsWorkspaceOnFormClose && launchPatientWorkspace('clinical-forms-workspace');
+  }, [closeWorkspace, encounterUuid, openClinicalFormsWorkspaceOnFormClose]);
 
   const handleConfirmQuestionDeletion = useCallback(() => {
     return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds logic to not automatically open the `clinical-forms-workspace` whenever the `patient-form-entry-workspace` is closed.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
