### PR TITLE
(fix) O3-3979: Visit start date field not populating correctly when editing a visit

### DIFF
--- a/e2e/specs/edit-existing-visit.spec.ts
+++ b/e2e/specs/edit-existing-visit.spec.ts
@@ -27,7 +27,12 @@ test('Edit an existing visit', async ({ page }) => {
 
   await test.step('Then I should see the `Edit Visit` form launch in the workspace', async () => {
     await expect(chartPage.page.getByText(/visit start date and time/i)).toBeVisible();
-    await expect(chartPage.page.getByPlaceholder(/dd\/mm\/yyyy/i)).toBeVisible();
+    const datePickerInput = chartPage.page.getByPlaceholder(/dd\/mm\/yyyy/i);
+    await expect(datePickerInput).toBeVisible();
+    const dateValue = await datePickerInput.inputValue();
+    expect(dateValue).not.toBe('');
+    expect(dateValue).toMatch(/^\d{2}\/\d{2}\/\d{4}$/);
+
     await expect(chartPage.page.getByPlaceholder(/hh\:mm/i)).toBeVisible();
     await expect(chartPage.page.getByRole('combobox', { name: /select a location/i })).toBeVisible();
     await expect(chartPage.page.getByRole('combobox', { name: /select a location/i })).toHaveValue('Outpatient Clinic');

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -54,8 +54,6 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
                 datePickerType="single"
                 id={dateFieldName}
                 style={{ paddingBottom: '1rem' }}
-                minDate={minDateObj}
-                maxDate={maxDateObj}
                 onChange={([date]) => onChange(date)}
                 value={value}
               >

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import styles from './visit-form.scss';
-import { Controller, useFormContext } from 'react-hook-form';
-import { type VisitFormData } from './visit-form.resource';
-import { DatePicker, DatePickerInput, SelectItem, TimePicker, TimePickerSelect } from '@carbon/react';
 import classNames from 'classnames';
-import { useLayoutType, ResponsiveWrapper } from '@openmrs/esm-framework';
-import { useTranslation } from 'react-i18next';
-import { type amPm } from '@openmrs/esm-patient-common-lib';
 import dayjs from 'dayjs';
+import { DatePicker, DatePickerInput, SelectItem, TimePicker, TimePickerSelect } from '@carbon/react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { ResponsiveWrapper } from '@openmrs/esm-framework';
+import { type amPm } from '@openmrs/esm-patient-common-lib';
+import { type VisitFormData } from './visit-form.resource';
+import styles from './visit-form.scss';
 
 interface VisitDateTimeFieldProps {
   visitDatetimeLabel: string;
@@ -47,15 +47,17 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
         <Controller
           name={dateFieldName}
           control={control}
-          render={({ field: { onBlur, onChange, value } }) => (
+          render={({ field: { onChange, value } }) => (
             <ResponsiveWrapper>
               <DatePicker
+                className={styles.datePicker}
                 dateFormat="d/m/Y"
                 datePickerType="single"
                 id={dateFieldName}
-                style={{ paddingBottom: '1rem' }}
+                minDate={minDateObj}
+                maxDate={maxDateObj}
                 onChange={([date]) => onChange(date)}
-                value={value}
+                value={value ? dayjs(value).format('DD/MM/YYYY') : null}
               >
                 <DatePickerInput
                   id={`${dateFieldName}Input`}

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx
@@ -178,6 +178,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
   const defaultValues = useMemo(() => {
     const visitStartDate = visitToEdit?.startDatetime ? new Date(visitToEdit?.startDatetime) : new Date();
     const visitStopDate = visitToEdit?.stopDatetime ? new Date(visitToEdit?.stopDatetime) : null;
+
     let defaultValues: Partial<VisitFormData> = {
       visitStartDate,
       visitStartTime: dayjs(visitStartDate).format('hh:mm'),
@@ -689,20 +690,20 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
           )}
           <Stack gap={1} className={styles.container}>
             <VisitDateTimeField
-              visitDatetimeLabel={t('visitStartDatetime', 'Visit start date and time')}
               dateFieldName="visitStartDate"
+              maxDate={maxVisitStartDatetime}
               timeFieldName="visitStartTime"
               timeFormatFieldName="visitStartTimeFormat"
-              maxDate={maxVisitStartDatetime}
+              visitDatetimeLabel={t('visitStartDatetime', 'Visit start date and time')}
             />
 
             {displayVisitStopDateTimeFields && (
               <VisitDateTimeField
-                visitDatetimeLabel={t('visitStopDatetime', 'Visit stop date and time')}
                 dateFieldName="visitStopDate"
+                minDate={minVisitStopDatetime}
                 timeFieldName="visitStopTime"
                 timeFormatFieldName="visitStopTimeFormat"
-                minDate={minVisitStopDatetime}
+                visitDatetimeLabel={t('visitStopDatetime', 'Visit stop date and time')}
               />
             )}
 

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.scss
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.scss
@@ -122,3 +122,7 @@
 .bodyShort02 {
   @include type.type-style('body-compact-02');
 }
+
+.datePicker {
+  padding-bottom: layout.$spacing-05;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the issue where the visit start date field was not populating correctly when editing a visit. The root issue seems to be that while the visit date is correctly captured in the field control, the date value is not being set correctly in the field because the date format is not being set correctly. This PR explicitly sets the date format to `DD/MM/YYYY` in the `DatePicker` component. It also amends the existing E2E test to check that the date is correctly captured to prevent future regressions.

## Screenshots
<!-- Required if you are making UI changes. -->
Before 
<img width="1156" alt="Screenshot 2024-09-18 at 7 23 09 PM" src="https://github.com/user-attachments/assets/cb8d088e-febf-4e4d-96a1-14ce12395a28">

After 
<img width="1135" alt="Screenshot 2024-09-18 at 7 24 26 PM" src="https://github.com/user-attachments/assets/90bbe7bb-84bc-4c23-ba09-e688c8049dc3">




## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

[O3-3979](https://openmrs.atlassian.net/browse/O3-3979)


## Other
<!-- Anything not covered above -->


[O3-3979]: https://openmrs.atlassian.net/browse/O3-3979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ