### PR TITLE
(feat) O3-4166 - add option to hide links in vitals header

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
@@ -24,9 +24,14 @@ import styles from './vitals-header.scss';
 
 interface VitalsHeaderProps {
   patientUuid: string;
+
+  /**
+   * This is useful for extensions slots using the Vitals Header
+   */
+  hideLinks?: boolean;
 }
 
-const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid }) => {
+const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, hideLinks = false }) => {
   const { t } = useTranslation();
   const config = useConfig<ConfigObject>();
   const { data: conceptUnits, conceptMetadata } = useVitalsConceptMetadata();
@@ -102,30 +107,34 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid }) => {
                 <span className={styles.overdueIndicator}>{overdueVitalsTagContent}</span>
               </Tag>
             ) : null}
-            <ConfigurableLink
-              className={styles.link}
-              to={`\${openmrsSpaBase}/patient/${patientUuid}/chart/Vitals & Biometrics`}
-            >
-              {t('vitalsHistory', 'Vitals history')}
-            </ConfigurableLink>
+            {!hideLinks && (
+              <ConfigurableLink
+                className={styles.link}
+                to={`\${openmrsSpaBase}/patient/${patientUuid}/chart/Vitals & Biometrics`}
+              >
+                {t('vitalsHistory', 'Vitals history')}
+              </ConfigurableLink>
+            )}
           </div>
           {isValidating ? (
             <div className={styles.backgroundDataFetchingIndicator}>
               <span>{isValidating ? <InlineLoading /> : null}</span>
             </div>
           ) : null}
-          <div className={styles.buttonContainer}>
-            <Button
-              className={styles.recordVitalsButton}
-              data-openmrs-role="Record Vitals"
-              kind="ghost"
-              onClick={launchVitalsAndBiometricsForm}
-              size="sm"
-            >
-              {t('recordVitals', 'Record vitals')}
-              <ArrowRight size={16} className={styles.recordVitalsIconButton} />
-            </Button>
-          </div>
+          {!hideLinks && (
+            <div className={styles.buttonContainer}>
+              <Button
+                className={styles.recordVitalsButton}
+                data-openmrs-role="Record Vitals"
+                kind="ghost"
+                onClick={launchVitalsAndBiometricsForm}
+                size="sm"
+              >
+                {t('recordVitals', 'Record vitals')}
+                <ArrowRight size={16} className={styles.recordVitalsIconButton} />
+              </Button>
+            </div>
+          )}
         </div>
         <div
           className={classNames(styles.rowContainer, {
@@ -210,10 +219,12 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid }) => {
         <span className={styles.bodyText}>{t('noDataRecorded', 'No data has been recorded for this patient')}</span>
       </div>
 
-      <Button className={styles.recordVitalsButton} kind="ghost" onClick={launchVitalsAndBiometricsForm} size="sm">
-        {t('recordVitals', 'Record vitals')}
-        <ArrowRight size={16} className={styles.recordVitalsIconButton} />
-      </Button>
+      {!hideLinks && (
+        <Button className={styles.recordVitalsButton} kind="ghost" onClick={launchVitalsAndBiometricsForm} size="sm">
+          {t('recordVitals', 'Record vitals')}
+          <ArrowRight size={16} className={styles.recordVitalsIconButton} />
+        </Button>
+      )}
     </div>
   );
 };

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
@@ -190,4 +190,47 @@ describe('VitalsHeader', () => {
       workspaceTitle: 'Triage',
     });
   });
+
+  it('should show links in vitals header by default', async () => {
+    const fiveDaysAgo = dayjs().subtract(5, 'days').toISOString();
+    const vitalsData = [
+      {
+        ...formattedVitals[0],
+        date: fiveDaysAgo,
+      },
+    ];
+
+    mockUseVitalsAndBiometrics.mockReturnValue({
+      data: vitalsData,
+    } as ReturnType<typeof useVitalsAndBiometrics>);
+    renderWithSwr(<VitalsHeader {...testProps} />);
+
+    await waitForLoadingToFinish();
+
+    expect(screen.getByRole('link', { name: /vitals history/i })).toBeInTheDocument();
+
+    // TODO: I don't know why this doesn't work:
+    // screen.getByRole('button', {name: /record vitals/i})
+    expect(screen.getByText(/record vitals/i)).toBeInTheDocument();
+  });
+
+  it('should show not links in vitals header when hideLinks is true', async () => {
+    const fiveDaysAgo = dayjs().subtract(5, 'days').toISOString();
+    const vitalsData = [
+      {
+        ...formattedVitals[0],
+        date: fiveDaysAgo,
+      },
+    ];
+
+    mockUseVitalsAndBiometrics.mockReturnValue({
+      data: vitalsData,
+    } as ReturnType<typeof useVitalsAndBiometrics>);
+    renderWithSwr(<VitalsHeader {...{ ...testProps, hideLinks: true }} />);
+
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('link', { name: /vitals history/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /record vitals/i })).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
https://openmrs.atlassian.net/browse/O3-4166

We have a use case to include the vitals header in the ward app, and have it not display any links to the O3 patient chart or launch the record vitals workspace. 

I thought about adding a config option in the vitals app to configure custom links and use `<ConfigurableLink>`, but that doesn't let us represent `launchWorkspace` actions.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
