### PR TITLE
(fix) Fix `Last completed date` in forms dashboard

### DIFF
--- a/__mocks__/forms.mock.ts
+++ b/__mocks__/forms.mock.ts
@@ -55,6 +55,6 @@ export const mockForms = [
         },
       },
     ],
-    lastCompleted: new Date('2022-04-08T06:21:48.000Z'),
+    lastCompletedDate: new Date('2022-04-08T06:21:48.000Z'),
   },
 ];

--- a/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
@@ -102,7 +102,7 @@ const FormView: React.FC<FormViewProps> = ({
       results?.map((formInfo) => {
         return {
           id: formInfo.form.uuid,
-          lastCompleted: formInfo.lastCompleted ? formatDatetime(formInfo.lastCompleted) : undefined,
+          lastCompleted: formInfo.lastCompletedDate ? formatDatetime(formInfo.lastCompletedDate) : undefined,
           formName: formInfo.form.display ?? formInfo.form.name,
           formUuid: formInfo.form.uuid,
           encounterUuid: formInfo?.associatedEncounters[0]?.uuid,

--- a/packages/esm-patient-forms-app/src/forms/forms-dashboard.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-dashboard.component.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Tile } from '@carbon/react';
 import { ResponsiveWrapper, useConfig, useConnectivity, usePatient } from '@openmrs/esm-framework';
 import {
@@ -8,10 +9,9 @@ import {
   useVisitOrOfflineVisit,
 } from '@openmrs/esm-patient-common-lib';
 import type { ConfigObject } from '../config-schema';
+import { useForms } from '../hooks/use-forms';
 import FormsList from './forms-list.component';
 import styles from './forms-dashboard.scss';
-import { useForms } from '../hooks/use-forms';
-import { useTranslation } from 'react-i18next';
 
 interface FormsDashboardProps extends DefaultPatientWorkspaceProps {
   clinicalFormsWorkspaceName?: string;
@@ -29,7 +29,7 @@ const FormsDashboard: React.FC<FormsDashboardProps> = ({
   const config = useConfig<ConfigObject>();
   const isOnline = useConnectivity();
   const htmlFormEntryForms = config.htmlFormEntryForms;
-  const { patient, patientUuid: fetchedPatientUuid } = usePatient(patientUuid);
+  const { patientUuid: fetchedPatientUuid } = usePatient(patientUuid);
   const { data: forms, error, mutateForms } = useForms(patientUuid, undefined, undefined, !isOnline, config.orderBy);
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
 

--- a/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import debounce from 'lodash-es/debounce';
+import { debounce } from 'lodash-es';
 import fuzzy from 'fuzzy';
 import { DataTableSkeleton } from '@carbon/react';
 import { formatDatetime, useLayoutType, ResponsiveWrapper } from '@openmrs/esm-framework';
@@ -65,7 +65,7 @@ const FormsList: React.FC<FormsListProps> = ({ completedForms, error, sectionNam
       filteredForms?.map((formData) => {
         return {
           id: formData.form.uuid,
-          lastCompleted: formData.lastCompleted ? formatDatetime(formData.lastCompleted) : undefined,
+          lastCompleted: formData.lastCompletedDate ? formatDatetime(formData.lastCompletedDate) : undefined,
           formName: formData.form.display ?? formData.form.name,
           formUuid: formData.form.uuid,
           encounterUuid: formData?.associatedEncounters[0]?.uuid,

--- a/packages/esm-patient-forms-app/src/hooks/use-forms.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-forms.ts
@@ -8,9 +8,9 @@ import {
   userHasAccess,
   useSession,
 } from '@openmrs/esm-framework';
-import { type ListResponse, type Form, type EncounterWithFormRef, type CompletedFormInfo } from '../types';
+import type { ConfigObject } from '../config-schema';
+import type { ListResponse, Form, EncounterWithFormRef, CompletedFormInfo } from '../types';
 import { customEncounterRepresentation, formEncounterUrl, formEncounterUrlPoc } from '../constants';
-import { type ConfigObject } from '../config-schema';
 import { isValidOfflineFormEncounter } from '../offline-forms/offline-form-helpers';
 
 export function useFormEncounters(cachedOfflineFormsOnly = false, patientUuid: string = '') {
@@ -94,7 +94,8 @@ export function useForms(
   } else {
     formsToDisplay?.sort(
       (formInfo1, formInfo2) =>
-        (formInfo1.lastCompleted ?? MINIMUM_DATE).getDate() - (formInfo2.lastCompleted ?? MINIMUM_DATE).getDate(),
+        (formInfo1.lastCompletedDate ?? MINIMUM_DATE).getDate() -
+        (formInfo2.lastCompletedDate ?? MINIMUM_DATE).getDate(),
     );
   }
 
@@ -113,13 +114,15 @@ function mapToFormCompletedInfo(
 ): Array<CompletedFormInfo> {
   return allForms.map((form) => {
     const associatedEncounters = encounters.filter((encounter) => encounter.form?.uuid === form?.uuid);
-    const lastCompleted =
-      associatedEncounters.length > 0 ? new Date(associatedEncounters?.[0].encounterDatetime) : undefined;
+    const lastCompletedDate =
+      associatedEncounters.length > 0
+        ? new Date(Math.max(...associatedEncounters.map((e) => new Date(e.encounterDatetime).getTime())))
+        : undefined;
 
     return {
       form,
       associatedEncounters,
-      lastCompleted,
+      lastCompletedDate,
     };
   });
 }

--- a/packages/esm-patient-forms-app/src/types/index.ts
+++ b/packages/esm-patient-forms-app/src/types/index.ts
@@ -12,7 +12,7 @@ export interface SectionConfig {
     id: string;
     uuid: string;
     display: string;
-    lastCompleted: string;
+    lastCompletedDate: string;
     formUuid: string;
   }>;
 }
@@ -73,7 +73,7 @@ export interface ListResponse<T> {
 export interface CompletedFormInfo {
   form: Form;
   associatedEncounters: Array<EncounterWithFormRef>;
-  lastCompleted?: Date;
+  lastCompletedDate?: Date;
 }
 
 export interface FormsSection {


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue where the `Last completed date` in the forms dashboard was not being displayed correctly. The logic that determines the last completed date was not correctly sorting the encounters by date, and was not using the most recent encounter date. This PR fixes these issues and ensures that the last completed date is the most recent encounter date for each form.

## Screenshots

https://github.com/user-attachments/assets/b0170024-f1fc-4f0f-86a3-a81a3cf1c97c

## Related Issue

https://openmrs.atlassian.net/browse/O3-4010

## Other
<!-- Anything not covered above -->
