### PR TITLE
(fix) Fix required validation in Visit Note form

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -62,36 +62,37 @@ test('renders the visit notes form with all the relevant fields and values', () 
 
   renderVisitNotesForm();
 
-  expect(screen.getByRole('textbox', { name: /Visit date/i })).toBeInTheDocument();
-  expect(screen.getByRole('textbox', { name: /Write your notes/i })).toBeInTheDocument();
-  expect(screen.getByRole('searchbox', { name: /Enter Primary diagnoses/i })).toBeInTheDocument();
-  expect(screen.getByRole('searchbox', { name: /Enter Secondary diagnoses/i })).toBeInTheDocument();
-  expect(screen.getByRole('group', { name: /Add an image to this visit/i })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /Add image/i })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /Discard/i })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /Save and close/i })).toBeInTheDocument();
+  expect(screen.getByRole('textbox', { name: /visit date/i })).toBeInTheDocument();
+  expect(screen.getByRole('textbox', { name: /write your notes/i })).toBeInTheDocument();
+  expect(screen.getByRole('searchbox', { name: /enter primary diagnoses/i })).toBeInTheDocument();
+  expect(screen.getByRole('searchbox', { name: /enter secondary diagnoses/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /add image/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /discard/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /save and close/i })).toBeInTheDocument();
 });
 
-test.only('typing in the diagnosis search input triggers a search', async () => {
+test('typing in the diagnosis search input triggers a search', async () => {
+  const user = userEvent.setup();
+
   mockFetchDiagnosisConceptsByName.mockResolvedValue(diagnosisSearchResponse.results);
 
   renderVisitNotesForm();
 
   const searchBox = screen.getByPlaceholderText('Choose a primary diagnosis');
-  await userEvent.type(searchBox, 'Diabetes Mellitus');
+  await user.type(searchBox, 'Diabetes Mellitus');
   const targetSearchResult = screen.getByText('Diabetes Mellitus');
   expect(targetSearchResult).toBeInTheDocument();
   expect(screen.getByText('Diabetes Mellitus, Type II')).toBeInTheDocument();
 
   // clicking on a search result displays the selected diagnosis as a tag
-  await userEvent.click(targetSearchResult);
+  await user.click(targetSearchResult);
   expect(screen.getByTitle('Diabetes Mellitus')).toBeInTheDocument();
   const diabetesMellitusTag = screen.getByTitle(/^Diabetes Mellitus$/i);
   expect(diabetesMellitusTag).toBeInTheDocument();
 
   const closeTagButton = screen.getByRole('button', { name: /clear filter/i });
   // Clicking the close button on the tag removes the selected diagnosis
-  await userEvent.click(closeTagButton);
+  await user.click(closeTagButton);
   // no selected diagnoses left
   expect(screen.getByText(/No diagnosis selected — Enter a diagnosis below/i)).toBeInTheDocument();
 });
@@ -109,25 +110,29 @@ test('renders an error message when no matching diagnoses are found', async () =
 });
 
 test('closes the form and the workspace when the cancel button is clicked', async () => {
+  const user = userEvent.setup();
+
   renderVisitNotesForm();
 
   const cancelButton = screen.getByRole('button', { name: /Discard/i });
-  await userEvent.click(cancelButton);
+  await user.click(cancelButton);
 
   expect(defaultProps.closeWorkspace).toHaveBeenCalledTimes(1);
 });
 
 test('renders a success snackbar upon successfully recording a visit note', async () => {
+  const user = userEvent.setup();
+
   const successPayload = {
     encounterProviders: expect.arrayContaining([
       {
         encounterRole: ConfigMock.visitNoteConfig.clinicianEncounterRole,
-        provider: undefined,
+        provider: mockSessionDataResponse.data.currentProvider.uuid,
       },
     ]),
     encounterType: ConfigMock.visitNoteConfig.encounterTypeUuid,
     form: ConfigMock.visitNoteConfig.formConceptUuid,
-    location: undefined,
+    location: mockSessionDataResponse.data.sessionLocation.uuid,
     obs: expect.arrayContaining([
       {
         concept: { display: '', uuid: '162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
@@ -135,6 +140,7 @@ test('renders a success snackbar upon successfully recording a visit note', asyn
       },
     ]),
     patient: mockPatient.id,
+    encounterDatetime: undefined,
   };
 
   mockSaveVisitNote.mockResolvedValueOnce({ status: 201, body: 'Condition created' } as unknown as ReturnType<
@@ -144,27 +150,32 @@ test('renders a success snackbar upon successfully recording a visit note', asyn
 
   renderVisitNotesForm();
 
+  const submitButton = screen.getByRole('button', { name: /Save and close/i });
+  await user.click(submitButton);
+
+  expect(screen.getByText(/choose at least one primary diagnosis/i)).toBeInTheDocument();
+
   const searchBox = screen.getByPlaceholderText('Choose a primary diagnosis');
-  await userEvent.type(searchBox, 'Diabetes Mellitus');
+  await user.type(searchBox, 'Diabetes Mellitus');
   const targetSearchResult = screen.getByText('Diabetes Mellitus');
   expect(targetSearchResult).toBeInTheDocument();
 
-  await userEvent.click(targetSearchResult);
+  await user.click(targetSearchResult);
 
   const clinicalNote = screen.getByRole('textbox', { name: /Write your notes/i });
-  await userEvent.clear(clinicalNote);
-  await userEvent.type(clinicalNote, 'Sample clinical note');
+  await user.clear(clinicalNote);
+  await user.type(clinicalNote, 'Sample clinical note');
   expect(clinicalNote).toHaveValue('Sample clinical note');
 
-  const submitButton = screen.getByRole('button', { name: /Save and close/i });
-
-  await userEvent.click(submitButton);
+  await user.click(submitButton);
 
   expect(mockSaveVisitNote).toHaveBeenCalledTimes(1);
   expect(mockSaveVisitNote).toHaveBeenCalledWith(new AbortController(), expect.objectContaining(successPayload));
 });
 
 test('renders an error snackbar if there was a problem recording a condition', async () => {
+  const user = userEvent.setup();
+
   const error = {
     message: 'Internal Server Error',
     response: {
@@ -178,21 +189,21 @@ test('renders an error snackbar if there was a problem recording a condition', a
 
   renderVisitNotesForm();
 
+  const submitButton = screen.getByRole('button', { name: /Save and close/i });
+
   const searchBox = screen.getByPlaceholderText('Choose a primary diagnosis');
-  await userEvent.type(searchBox, 'Diabetes Mellitus');
+  await user.type(searchBox, 'Diabetes Mellitus');
   const targetSearchResult = screen.getByText('Diabetes Mellitus');
   expect(targetSearchResult).toBeInTheDocument();
 
-  await userEvent.click(targetSearchResult);
+  await user.click(targetSearchResult);
 
   const clinicalNote = screen.getByRole('textbox', { name: /Write your notes/i });
-  await userEvent.clear(clinicalNote);
-  await userEvent.type(clinicalNote, 'Sample clinical note');
+  await user.clear(clinicalNote);
+  await user.type(clinicalNote, 'Sample clinical note');
   expect(clinicalNote).toHaveValue('Sample clinical note');
 
-  const submitButton = screen.getByRole('button', { name: /Save and close/i });
-
-  await userEvent.click(submitButton);
+  await user.click(submitButton);
 
   expect(mockShowSnackbar).toHaveBeenCalledWith({
     isLowContrast: false,

--- a/packages/esm-patient-notes-app/translations/en.json
+++ b/packages/esm-patient-notes-app/translations/en.json
@@ -20,6 +20,7 @@
   "noVisitNoteToDisplay": "No visit note to display",
   "primaryDiagnosis": "Primary diagnosis",
   "primaryDiagnosisInputPlaceholder": "Choose a primary diagnosis",
+  "primaryDiagnosisRequired": "Choose at least one primary diagnosis",
   "saveAndClose": "Save and close",
   "saving": "Saving",
   "searchForPrimaryDiagnosis": "Search for a primary diagnosis",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes a regression in the required validation in the Visit Notes form. Presently, the zod schema associated with the form is meant to show a validation error if a user tries to submit the form without selecting a primary diagnosis. This doesn't work as expected. In this PR, I've fixed the validation by tweaking the schema to react to changes to the `selectedPrimaryDiagnosis` array (which gets populated when a primary diagnosis is selected). 

I've also restored some tests in the accompanying suite that had been commented out and added some coverage for the new behaviour.

## Screenshots

### Before

https://github.com/user-attachments/assets/45ad006d-5d69-4959-be71-757c1deaa866

### After

https://github.com/user-attachments/assets/ab739d56-1116-4537-a808-c816ed9e3646

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
