### PR TITLE
(feat) Remove double bottom borders from datatables

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -267,7 +267,7 @@ const MedicationsDetailsTable: React.FC<ActiveMedicationsProps> = ({
         >
           {({ rows, headers, getTableProps, getHeaderProps, getRowProps }) => (
             <TableContainer>
-              <Table aria-label="medications" {...getTableProps()}>
+              <Table aria-label="medications" className={styles.table} {...getTableProps()}>
                 <TableHead>
                   <TableRow>
                     {headers.map((header) => (

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.scss
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.scss
@@ -60,3 +60,9 @@
 .bodyLong01 {
   @include type.type-style('body-01');
 }
+
+.table {
+  td {
+    border-bottom: none !important;
+  }
+}

--- a/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
@@ -82,7 +82,7 @@ const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
       >
         {({ rows, headers, getHeaderProps, getTableProps }) => (
           <TableContainer className={styles.tableContainer}>
-            <Table aria-label="biometrics" {...getTableProps()}>
+            <Table aria-label="biometrics" className={styles.table} {...getTableProps()}>
               <TableHead>
                 <TableRow>
                   {headers.map((header) => (

--- a/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.scss
+++ b/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.scss
@@ -1,3 +1,9 @@
 .tableContainer {
   flex: 1;
 }
+
+.table {
+  td {
+    border-bottom: none !important;
+  }
+}

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.scss
@@ -2,14 +2,11 @@
 @use '@carbon/layout';
 @use '@carbon/type';
 
-.tableContainer {
-  flex: 1;
-}
-
 .table {
   td {
     white-space: nowrap;
     border-top: 1px solid colors.$gray-20;
+    border-bottom: none !important;
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue where some double borders would appear on datatables in the Patient Chart

## Screenshots

### Before

![CleanShot 2024-09-05 at 9  45 39@2x](https://github.com/user-attachments/assets/1c16ed75-c68c-45aa-9692-8c5ce5b87e35)

### After

![CleanShot 2024-09-05 at 9  49 54@2x](https://github.com/user-attachments/assets/1cfd2c5b-170c-4139-8e6c-07e2ccaf578c)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
