### PR TITLE
(fix) O3-4059 Fix Inaccurate Test Result Time Stamps

### DIFF
--- a/packages/esm-patient-tests-app/src/test-results/filter/filter-types.ts
+++ b/packages/esm-patient-tests-app/src/test-results/filter/filter-types.ts
@@ -101,6 +101,7 @@ export interface TimelineData {
 
 export interface FilterContextProps extends ReducerState {
   timelineData: TimelineData;
+  tableData?: any;
   activeTests: string[];
   someChecked: boolean;
   totalResultsCount: number;

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
@@ -13,7 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from '@carbon/react';
-import { ArrowRightIcon, showModal, useLayoutType, isDesktop } from '@openmrs/esm-framework';
+import { ArrowRightIcon, showModal, useLayoutType, isDesktop, formatDate } from '@openmrs/esm-framework';
 import { getPatientUuidFromStore, type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import styles from './individual-results-table.scss';
 import { type GroupedObservation } from '../../types';
@@ -124,7 +124,7 @@ const IndividualResultsTable: React.FC<IndividualResultsTableProps> = ({ isLoadi
             <div className={styles.cardTitle}>
               <h4 className={styles.resultType}>{headerTitle}</h4>
               <div className={styles.displayFlex}>
-                <span className={styles.date}>{subRows.date ?? ''}</span>
+                <span className={styles.date}>{formatDate(new Date(subRows.date), { mode: 'standard' })}</span>
                 <Button
                   className={styles.viewTimeline}
                   iconDescription="view timeline"

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.test.tsx
@@ -41,7 +41,7 @@ describe('IndividualResultsTable', () => {
   it('renders a tabular overview of the available test result data', () => {
     render(<IndividualResultsTable isLoading={false} subRows={mockSubRows} index={0} title={'HIV viral load'} />);
 
-    expect(screen.getByText(/2024-10-15/i)).toBeInTheDocument();
+    expect(screen.getByText(/15-Oct-2024/i)).toBeInTheDocument();
     expect(screen.getByText(/test name/i)).toBeInTheDocument();
     expect(screen.getByText(/reference range/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /view timeline/i })).toBeInTheDocument();

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.test.tsx
@@ -1,53 +1,50 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import IndividualResultsTable from './individual-results-table.component';
+import { type GroupedObservation } from '../../types';
 
 describe('IndividualResultsTable', () => {
-  const mockSubRows = [
-    {
-      obs: [
-        {
-          obsDatetime: '2021-01-13 02:10:06.0',
-          value: '52.1',
-          interpretation: 'NORMAL' as const as OBSERVATION_INTERPRETATION,
-        },
-      ],
-      datatype: 'Numeric',
-      lowAbsolute: 0,
-      display: 'Prothrombin time',
-      conceptUuid: '161481AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-      units: 'Minute',
-      flatName: 'Hematology-Prothrombin Time (with INR)-Prothrombin time',
-      hasData: true,
-      entries: [
-        null,
-        null,
-        null,
-        {
-          obsDatetime: '2021-01-13 02:10:06.0',
-          value: '52.1',
-          interpretation: 'NORMAL' as const as OBSERVATION_INTERPRETATION,
-        },
-      ],
-    },
-  ];
+  const mockSubRows = {
+    key: 'HIV viral load',
+    date: '2024-10-15',
+    flatName: 'HIV viral load-HIV viral load',
+    entries: [
+      {
+        obsDatetime: '2024-10-15 03:20:19.0',
+        value: '45',
+        interpretation: 'NORMAL',
+        key: 'HIV viral load-HIV viral load',
+        datatype: 'Numeric',
+        lowAbsolute: 0,
+        display: 'HIV viral load',
+        conceptUuid: '856AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        units: 'copies/ml',
+        flatName: 'HIV viral load-HIV viral load',
+        hasData: true,
+      },
+    ],
+  } as GroupedObservation;
+
+  const mockEmptySubRows = {
+    key: 'HIV viral load',
+    date: '2024-10-15',
+    flatName: 'HIV viral load-HIV viral load',
+    entries: [],
+  } as GroupedObservation;
 
   it('renders a loading skeleton when fetching results data', () => {
-    render(<IndividualResultsTable isLoading={true} parent={{ display: 'Parent Test' }} subRows={[]} index={0} />);
+    render(<IndividualResultsTable isLoading={true} subRows={mockEmptySubRows} index={0} title={'HIV viral load'} />);
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 
   it('renders a tabular overview of the available test result data', () => {
-    render(
-      <IndividualResultsTable isLoading={false} parent={{ display: 'Parent Test' }} subRows={mockSubRows} index={0} />,
-    );
+    render(<IndividualResultsTable isLoading={false} subRows={mockSubRows} index={0} title={'HIV viral load'} />);
 
-    expect(screen.getByText(/13-jan-2021/i)).toBeInTheDocument();
+    expect(screen.getByText(/2024-10-15/i)).toBeInTheDocument();
     expect(screen.getByText(/test name/i)).toBeInTheDocument();
     expect(screen.getByText(/reference range/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /view timeline/i })).toBeInTheDocument();
-    expect(screen.getByRole('row', { name: /prothrombin time 52.1 minute -- minute/i })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: /hiv viral load 45 copies\/ml -- copies\/ml/i })).toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-tests-app/src/test-results/panel-timeline/panel-timeline-component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/panel-timeline/panel-timeline-component.tsx
@@ -13,6 +13,7 @@ const PanelTimelineComponent: React.FC<PanelTimelineComponentProps> = ({ activeP
   const { t } = useTranslation();
   const rows: Array<ObsRecord> = activePanel ? [activePanel, ...activePanel?.relatedObs] : [];
   const mappedObservations = Object.fromEntries(rows.map((obs) => [obs.name, groupedObservations[obs.conceptUuid]]));
+
   const allTimes = []
     .concat(...Object.values(mappedObservations).map((obsRecords) => obsRecords.map((obs) => obs.effectiveDateTime)))
     .sort((time1, time2) => Date.parse(time2) - Date.parse(time1));

--- a/packages/esm-patient-tests-app/src/test-results/panel-timeline/panel-timeline-component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/panel-timeline/panel-timeline-component.tsx
@@ -13,7 +13,6 @@ const PanelTimelineComponent: React.FC<PanelTimelineComponentProps> = ({ activeP
   const { t } = useTranslation();
   const rows: Array<ObsRecord> = activePanel ? [activePanel, ...activePanel?.relatedObs] : [];
   const mappedObservations = Object.fromEntries(rows.map((obs) => [obs.name, groupedObservations[obs.conceptUuid]]));
-
   const allTimes = []
     .concat(...Object.values(mappedObservations).map((obsRecords) => obsRecords.map((obs) => obs.effectiveDateTime)))
     .sort((time1, time2) => Date.parse(time2) - Date.parse(time1));

--- a/packages/esm-patient-tests-app/src/types.ts
+++ b/packages/esm-patient-tests-app/src/types.ts
@@ -137,3 +137,49 @@ export interface ObservationSet {
 }
 
 export type viewOpts = 'individual-test' | 'over-time' | 'full';
+
+export type Observation = {
+  obsDatetime: string;
+  value: string;
+  interpretation: OBSERVATION_INTERPRETATION;
+};
+
+export type TestResult = {
+  obs: Observation[];
+  datatype: string;
+  lowAbsolute: number;
+  display: string;
+  conceptUuid: string;
+  lowNormal: number;
+  units: string;
+  lowCritical: number;
+  hiNormal: number;
+  flatName: string;
+  hasData: boolean;
+  range: string;
+};
+
+export type MappedObservation = {
+  datatype: string;
+  lowAbsolute: number;
+  display: string;
+  conceptUuid: string;
+  lowNormal: number;
+  units: string;
+  lowCritical: number;
+  hiNormal: number;
+  flatName: string;
+  hasData: boolean;
+  range: string;
+  obsDatetime: string;
+  value: string;
+  interpretation: OBSERVATION_INTERPRETATION;
+  key: string;
+};
+
+export interface GroupedObservation {
+  key: string;
+  date: string;
+  flatName: string;
+  entries: MappedObservation[];
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Fix Inaccurate Test Result Time Stamps that we caused by grouping tests based on names, not including dates

## Screenshots
<!-- Required if you are making UI changes. -->
-I have removed the date after showing that the grouping is based on similar dates.

<img width="1680" alt="Screenshot 2024-10-28 at 11 03 35" src="https://github.com/user-attachments/assets/cf783d08-b43c-4e85-8236-b1e232bdac01">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
