### PR TITLE
(fix) O3-3845: Editing a visit does not immediately update the displayed values

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -59,7 +59,7 @@ import { useMutateAppointments } from '../hooks/useMutateAppointments';
 import { useOfflineVisitType } from '../hooks/useOfflineVisitType';
 import { useVisitAttributeTypes } from '../hooks/useVisitAttributeType';
 import { useVisitQueueEntry } from '../queue-entry/queue.resource';
-import { useVisits } from '../visits-widget/visit.resource';
+import { useInfiniteVisits, useVisits } from '../visits-widget/visit.resource';
 import BaseVisitType from './base-visit-type.component';
 import LocationSelector from './location-selector.component';
 import VisitAttributeTypeFields from './visit-attribute-type.component';
@@ -97,6 +97,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
   const { activePatientEnrollment, isLoading } = useActivePatientEnrollment(patientUuid);
   const { mutate: mutateCurrentVisit } = useVisit(patientUuid);
   const { mutateVisits } = useVisits(patientUuid);
+  const { mutateVisits: mutateInfiniteVisits } = useInfiniteVisits(patientUuid);
   const { mutateAppointments } = useMutateAppointments();
   const allVisitTypes = useConditionalVisitTypes();
 
@@ -482,6 +483,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
                       if (status === 201) {
                         mutateCurrentVisit();
                         mutateVisits();
+                        mutateInfiniteVisits();
                         mutateQueueEntry();
                         showSnackbar({
                           kind: 'success',
@@ -506,6 +508,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
                     () => {
                       mutateCurrentVisit();
                       mutateVisits();
+                      mutateInfiniteVisits();
                       mutateAppointments();
                       showSnackbar({
                         isLowContrast: true,
@@ -537,6 +540,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
                     if (!attributesResponses.includes(undefined)) {
                       mutateCurrentVisit();
                       mutateVisits();
+                      mutateInfiniteVisits();
                       closeWorkspace({ ignoreChanges: true });
                       showSnackbar({
                         isLowContrast: true,
@@ -623,6 +627,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
       mutateCurrentVisit,
       mutateQueueEntry,
       mutateVisits,
+      mutateInfiniteVisits,
       patientUuid,
       priority,
       queueLocation,

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -38,7 +38,7 @@ export function useInfiniteVisits(patientUuid: string) {
   );
 
   return {
-    visits: data ? [].concat(data?.flatMap((page) => page.data.results)) : null,
+    visits: data ? [].concat(data?.flatMap((page) => page?.data?.results)) : null,
     error,
     hasMore: data?.length ? !!data[data.length - 1].data?.links?.some((link) => link.rel === 'next') : false,
     isLoading,


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR attempt to solve an issue in the visits section of the patient chart. 
When you edit a visit under the visits section of the patient chart, the details of the visit are not immediately updated. Yet when you reload the page the updated visit details will be displayed. 
The visits displayed are obtained from the `useInfiniteVisits` hook yet when the form is successfully submitted, the mutate function from the hook is not called. This create a situation where the displayed data is stale and needs a reload of the page to re-fetch the upto date data.

The suggested solution in this PR is to call the mutate function of the useInfinteVisits hooks whenever the form is successfully submited under the different scenarios.


## Screenshots
https://github.com/user-attachments/assets/e3f42d48-2575-44f8-a505-1da7d1f08853


## Related Issue
https://openmrs.atlassian.net/browse/O3-3845
