### PR TITLE
(fix) O3-4009: Display stock information only when available

### DIFF
--- a/packages/esm-patient-orders-app/src/components/order-stock-details.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-stock-details.component.tsx
@@ -27,7 +27,7 @@ const OrderStockDetailsComponent: React.FC<OrderStockDetailsComponentProps> = ({
     return <SkeletonText width="100px" role="progressbar" />;
   }
 
-  if (!stockData || error) {
+  if (!stockData?.entry || error) {
     return null;
   }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This is a follow up PR to [PR-2028](https://github.com/openmrs/openmrs-esm-patient-chart/pull/2028), that service orders display no stock info.

>the stock information should not show for services (since, those are not stockable products).

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/user-attachments/assets/0c86af66-7e59-49d9-91c1-32decd4f1857)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4009

## Other
<!-- Anything not covered above -->
