### PR TITLE
(refactor) Remove the dependency of using `patientUuid` from the URL

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
@@ -17,6 +17,7 @@ import Loader from '../loader/loader.component';
 import styles from './patient-chart.scss';
 import VisitHeader from '../visit-header/visit-header.component';
 import SideMenuPanel from '../side-nav/side-menu.component';
+import { getPatientChartStore } from '@openmrs/esm-patient-common-lib';
 
 const PatientChart: React.FC = () => {
   const { patientUuid, view: encodedView } = useParams();
@@ -38,6 +39,17 @@ const PatientChart: React.FC = () => {
   useEffect(() => {
     return () => {
       setCurrentVisit(null, null);
+    };
+  }, [patientUuid]);
+
+  useEffect(() => {
+    getPatientChartStore().setState({
+      patientUuid,
+    });
+    return () => {
+      getPatientChartStore().setState({
+        patientUuid: null,
+      });
     };
   }, [patientUuid]);
 

--- a/packages/esm-patient-common-lib/src/get-patient-uuid-from-url.ts
+++ b/packages/esm-patient-common-lib/src/get-patient-uuid-from-url.ts
@@ -1,4 +1,7 @@
+import { getPatientChartStore } from './store/patient-chart-store';
+
 export function getPatientUuidFromUrl(): string {
   const match = /\/patient\/([a-zA-Z0-9\-]+)\/?/.exec(location.pathname);
-  return match && match[1];
+  const patientUuidFromUrl = match && match[1];
+  return patientUuidFromUrl || getPatientChartStore().getState().patientUuid;
 }

--- a/packages/esm-patient-common-lib/src/get-patient-uuid-from-url.ts
+++ b/packages/esm-patient-common-lib/src/get-patient-uuid-from-url.ts
@@ -1,7 +1,11 @@
-import { getPatientUuidFromUrlOrStore } from './store/patient-chart-store';
+import { getPatientUuidFromStore } from './store/patient-chart-store';
 
 /**
- * @deprecated This function is now replaced with `getPatientUuidFromUrlOrStore`. This function will be removed in upcoming releases.
+ * @deprecated This function is now replaced with `getPatientUuidFromStore`. This function will be removed in upcoming releases.
  * @returns {string} patientUuid
  */
-export const getPatientUuidFromUrl = getPatientUuidFromUrlOrStore;
+export function getPatientUuidFromUrl(): string {
+  const match = /\/patient\/([a-zA-Z0-9\-]+)\/?/.exec(location.pathname);
+  const patientUuidFromUrl = match && match[1];
+  return patientUuidFromUrl || getPatientUuidFromStore();
+}

--- a/packages/esm-patient-common-lib/src/get-patient-uuid-from-url.ts
+++ b/packages/esm-patient-common-lib/src/get-patient-uuid-from-url.ts
@@ -1,7 +1,7 @@
-import { getPatientChartStore } from './store/patient-chart-store';
+import { getPatientUuidFromUrlOrStore } from './store/patient-chart-store';
 
-export function getPatientUuidFromUrl(): string {
-  const match = /\/patient\/([a-zA-Z0-9\-]+)\/?/.exec(location.pathname);
-  const patientUuidFromUrl = match && match[1];
-  return patientUuidFromUrl || getPatientChartStore().getState().patientUuid;
-}
+/**
+ * @deprecated This function is now replaced with `getPatientUuidFromUrlOrStore`. This function will be removed in upcoming releases.
+ * @returns {string} patientUuid
+ */
+export const getPatientUuidFromUrl = getPatientUuidFromUrlOrStore;

--- a/packages/esm-patient-common-lib/src/index.ts
+++ b/packages/esm-patient-common-lib/src/index.ts
@@ -20,3 +20,4 @@ export * from './types';
 export * from './useAllowedFileExtensions';
 export * from './useSystemVisitSetting';
 export * from './workspaces';
+export * from './store/patient-chart-store';

--- a/packages/esm-patient-common-lib/src/orders/postOrders.ts
+++ b/packages/esm-patient-common-lib/src/orders/postOrders.ts
@@ -1,5 +1,5 @@
 import { openmrsFetch, type OpenmrsResource, parseDate, restBaseUrl, type Visit } from '@openmrs/esm-framework';
-import { getPatientUuidFromUrl } from '../get-patient-uuid-from-url';
+import { getPatientUuidFromUrlOrStore } from '../store/patient-chart-store';
 import { type OrderBasketStore, orderBasketStore } from './store';
 import { type ExtractedOrderErrorObject, type OrderBasketItem, type OrderErrorObject, type OrderPost } from './types';
 
@@ -55,7 +55,7 @@ export async function postOrdersOnNewEncounter(
 }
 
 export async function postOrders(encounterUuid: string, abortController: AbortController) {
-  const patientUuid = getPatientUuidFromUrl();
+  const patientUuid = getPatientUuidFromUrlOrStore();
   const { items, postDataPrepFunctions }: OrderBasketStore = orderBasketStore.getState();
   const patientItems = items[patientUuid];
 

--- a/packages/esm-patient-common-lib/src/orders/postOrders.ts
+++ b/packages/esm-patient-common-lib/src/orders/postOrders.ts
@@ -1,5 +1,5 @@
 import { openmrsFetch, type OpenmrsResource, parseDate, restBaseUrl, type Visit } from '@openmrs/esm-framework';
-import { getPatientUuidFromUrlOrStore } from '../store/patient-chart-store';
+import { getPatientUuidFromStore } from '../store/patient-chart-store';
 import { type OrderBasketStore, orderBasketStore } from './store';
 import { type ExtractedOrderErrorObject, type OrderBasketItem, type OrderErrorObject, type OrderPost } from './types';
 
@@ -55,7 +55,7 @@ export async function postOrdersOnNewEncounter(
 }
 
 export async function postOrders(encounterUuid: string, abortController: AbortController) {
-  const patientUuid = getPatientUuidFromUrlOrStore();
+  const patientUuid = getPatientUuidFromStore();
   const { items, postDataPrepFunctions }: OrderBasketStore = orderBasketStore.getState();
   const patientItems = items[patientUuid];
 

--- a/packages/esm-patient-common-lib/src/orders/useOrderBasket.ts
+++ b/packages/esm-patient-common-lib/src/orders/useOrderBasket.ts
@@ -1,6 +1,6 @@
 import { useStoreWithActions } from '@openmrs/esm-framework';
 import type { OrderBasketItem, PostDataPrepFunction } from './types';
-import { getPatientUuidFromUrl } from '../get-patient-uuid-from-url';
+import { getPatientUuidFromUrlOrStore } from '../store/patient-chart-store';
 import { useEffect } from 'react';
 import { type OrderBasketStore, orderBasketStore } from './store';
 
@@ -10,7 +10,7 @@ const orderBasketStoreActions = {
     grouping: string,
     value: Array<OrderBasketItem> | (() => Array<OrderBasketItem>),
   ) {
-    const patientUuid = getPatientUuidFromUrl();
+    const patientUuid = getPatientUuidFromUrlOrStore();
     if (!Object.keys(state.postDataPrepFunctions).includes(grouping)) {
       console.warn(`Programming error: You must register a postDataPrepFunction for grouping ${grouping} `);
     }
@@ -35,7 +35,7 @@ const orderBasketStoreActions = {
 };
 
 function getOrderItems(items: OrderBasketStore['items'], grouping?: string | null): Array<OrderBasketItem> {
-  const patientUuid = getPatientUuidFromUrl();
+  const patientUuid = getPatientUuidFromUrlOrStore();
   const patientItems = items?.[patientUuid] ?? {};
   return grouping ? patientItems[grouping] ?? [] : Object.values(patientItems).flat();
 }
@@ -46,7 +46,7 @@ export interface ClearOrdersOptions {
 
 function clearOrders(options?: ClearOrdersOptions) {
   const exceptThoseMatchingFcn = options?.exceptThoseMatching ?? (() => false);
-  const patientUuid = getPatientUuidFromUrl();
+  const patientUuid = getPatientUuidFromUrlOrStore();
   const items = orderBasketStore.getState().items;
   const patientItems = items[patientUuid] ?? {};
   const newPatientItems = Object.fromEntries(

--- a/packages/esm-patient-common-lib/src/orders/useOrderBasket.ts
+++ b/packages/esm-patient-common-lib/src/orders/useOrderBasket.ts
@@ -1,6 +1,6 @@
 import { useStoreWithActions } from '@openmrs/esm-framework';
 import type { OrderBasketItem, PostDataPrepFunction } from './types';
-import { getPatientUuidFromUrlOrStore } from '../store/patient-chart-store';
+import { getPatientUuidFromStore } from '../store/patient-chart-store';
 import { useEffect } from 'react';
 import { type OrderBasketStore, orderBasketStore } from './store';
 
@@ -10,7 +10,7 @@ const orderBasketStoreActions = {
     grouping: string,
     value: Array<OrderBasketItem> | (() => Array<OrderBasketItem>),
   ) {
-    const patientUuid = getPatientUuidFromUrlOrStore();
+    const patientUuid = getPatientUuidFromStore();
     if (!Object.keys(state.postDataPrepFunctions).includes(grouping)) {
       console.warn(`Programming error: You must register a postDataPrepFunction for grouping ${grouping} `);
     }
@@ -35,7 +35,7 @@ const orderBasketStoreActions = {
 };
 
 function getOrderItems(items: OrderBasketStore['items'], grouping?: string | null): Array<OrderBasketItem> {
-  const patientUuid = getPatientUuidFromUrlOrStore();
+  const patientUuid = getPatientUuidFromStore();
   const patientItems = items?.[patientUuid] ?? {};
   return grouping ? patientItems[grouping] ?? [] : Object.values(patientItems).flat();
 }
@@ -46,7 +46,7 @@ export interface ClearOrdersOptions {
 
 function clearOrders(options?: ClearOrdersOptions) {
   const exceptThoseMatchingFcn = options?.exceptThoseMatching ?? (() => false);
-  const patientUuid = getPatientUuidFromUrlOrStore();
+  const patientUuid = getPatientUuidFromStore();
   const items = orderBasketStore.getState().items;
   const patientItems = items[patientUuid] ?? {};
   const newPatientItems = Object.fromEntries(

--- a/packages/esm-patient-common-lib/src/store/patient-chart-store.ts
+++ b/packages/esm-patient-common-lib/src/store/patient-chart-store.ts
@@ -1,0 +1,19 @@
+import { createGlobalStore, useStore } from '@openmrs/esm-framework';
+
+export interface PatientChartStore {
+  patientUuid: string;
+}
+
+const patientChartStoreName = 'patient-chart-global-store';
+
+const patientChartStore = createGlobalStore<PatientChartStore>(patientChartStoreName, {
+  patientUuid: '',
+});
+
+export function getPatientChartStore() {
+  return patientChartStore;
+}
+
+export function usePatientChartStore() {
+  return useStore(patientChartStore);
+}

--- a/packages/esm-patient-common-lib/src/store/patient-chart-store.ts
+++ b/packages/esm-patient-common-lib/src/store/patient-chart-store.ts
@@ -10,10 +10,26 @@ const patientChartStore = createGlobalStore<PatientChartStore>(patientChartStore
   patientUuid: '',
 });
 
+/**
+ * This function returns the patient chart store.
+ *
+ * The patient chart store is used to store all global variables used in the patient chart.
+ * In the recent requirements, patient chart is now not only bound with `/patient/{patientUuid}/` path.
+ */
 export function getPatientChartStore() {
   return patientChartStore;
 }
 
 export function usePatientChartStore() {
   return useStore(patientChartStore);
+}
+
+/**
+ * This function will get the patient UUID from either URL, or will look into the patient chart store.
+ * @returns {string} patientUuid
+ */
+export function getPatientUuidFromUrlOrStore() {
+  const match = /\/patient\/([a-zA-Z0-9\-]+)\/?/.exec(location.pathname);
+  const patientUuidFromUrl = match && match[1];
+  return patientUuidFromUrl || patientChartStore.getState().patientUuid;
 }

--- a/packages/esm-patient-common-lib/src/store/patient-chart-store.ts
+++ b/packages/esm-patient-common-lib/src/store/patient-chart-store.ts
@@ -28,8 +28,6 @@ export function usePatientChartStore() {
  * This function will get the patient UUID from either URL, or will look into the patient chart store.
  * @returns {string} patientUuid
  */
-export function getPatientUuidFromUrlOrStore() {
-  const match = /\/patient\/([a-zA-Z0-9\-]+)\/?/.exec(location.pathname);
-  const patientUuidFromUrl = match && match[1];
-  return patientUuidFromUrl || patientChartStore.getState().patientUuid;
+export function getPatientUuidFromStore(): string {
+  return patientChartStore.getState()?.patientUuid;
 }

--- a/packages/esm-patient-common-lib/src/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces.ts
@@ -9,6 +9,7 @@ import { useSystemVisitSetting } from './useSystemVisitSetting';
 import { useVisitOrOfflineVisit } from './offline/visit';
 import { useCallback } from 'react';
 import { launchStartVisitPrompt } from './launchStartVisitPrompt';
+import { usePatientChartStore } from './store/patient-chart-store';
 
 export interface DefaultPatientWorkspaceProps extends DefaultWorkspaceProps {
   patientUuid: string;
@@ -42,7 +43,7 @@ export function launchPatientChartWithWorkspaceOpen({
 }
 
 export function useLaunchWorkspaceRequiringVisit<T extends object>(workspaceName: string) {
-  const { patientUuid } = usePatient();
+  const { patientUuid } = usePatientChartStore();
   const { systemVisitEnabled } = useSystemVisitSetting();
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
 

--- a/packages/esm-patient-common-lib/src/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces.ts
@@ -4,7 +4,7 @@ import {
   navigateAndLaunchWorkspace,
   usePatient,
 } from '@openmrs/esm-framework';
-import { getPatientUuidFromUrl } from './get-patient-uuid-from-url';
+import { getPatientUuidFromUrlOrStore } from './store/patient-chart-store';
 import { useSystemVisitSetting } from './useSystemVisitSetting';
 import { useVisitOrOfflineVisit } from './offline/visit';
 import { useCallback } from 'react';
@@ -16,7 +16,7 @@ export interface DefaultPatientWorkspaceProps extends DefaultWorkspaceProps {
 }
 
 export function launchPatientWorkspace(workspaceName: string, additionalProps?: object) {
-  const patientUuid = getPatientUuidFromUrl();
+  const patientUuid = getPatientUuidFromUrlOrStore();
   launchWorkspace(workspaceName, {
     patientUuid: patientUuid,
     ...additionalProps,

--- a/packages/esm-patient-common-lib/src/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces.ts
@@ -4,7 +4,7 @@ import {
   navigateAndLaunchWorkspace,
   usePatient,
 } from '@openmrs/esm-framework';
-import { getPatientUuidFromUrlOrStore } from './store/patient-chart-store';
+import { getPatientUuidFromStore } from './store/patient-chart-store';
 import { useSystemVisitSetting } from './useSystemVisitSetting';
 import { useVisitOrOfflineVisit } from './offline/visit';
 import { useCallback } from 'react';
@@ -16,7 +16,7 @@ export interface DefaultPatientWorkspaceProps extends DefaultWorkspaceProps {
 }
 
 export function launchPatientWorkspace(workspaceName: string, additionalProps?: object) {
-  const patientUuid = getPatientUuidFromUrlOrStore();
+  const patientUuid = getPatientUuidFromStore();
   launchWorkspace(workspaceName, {
     patientUuid: patientUuid,
     ...additionalProps,

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -51,6 +51,7 @@ import type {
 } from '../types';
 import { useRequireOutpatientQuantity } from '../api';
 import styles from './drug-order-form.scss';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 
 export interface DrugOrderFormProps {
   initialOrderBasketItem: DrugOrderBasketItem;
@@ -354,7 +355,8 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
   }, []);
 
   const [showStickyMedicationHeader, setShowMedicationHeader] = useState(false);
-  const { patient, isLoading: isLoadingPatientDetails } = usePatient();
+  const { patientUuid } = usePatientChartStore();
+  const { patient, isLoading: isLoadingPatientDetails } = usePatient(patientUuid);
   const patientName = patient ? getPatientName(patient) : '';
   const { maxDispenseDurationInDays } = useConfig<ConfigObject>();
 

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
@@ -24,6 +24,7 @@ import {
 } from './drug-search.resource';
 import type { DrugOrderBasketItem } from '../../types';
 import styles from './order-basket-search-results.scss';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 
 export interface OrderBasketSearchResultsProps {
   searchTerm: string;
@@ -114,8 +115,8 @@ export default function OrderBasketSearchResults({
 const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({ drug, openOrderForm }) => {
   const isTablet = useLayoutType() === 'tablet';
   const { orders, setOrders } = useOrderBasket<DrugOrderBasketItem>('medications', prepMedicationOrderPostData);
-  const patient = usePatient();
-  const { data: activeOrders, isLoading: isLoadingActiveOrders } = usePatientOrders(patient.patientUuid);
+  const { patientUuid } = usePatientChartStore();
+  const { data: activeOrders, isLoading: isLoadingActiveOrders } = usePatientOrders(patientUuid);
   const drugAlreadyInBasket = useMemo(
     () => orders?.some((order) => ordersEqual(order, getTemplateOrderBasketItem(drug))),
     [orders, drug],

--- a/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.test.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.test.tsx
@@ -2,12 +2,7 @@ import React from 'react';
 import { screen, render, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ActionMenuButton, launchWorkspace, useLayoutType, usePatient, useWorkspaces } from '@openmrs/esm-framework';
-import {
-  getPatientUuidFromUrlOrStore,
-  type OrderBasketItem,
-  useOrderBasket,
-  usePatientChartStore,
-} from '@openmrs/esm-patient-common-lib';
+import { type OrderBasketItem, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { mockPatient } from 'tools';
 import { orderBasketStore } from '@openmrs/esm-patient-common-lib/src/orders/store';
 import OrderBasketActionButton from './order-basket-action-button.extension';
@@ -52,7 +47,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   return {
     ...originalModule,
     getPatientUuidFromUrl: () => mockGetPatientUuidFromUrl(),
-    getPatientUuidFromUrlOrStore: () => mockGetPatientUuidFromUrl(),
+    getPatientUuidFromStore: () => mockGetPatientUuidFromUrl(),
     launchPatientWorkspace: (arg) => mockLaunchPatientWorkspace(arg),
   };
 });
@@ -69,7 +64,7 @@ jest.mock('@openmrs/esm-patient-common-lib/src/launchStartVisitPrompt', () => {
 
 jest.mock('@openmrs/esm-patient-common-lib/src/store/patient-chart-store', () => {
   return {
-    getPatientUuidFromUrlOrStore: () => mockGetPatientUuidFromUrl(),
+    getPatientUuidFromStore: () => mockGetPatientUuidFromUrl(),
     usePatientChartStore: () => ({ patientUuid: mockPatient.id }),
   };
 });

--- a/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.test.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.test.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { screen, render, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ActionMenuButton, launchWorkspace, useLayoutType, usePatient, useWorkspaces } from '@openmrs/esm-framework';
-import { type OrderBasketItem, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import {
+  getPatientUuidFromUrlOrStore,
+  type OrderBasketItem,
+  useOrderBasket,
+  usePatientChartStore,
+} from '@openmrs/esm-patient-common-lib';
 import { mockPatient } from 'tools';
 import { orderBasketStore } from '@openmrs/esm-patient-common-lib/src/orders/store';
 import OrderBasketActionButton from './order-basket-action-button.extension';
@@ -47,6 +52,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   return {
     ...originalModule,
     getPatientUuidFromUrl: () => mockGetPatientUuidFromUrl(),
+    getPatientUuidFromUrlOrStore: () => mockGetPatientUuidFromUrl(),
     launchPatientWorkspace: (arg) => mockLaunchPatientWorkspace(arg),
   };
 });
@@ -61,8 +67,11 @@ jest.mock('@openmrs/esm-patient-common-lib/src/launchStartVisitPrompt', () => {
   return { launchStartVisitPrompt: () => mockLaunchStartVisitPrompt() };
 });
 
-jest.mock('@openmrs/esm-patient-common-lib/src/get-patient-uuid-from-url', () => {
-  return { getPatientUuidFromUrl: () => mockGetPatientUuidFromUrl() };
+jest.mock('@openmrs/esm-patient-common-lib/src/store/patient-chart-store', () => {
+  return {
+    getPatientUuidFromUrlOrStore: () => mockGetPatientUuidFromUrl(),
+    usePatientChartStore: () => ({ patientUuid: mockPatient.id }),
+  };
 });
 
 jest.mock('@openmrs/esm-patient-common-lib/src/offline/visit', () => {

--- a/packages/esm-patient-tests-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
+++ b/packages/esm-patient-tests-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
@@ -65,7 +65,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => ({
 }));
 
 jest.mock('@openmrs/esm-patient-common-lib/src/store/patient-chart-store', () => ({
-  getPatientUuidFromUrlOrStore: jest.fn(() => ptUuid),
+  getPatientUuidFromStore: jest.fn(() => ptUuid),
   usePatientChartStore: jest.fn(() => ({
     patientUuid: ptUuid,
   })),

--- a/packages/esm-patient-tests-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
+++ b/packages/esm-patient-tests-app/src/lab-orders/add-lab-order/add-lab-order.test.tsx
@@ -64,8 +64,11 @@ jest.mock('@openmrs/esm-patient-common-lib', () => ({
   launchPatientWorkspace: (...args) => mockLaunchPatientWorkspace(...args),
 }));
 
-jest.mock('@openmrs/esm-patient-common-lib/src/get-patient-uuid-from-url', () => ({
-  getPatientUuidFromUrl: jest.fn(() => ptUuid),
+jest.mock('@openmrs/esm-patient-common-lib/src/store/patient-chart-store', () => ({
+  getPatientUuidFromUrlOrStore: jest.fn(() => ptUuid),
+  usePatientChartStore: jest.fn(() => ({
+    patientUuid: ptUuid,
+  })),
 }));
 
 function renderAddLabOrderWorkspace() {

--- a/packages/esm-patient-tests-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
+++ b/packages/esm-patient-tests-app/src/lab-orders/add-lab-order/add-lab-order.workspace.tsx
@@ -17,6 +17,7 @@ import {
   type OrderBasketItem,
   type LabOrderBasketItem,
   launchPatientWorkspace,
+  usePatientChartStore,
 } from '@openmrs/esm-patient-common-lib';
 import { LabOrderForm } from './lab-order-form.component';
 import { TestTypeSearch } from './test-type-search.component';
@@ -37,7 +38,8 @@ export default function AddLabOrderWorkspace({
 }: AddLabOrderWorkspace) {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
-  const { patient, isLoading: isLoadingPatient, patientUuid } = usePatient();
+  const { patientUuid } = usePatientChartStore();
+  const { patient, isLoading: isLoadingPatient } = usePatient(patientUuid);
   const [currentLabOrder, setCurrentLabOrder] = useState(initialOrder as LabOrderBasketItem);
 
   const patientName = patient ? getPatientName(patient) : '';

--- a/packages/esm-patient-tests-app/src/test-results/grouped-timeline/useObstreeData.ts
+++ b/packages/esm-patient-tests-app/src/test-results/grouped-timeline/useObstreeData.ts
@@ -3,6 +3,7 @@ import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
 import { usePatient, openmrsFetch, restBaseUrl, type FetchResponse } from '@openmrs/esm-framework';
 import { assessValue, exist } from '../loadPatientTestData/helpers';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 
 export const getName = (prefix: string | undefined, name: string) => {
   return prefix ? `${prefix}-${name}` : name;
@@ -43,7 +44,7 @@ const augmentObstreeData = (node: ObsTreeNode, prefix: string | undefined) => {
 };
 
 const useGetObstreeData = (conceptUuid: string) => {
-  const { patientUuid } = usePatient();
+  const { patientUuid } = usePatientChartStore();
   const response = useSWR<FetchResponse<ObsTreeNode>, Error>(
     `${restBaseUrl}/obstree?patient=${patientUuid}&concept=${conceptUuid}`,
     openmrsFetch,
@@ -65,7 +66,7 @@ const useGetObstreeData = (conceptUuid: string) => {
 };
 
 const useGetManyObstreeData = (uuidArray: Array<string>) => {
-  const { patientUuid } = usePatient();
+  const { patientUuid } = usePatientChartStore();
   const getObstreeUrl = (index: number) => {
     if (index < uuidArray.length && patientUuid) {
       return `${restBaseUrl}/obstree?patient=${patientUuid}&concept=${uuidArray[index]}`;

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
@@ -14,7 +14,7 @@ import {
   TableRow,
 } from '@carbon/react';
 import { ArrowRightIcon, showModal, useLayoutType, isDesktop, formatDate } from '@openmrs/esm-framework';
-import { getPatientUuidFromUrlOrStore, type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
+import { getPatientUuidFromStore, type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import { type RowData } from '../filter/filter-types';
 import styles from './individual-results-table.scss';
 
@@ -56,7 +56,7 @@ const getClasses = (interpretation: OBSERVATION_INTERPRETATION) => {
 const IndividualResultsTable: React.FC<IndividualResultsTableProps> = ({ isLoading, parent, subRows, index }) => {
   const { t } = useTranslation();
   const layout = useLayoutType();
-  const patientUuid = getPatientUuidFromUrlOrStore();
+  const patientUuid = getPatientUuidFromStore();
 
   const headerTitle = t(parent.display);
 

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
@@ -14,7 +14,7 @@ import {
   TableRow,
 } from '@carbon/react';
 import { ArrowRightIcon, showModal, useLayoutType, isDesktop, formatDate } from '@openmrs/esm-framework';
-import { getPatientUuidFromUrl, type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
+import { getPatientUuidFromUrlOrStore, type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import { type RowData } from '../filter/filter-types';
 import styles from './individual-results-table.scss';
 
@@ -56,7 +56,7 @@ const getClasses = (interpretation: OBSERVATION_INTERPRETATION) => {
 const IndividualResultsTable: React.FC<IndividualResultsTableProps> = ({ isLoading, parent, subRows, index }) => {
   const { t } = useTranslation();
   const layout = useLayoutType();
-  const patientUuid = getPatientUuidFromUrl();
+  const patientUuid = getPatientUuidFromUrlOrStore();
 
   const headerTitle = t(parent.display);
 

--- a/packages/esm-patient-tests-app/src/test-results/panel-timeline/helpers.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/panel-timeline/helpers.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { formatDate, formatTime, parseDate, showModal } from '@openmrs/esm-framework';
-import { type OBSERVATION_INTERPRETATION, getPatientUuidFromUrlOrStore } from '@openmrs/esm-patient-common-lib';
+import { type OBSERVATION_INTERPRETATION, getPatientUuidFromStore } from '@openmrs/esm-patient-common-lib';
 import { type ParsedTimeType } from '../filter/filter-types';
 import type { ObsRecord } from '../../types';
 import styles from './timeline.scss';
@@ -121,7 +121,7 @@ export const TimelineCell: React.FC<{
 };
 
 export const RowStartCell = ({ title, range, units, shadow = false, testUuid, isString = false }) => {
-  const patientUuid = getPatientUuidFromUrlOrStore();
+  const patientUuid = getPatientUuidFromStore();
   const launchResultsDialog = (patientUuid: string, title: string, testUuid: string) => {
     const dispose = showModal('timeline-results-modal', {
       closeDeleteModal: () => dispose(),

--- a/packages/esm-patient-tests-app/src/test-results/panel-timeline/helpers.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/panel-timeline/helpers.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { formatDate, formatTime, parseDate, showModal } from '@openmrs/esm-framework';
-import { type OBSERVATION_INTERPRETATION, getPatientUuidFromUrl } from '@openmrs/esm-patient-common-lib';
+import { type OBSERVATION_INTERPRETATION, getPatientUuidFromUrlOrStore } from '@openmrs/esm-patient-common-lib';
 import { type ParsedTimeType } from '../filter/filter-types';
 import type { ObsRecord } from '../../types';
 import styles from './timeline.scss';
@@ -121,7 +121,7 @@ export const TimelineCell: React.FC<{
 };
 
 export const RowStartCell = ({ title, range, units, shadow = false, testUuid, isString = false }) => {
-  const patientUuid = getPatientUuidFromUrl();
+  const patientUuid = getPatientUuidFromUrlOrStore();
   const launchResultsDialog = (patientUuid: string, title: string, testUuid: string) => {
     const dispose = showModal('timeline-results-modal', {
       closeDeleteModal: () => dispose(),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR aims to refactor the code locations that retrieve the patient UUID from the URL of the patient chart. The primary motivation for this refactor is that the extensions, widgets, and workspaces utilized in the patient chart are no longer guaranteed to be present in the patient chart. For instance, the Patient chart summary workspaces in the IPD. To reuse these widgets/workspaces in the IPD’s patient summary workspace and potentially in other future locations, I have implemented a global Patient Chart Store, which must be accessible by all components in the patient chart. 

I also modified the `getPatientUuidFromUrl` function to get the patient UUID from the URL, but if not present it will look into the store.

I also removed the instances where `patientUuid` was being fetched from the `usePatient`, which should now be fetched from the `usePatientChartStore` hook. 


## Screenshots
None

## Related Issue
None

## Other
<!-- Anything not covered above -->
