### PR TITLE
(fix) O3-2846: Adding Medications from Past Medications Section Places Them in Active Medications List

### DIFF
--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -45,7 +45,7 @@ import { type ConfigObject } from '../config-schema';
 import PrintComponent from '../print/print.component';
 import styles from './medications-details-table.scss';
 
-export interface ActiveMedicationsProps {
+export interface MedicationsDetailsTableProps {
   isValidating?: boolean;
   title?: string;
   medications?: Array<Order> | null;
@@ -56,7 +56,7 @@ export interface ActiveMedicationsProps {
   patient: fhir.Patient;
 }
 
-const MedicationsDetailsTable: React.FC<ActiveMedicationsProps> = ({
+const MedicationsDetailsTable: React.FC<MedicationsDetailsTableProps> = ({
   isValidating,
   title,
   medications,

--- a/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
+++ b/packages/esm-patient-medications-app/src/medications-summary/medications-summary.component.tsx
@@ -62,7 +62,7 @@ export default function MedicationsSummary({ patient }: MedicationsSummaryProps)
           const displayText = t('pastMedicationsDisplayText', 'Past medications');
           const headerTitle = t('pastMedicationsHeaderTitle', 'past medications');
 
-          if (isValidatingPastOrders) return <DataTableSkeleton role="progressbar" />;
+          if (isLoadingPastOrders) return <DataTableSkeleton role="progressbar" />;
 
           if (pastOrdersError) return <ErrorState error={pastOrdersError} headerTitle={headerTitle} />;
 
@@ -72,6 +72,7 @@ export default function MedicationsSummary({ patient }: MedicationsSummaryProps)
                 isValidating={isValidatingPastOrders}
                 title={t('pastMedicationsTableTitle', 'Past Medications')}
                 medications={pastOrders}
+                showAddButton={false}
                 showDiscontinueButton={false}
                 showModifyButton={false}
                 showReorderButton={true}


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I added the `showAddButton={false}` to the Past Medications Table to ensure the "Add" button is not shown, aligning with the context of managing past (discontinued) medications. This prevents users from attempting actions that don’t apply to historical data.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/05312265-6964-42ca-b9a8-360d44c609d4



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-2846

## Other
<!-- Anything not covered above -->
