### PR TITLE
(feat) O3-3865: Avail entire patient object to angular form engine

### DIFF
--- a/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
@@ -341,17 +341,15 @@ export class FormDataSourceService {
     }
   }
   public getPatientObject(patient): PatientModel {
-    let model: PatientModel = {
-      sex: this.getGender(patient?.gender),
-      birthdate: new Date(patient?.birthDate),
-      age: this.calculateAge(patient?.birthDate),
-      identifiers: [],
-      gendercreatconstant: patient?.gender === 'female' ? 0.85 : patient?.gender === 'male' ? 1 : undefined,
+    return {
+      ...patient,
+      patientUuid: patient.id,
+      sex: this.getGender(patient.gender),
+      birthdate: patient.birthDate ? new Date(patient.birthDate) : undefined,
+      age: this.calculateAge(patient.birthDate),
+      gendercreatconstant: patient.gender === 'female' ? 0.85 : patient.gender === 'male' ? 1 : undefined,
+      identifiers: this.mapFHIRPatientIdentifiersToOpenMRSIdentifiers(patient),
     };
-
-    model.identifiers = this.mapFHIRPatientIdentifiersToOpenMRSIdentifiers(patient);
-
-    return model;
   }
 
   private calculateAge(birthday) {

--- a/packages/esm-form-entry-app/src/app/types/index.ts
+++ b/packages/esm-form-entry-app/src/app/types/index.ts
@@ -454,6 +454,8 @@ export interface PatientModel {
   age: number;
   gendercreatconstant?: number;
   identifiers: Array<Identifier>;
+  patientUuid: string;
+  [key: string]: any;
 }
 
 export interface IdentifierPayload {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Avail entire patient object to form entry so that we could use it for evaluating expression e.g we use `patientUuid` it to generate Unique Patient Identifier in forms.

## Screenshots
No UI changes made

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
