### PR TITLE
(feat) O3-4084: Implement numeric validation for lab results entry form

### DIFF
--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form-field.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form-field.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NumberInput, Select, SelectItem, TextInput } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { type Control, Controller } from 'react-hook-form';
+import { type Control, Controller, type FieldErrors } from 'react-hook-form';
 import { type LabOrderConcept } from './lab-results.resource';
 import styles from './lab-results-form.scss';
 
@@ -9,9 +9,10 @@ interface ResultFormFieldProps {
   concept: LabOrderConcept;
   control: Control<any, any>;
   defaultValue: any;
+  errors: FieldErrors;
 }
 
-const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control, defaultValue }) => {
+const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control, defaultValue, errors }) => {
   const { t } = useTranslation();
 
   const isCoded = (concept: LabOrderConcept) => concept.datatype?.display === 'Coded';
@@ -42,12 +43,14 @@ const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control, def
           name={concept.uuid}
           render={({ field }) => (
             <TextInput
+              {...field}
               className={styles.textInput}
               id={concept.uuid}
               key={concept.uuid}
               labelText={concept?.display ?? ''}
               type="text"
-              {...field}
+              invalidText={errors[concept.uuid]?.message}
+              invalid={!!errors[concept.uuid]}
             />
           )}
         />
@@ -66,8 +69,10 @@ const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control, def
               id={concept.uuid}
               key={concept.uuid}
               label={concept?.display + printValueRange(concept)}
-              onChange={(event) => field.onChange(event.target.value)}
+              onChange={(event) => field.onChange(parseFloat(event.target.value))}
               value={field.value || ''}
+              invalidText={errors[concept.uuid]?.message}
+              invalid={!!errors[concept.uuid]}
             />
           )}
         />
@@ -85,6 +90,8 @@ const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control, def
               id={`select-${concept.uuid}`}
               key={concept.uuid}
               labelText={concept?.display}
+              invalidText={errors[concept.uuid]?.message}
+              invalid={!!errors[concept.uuid]}
             >
               <SelectItem text={t('chooseAnOption', 'Choose an option')} value="" />
               {concept?.answers?.length &&
@@ -113,6 +120,8 @@ const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control, def
                     key={member.uuid}
                     labelText={member?.display ?? ''}
                     type="text"
+                    invalidText={errors[member.uuid]?.message}
+                    invalid={!!errors[member.uuid]}
                   />
                 )}
               />
@@ -130,8 +139,10 @@ const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control, def
                     id={`number-${member.uuid}`}
                     key={member.uuid}
                     label={member?.display + printValueRange(member)}
-                    onChange={(event) => field.onChange(event.target.value)}
+                    onChange={(event) => field.onChange(parseFloat(event.target.value))}
                     value={field.value || ''}
+                    invalidText={errors[member.uuid]?.message}
+                    invalid={!!errors[member.uuid]}
                   />
                 )}
               />
@@ -149,6 +160,8 @@ const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control, def
                     key={member.uuid}
                     labelText={member?.display}
                     type="text"
+                    invalidText={errors[member.uuid]?.message}
+                    invalid={!!errors[member.uuid]}
                   >
                     <SelectItem text={t('chooseAnOption', 'Choose an option')} value="" />
 

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
@@ -39,7 +39,6 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
     formState: { errors, isDirty, isSubmitting },
     getValues,
     handleSubmit,
-    setError,
   } = useForm<{ testResult: any }>({
     defaultValues: {},
     resolver: zodResolver(schema),
@@ -192,10 +191,6 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
         title: t('errorSavingLabResults', 'Error saving lab results'),
         kind: 'error',
         subtitle: err?.message,
-      });
-      setError('root', {
-        type: 'manual',
-        message: err?.message || t('unknownError', 'An unknown error occurred'),
       });
     } finally {
       setShowEmptyFormErrorNotification(false);

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
@@ -8,6 +8,8 @@ import { restBaseUrl, showSnackbar, useAbortController, useLayoutType } from '@o
 import { useOrderConceptByUuid, updateOrderResult, useLabEncounter, useObservation } from './lab-results.resource';
 import ResultFormField from './lab-results-form-field.component';
 import styles from './lab-results-form.scss';
+import { useLabResultsFormSchema } from './useLabResultsFormSchema';
+import { zodResolver } from '@hookform/resolvers/zod';
 
 export interface LabResultsFormProps extends DefaultPatientWorkspaceProps {
   order: Order;
@@ -30,19 +32,22 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
   const { encounter, isLoading: isLoadingEncounter, mutate: mutateLabOrders } = useLabEncounter(order.encounter.uuid);
   const { data, isLoading: isLoadingObs, error: isErrorObs } = useObservation(obsUuid);
   const [showEmptyFormErrorNotification, setShowEmptyFormErrorNotification] = useState(false);
+  const schema = useLabResultsFormSchema(order.concept.uuid);
 
   const {
     control,
-    register,
     formState: { errors, isDirty, isSubmitting },
     getValues,
     handleSubmit,
+    setError,
   } = useForm<{ testResult: any }>({
     defaultValues: {},
+    resolver: zodResolver(schema),
+    mode: 'all',
   });
 
   useEffect(() => {
-    if (!isLoadingEncounter && encounter?.obs.length > 0 && !isEditing) {
+    if (!isLoadingEncounter && encounter?.obs?.length > 0 && !isEditing) {
       const obs = encounter.obs.find((obs) => obs.concept?.uuid === order?.concept.uuid);
       if (obs) {
         setObsUuid(obs.uuid);
@@ -82,7 +87,7 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
     );
   }
 
-  const saveLabResults = () => {
+  const saveLabResults = async (formData) => {
     const formValues = getValues();
 
     const isEmptyForm = Object.values(formValues).every(
@@ -158,50 +163,53 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
       fulfillerComment: 'Test Results Entered',
     };
 
-    updateOrderResult(
-      order.uuid,
-      order.encounter.uuid,
-      obsPayload,
-      resultsStatusPayload,
-      orderDiscontinuationPayload,
-      abortController,
-    ).then(
-      () => {
-        closeWorkspaceWithSavedChanges();
-        mutateLabOrders();
-        mutate(
-          (key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?patient=${order.patient.uuid}`),
-          undefined,
-          { revalidate: true },
-        );
-        showSnackbar({
-          title: t('saveLabResults', 'Save lab results'),
-          kind: 'success',
-          subtitle: t('successfullySavedLabResults', 'Lab results for {{orderNumber}} have been successfully updated', {
-            orderNumber: order?.orderNumber,
-          }),
-        });
-      },
-      (err) => {
-        showSnackbar({
-          title: t('errorSavingLabResults', 'Error saving lab results'),
-          kind: 'error',
-          subtitle: err?.message,
-        });
-      },
-    );
+    try {
+      await updateOrderResult(
+        order.uuid,
+        order.encounter.uuid,
+        obsPayload,
+        resultsStatusPayload,
+        orderDiscontinuationPayload,
+        abortController,
+      );
 
-    setShowEmptyFormErrorNotification(false);
+      closeWorkspaceWithSavedChanges();
+      mutateLabOrders();
+      mutate(
+        (key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?patient=${order.patient.uuid}`),
+        undefined,
+        { revalidate: true },
+      );
+      showSnackbar({
+        title: t('saveLabResults', 'Save lab results'),
+        kind: 'success',
+        subtitle: t('successfullySavedLabResults', 'Lab results for {{orderNumber}} have been successfully updated', {
+          orderNumber: order?.orderNumber,
+        }),
+      });
+    } catch (err) {
+      showSnackbar({
+        title: t('errorSavingLabResults', 'Error saving lab results'),
+        kind: 'error',
+        subtitle: err?.message,
+      });
+      setError('root', {
+        type: 'manual',
+        message: err?.message || t('unknownError', 'An unknown error occurred'),
+      });
+    } finally {
+      setShowEmptyFormErrorNotification(false);
+    }
   };
 
   return (
-    <Form className={styles.form}>
+    <Form className={styles.form} onSubmit={handleSubmit(saveLabResults)}>
       <div className={styles.grid}>
         {concept.setMembers.length > 0 && <p className={styles.heading}>{concept.display}</p>}
         {concept && (
           <Stack gap={5}>
             {!isLoadingInitialValues ? (
-              <ResultFormField defaultValue={initialValues} concept={concept} control={control} />
+              <ResultFormField defaultValue={initialValues} concept={concept} control={control} errors={errors} />
             ) : (
               <InlineLoading description={t('loadingInitialValues', 'Loading initial values') + '...'} />
             )}
@@ -220,13 +228,7 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
         <Button className={styles.button} kind="secondary" disabled={isSubmitting} onClick={closeWorkspace}>
           {t('discard', 'Discard')}
         </Button>
-        <Button
-          className={styles.button}
-          kind="primary"
-          onClick={handleSubmit(saveLabResults)}
-          disabled={isSubmitting}
-          type="submit"
-        >
+        <Button className={styles.button} kind="primary" disabled={isSubmitting} type="submit">
           {isSubmitting ? (
             <InlineLoading description={t('saving', 'Saving') + '...'} />
           ) : (

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { mutate } from 'swr';
@@ -44,6 +44,14 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
     resolver: zodResolver(schema),
     mode: 'all',
   });
+
+  const mutateOrderData = useCallback(() => {
+    mutate(
+      (key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?patient=${order.patient.uuid}`),
+      undefined,
+      { revalidate: true },
+    );
+  }, [order.patient.uuid]);
 
   useEffect(() => {
     if (!isLoadingEncounter && encounter?.obs?.length > 0 && !isEditing) {
@@ -174,11 +182,7 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
 
       closeWorkspaceWithSavedChanges();
       mutateLabOrders();
-      mutate(
-        (key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?patient=${order.patient.uuid}`),
-        undefined,
-        { revalidate: true },
-      );
+      mutateOrderData();
       showSnackbar({
         title: t('saveLabResults', 'Save lab results'),
         kind: 'success',

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.test.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.test.tsx
@@ -1,0 +1,258 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useOrderConceptByUuid, useLabEncounter, useObservation } from './lab-results.resource';
+import LabResultsForm from './lab-results-form.component';
+import { type Order } from '@openmrs/esm-patient-common-lib';
+
+jest.mock('./lab-results.resource', () => ({
+  useOrderConceptByUuid: jest.fn(),
+  useLabEncounter: jest
+    .fn()
+    .mockReturnValue({ encounter: [{ obs: [] }], isLoading: false, mutateLabOrders: jest.fn() }),
+  useObservation: jest.fn().mockReturnValue({ data: [], isLoading: false }),
+  updateOrderResult: jest.fn().mockReturnValue(Promise.resolve()),
+}));
+
+jest.mock('@openmrs/esm-framework', () => ({
+  useAbortController: jest.fn(() => ({ signal: new AbortController().signal })),
+  useLayoutType: jest.fn(() => 'desktop'),
+  showSnackbar: jest.fn(),
+}));
+
+const mockOrder = {
+  uuid: 'order-uuid',
+  concept: { uuid: 'concept-uuid' },
+  encounter: { uuid: 'encounter-uuid' },
+  patient: { uuid: 'patient-uuid' },
+  orderNumber: 'ORD-1',
+  careSetting: { uuid: 'care-setting-uuid' },
+};
+
+const testProps = {
+  closeWorkspace: jest.fn(),
+  closeWorkspaceWithSavedChanges: jest.fn(),
+  order: mockOrder as Order,
+  promptBeforeClosing: jest.fn(),
+  setTitle: jest.fn(),
+  patientUuid: 'patient-uuid',
+};
+
+describe('LabResultsForm', () => {
+  beforeEach(() => {
+    (useOrderConceptByUuid as jest.Mock).mockReturnValue({
+      concept: {
+        uuid: 'concept-uuid',
+        display: 'Test Concept',
+        setMembers: [],
+        datatype: { display: 'Numeric' },
+        hiAbsolute: 100,
+        hiCritical: 80,
+        hiNormal: 70,
+        lowAbsolute: 0,
+        lowCritical: 40,
+        lowNormal: 50,
+        units: 'mg/dL',
+      },
+      isLoading: false,
+    });
+    (useLabEncounter as jest.Mock).mockReturnValue({ encounter: { obs: [] }, isLoading: false, mutate: jest.fn() });
+    (useObservation as jest.Mock).mockReturnValue({ data: null, isLoading: false });
+  });
+
+  test('validates numeric input correctly', async () => {
+    const user = userEvent.setup();
+    render(<LabResultsForm {...testProps} />);
+
+    const input = await screen.findByLabelText(`Test Concept (0 - 100 mg/dL)`);
+    await user.type(input, '150');
+
+    const saveButton = screen.getByRole('button', { name: /Save and close/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Concept must be between 0 and 100')).toBeInTheDocument();
+    });
+  });
+
+  test('validate numeric input with negative value', async () => {
+    const user = userEvent.setup();
+    render(<LabResultsForm {...testProps} />);
+
+    const input = await screen.findByLabelText(`Test Concept (0 - 100 mg/dL)`);
+    await user.type(input, '-50');
+
+    const saveButton = screen.getByRole('button', { name: /Save and close/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Concept must be between 0 and 100')).toBeInTheDocument();
+    });
+  });
+
+  test('validate numeric input with zero value', async () => {
+    const user = userEvent.setup();
+    render(<LabResultsForm {...testProps} />);
+
+    const input = await screen.findByLabelText(`Test Concept (0 - 100 mg/dL)`);
+    await user.type(input, '0');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Test Concept must be between 0 and 100')).not.toBeInTheDocument();
+    });
+  });
+
+  test('validate numeric input with concept having only hiAbsolute', async () => {
+    const user = userEvent.setup();
+    (useOrderConceptByUuid as jest.Mock).mockReturnValue({
+      concept: {
+        uuid: 'concept-uuid',
+        display: 'Test Concept',
+        setMembers: [],
+        datatype: { display: 'Numeric' },
+        hiAbsolute: 100,
+        lowAbsolute: null,
+        lowCritical: null,
+        lowNormal: null,
+        hiCritical: null,
+        hiNormal: null,
+        units: 'mg/dL',
+      },
+    });
+    render(<LabResultsForm {...testProps} />);
+
+    const input = await screen.findByLabelText(`Test Concept (0 - 100 mg/dL)`);
+    await user.type(input, '150');
+
+    const saveButton = screen.getByRole('button', { name: /Save and close/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Concept must be less than or equal to 100')).toBeInTheDocument();
+    });
+  });
+
+  test('validate numeric input with concept having only lowAbsolute', async () => {
+    const user = userEvent.setup();
+    (useOrderConceptByUuid as jest.Mock).mockReturnValue({
+      concept: {
+        uuid: 'concept-uuid',
+        display: 'Test Concept',
+        setMembers: [],
+        datatype: { display: 'Numeric' },
+        lowAbsolute: 0,
+        lowCritical: null,
+        lowNormal: null,
+        hiCritical: null,
+        hiNormal: null,
+        hiAbsolute: null,
+        units: 'mg/dL',
+      },
+    });
+    render(<LabResultsForm {...testProps} />);
+
+    const input = await screen.findByLabelText(`Test Concept (0 - -- mg/dL)`);
+    await user.type(input, '-50');
+
+    const saveButton = screen.getByRole('button', { name: /Save and close/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Concept must be greater than or equal to 0')).toBeInTheDocument();
+    });
+  });
+
+  test('submits form with valid data', async () => {
+    const user = userEvent.setup();
+    const mockCloseWorkspace = jest.fn();
+    const mockCloseWorkspaceWithSavedChanges = jest.fn();
+
+    render(
+      <LabResultsForm
+        {...testProps}
+        closeWorkspace={mockCloseWorkspace}
+        closeWorkspaceWithSavedChanges={mockCloseWorkspaceWithSavedChanges}
+      />,
+    );
+
+    const input = await screen.findByLabelText(`Test Concept (0 - 100 mg/dL)`);
+    await user.type(input, '50');
+
+    const saveButton = screen.getByRole('button', { name: /Save and close/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockCloseWorkspaceWithSavedChanges).toHaveBeenCalled();
+    });
+  });
+
+  test('validate numeric input where concept is a panel', async () => {
+    const user = userEvent.setup();
+    (useOrderConceptByUuid as jest.Mock).mockReturnValue({
+      concept: {
+        uuid: 'concept-uuid',
+        display: 'Test Concept',
+        datatype: { display: 'Numeric' },
+        lowAbsolute: 0,
+        lowCritical: null,
+        lowNormal: null,
+        hiCritical: null,
+        hiNormal: null,
+        hiAbsolute: null,
+        units: 'mg/dL',
+        setMembers: [
+          {
+            uuid: 'set-member-uuid',
+            display: 'Set Member',
+            setMembers: [],
+            datatype: { display: 'Numeric' },
+            lowAbsolute: 50,
+            lowCritical: 70,
+            lowNormal: 80,
+            hiCritical: 140,
+            hiNormal: 120,
+            hiAbsolute: 150,
+            units: 'mg/dL',
+          },
+          {
+            uuid: 'set-member-uuid-2',
+            display: 'Set Member 2',
+            setMembers: [],
+            datatype: { display: 'Numeric' },
+            lowAbsolute: 5,
+            lowCritical: 10,
+            lowNormal: 15,
+            hiCritical: 20,
+            hiNormal: 25,
+            hiAbsolute: 30,
+            units: 'mg/dL',
+          },
+        ],
+      },
+    });
+    render(<LabResultsForm {...testProps} />);
+
+    // Normal input range
+    const setMember1Input = screen.getByLabelText('Set Member (50 - 150 mg/dL)');
+    await user.type(setMember1Input, '50');
+    expect(screen.queryByText('Set Member must be between 50 and 150')).not.toBeInTheDocument();
+
+    const setMember2Input = screen.getByLabelText('Set Member 2 (5 - 30 mg/dL)');
+    await user.type(setMember2Input, '10');
+    expect(screen.queryByText('Set Member must be between 5 and 30')).not.toBeInTheDocument();
+
+    // Out of range input, upper limit
+    await user.type(setMember1Input, '151');
+    expect(await screen.findByText('Set Member must be between 50 and 150')).toBeInTheDocument();
+
+    await user.type(setMember2Input, '31');
+    expect(await screen.findByText('Set Member 2 must be between 5 and 30')).toBeInTheDocument();
+
+    // Out of range input, lower limit
+    await user.type(setMember1Input, '49');
+    expect(await screen.findByText('Set Member must be between 50 and 150')).toBeInTheDocument();
+
+    await user.type(setMember2Input, '4');
+    expect(await screen.findByText('Set Member 2 must be between 5 and 30')).toBeInTheDocument();
+  });
+});

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results.resource.ts
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results.resource.ts
@@ -25,12 +25,12 @@ export interface LabOrderConcept {
   mappings?: Array<Mapping>;
   answers?: Array<OpenmrsResource>;
   setMembers?: Array<LabOrderConcept>;
-  hiNormal?: number;
-  hiAbsolute?: number;
-  hiCritical?: number;
-  lowNormal?: number;
-  lowAbsolute?: number;
-  lowCritical?: number;
+  hiNormal?: number | null | undefined;
+  hiAbsolute?: number | null | undefined;
+  hiCritical?: number | null | undefined;
+  lowNormal?: number | null | undefined;
+  lowAbsolute?: number | null | undefined;
+  lowCritical?: number | null | undefined;
   units?: string;
 }
 

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results.resource.ts
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results.resource.ts
@@ -13,6 +13,7 @@ const labConceptRepresentation =
   'setMembers:(uuid,display,answers,datatype,hiNormal,hiAbsolute,hiCritical,lowNormal,lowAbsolute,lowCritical,units))';
 const conceptObsRepresentation = 'custom:(uuid,display,concept:(uuid,display),groupMembers,value)';
 
+type NullableNumber = number | null | undefined;
 export interface LabOrderConcept {
   uuid: string;
   display: string;
@@ -25,12 +26,12 @@ export interface LabOrderConcept {
   mappings?: Array<Mapping>;
   answers?: Array<OpenmrsResource>;
   setMembers?: Array<LabOrderConcept>;
-  hiNormal?: number | null | undefined;
-  hiAbsolute?: number | null | undefined;
-  hiCritical?: number | null | undefined;
-  lowNormal?: number | null | undefined;
-  lowAbsolute?: number | null | undefined;
-  lowCritical?: number | null | undefined;
+  hiNormal?: NullableNumber;
+  hiAbsolute?: NullableNumber;
+  hiCritical?: NullableNumber;
+  lowNormal?: NullableNumber;
+  lowAbsolute?: NullableNumber;
+  lowCritical?: NullableNumber;
   units?: string;
 }
 

--- a/packages/esm-patient-orders-app/src/lab-results/useLabResultsFormSchema.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/useLabResultsFormSchema.tsx
@@ -1,0 +1,124 @@
+import { z } from 'zod';
+import { type LabOrderConcept, useOrderConceptByUuid } from './lab-results.resource';
+
+type SchemaRecord = Record<string, z.ZodType>;
+
+/**
+ * Custom hook to generate a Zod schema for lab results form based on a lab order concept.
+ * @param labOrderConceptUuid - The UUID of the lab order concept.
+ * @returns A Zod schema object for the lab results form.
+ */
+export const useLabResultsFormSchema = (labOrderConceptUuid: string) => {
+  const { concept, isLoading: isLoadingConcept } = useOrderConceptByUuid(labOrderConceptUuid);
+
+  if (isLoadingConcept) {
+    return z.object({});
+  }
+
+  const setMembers = concept?.setMembers ?? [];
+
+  if (setMembers.length > 0) {
+    return createSetMembersSchema(setMembers);
+  }
+
+  return createSingleConceptSchema(concept);
+};
+
+/**
+ * Creates a Zod schema for a single lab order concept.
+ * @param labOrderConcept - The lab order concept to create a schema for.
+ * @returns A Zod schema object for the single concept.
+ */
+const createSingleConceptSchema = (labOrderConcept: LabOrderConcept) => {
+  const { hiAbsolute: upperLimit, lowAbsolute: lowerLimit, datatype } = labOrderConcept;
+  if (datatype.display?.toLowerCase() === 'numeric') {
+    const zodObject = createNumericSchema(labOrderConcept, upperLimit, lowerLimit);
+
+    return z.object({
+      [labOrderConcept.uuid]: zodObject,
+    });
+  }
+
+  return z.object({
+    [labOrderConcept.uuid]: z.any(),
+  });
+};
+
+/**
+ * Creates a Zod schema for a set of lab order concepts.
+ * @param labOrderConcepts - An array of lab order concepts.
+ * @returns A Zod schema object for the set of concepts.
+ */
+const createSetMembersSchema = (labOrderConcepts: Array<LabOrderConcept>): z.ZodObject<SchemaRecord> => {
+  const schema = z.object(
+    labOrderConcepts.reduce<SchemaRecord>((acc, member) => {
+      acc[member.uuid] = createSchema(member);
+      return acc;
+    }, {}),
+  );
+
+  return schema;
+};
+
+/**
+ * Determines and returns the appropriate Zod schema for a given lab order concept.
+ * @param labOrderConcept - The lab order concept to create a schema for.
+ * @returns A Zod schema type based on the concept's data type.
+ */
+const createSchema = (labOrderConcept: LabOrderConcept): z.ZodType => {
+  const conceptDataType = labOrderConcept.datatype.display?.toLowerCase();
+  const { hiAbsolute: upperLimit, lowAbsolute: lowerLimit } = labOrderConcept;
+  if (conceptDataType === 'text') {
+    return z.string().optional();
+  }
+
+  if (conceptDataType === 'numeric') {
+    return createNumericSchema(labOrderConcept, upperLimit, lowerLimit);
+  }
+
+  // Default case
+  return z.unknown();
+};
+
+/**
+ * Creates a Zod schema for a numeric lab order concept, including validation for upper and lower limits.
+ * @param labOrderConcept - The lab order concept to create a schema for.
+ * @param upperLimit - The upper limit for the numeric value.
+ * @param lowerLimit - The lower limit for the numeric value.
+ * @returns A Zod schema type with appropriate numeric validations.
+ */
+const createNumericSchema = (
+  labOrderConcept: LabOrderConcept,
+  upperLimit: number | undefined,
+  lowerLimit: number | undefined,
+): z.ZodType => {
+  let baseSchema = z
+    .preprocess((val) => {
+      if (val === '' || val === null || val === undefined) return undefined;
+      const parsed = Number(val);
+      return isNaN(parsed) ? undefined : parsed;
+    }, z.number().optional())
+    .refine((val) => val === undefined || !isNaN(val), {
+      message: `${labOrderConcept.display} must be a valid number`,
+    });
+
+  if (lowerLimit === null && upperLimit === null) {
+    return baseSchema;
+  }
+
+  if (lowerLimit !== null && upperLimit !== null) {
+    return baseSchema.refine((val) => val === undefined || (val >= lowerLimit && val <= upperLimit), {
+      message: `${labOrderConcept.display} must be between ${lowerLimit} and ${upperLimit}`,
+    });
+  }
+
+  if (lowerLimit !== null) {
+    return baseSchema.refine((val) => val === undefined || val >= lowerLimit, {
+      message: `${labOrderConcept.display} must be greater than or equal to ${lowerLimit}`,
+    });
+  }
+
+  return baseSchema.refine((val) => val === undefined || val <= upperLimit!, {
+    message: `${labOrderConcept.display} must be less than or equal to ${upperLimit}`,
+  });
+};


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
See https://openmrs.atlassian.net/browse/O3-4084

I have implemented the validation logic as follows:
- Uses `hiAbsolute` and `lowAbsolute` as they represent the max and min thresholds supported by the backend.
- If both values are absent, validation is skipped.
- If either value is present, it's used in the validation.
- If both values are present, both are used in the validation.

I have not used the critical high or low values for validation because there are cases where values might fall outside of their ranges. should we leverage these values for validation. cc @ibacher @makombe @ojwanganto @denniskigen @CynthiaKamau 

## Screenshots
![Kapture 2024-10-14 at 17 23 31](https://github.com/user-attachments/assets/f82534c6-aafe-44fa-b688-6194cebeaa1d)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
