### PR TITLE
(fix) Fix invalid prop warning for some Carbon components

### DIFF
--- a/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
@@ -219,8 +219,8 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
               render={({ field: { onChange, value } }) => (
                 <TextInput
                   id="freeTextCauseOfDeath"
-                  invalid={errors?.nonCodedCauseOfDeath}
-                  invalidText={errors?.nonCodedCauseOfDeath && errors?.nonCodedCauseOfDeath?.message}
+                  invalid={!!errors?.nonCodedCauseOfDeath}
+                  invalidText={errors?.nonCodedCauseOfDeath?.message}
                   labelText={t('nonCodedCauseOfDeath', 'Non-coded cause of death')}
                   onChange={onChange}
                   placeholder={t('enterNonCodedCauseOfDeath', 'Enter non-coded cause of death')}

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -64,7 +64,7 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
                   labelText={t('date', 'Date')}
                   placeholder="dd/mm/yyyy"
                   style={{ width: '100%' }}
-                  invalid={errors[dateFieldName]?.message}
+                  invalid={!!errors[dateFieldName]}
                   invalidText={errors[dateFieldName]?.message}
                 />
               </DatePicker>
@@ -84,7 +84,7 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
                 style={{ marginLeft: '0.125rem', flex: 'none' }}
                 value={value}
                 onBlur={onBlur}
-                invalid={errors[timeFieldName]?.message}
+                invalid={!!errors[timeFieldName]}
                 invalidText={errors[timeFieldName]?.message}
               >
                 <Controller
@@ -96,7 +96,7 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
                       onChange={(event) => onChange(event.target.value as amPm)}
                       value={value}
                       aria-label={t('timeFormat ', 'Time Format')}
-                      invalid={errors[timeFormatFieldName]?.message}
+                      invalid={!!errors[timeFormatFieldName]}
                       invalidText={errors[timeFormatFieldName]?.message}
                     >
                       <SelectItem value="AM" text="AM" />

--- a/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
+++ b/packages/esm-patient-labs-app/src/lab-orders/add-lab-order/lab-order-form.component.tsx
@@ -193,7 +193,7 @@ export function LabOrderForm({
                       value={value}
                       onChange={onChange}
                       onBlur={onBlur}
-                      invalid={errors.accessionNumber?.message}
+                      invalid={!!errors.accessionNumber}
                       invalidText={errors.accessionNumber?.message}
                     />
                   )}
@@ -216,7 +216,7 @@ export function LabOrderForm({
                       items={priorityOptions}
                       onBlur={onBlur}
                       onChange={({ selectedItem }) => onChange(selectedItem?.value || '')}
-                      invalid={errors.urgency?.message}
+                      invalid={!!errors.urgency}
                       invalidText={errors.urgency?.message}
                     />
                   )}
@@ -241,7 +241,7 @@ export function LabOrderForm({
                         items={orderReasons}
                         onBlur={onBlur}
                         onChange={({ selectedItem }) => onChange(selectedItem?.uuid || '')}
-                        invalid={errors.orderReason?.message}
+                        invalid={!!errors.orderReason}
                         invalidText={errors.orderReason?.message}
                       />
                     )}
@@ -266,7 +266,7 @@ export function LabOrderForm({
                       onChange={onChange}
                       onBlur={onBlur}
                       maxCount={500}
-                      invalid={errors.instructions?.message}
+                      invalid={!!errors.instructions}
                       invalidText={errors.instructions?.message}
                     />
                   )}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the value passed as the `invalid` prop for several Carbon Components, ensuring that the value is always a boolean.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
