### PR TITLE
(feat) O3-4014: Add ability to warn user of unsaved changes on form-entry-app

### DIFF
--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -40,6 +40,7 @@ const store = createGlobalStore<Record<string, FormState>>('ampath-form-state', 
 })
 export class FeWrapperComponent implements OnInit, OnDestroy {
   private launchFormSubscription?: Subscription;
+  private workspaceDirtyStateListenerSubscription: Subscription;
   private unsubscribeStore: () => void | undefined;
 
   public formUuid: string;
@@ -77,6 +78,7 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
   public ngOnDestroy() {
     this.unsubscribeStore && this.unsubscribeStore();
     this.launchFormSubscription?.unsubscribe();
+    this.workspaceDirtyStateListenerSubscription?.unsubscribe();
   }
 
   public launchForm() {
@@ -387,9 +389,9 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
   private setupWorkspaceDirtyStateListener(): void {
     const promptBeforeClosing = this.singleSpaPropsService.getPropOrThrow('promptBeforeClosing');
 
-    this.form.rootNode.control.valueChanges
+    this.workspaceDirtyStateListenerSubscription = this.form.rootNode.control.valueChanges
       .pipe(
-        map((control) => Boolean(control)),
+        map(() => this.form.rootNode.control.dirty),
         filter((isDirty) => isDirty),
         take(1),
       )

--- a/packages/esm-form-entry-app/src/single-spa-props.ts
+++ b/packages/esm-form-entry-app/src/single-spa-props.ts
@@ -1,6 +1,7 @@
 import { ReplaySubject } from 'rxjs';
 import { AppProps } from 'single-spa';
 import { Encounter, EncounterCreate } from './app/types';
+import { DefaultWorkspaceProps } from '@openmrs/esm-framework';
 
 export const singleSpaPropsSubject = new ReplaySubject<SingleSpaProps>(1);
 
@@ -52,4 +53,4 @@ export type SingleSpaProps = AppProps &
   PreFilledQuestions &
   ApplicationStatus & {
     additionalProps?: any;
-  };
+  } & Partial<DefaultWorkspaceProps>;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds ability to warn user before closing unsaved form while using angular form engine

## Screenshots
https://github.com/user-attachments/assets/eb24abed-5099-412f-83bb-12bc303ced1b


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
