### PR TITLE
(feat) Test types should be filterable by synonyms

### DIFF
--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
@@ -34,10 +34,17 @@ const mockTestTypes = [
   {
     conceptUuid: 'test-lab-uuid-1',
     label: 'HIV VIRAL LOAD',
+    synonyms: ['HIV VIRAL LOAD', 'HIV VL'],
   },
   {
     conceptUuid: 'test-lab-uuid-2',
     label: 'CD4 COUNT',
+    synonyms: ['CD4 COUNT', 'CD4'],
+  },
+  {
+    conceptUuid: 'test-lab-uuid-3',
+    label: 'HEMOGLOBIN',
+    synonyms: ['HEMOGLOBIN', 'HGB'],
   },
 ];
 const mockUseTestTypes = jest.fn().mockReturnValue({
@@ -198,6 +205,15 @@ describe('AddLabOrder', () => {
     expect(screen.getByText(/male/i)).toBeInTheDocument();
     expect(screen.getByText(/52 yrs/i)).toBeInTheDocument();
     expect(screen.getByText('04 — Apr — 1972')).toBeInTheDocument();
+  });
+
+  test('should be possible to search for test types by synonyms', async () => {
+    const user = userEvent.setup();
+    renderAddLabOrderWorkspace();
+    const searchInput = screen.getByRole('searchbox');
+    await user.type(searchInput, 'hgb');
+    await screen.findByText(/hemoglobin/i);
+    expect(screen.queryByText(/hiv viral load/i)).not.toBeInTheDocument();
   });
 
   test('should display an error message if test types fail to load', () => {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/test-type-search.component.tsx
@@ -74,7 +74,9 @@ function TestTypeSearchResults({ searchTerm, openOrderForm, focusAndClearSearchI
     }
 
     if (searchTerm && searchTerm.trim() !== '') {
-      return testTypes.filter((testType) => testType.label.toLowerCase().includes(searchTerm.toLowerCase()));
+      return testTypes?.filter((testType) =>
+        testType.synonyms.some((name) => name.toLowerCase().includes(searchTerm.toLowerCase())),
+      );
     }
   }, [searchTerm, testTypes]);
 

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
@@ -43,7 +43,7 @@ describe('useTestTypes is configurable', () => {
   it('should return all test concepts when no labOrderableConcepts are provided', async () => {
     const { result } = renderHook(() => useTestTypes());
     expect(mockOpenrsFetch).toHaveBeenCalledWith(
-      '/ws/rest/v1/concept?class=Test?v=custom:(display,names:(display),uuid,setMembers:(display,uuid,setMembers:(display,uuid,names:(display))))',
+      '/ws/rest/v1/concept?class=Test?v=custom:(display,names:(display),uuid,setMembers:(display,uuid,names:(display),setMembers:(display,uuid,names:(display))))',
     );
     await waitFor(() => expect(result.current.isLoading).toBeFalsy());
     expect(result.current.error).toBeFalsy();
@@ -54,7 +54,7 @@ describe('useTestTypes is configurable', () => {
     const { result } = renderHook(() => useTestTypes());
     expect(mockOpenrsFetch).toHaveBeenCalledWith(
       expect.stringContaining(
-        '/ws/rest/v1/concept?class=Test?v=custom:(display,names,uuid,setMembers:(display,uuid,setMembers:(display,uuid,names)))',
+        '/ws/rest/v1/concept?class=Test?v=custom:(display,names:(display),uuid,setMembers:(display,uuid,names:(display),setMembers:(display,uuid,names:(display))))',
       ),
     );
     await waitFor(() => expect(result.current.isLoading).toBeFalsy());

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
@@ -43,7 +43,7 @@ describe('useTestTypes is configurable', () => {
   it('should return all test concepts when no labOrderableConcepts are provided', async () => {
     const { result } = renderHook(() => useTestTypes());
     expect(mockOpenrsFetch).toHaveBeenCalledWith(
-      '/ws/rest/v1/concept?class=Test?v=custom:(display,names,uuid,setMembers:(display,uuid,setMembers:(display,uuid,names)))',
+      '/ws/rest/v1/concept?class=Test?v=custom:(display,names:(display),uuid,setMembers:(display,uuid,setMembers:(display,uuid,names:(display))))',
     );
     await waitFor(() => expect(result.current.isLoading).toBeFalsy());
     expect(result.current.error).toBeFalsy();

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.test.ts
@@ -40,10 +40,10 @@ mockOpenrsFetch.mockImplementation((url: string) => {
 });
 
 describe('useTestTypes is configurable', () => {
-  it('should return all Test concepts when no labOrderableConcepts are provided', async () => {
+  it('should return all test concepts when no labOrderableConcepts are provided', async () => {
     const { result } = renderHook(() => useTestTypes());
     expect(mockOpenrsFetch).toHaveBeenCalledWith(
-      '/ws/rest/v1/concept?class=Test?v=custom:(display,uuid,setMembers:(display,uuid,setMembers:(display,uuid)))',
+      '/ws/rest/v1/concept?class=Test?v=custom:(display,names,uuid,setMembers:(display,uuid,setMembers:(display,uuid,names)))',
     );
     await waitFor(() => expect(result.current.isLoading).toBeFalsy());
     expect(result.current.error).toBeFalsy();
@@ -54,7 +54,7 @@ describe('useTestTypes is configurable', () => {
     const { result } = renderHook(() => useTestTypes());
     expect(mockOpenrsFetch).toHaveBeenCalledWith(
       expect.stringContaining(
-        '/ws/rest/v1/concept?class=Test?v=custom:(display,uuid,setMembers:(display,uuid,setMembers:(display,uuid)))',
+        '/ws/rest/v1/concept?class=Test?v=custom:(display,names,uuid,setMembers:(display,uuid,setMembers:(display,uuid,names)))',
       ),
     );
     await waitFor(() => expect(result.current.isLoading).toBeFalsy());

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
@@ -32,9 +32,9 @@ function useTestConceptsSWR(labOrderableConcepts?: Array<string>) {
       labOrderableConcepts
         ? labOrderableConcepts.map(
             (c) =>
-              `${restBaseUrl}/concept/${c}?v=custom:(display,names,uuid,setMembers:(display,uuid,names,setMembers:(display,uuid,names)))`,
+              `${restBaseUrl}/concept/${c}?v=custom:(display,names:(display),uuid,setMembers:(display,uuid,names:(display),setMembers:(display,uuid,names:(display))))`,
           )
-        : `${restBaseUrl}/concept?class=Test?v=custom:(display,names,uuid,setMembers:(display,uuid,setMembers:(display,uuid,names)))`,
+        : `${restBaseUrl}/concept?class=Test?v=custom:(display,names:(display),uuid,setMembers:(display,uuid,names:(display),setMembers:(display,uuid,names:(display))))`,
     (labOrderableConcepts ? openmrsFetchMultiple : openmrsFetch) as any,
     {
       shouldRetryOnError(err) {

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/useTestTypes.ts
@@ -10,6 +10,7 @@ type ConceptResults = FetchResponse<{ results: Array<Concept> }>;
 export interface TestType {
   label: string;
   conceptUuid: string;
+  synonyms: string[];
 }
 
 export interface UseTestType {
@@ -31,9 +32,9 @@ function useTestConceptsSWR(labOrderableConcepts?: Array<string>) {
       labOrderableConcepts
         ? labOrderableConcepts.map(
             (c) =>
-              `${restBaseUrl}/concept/${c}?v=custom:(display,uuid,setMembers:(display,uuid,setMembers:(display,uuid)))`,
+              `${restBaseUrl}/concept/${c}?v=custom:(display,names,uuid,setMembers:(display,uuid,names,setMembers:(display,uuid,names)))`,
           )
-        : `${restBaseUrl}/concept?class=Test?v=custom:(display,uuid,setMembers:(display,uuid,setMembers:(display,uuid)))`,
+        : `${restBaseUrl}/concept?class=Test?v=custom:(display,names,uuid,setMembers:(display,uuid,setMembers:(display,uuid,names)))`,
     (labOrderableConcepts ? openmrsFetchMultiple : openmrsFetch) as any,
     {
       shouldRetryOnError(err) {
@@ -58,7 +59,6 @@ function useTestConceptsSWR(labOrderableConcepts?: Array<string>) {
 
 export function useTestTypes(): UseTestType {
   const { labOrderableConcepts } = useConfig<ConfigObject>().orders;
-
   const { data, isLoading, error } = useTestConceptsSWR(labOrderableConcepts.length ? labOrderableConcepts : null);
 
   useEffect(() => {
@@ -73,6 +73,7 @@ export function useTestTypes(): UseTestType {
         ?.map((concept) => ({
           label: concept.display,
           conceptUuid: concept.uuid,
+          synonyms: concept.names?.flatMap((name) => name.display) ?? [],
         }))
         ?.sort((testConcept1, testConcept2) => testConcept1.label.localeCompare(testConcept2.label))
         ?.filter((item, pos, array) => !pos || array[pos - 1].conceptUuid !== item.conceptUuid),

--- a/packages/esm-patient-labs-app/src/types.ts
+++ b/packages/esm-patient-labs-app/src/types.ts
@@ -77,6 +77,9 @@ export interface Concept {
     display: string;
     name: string;
   };
+  names: Array<{
+    display: string;
+  }>;
   answers: [];
   setMembers: [];
   hiNormal: number;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR makes it possible to filter test types using the test concept synonyms. This makes it possible to type in something like `ALP` in the test types searchbox and see `Alkaline phosphatase` listed in the search results. To achieve this, I've altered the filter logic to search through test synonym names instead of searching against individual test names.

## Screenshots

https://github.com/user-attachments/assets/e9ba869a-7050-4c6e-a05c-cee07b9cf124

## Related Issue

https://openmrs.atlassian.net/browse/O3-3974

## Other
<!-- Anything not covered above -->
