### PR TITLE
(refactor) Port modal registrations to use the modal system

### DIFF
--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -181,33 +181,33 @@ export const markPatientDeceasedForm = getAsyncLifecycle(
   },
 );
 
-export const cancelVisitDialog = getAsyncLifecycle(() => import('./visit/visit-prompt/cancel-visit-dialog.component'), {
+export const cancelVisitModal = getAsyncLifecycle(() => import('./visit/visit-prompt/cancel-visit-dialog.component'), {
   featureName: 'cancel visit',
   moduleName,
 });
 
-export const startVisitDialog = getAsyncLifecycle(() => import('./visit/visit-prompt/start-visit-dialog.component'), {
+export const startVisitModal = getAsyncLifecycle(() => import('./visit/visit-prompt/start-visit-dialog.component'), {
   featureName: 'start visit',
   moduleName,
 });
 
-export const deleteVisitDialog = getAsyncLifecycle(() => import('./visit/visit-prompt/delete-visit-dialog.component'), {
+export const deleteVisitModal = getAsyncLifecycle(() => import('./visit/visit-prompt/delete-visit-dialog.component'), {
   featureName: 'delete visit',
   moduleName,
 });
 
-export const modifyVisitDateDialog = getAsyncLifecycle(() => import('./visit/visit-prompt/modify-visit-date.modal'), {
-  featureName: 'delete visit',
+export const modifyVisitDateModal = getAsyncLifecycle(() => import('./visit/visit-prompt/modify-visit-date.modal'), {
+  featureName: 'modify visit date',
   moduleName,
 });
 
-export const endVisitDialog = getAsyncLifecycle(() => import('./visit/visit-prompt/end-visit-dialog.component'), {
+export const endVisitModal = getAsyncLifecycle(() => import('./visit/visit-prompt/end-visit-dialog.component'), {
   featureName: 'end visit',
   moduleName,
 });
 
 export const markPatientAliveModal = getAsyncLifecycle(() => import('./mark-patient-alive/mark-patient-alive.modal'), {
-  featureName: 'Mark patient alive',
+  featureName: 'mark patient alive',
   moduleName,
 });
 

--- a/packages/esm-patient-chart-app/src/routes.json
+++ b/packages/esm-patient-chart-app/src/routes.json
@@ -147,36 +147,6 @@
       "offline": true
     },
     {
-      "name": "cancel-visit-dialog",
-      "component": "cancelVisitDialog",
-      "online": true,
-      "offline": true
-    },
-    {
-      "name": "start-visit-dialog",
-      "component": "startVisitDialog",
-      "online": true,
-      "offline": true
-    },
-    {
-      "name": "delete-visit-dialog",
-      "component": "deleteVisitDialog",
-      "online": true,
-      "offline": true
-    },
-    {
-      "name": "modify-visit-date-dialog",
-      "component": "modifyVisitDateDialog",
-      "online": true,
-      "offline": true
-    },
-    {
-      "name": "end-visit-dialog",
-      "component": "endVisitDialog",
-      "online": true,
-      "offline": true
-    },
-    {
       "name": "start-visit-button-patient-search",
       "slot": "start-visit-button-slot",
       "component": "startVisitPatientSearchActionButton",
@@ -187,12 +157,6 @@
       "name": "visit-attribute-tags",
       "slot": "patient-banner-tags-slot",
       "component": "visitAttributeTags",
-      "online": true,
-      "offline": true
-    },
-    {
-      "name": "delete-encounter-modal",
-      "component": "deleteEncounterModal",
       "online": true,
       "offline": true
     },
@@ -232,8 +196,32 @@
   ],
   "modals": [
     {
+      "name": "cancel-visit-dialog",
+      "component": "cancelVisitModal"
+    },
+    {
+      "name": "delete-encounter-modal",
+      "component": "deleteEncounterModal"
+    },
+    {
+      "name": "delete-visit-dialog",
+      "component": "deleteVisitModal"
+    },
+    {
+      "name": "end-visit-dialog",
+      "component": "endVisitModal"
+    },
+    {
       "name": "mark-patient-alive-modal",
       "component": "markPatientAliveModal"
+    },
+    {
+      "name": "modify-visit-date-dialog",
+      "component": "modifyVisitDateModal"
+    },
+    {
+      "name": "start-visit-dialog",
+      "component": "startVisitModal"
     }
   ],
   "pages": [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR ports over a few modal registrations in the Patient Chart routes registry from using the extension system to using the modal system. It also refactors a few component export names from using the `Dialog` suffix to using the `Modal` suffix for consistency.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
