### PR TITLE
(fix) Disable scroll wheel functionality in the drug order form

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -848,6 +848,7 @@ const ControlledFieldInput = ({
       return (
         <NumberInput
           className={fieldErrorStyles}
+          disableWheel
           onBlur={onBlur}
           onChange={(e, { value }) => {
             const number = parseFloat(value);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR disables the scroll wheel functionality in [NumberInput](https://react.carbondesignsystem.com/?path=/docs/components-numberinput--overview) fields in the Drug Order form by setting the `disableWheel` prop. Before this change, when a NumberInput field was focused and the user scrolled past with their mouse wheel, the value in the input would increment or decrement. This can lead to accidental value changes that the user might overlook. Setting the prop fixes makes the NumberInput ignore mouse wheel events when focused, reducing the likelihood of unintentional value changes.

## Screenshots

https://github.com/user-attachments/assets/9c884127-5562-4678-887b-1cbb38ece965

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
