### PR TITLE
(fix) O3-3992: Add safeguards for service queue entry creation to visit form

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -823,10 +823,9 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
           </Stack>
         </div>
         <ButtonSet
-          className={classNames({
+          className={classNames(styles.buttonSet, {
             [styles.tablet]: isTablet,
             [styles.desktop]: !isTablet,
-            [styles.buttonSet]: true,
           })}
         >
           <Button className={styles.button} kind="secondary" onClick={closeWorkspace}>

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -464,7 +464,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
           .subscribe({
             next: (response) => {
               if (response.status === 201) {
-                if (config.showServiceQueueFields) {
+                if (config.showServiceQueueFields && queueLocation && service && priority) {
                   // retrieve values from the queue extension
                   setVisitUuid(response.data.uuid);
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -568,7 +568,7 @@ describe('Visit form', () => {
     expect(mockSaveVisit).not.toHaveBeenCalled();
   });
 
-  it('should disable the submit button show an inline error notification if required visit attribute fields fail to load', async () => {
+  it('should disable the submit button and display an inline error notification if required visit attribute fields fail to load', async () => {
     mockUseVisitAttributeType.mockReturnValue({
       isLoading: false,
       error: new Error('failed to load'),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds checks for `queueLocation`, `service`, and `priority` as a safeguard to ensure that all necessary information is available before attempting to add a patient to the service queue when starting or editing a visit using the Visit form. Even if the `showServiceQueueFields` config property is truthy, there might be cases where the user hasn't selected all required queue fields. This check ensures that we only proceed with queue entry creation when all necessary data has been provided.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3992

## Other
<!-- Anything not covered above -->
