### PR TITLE
(feat) O3-4088: Sort Diagnoses Tags by Primary and Secondary Order on Visits Summaries

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { Tab, Tabs, TabList, TabPanel, TabPanels, Tag } from '@carbon/react';
+import { Tab, TabList, TabPanel, TabPanels, Tabs, Tag } from '@carbon/react';
 import {
   type AssignedExtension,
   Extension,
@@ -14,13 +14,13 @@ import {
   type Visit,
 } from '@openmrs/esm-framework';
 import {
-  type Order,
+  type Diagnosis,
   type Encounter,
+  mapEncounters,
   type Note,
   type Observation,
+  type Order,
   type OrderItem,
-  type Diagnosis,
-  mapEncounters,
 } from '../visit.resource';
 import VisitsTable from './visits-table/visits-table.component';
 import MedicationSummary from './medications-summary.component';
@@ -117,11 +117,13 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
       <p className={styles.diagnosisLabel}>{t('diagnoses', 'Diagnoses')}</p>
       <div className={styles.diagnosesList}>
         {diagnoses.length > 0 ? (
-          diagnoses.map((diagnosis, i) => (
-            <Tag key={i} type={diagnosis.order === 'Primary' ? 'red' : 'blue'}>
-              {diagnosis.diagnosis}
-            </Tag>
-          ))
+          diagnoses
+            .sort((diagnosis) => (diagnosis.order === 'Primary' ? -1 : 1))
+            .map((diagnosis, i) => (
+              <Tag key={i} type={diagnosis.order === 'Primary' ? 'red' : 'blue'}>
+                {diagnosis.diagnosis}
+              </Tag>
+            ))
         ) : (
           <p className={classNames(styles.bodyLong01, styles.text02)} style={{ marginBottom: '0.5rem' }}>
             {t('noDiagnosesFound', 'No diagnoses found')}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR add that diagnoses are properly sorted, with Primary diagnoses appearing first (displayed in red), followed by Secondary diagnoses (displayed in blue). 

## Screenshots
<!-- Required if you are making UI changes. -->
![order-by-primary](https://github.com/user-attachments/assets/48e419fd-1984-49ca-8ef8-31d670f214e4)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4088

## Other
<!-- Anything not covered above -->
