### PR TITLE
(fix) O3-3978: Fix error in orders details table when orders are potentially undefined

### DIFF
--- a/packages/esm-patient-common-lib/src/orders/useOrders.ts
+++ b/packages/esm-patient-common-lib/src/orders/useOrders.ts
@@ -1,8 +1,9 @@
+import { useCallback, useMemo } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
 import { type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
-import { useCallback, useMemo } from 'react';
 import { type OrderTypeFetchResponse, type PatientOrderFetchResponse } from '@openmrs/esm-patient-common-lib';
 
+export type Status = 'ACTIVE' | 'any';
 export const careSettingUuid = '6f0c9a92-6f24-11e3-af88-005056821db0';
 
 export const drugCustomRepresentation =
@@ -13,7 +14,7 @@ export const drugCustomRepresentation =
   'frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,numRefills,dosingInstructions,' +
   'duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)';
 
-export function usePatientOrders(patientUuid: string, status?: 'ACTIVE' | 'any', orderType?: string) {
+export function usePatientOrders(patientUuid: string, status?: Status, orderType?: string) {
   const { mutate } = useSWRConfig();
   const baseOrdersUrl = `${restBaseUrl}/order?patient=${patientUuid}&careSetting=${careSettingUuid}&v=full&status=${status}`;
   const ordersUrl = orderType ? `${baseOrdersUrl}&orderType=${orderType}` : baseOrdersUrl;
@@ -26,14 +27,14 @@ export function usePatientOrders(patientUuid: string, status?: 'ACTIVE' | 'any',
   const mutateOrders = useCallback(
     () =>
       mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?patient=${patientUuid}`), data),
-    [patientUuid, data, mutate],
+    [data, mutate, patientUuid],
   );
 
   const orders = useMemo(
     () =>
       data?.data?.results
         ? data.data.results?.sort((order1, order2) => (order2.dateActivated > order1.dateActivated ? 1 : -1))
-        : [],
+        : null,
     [data],
   );
 
@@ -54,7 +55,7 @@ export function useOrderTypes() {
   );
 
   return {
-    data: data?.data?.results,
+    data: data?.data?.results ?? null,
     error,
     isLoading,
     isValidating,

--- a/packages/esm-patient-common-lib/src/orders/useOrders.ts
+++ b/packages/esm-patient-common-lib/src/orders/useOrders.ts
@@ -33,7 +33,7 @@ export function usePatientOrders(patientUuid: string, status?: 'ACTIVE' | 'any',
     () =>
       data?.data?.results
         ? data.data.results?.sort((order1, order2) => (order2.dateActivated > order1.dateActivated ? 1 : -1))
-        : null,
+        : [],
     [data],
   );
 

--- a/packages/esm-patient-orders-app/src/components/order-details-table.scss
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.scss
@@ -31,6 +31,10 @@
 
 .dropdownContainer {
   min-width: max-content;
+
+  :global(.cds--dropdown__wrapper--inline) {
+    grid-gap: 0 0.5rem;
+  }
 }
 
 .buttons {

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -318,7 +318,7 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ patientUuid, showAddBu
         if (orderTypes && orderTypes?.length > 0) {
           return (
             <>
-              {!tableRows.length ? (
+              {!tableRows?.length ? (
                 // FIXME: The displayText translation is not working as expected
                 <EmptyState
                   headerTitle={headerTitle}

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -177,43 +177,45 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ patientUuid, showAddBu
     },
   ];
 
-  const tableRows = useMemo(() => {
-    return allOrders?.map((order) => ({
-      id: order.uuid,
-      dateActivated: order.dateActivated,
-      orderNumber: order.orderNumber,
-      dateOfOrder: <div className={styles.singleLineText}>{formatDate(new Date(order.dateActivated))}</div>,
-      orderType: capitalize(order.orderType?.display ?? '--'),
-      order: order.display,
-      priority: (
-        <div className={styles.priorityPill} data-priority={lowerCase(order.urgency)}>
-          {
-            // t('ON_SCHEDULED_DATE', 'On scheduled date')
-            // t('ROUTINE', 'Routine')
-            // t('STAT', 'STAT')
-          }
-          {t(order.urgency, capitalize(order.urgency.replace('_', ' ')))}
-        </div>
-      ),
-      orderedBy: order.orderer?.display,
-      status: order.fulfillerStatus ? (
-        <div className={styles.statusPill} data-status={lowerCase(order.fulfillerStatus.replace('_', ' '))}>
-          {
-            // t('RECEIVED', 'Received')
-            // t('IN_PROGRESS', 'In progress')
-            // t('EXCEPTION', 'Exception')
-            // t('ON_HOLD', 'On hold')
-            // t('DECLINED', 'Declined')
-            // t('COMPLETED', 'Completed')
-            // t('DISCONTINUED', 'Discontinued')
-          }
-          {t(order.fulfillerStatus, capitalize(order.fulfillerStatus.replace('_', ' ')))}
-        </div>
-      ) : (
-        '--'
-      ),
-    }));
-  }, [allOrders, t]);
+  const tableRows = useMemo(
+    () =>
+      allOrders?.map((order) => ({
+        id: order.uuid,
+        dateActivated: order.dateActivated,
+        orderNumber: order.orderNumber,
+        dateOfOrder: <div className={styles.singleLineText}>{formatDate(new Date(order.dateActivated))}</div>,
+        orderType: capitalize(order.orderType?.display ?? '--'),
+        order: order.display,
+        priority: (
+          <div className={styles.priorityPill} data-priority={lowerCase(order.urgency)}>
+            {
+              // t('ON_SCHEDULED_DATE', 'On scheduled date')
+              // t('ROUTINE', 'Routine')
+              // t('STAT', 'STAT')
+            }
+            {t(order.urgency, capitalize(order.urgency.replace('_', ' ')))}
+          </div>
+        ),
+        orderedBy: order.orderer?.display,
+        status: order.fulfillerStatus ? (
+          <div className={styles.statusPill} data-status={lowerCase(order.fulfillerStatus.replace('_', ' '))}>
+            {
+              // t('RECEIVED', 'Received')
+              // t('IN_PROGRESS', 'In progress')
+              // t('EXCEPTION', 'Exception')
+              // t('ON_HOLD', 'On hold')
+              // t('DECLINED', 'Declined')
+              // t('COMPLETED', 'Completed')
+              // t('DISCONTINUED', 'Discontinued')
+            }
+            {t(order.fulfillerStatus, capitalize(order.fulfillerStatus.replace('_', ' ')))}
+          </div>
+        ) : (
+          '--'
+        ),
+      })) ?? [],
+    [allOrders, t],
+  );
 
   const { results: paginatedOrders, goTo, currentPage } = usePagination(tableRows, defaultPageSize);
 
@@ -301,7 +303,7 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ patientUuid, showAddBu
             setSelectedOrderTypeUuid(e.selectedItem.uuid);
           }}
           selectedItem={orderTypes?.find((x) => x.uuid === selectedOrderTypeUuid)}
-          titleText={t('selectOrderType', 'Select order type')}
+          titleText={t('selectOrderType', 'Select order type') + ':'}
           type="inline"
         />
       </div>
@@ -319,7 +321,6 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ patientUuid, showAddBu
           return (
             <>
               {!tableRows?.length ? (
-                // FIXME: The displayText translation is not working as expected
                 <EmptyState
                   headerTitle={headerTitle}
                   displayText={
@@ -327,7 +328,7 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ patientUuid, showAddBu
                       ? t('orders', 'Orders')
                       : // t('Drug Order_few', 'Drug Orders')
                         // t('Test Order_few', 'Test Orders')
-                        t(selectedOrderName, {
+                        t(selectedOrderName?.toLowerCase() ?? 'orders', {
                           count: 3,
                           default: selectedOrderName,
                         })


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR addresses an issue where filling in the test results of a lab order from the laboratory app and then navigating to the patient chart and then to the orders section throws an error “Cannot read property of undefined (reading length). The same issue does not exist when the test results are filled in from the patient chart.
The error is caused by reading the property `length` on` tableRows` [here](https://github.com/openmrs/openmrs-esm-patient-chart/blob/main/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx#L321) when `tableRows `is undefined. `tableRows` derives its value from `allOrders` as shown [here ](https://github.com/openmrs/openmrs-esm-patient-chart/blob/main/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx#L180)which is returned by the [usePatientOrders()](https://github.com/openmrs/openmrs-esm-patient-chart/blob/main/packages/esm-patient-common-lib/src/orders/useOrders.ts#L16) hook. 
For this PR we are going to focus on the orders key /order/patientUuid={patientUuid} as it's the one we use to fetch the orders.
In both cases, where the results are filled in from the patient chart and when they are filled in from the laboratory app, the mutation [logic ](https://github.com/openmrs/openmrs-esm-patient-chart/blob/main/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx#L172)is the same. But the implications are different due to the orders key being mounted in the patient chart scenario(because the orders widget is mounted as the results are being filled in) versus not being mounted in the laboratory scenario.

In both scenarios, the client cache is mutated to `undefined`. But in the patient chart scenario there is an immediate revalidation triggered - a console.log shows that for a brief moment data is undefined, isLoading is true, isValidating is true. And a fetch request for the orders key is seen in the network tab. Although data is `undefined`, `isLoading `is `true `so a skeleton is rendered then eventually the data is displayed when its fetched.

In the laboratory app scenario, there is no re-fetch of the data related to the orders key after filling in the results as the key is not currently mounted- the network tabs proves this. If the user then navigates to the orders section in the patient chart, the orders key returns data as `undefined `but now `isLoading `and `isValidating `are both `false`. It is as if the orders key is not treated as being mounted for the first time(such that isLoading is true) but rather one for which data already exists although `undefined`. So there is a brief moment when the orders widget mounts, before it revalidates on mount ,where `data `is `undefined` and `isLoading ` and `isValidating `are both `false`. So the last if clause is executed and throws on reading the property length on tablesRows which is now undefined.

The suggested solution is to add an optional chaining operator to `tableRows.length` and to return an empty array from the useOrders hook when the value of data from the orders key is undefined or null. 




## Screenshots
https://github.com/user-attachments/assets/5fb87dfc-fd82-4a85-a0c4-6298cd426a73


## Related Issue
https://openmrs.atlassian.net/browse/O3-3978
