### PR TITLE
(fix) O3-4144 Use allowedFileExtension Hook rather than allowedExtensions from Context type.

### DIFF
--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { Button, Form, ModalBody, ModalFooter, ModalHeader, Stack, TextArea, TextInput } from '@carbon/react';
 import { DocumentPdf, DocumentUnknown } from '@carbon/react/icons';
+import { useAllowedFileExtensions } from '@openmrs/esm-patient-common-lib';
 import { type UploadedFile, UserHasAccess } from '@openmrs/esm-framework';
 import CameraMediaUploaderContext from './camera-media-uploader-context.resources';
 import styles from './file-review.scss';
@@ -74,7 +75,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({
   clearData,
 }) => {
   const { t } = useTranslation();
-  const { allowedExtensions } = useContext(CameraMediaUploaderContext);
+  const { allowedFileExtensions } = useAllowedFileExtensions();
   const fileNameWithoutExtension = uploadedFile.fileName.trim().replace(/\.[^\\/.]+$/, '');
 
   const schema = z.object({
@@ -99,7 +100,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({
     const { fileName, fileDescription } = data;
 
     const sanitizedFileName =
-      allowedExtensions?.reduce((name, extension) => {
+      allowedFileExtensions?.reduce((name, extension) => {
         const regex = new RegExp(`\\.(${extension})+$`, 'i');
         return name.replace(regex, '');
       }, fileName) || fileName;

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/media-uploader.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/media-uploader.component.tsx
@@ -3,6 +3,7 @@ import { FileUploaderDropContainer, InlineNotification } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import { useConfig } from '@openmrs/esm-framework';
 import { readFileAsString } from '../utils';
+import { useAllowedFileExtensions } from '@openmrs/esm-patient-common-lib';
 import CameraMediaUploaderContext from './camera-media-uploader-context.resources';
 import styles from './media-uploader.scss';
 
@@ -14,7 +15,8 @@ interface ErrorNotification {
 const MediaUploaderComponent = () => {
   const { t } = useTranslation();
   const { maxFileSize } = useConfig();
-  const { setFilesToUpload, allowedExtensions, multipleFiles } = useContext(CameraMediaUploaderContext);
+  const { setFilesToUpload, multipleFiles } = useContext(CameraMediaUploaderContext);
+  const { allowedFileExtensions } = useAllowedFileExtensions();
   const [errorNotification, setErrorNotification] = useState<ErrorNotification>(null);
 
   const upload = useCallback(
@@ -28,8 +30,8 @@ const MediaUploaderComponent = () => {
               'exceeds the size limit of',
             )} ${maxFileSize} MB.`,
           });
-        } else if (!isFileExtensionAllowed(file.name, allowedExtensions)) {
-          const lastExtension = allowedExtensions.pop();
+        } else if (!isFileExtensionAllowed(file.name, allowedFileExtensions)) {
+          const lastExtension = allowedFileExtensions.pop();
 
           setErrorNotification({
             title: t('unsupportedFileType', 'Unsupported file type'),
@@ -39,7 +41,7 @@ const MediaUploaderComponent = () => {
               {
                 fileName: file.name,
                 lastExtension: lastExtension,
-                supportedExtensions: allowedExtensions.join(', '),
+                supportedExtensions: allowedFileExtensions.join(', '),
               },
             ),
           });
@@ -62,16 +64,16 @@ const MediaUploaderComponent = () => {
         }
       });
     },
-    [setFilesToUpload, maxFileSize, t, allowedExtensions],
+    [setFilesToUpload, maxFileSize, t, allowedFileExtensions],
   );
 
-  const isFileExtensionAllowed = (fileName: string, allowedExtensions: string[]): boolean => {
-    if (!allowedExtensions) {
+  const isFileExtensionAllowed = (fileName: string, allowedFileExtensions: string[]): boolean => {
+    if (!allowedFileExtensions) {
       return true;
     }
 
     const fileExtension = fileName.split('.').pop();
-    return allowedExtensions?.includes(fileExtension.toLowerCase());
+    return allowedFileExtensions?.includes(fileExtension.toLowerCase());
   };
 
   return (
@@ -93,13 +95,13 @@ const MediaUploaderComponent = () => {
         })}
         .{' '}
         {t('supportedFiletypes', 'Supported files are {{supportedFiles}}', {
-          supportedFiles: allowedExtensions?.join(', '),
+          supportedFiles: allowedFileExtensions?.join(', '),
         })}
         .
       </p>
       <div className={styles.uploadFile}>
         <FileUploaderDropContainer
-          accept={allowedExtensions?.map((ext) => '.' + ext) || ['*']}
+          accept={allowedFileExtensions?.map((ext) => '.' + ext) || ['*']}
           labelText={t('fileSizeInstructions', 'Drag and drop files here or click to upload')}
           tabIndex={0}
           multiple={multipleFiles}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Previously the `allowedFileExtensions`which utilizes the global property,  has not been used in `media-uploader-component` but rather was using the `allowedExtensions` from the `CameraMediaUploaderContextType` . Which I think was creating the issue of the file extensions not showing. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-4144

## Other
<!-- Anything not covered above -->
