### PR TITLE
(feat) O3-4087: Enable input for set-based lab tests on lab results form and handle partial set results

### DIFF
--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
@@ -43,7 +43,6 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
   const {
     control,
     formState: { errors, isDirty, isSubmitting },
-    getValues,
     handleSubmit,
   } = useForm<{ testResult: Record<string, unknown> }>({
     defaultValues: {},
@@ -108,7 +107,8 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
       setShowEmptyFormErrorNotification(true);
       return;
     }
-    const obsPayload = createObservationPayload(concept, order, formValues);
+    // Set the observation status to 'FINAL' as we're not capturing it in the form
+    const obsPayload = createObservationPayload(concept, order, formValues, 'FINAL');
     const orderDiscontinuationPayload = {
       previousOrder: order.uuid,
       type: 'testorder',
@@ -133,7 +133,6 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
         orderDiscontinuationPayload,
         abortController,
       );
-
       closeWorkspaceWithSavedChanges();
       mutateLabOrders();
       mutateOrderData();
@@ -181,7 +180,12 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
         <Button className={styles.button} kind="secondary" disabled={isSubmitting} onClick={closeWorkspace}>
           {t('discard', 'Discard')}
         </Button>
-        <Button className={styles.button} kind="primary" disabled={isSubmitting} type="submit">
+        <Button
+          className={styles.button}
+          kind="primary"
+          disabled={isSubmitting || Object.keys(errors).length > 0}
+          type="submit"
+        >
           {isSubmitting ? (
             <InlineLoading description={t('saving', 'Saving') + '...'} />
           ) : (

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
@@ -5,7 +5,13 @@ import { mutate } from 'swr';
 import { Button, ButtonSet, Form, InlineLoading, InlineNotification, Stack } from '@carbon/react';
 import { type DefaultPatientWorkspaceProps, type Order } from '@openmrs/esm-patient-common-lib';
 import { restBaseUrl, showSnackbar, useAbortController, useLayoutType } from '@openmrs/esm-framework';
-import { useOrderConceptByUuid, updateOrderResult, useLabEncounter, useObservation } from './lab-results.resource';
+import {
+  useOrderConceptByUuid,
+  updateOrderResult,
+  useLabEncounter,
+  useObservation,
+  createObservationPayload,
+} from './lab-results.resource';
 import ResultFormField from './lab-results-form-field.component';
 import styles from './lab-results-form.scss';
 import { useLabResultsFormSchema } from './useLabResultsFormSchema';
@@ -39,7 +45,7 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
     formState: { errors, isDirty, isSubmitting },
     getValues,
     handleSubmit,
-  } = useForm<{ testResult: any }>({
+  } = useForm<{ testResult: Record<string, unknown> }>({
     defaultValues: {},
     resolver: zodResolver(schema),
     mode: 'all',
@@ -94,66 +100,15 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
     );
   }
 
-  const saveLabResults = async (formData) => {
-    const formValues = getValues();
-
+  const saveLabResults = async (formValues: Record<string, unknown>) => {
     const isEmptyForm = Object.values(formValues).every(
       (value) => value === '' || value === null || value === undefined,
     );
-
     if (isEmptyForm) {
       setShowEmptyFormErrorNotification(true);
       return;
     }
-
-    let obsValue = [];
-
-    if (concept.set && concept.setMembers.length > 0) {
-      let groupMembers = [];
-      concept.setMembers.forEach((member) => {
-        let value;
-        if (member.datatype.display === 'Numeric' || member.datatype.display === 'Text') {
-          value = getValues()[`${member.uuid}`];
-        } else if (member.datatype.display === 'Coded') {
-          value = {
-            uuid: getValues()[`${member.uuid}`],
-          };
-        }
-        const groupMember = {
-          concept: { uuid: member.uuid },
-          value: value,
-          status: 'FINAL',
-          order: { uuid: order.uuid },
-        };
-        groupMembers.push(groupMember);
-      });
-
-      obsValue.push({
-        concept: { uuid: order.concept.uuid },
-        status: 'FINAL',
-        order: { uuid: order.uuid },
-        groupMembers: groupMembers,
-      });
-    } else if (!concept.set && concept.setMembers.length === 0) {
-      let value;
-      if (concept.datatype.display === 'Numeric' || concept.datatype.display === 'Text') {
-        value = getValues()[`${concept.uuid}`];
-      } else if (concept.datatype.display === 'Coded') {
-        value = {
-          uuid: getValues()[`${concept.uuid}`],
-        };
-      }
-
-      obsValue.push({
-        concept: { uuid: order.concept.uuid },
-        status: 'FINAL',
-        order: { uuid: order.uuid },
-        value: value,
-      });
-    }
-
-    const obsPayload = { obs: obsValue };
-
+    const obsPayload = createObservationPayload(concept, order, formValues);
     const orderDiscontinuationPayload = {
       previousOrder: order.uuid,
       type: 'testorder',
@@ -164,7 +119,6 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
       concept: order.concept.uuid,
       orderer: order.orderer,
     };
-
     const resultsStatusPayload = {
       fulfillerStatus: 'COMPLETED',
       fulfillerComment: 'Test Results Entered',

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results.resource.ts
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results.resource.ts
@@ -220,7 +220,7 @@ function getValue(concept: LabOrderConcept, values: Record<string, unknown>) {
   if (['NM', 'ST'].includes(datatype.hl7Abbreviation)) {
     return value;
   }
-
+  // hl7Abbreviation is CWE for Coded with exceptions datatype
   if (datatype.hl7Abbreviation === 'CWE') {
     return { uuid: value };
   }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
See https://openmrs.atlassian.net/browse/O3-4087

In this PR, I have updated the logic for generating lab observation (obs) values:

- **Non-set lab order concepts**: If the lab order concept is not a set, we generate the payload. If no values are present for the concept, we return an empty array.

- **Set member lab order concepts**: For concepts that are part of a set, we only return observation payloads for set members that have values. This ensures that incomplete results (missing values for some set members) do not affect the generation process.

## Screenshots
![Kapture 2024-10-15 at 11 46 28](https://github.com/user-attachments/assets/4e7b3b40-0732-4b6f-8046-145981acc1d4)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
