### PR TITLE
(feat) Comboboxes in the order form should filter out non-matching items

### DIFF
--- a/e2e/specs/drug-orders.spec.ts
+++ b/e2e/specs/drug-orders.spec.ts
@@ -148,7 +148,6 @@ test('Record, edit and discontinue a drug order', async ({ page }) => {
     await form.getByPlaceholder(/route/i).clear();
     await form.getByPlaceholder(/route/i).fill('Inhalation');
     await form.getByText('Inhalation', { exact: true }).click();
-    await page.pause();
   });
 
   await test.step('And I change the frequency to `Twice daily`', async () => {

--- a/e2e/specs/drug-orders.spec.ts
+++ b/e2e/specs/drug-orders.spec.ts
@@ -145,7 +145,10 @@ test('Record, edit and discontinue a drug order', async ({ page }) => {
 
   await test.step('And I change the route to `Inhalation`', async () => {
     await form.getByPlaceholder(/route/i).click();
+    await form.getByPlaceholder(/route/i).clear();
+    await form.getByPlaceholder(/route/i).fill('Inhalation');
     await form.getByText('Inhalation', { exact: true }).click();
+    await page.pause();
   });
 
   await test.step('And I change the frequency to `Twice daily`', async () => {

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -338,7 +338,11 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
     return orderConfigObject?.orderFrequencies ?? [];
   }, [orderConfigObject]);
 
-  const filterItems = useCallback((menu) => {
+  const filterItemsByName = useCallback((menu) => {
+    return menu?.item?.value?.toLowerCase().includes(menu?.inputValue?.toLowerCase());
+  }, []);
+
+  const filterItemsBySynonymNames = useCallback((menu) => {
     if (menu?.inputValue?.length) {
       return menu.item?.names?.some((abbr: string) => abbr.toLowerCase().includes(menu.inputValue.toLowerCase()));
     }
@@ -482,6 +486,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                         getValues={getValues}
                         size={isTablet ? 'lg' : 'md'}
                         id="dosingUnits"
+                        shouldFilterItem={filterItemsByName}
                         items={drugDosingUnits}
                         placeholder={t('editDosageUnitsPlaceholder', 'Unit')}
                         titleText={t('editDosageUnitsTitle', 'Dose unit')}
@@ -496,14 +501,15 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                     <InputWrapper>
                       <ControlledFieldInput
                         control={control}
-                        name="route"
-                        type="comboBox"
-                        size={isTablet ? 'lg' : 'md'}
                         id="editRoute"
                         items={drugRoutes}
-                        placeholder={t('editRouteComboBoxTitle', 'Route')}
-                        titleText={t('editRouteComboBoxTitle', 'Route')}
                         itemToString={(item) => item?.value}
+                        name="route"
+                        placeholder={t('editRouteComboBoxTitle', 'Route')}
+                        shouldFilterItem={filterItemsByName}
+                        size={isTablet ? 'lg' : 'md'}
+                        titleText={t('editRouteComboBoxTitle', 'Route')}
+                        type="comboBox"
                       />
                     </InputWrapper>
                   </Column>
@@ -516,7 +522,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                         size={isTablet ? 'lg' : 'md'}
                         id="editFrequency"
                         items={orderFrequencies}
-                        shouldFilterItem={filterItems}
+                        shouldFilterItem={filterItemsBySynonymNames}
                         placeholder={t('editFrequencyComboBoxTitle', 'Frequency')}
                         titleText={t('editFrequencyComboBoxTitle', 'Frequency')}
                         itemToString={(item) => item?.value}
@@ -647,6 +653,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                     items={durationUnits}
                     itemToString={(item) => item?.value}
                     placeholder={t('durationUnitPlaceholder', 'Duration Unit')}
+                    shouldFilterItem={filterItemsByName}
                   />
                 </InputWrapper>
               </Column>
@@ -674,14 +681,15 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                 <InputWrapper>
                   <ControlledFieldInput
                     control={control}
-                    name="quantityUnits"
-                    type="comboBox"
-                    size="lg"
                     id="dispensingUnits"
                     items={drugDispensingUnits}
-                    placeholder={t('editDispensingUnit', 'Quantity unit')}
-                    titleText={t('editDispensingUnit', 'Quantity unit')}
                     itemToString={(item) => item?.value}
+                    name="quantityUnits"
+                    placeholder={t('editDispensingUnit', 'Quantity unit')}
+                    shouldFilterItem={filterItemsByName}
+                    size="lg"
+                    titleText={t('editDispensingUnit', 'Quantity unit')}
+                    type="comboBox"
                   />
                 </InputWrapper>
               </Column>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

By default, the Carbon Combobox component [does not filter out](https://react.carbondesignsystem.com/?path=/docs/components-combobox--overview#shouldfilteritem) items that do not match the input string. To make this behaviour possible, we need to pass in our own filtering function to the Combobox’s shouldFilterItem prop. This PR adds this functionality to several comboboxes in the order form so that filtering happens more intuitively.

## Screenshots

https://github.com/user-attachments/assets/d5b6e8a7-5bfe-433f-94a0-e6e999fdd20f

es.mp4

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
