### PR TITLE
(fix) Visit summary medications list fixes

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
@@ -13,93 +13,91 @@ interface MedicationSummaryProps {
 const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications }) => {
   const { t } = useTranslation();
 
-  return (
-    <>
-      {medications.length > 0 ? (
-        <div className={styles.medicationRecord}>
-          {medications.map(
-            (medication, i) =>
-              medication?.order?.dose &&
-              medication?.order?.orderType?.display === 'Drug Order' && (
-                <React.Fragment key={i}>
-                  <div className={styles.medicationContainer}>
-                    <div>
-                      <p className={styles.bodyLong01}>
-                        <strong>{capitalize(medication?.order?.drug?.display)}</strong>{' '}
-                        {medication?.order?.drug?.strength && (
-                          <>&mdash; {medication?.order?.drug?.strength?.toLowerCase()}</>
-                        )}{' '}
-                        {medication?.order?.doseUnits?.display && (
-                          <>&mdash; {medication?.order?.doseUnits?.display?.toLowerCase()}</>
-                        )}{' '}
-                      </p>
-                      <p className={styles.bodyLong01}>
-                        <span className={styles.label01}> {t('dose', 'Dose').toUpperCase()} </span>{' '}
-                        <span className={styles.dosage}>
-                          {medication?.order?.dose} {medication?.order?.doseUnits?.display?.toLowerCase()}
-                        </span>{' '}
-                        {medication.order?.route?.display && (
-                          <span>&mdash; {medication?.order?.route?.display?.toLowerCase()} &mdash; </span>
-                        )}
-                        {medication?.order?.frequency?.display?.toLowerCase()} &mdash;{' '}
-                        {!medication?.order?.duration
-                          ? t('orderIndefiniteDuration', 'Indefinite duration')
-                          : t('orderDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
-                              duration: medication?.order?.duration,
-                              durationUnit: medication?.order?.durationUnits?.display?.toLowerCase(),
-                            })}
-                        {medication?.order?.numRefills !== 0 && (
-                          <span>
-                            <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
-                            {medication?.order?.numRefills}
-                            {''}
-                          </span>
-                        )}
-                        {medication?.order?.dosingInstructions && (
-                          <span> &mdash; {medication?.order?.dosingInstructions?.toLocaleLowerCase()}</span>
-                        )}
-                      </p>
-                      <p className={styles.bodyLong01}>
-                        {medication?.order?.orderReasonNonCoded ? (
-                          <span>
-                            <span className={styles.label01}>{t('indication', 'Indication').toUpperCase()}</span>{' '}
-                            {medication?.order?.orderReasonNonCoded}
-                          </span>
-                        ) : null}
-                        {medication?.order?.quantity ? (
-                          <span>
-                            <span className={styles.label01}> &mdash; {t('quantity', 'Quantity').toUpperCase()}</span>{' '}
-                            {medication?.order?.quantity}
-                          </span>
-                        ) : null}
-                        {medication?.order?.dateStopped ? (
-                          <span className={styles.bodyShort01}>
-                            <span className={styles.label01}>
-                              {medication?.order?.quantity ? ` — ` : ''} {t('endDate', 'End date').toUpperCase()}
-                            </span>{' '}
-                            {formatDate(new Date(medication?.order?.dateStopped))}
-                          </span>
-                        ) : null}
-                      </p>
-                    </div>
-                  </div>
+  const drugOrders = medications?.filter((medication) => medication?.order?.orderType?.display === 'Drug Order');
 
-                  <p className={styles.metadata}>
-                    {formatTime(parseDate(medication?.order?.dateActivated))}
-                    {medication?.provider?.name && <> &middot; {medication?.provider?.name}</>}
-                    {medication?.provider?.role && <>, {medication?.provider?.role}</>}
+  if (drugOrders.length === 0) {
+    return (
+      <EmptyState displayText={t('medications__lower', 'medications')} headerTitle={t('medications', 'Medications')} />
+    );
+  }
+
+  return (
+    <div className={styles.medicationRecord}>
+      {drugOrders.map(
+        (medication, index) =>
+          medication?.order?.dose && (
+            <React.Fragment key={index}>
+              <div className={styles.medicationContainer}>
+                <div>
+                  <p className={styles.bodyLong01}>
+                    <strong>{capitalize(medication?.order?.drug?.display)}</strong>{' '}
+                    {medication?.order?.drug?.strength && (
+                      <>&mdash; {medication?.order?.drug?.strength?.toLowerCase()}</>
+                    )}{' '}
+                    {medication?.order?.doseUnits?.display && (
+                      <>&mdash; {medication?.order?.doseUnits?.display?.toLowerCase()}</>
+                    )}{' '}
                   </p>
-                </React.Fragment>
-              ),
-          )}
-        </div>
-      ) : (
-        <EmptyState
-          displayText={t('medications__lower', 'medications')}
-          headerTitle={t('medications', 'Medications')}
-        ></EmptyState>
+                  <p className={styles.bodyLong01}>
+                    <span className={styles.label01}> {t('dose', 'Dose').toUpperCase()} </span>{' '}
+                    <span className={styles.dosage}>
+                      {medication?.order?.dose} {medication?.order?.doseUnits?.display?.toLowerCase()}
+                    </span>{' '}
+                    {medication.order?.route?.display && (
+                      <span>&mdash; {medication?.order?.route?.display?.toLowerCase()} &mdash; </span>
+                    )}
+                    {medication?.order?.frequency?.display?.toLowerCase()} &mdash;{' '}
+                    {!medication?.order?.duration
+                      ? t('orderIndefiniteDuration', 'Indefinite duration')
+                      : t('orderDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
+                          duration: medication?.order?.duration,
+                          durationUnit: medication?.order?.durationUnits?.display?.toLowerCase(),
+                        })}
+                    {medication?.order?.numRefills !== 0 && (
+                      <span>
+                        <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
+                        {medication?.order?.numRefills}
+                        {''}
+                      </span>
+                    )}
+                    {medication?.order?.dosingInstructions && (
+                      <span> &mdash; {medication?.order?.dosingInstructions?.toLocaleLowerCase()}</span>
+                    )}
+                  </p>
+                  <p className={styles.bodyLong01}>
+                    {medication?.order?.orderReasonNonCoded ? (
+                      <span>
+                        <span className={styles.label01}>{t('indication', 'Indication').toUpperCase()}</span>{' '}
+                        {medication?.order?.orderReasonNonCoded}
+                      </span>
+                    ) : null}
+                    {medication?.order?.quantity ? (
+                      <span>
+                        <span className={styles.label01}> &mdash; {t('quantity', 'Quantity').toUpperCase()}</span>{' '}
+                        {medication?.order?.quantity}
+                      </span>
+                    ) : null}
+                    {medication?.order?.dateStopped ? (
+                      <span className={styles.bodyShort01}>
+                        <span className={styles.label01}>
+                          {medication?.order?.quantity ? ` — ` : ''} {t('endDate', 'End date').toUpperCase()}
+                        </span>{' '}
+                        {formatDate(new Date(medication?.order?.dateStopped))}
+                      </span>
+                    ) : null}
+                  </p>
+                </div>
+              </div>
+
+              <p className={styles.metadata}>
+                {formatTime(parseDate(medication?.order?.dateActivated))}
+                {medication?.provider?.name && <> &middot; {medication?.provider?.name}</>}
+                {medication?.provider?.role && <>, {medication?.provider?.role}</>}
+              </p>
+            </React.Fragment>
+          ),
       )}
-    </>
+    </div>
   );
 };
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/notes-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/notes-summary.component.tsx
@@ -12,21 +12,21 @@ interface NotesSummaryProps {
 const NotesSummary: React.FC<NotesSummaryProps> = ({ notes }) => {
   const { t } = useTranslation();
 
+  if (notes.length === 0) {
+    return <EmptyState displayText={t('notes__lower', 'notes')} headerTitle={t('notes', 'Notes')} />;
+  }
+
   return (
     <>
-      {notes.length ? (
-        notes.map((note: Note, i) => (
-          <div className={styles.notesContainer} key={i}>
-            <p className={classNames(styles.noteText, styles.bodyLong01)}>{note.note}</p>
-            <p className={styles.metadata}>
-              {note.time} {note.provider.name ? <span>&middot; {note.provider.name} </span> : null}
-              {note.provider.role ? <span>&middot; {note.provider.role}</span> : null}
-            </p>
-          </div>
-        ))
-      ) : (
-        <EmptyState displayText={t('notes__lower', 'notes')} headerTitle={t('notes', 'Notes')} />
-      )}
+      {notes.map((note: Note, index) => (
+        <div className={styles.notesContainer} key={index}>
+          <p className={classNames(styles.noteText, styles.bodyLong01)}>{note.note}</p>
+          <p className={styles.metadata}>
+            {note.time} {note.provider.name ? <span>&middot; {note.provider.name} </span> : null}
+            {note.provider.role ? <span>&middot; {note.provider.role}</span> : null}
+          </p>
+        </div>
+      ))}
     </>
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR filters the medications rendered in the Visit summary so that only drug orders are rendered. Presently, if the medications list passed down to `MedicationsSummary` includes test orders, the component won't render anything. Passing only drug orders to the component fixes the issue.

## Screenshots

### Before

![CleanShot 2024-09-23 at 2  09 50@2x](https://github.com/user-attachments/assets/93fb63fc-3752-42ea-b6da-b16fccb64e8a)

### After

![CleanShot 2024-09-23 at 2  28 02@2x](https://github.com/user-attachments/assets/262cd9dc-3782-4db7-909b-cd6ba94b29ac)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
