### PR TITLE
(fix) Move HtmlFormEntryForm type to patient-common-lib

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visits-table/visits-table.component.tsx
@@ -37,8 +37,12 @@ import {
   useSession,
   userHasAccess,
 } from '@openmrs/esm-framework';
-import { EmptyState, PatientChartPagination, launchFormEntryOrHtmlForms } from '@openmrs/esm-patient-common-lib';
-import type { HtmlFormEntryForm } from '@openmrs/esm-patient-forms-app/src/config-schema';
+import {
+  type HtmlFormEntryForm,
+  EmptyState,
+  PatientChartPagination,
+  launchFormEntryOrHtmlForms,
+} from '@openmrs/esm-patient-common-lib';
 import { deleteEncounter } from './visits-table.resource';
 import { type MappedEncounter } from '../../visit.resource';
 import EncounterObservations from '../../encounter-observations';

--- a/packages/esm-patient-common-lib/src/form-entry/form-entry.ts
+++ b/packages/esm-patient-common-lib/src/form-entry/form-entry.ts
@@ -1,4 +1,4 @@
-import { type HtmlFormEntryForm } from '@openmrs/esm-patient-forms-app/src/config-schema';
+import { type HtmlFormEntryForm } from '../types';
 
 export interface FormEntryProps {
   encounterUuid?: string;

--- a/packages/esm-patient-common-lib/src/types/index.ts
+++ b/packages/esm-patient-common-lib/src/types/index.ts
@@ -1,5 +1,3 @@
-import { type OpenmrsResource } from '@openmrs/esm-framework';
-
 export * from './test-results';
 
 export interface DashboardLinkConfig {
@@ -48,4 +46,12 @@ export interface DisplayMetadata {
   display: string;
   links: Links;
   uuid: string;
+}
+
+export interface HtmlFormEntryForm {
+  formUuid: string;
+  formName: string;
+  formUiResource: string;
+  formUiPage: 'enterHtmlFormWithSimpleUi' | 'enterHtmlFormWithStandardUi';
+  formEditUiPage: 'editHtmlFormWithSimpleUi' | 'editHtmlFormWithStandardUi';
 }

--- a/packages/esm-patient-forms-app/src/config-schema.ts
+++ b/packages/esm-patient-forms-app/src/config-schema.ts
@@ -1,4 +1,5 @@
 import { validator, Type } from '@openmrs/esm-framework';
+import { type HtmlFormEntryForm } from '@openmrs/esm-patient-common-lib';
 
 export const configSchema = {
   htmlFormEntryForms: {
@@ -132,14 +133,6 @@ export const configSchema = {
     _default: [],
   },
 };
-
-export interface HtmlFormEntryForm {
-  formUuid: string;
-  formName: string;
-  formUiResource: string;
-  formUiPage: 'enterHtmlFormWithSimpleUi' | 'enterHtmlFormWithStandardUi';
-  formEditUiPage: 'editHtmlFormWithSimpleUi' | 'editHtmlFormWithStandardUi';
-}
 
 export interface FormsSection {
   name: string;

--- a/packages/esm-patient-forms-app/src/form-entry-interop.ts
+++ b/packages/esm-patient-forms-app/src/form-entry-interop.ts
@@ -1,7 +1,10 @@
 import { navigate, type Visit } from '@openmrs/esm-framework';
-import { type HtmlFormEntryForm } from './config-schema';
-import isEmpty from 'lodash-es/isEmpty';
-import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
+import {
+  type HtmlFormEntryForm,
+  launchPatientWorkspace,
+  launchStartVisitPrompt,
+} from '@openmrs/esm-patient-common-lib';
+import { isEmpty } from 'lodash-es';
 
 export function launchFormEntryOrHtmlForms(
   currentVisit: Visit | undefined,

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-form-helpers.ts
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-form-helpers.ts
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 import { getDynamicOfflineDataEntries } from '@openmrs/esm-framework';
+import { type HtmlFormEntryForm } from '@openmrs/esm-patient-common-lib';
 import { type Form, type FormEncounterResource } from '../types';
-import { type HtmlFormEntryForm } from '../config-schema';
 
 /**
  * Returns whether the given form encounter is valid for offline mode and can be cached.


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The type `HtmlFormEntryForm` was defined in the patient-forms-app and imported into a few places, most importantly the patient-common-lib. This inadvertently made patient-common-lib have an undeclared, Typescript-only dependency on the patient-forms-app, which means that apps that are not part of this workspace, but depend on the patient common lib cannot correctly pass type-checks.

This PR fixes this issue by moving the type to the patient-common-lib and having everything import it from there.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
