### PR TITLE
(feat) O3-4238: Mutate the vitals and biometrics data when vitals O3 form is submitted

### DIFF
--- a/packages/esm-patient-vitals-app/src/utils.ts
+++ b/packages/esm-patient-vitals-app/src/utils.ts
@@ -2,6 +2,7 @@ import { type Visit } from '@openmrs/esm-framework';
 import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
 import { type ConfigObject } from './config-schema';
 import { patientVitalsBiometricsFormWorkspace } from './constants';
+import { invalidateCachedVitalsAndBiometrics } from './common';
 
 /**
  * Launches the for entry workspace with the custom form
@@ -14,6 +15,7 @@ export function launchFormEntry(formUuid: string, encounterUuid?: string, formNa
   launchPatientWorkspace('patient-form-entry-workspace', {
     workspaceTitle: formName,
     formInfo: { formUuid, encounterUuid },
+    mutateForm: invalidateCachedVitalsAndBiometrics,
   });
 }
 

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
@@ -8,7 +8,7 @@ import { mockPatient, getByTextWithMarkup, renderWithSwr, waitForLoadingToFinish
 import { mockVitalsConfig, mockCurrentVisit, mockConceptUnits, mockConceptMetadata, formattedVitals } from '__mocks__';
 import { configSchema, type ConfigObject } from '../config-schema';
 import { patientVitalsBiometricsFormWorkspace } from '../constants';
-import { useVitalsAndBiometrics } from '../common';
+import { invalidateCachedVitalsAndBiometrics, useVitalsAndBiometrics } from '../common';
 import VitalsHeader from './vitals-header.component';
 
 const testProps = {
@@ -188,6 +188,7 @@ describe('VitalsHeader', () => {
         formUuid: '9f26aad4-244a-46ca-be49-1196df1a8c9a',
       },
       workspaceTitle: 'Triage',
+      mutateForm: invalidateCachedVitalsAndBiometrics,
     });
   });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
The vitals and biometrics data should be refetched/ mutated, when the Vitals and Biometrics form is submitted.

## Screenshots

https://github.com/user-attachments/assets/f90ffa8d-9928-40c9-8095-89193f570132


## Related Issue
https://issues.openmrs.org/browse/O3-4238

## Other
<!-- Anything not covered above -->
