### PR TITLE
(chore) Bump RFE with calculate expression initialization fix

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5678,8 +5678,8 @@ __metadata:
   linkType: soft
 
 "@openmrs/esm-form-engine-lib@npm:next":
-  version: 2.1.0-pre.1524
-  resolution: "@openmrs/esm-form-engine-lib@npm:2.1.0-pre.1524"
+  version: 2.1.0-pre.1526
+  resolution: "@openmrs/esm-form-engine-lib@npm:2.1.0-pre.1526"
   dependencies:
     "@carbon/react": "npm:>1.47.0 <1.50.0"
     classnames: "npm:^2.5.1"
@@ -5697,7 +5697,7 @@ __metadata:
     react: 18.x
     react-i18next: 11.x
     swr: 2.x
-  checksum: 10/5d2fe6aabaadcfa70e439988094789926f10e98c30a003c3fbc6d746e06f957faf111b36a338c6d3a52b75a0fead03b64b6e664830d71d6fa1585a93380d3c71
+  checksum: 10/8aaf4e07ff29487c7559d708637d9064226f7e1f9830f53c30a77bb23a50752bde0cb7a42e157b9703d5fb7cd021d306dc84dc1c39bab3a5d6c137dced92235f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This RFE version bump resolves an issue where calculate expression fields from promise based functions were not being initiated. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
