### PR TITLE
(feat): Config to scale the patient identifier sticker content

### DIFF
--- a/packages/esm-patient-banner-app/src/config-schema.ts
+++ b/packages/esm-patient-banner-app/src/config-schema.ts
@@ -45,6 +45,11 @@ export const configSchema = {
         'Specifies the paper size for printing the sticker. You can define the size using units (e.g., mm, in) or named sizes (e.g., "148mm 210mm", "A1", "A2", "A4", "A5").',
       _default: 'A4',
     },
+    printScale: {
+      _type: Type.String,
+      _description: 'Specifies the scale of the printout. The default value is 1.0.',
+      _default: '1',
+    },
     identifiersToDisplay: {
       _type: Type.Array,
       _description:
@@ -74,6 +79,7 @@ export interface ConfigObject {
     };
     fields: Array<AllowedPatientFields>;
     pageSize: string;
+    printScale: string;
     identifiersToDisplay: Array<string>;
   };
   useRelationshipNameLink: boolean;

--- a/packages/esm-patient-banner-app/src/print-identifier-sticker/print-identifier-sticker.modal.tsx
+++ b/packages/esm-patient-banner-app/src/print-identifier-sticker/print-identifier-sticker.modal.tsx
@@ -20,7 +20,7 @@ interface PrintComponentProps extends Partial<ConfigObject> {
 const PrintIdentifierSticker: React.FC<PrintIdentifierStickerProps> = ({ closeModal, patient }) => {
   const { t } = useTranslation();
   const { printPatientSticker } = useConfig<ConfigObject>();
-  const { pageSize } = printPatientSticker ?? {};
+  const { pageSize, printScale = '1' } = printPatientSticker ?? {};
   const contentToPrintRef = useRef(null);
   const onBeforeGetContentResolve = useRef<() => void | null>(null);
   const [isPrinting, setIsPrinting] = useState(false);
@@ -46,8 +46,8 @@ const PrintIdentifierSticker: React.FC<PrintIdentifierStickerProps> = ({ closeMo
   const handleAfterPrint = useCallback(() => {
     onBeforeGetContentResolve.current = null;
     setIsPrinting(false);
-    closeModal();
-  }, [closeModal]);
+    // closeModal();
+  }, []);
 
   const handlePrintError = useCallback((errorLocation, error) => {
     onBeforeGetContentResolve.current = null;
@@ -64,12 +64,29 @@ const PrintIdentifierSticker: React.FC<PrintIdentifierStickerProps> = ({ closeMo
     setIsPrinting(false);
   }, []);
 
+  const handleInitiatePrint = useCallback(
+    (printWindow: HTMLIFrameElement | null): Promise<void> => {
+      return new Promise<void>((resolve) => {
+        if (printWindow) {
+          const printContent = printWindow.contentDocument || printWindow.contentWindow?.document;
+          if (printContent) {
+            printContent.documentElement.style.setProperty('--print-scale', printScale);
+            printWindow.contentWindow?.print();
+            resolve();
+          }
+        }
+      });
+    },
+    [printScale],
+  );
+
   const handlePrint = useReactToPrint({
     content: () => contentToPrintRef.current,
     documentTitle: `${getPatientName(patient)} - ${headerTitle}`,
     onAfterPrint: handleAfterPrint,
     onBeforeGetContent: handleBeforeGetContent,
     onPrintError: handlePrintError,
+    print: handleInitiatePrint,
     copyStyles: true,
   });
 

--- a/packages/esm-patient-banner-app/src/print-identifier-sticker/print-identifier-sticker.modal.tsx
+++ b/packages/esm-patient-banner-app/src/print-identifier-sticker/print-identifier-sticker.modal.tsx
@@ -46,8 +46,8 @@ const PrintIdentifierSticker: React.FC<PrintIdentifierStickerProps> = ({ closeMo
   const handleAfterPrint = useCallback(() => {
     onBeforeGetContentResolve.current = null;
     setIsPrinting(false);
-    // closeModal();
-  }, []);
+    closeModal();
+  }, [closeModal]);
 
   const handlePrintError = useCallback((errorLocation, error) => {
     onBeforeGetContentResolve.current = null;

--- a/packages/esm-patient-banner-app/src/print-identifier-sticker/print-identifier-sticker.scss
+++ b/packages/esm-patient-banner-app/src/print-identifier-sticker/print-identifier-sticker.scss
@@ -80,4 +80,9 @@
     padding: 0 !important;
     overflow: hidden;
   }
+
+  .stickerContainer {
+    transform: scale(var(--print-scale));
+    transform-origin: left top;
+  }
 }

--- a/packages/esm-patient-orders-app/src/routes.json
+++ b/packages/esm-patient-orders-app/src/routes.json
@@ -4,15 +4,9 @@
     "webservices.rest": "^2.2.0"
   },
   "optionalBackendDependencies": {
-    "fhirproxy": {
-      "version": "1.0.0-SNAPSHOT"
-    },
-    "stockmanagement": {
-      "version": "2.0.2-SNAPSHOT"
-    },
-    "billing": {
-      "version": "1.2.0-SNAPSHOT"
-    }
+    "fhirproxy": "^1.0.0-SNAPSHOT",
+    "stockmanagement": "^2.0.2-SNAPSHOT"
+    "billing": "^1.2.0-SNAPSHOT"
   },
   "extensions": [
     {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds a new config point to scale the patient identifier sticker content to fit into the small page sizes.

## Screenshots

https://github.com/user-attachments/assets/a113369b-7fe9-4186-bda2-bd10a7f04487



## Related Issue
None

## Other
<!-- Anything not covered above -->
