### PR TITLE
Hide Steppers in Numeric Input Fields on Drug Order Form

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -624,6 +624,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                       step={1}
                       max={maxDispenseDurationInDays}
                       allowEmpty={true}
+                      hideSteppers
                     />
                   ) : (
                     <CustomNumberInput
@@ -698,6 +699,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                       label={t('prescriptionRefills', 'Prescription refills')}
                       max={99}
                       allowEmpty
+                      hideSteppers
                     />
                   ) : (
                     <CustomNumberInput


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I modified the numeric input fields in the Drug Order Form to hide the increment and decrement steppers, ensuring a cleaner UI and preventing accidental changes.

## Screenshots
**Before making changes**
![Screenshot 2024-08-29 at 1 48 47 PM](https://github.com/user-attachments/assets/7f301b27-16bc-4a4e-86cb-58728622d624)


**After making changes**

![Screenshot 2024-08-29 at 1 51 57 PM](https://github.com/user-attachments/assets/789f650c-8ec0-45e1-b2f4-73c8913be5d6)

## Related Issue
https://openmrs.atlassian.net/browse/O3-3887

## Other
<!-- Anything not covered above -->
