### PR TITLE
(feat) Pass default form session intent to form Engine

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -30,6 +30,7 @@ const FormRenderer: React.FC<FormRendererProps> = ({
   const { t } = useTranslation();
   const { schema, error, isLoading } = useFormSchema(formUuid);
   const openClinicalFormsWorkspaceOnFormClose = additionalProps?.openClinicalFormsWorkspaceOnFormClose ?? true;
+  const formSessionIntent = additionalProps?.formSessionIntent ?? '*';
 
   const handleCloseForm = useCallback(() => {
     closeWorkspace();
@@ -82,7 +83,7 @@ const FormRenderer: React.FC<FormRendererProps> = ({
           handleConfirmQuestionDeletion={handleConfirmQuestionDeletion}
           markFormAsDirty={handleMarkFormAsDirty}
           mode={additionalProps?.mode}
-          formSessionIntent={additionalProps?.formSessionIntent}
+          formSessionIntent={formSessionIntent}
           onSubmit={closeWorkspaceWithSavedChanges}
           patientUUID={patientUuid}
           visit={visit}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR addresses an issue where session intents were not being passed when opening forms from the `clinical-forms-workspace`. The React form engine supports `session intents`, allowing business rules to be applied per intent via the `behaviors` property. However, forms created with intents were not applying the corresponding business rules due to the absence of intents when the form was opened.

To resolve this, the PR sets * (all) as the default intent when opening a form. This change ensures that business rules are applied to forms with intents while having no impact on forms without intents.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
