### PR TITLE
(fix) Add keys to visit attribute tags

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-banner-tags/visit-attribute-tags.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Tag } from '@carbon/react';
 import { formatDate, useConfig } from '@openmrs/esm-framework';
-import { type ChartConfig } from '../config-schema';
 import { useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
+import { type ChartConfig } from '../config-schema';
 
 interface VisitAttributeTagsProps {
   patientUuid: string;
@@ -28,7 +28,7 @@ const getAttributeValue = (attributeType, value) => {
 
 const VisitAttributeTags: React.FC<VisitAttributeTagsProps> = ({ patientUuid }) => {
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
-  const { visitAttributeTypes } = useConfig() as ChartConfig;
+  const { visitAttributeTypes } = useConfig<ChartConfig>();
 
   return (
     <>
@@ -37,7 +37,11 @@ const VisitAttributeTags: React.FC<VisitAttributeTagsProps> = ({ patientUuid }) 
           (attribute) =>
             visitAttributeTypes.find(({ uuid }) => attribute?.attributeType?.uuid === uuid)?.displayInThePatientBanner,
         )
-        .map((attribute) => <Tag type="gray">{getAttributeValue(attribute?.attributeType, attribute?.value)}</Tag>)}
+        .map((attribute) => (
+          <Tag key={attribute?.attributeType?.uuid} type="gray">
+            {getAttributeValue(attribute?.attributeType, attribute?.value)}
+          </Tag>
+        ))}
     </>
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes a React keys warning for visit attribute tags in the Patient header.

## Screenshots

![CleanShot 2024-12-06 at 3  37 19@2x](https://github.com/user-attachments/assets/f2521af9-92ef-4cbe-98ba-afccb64d44e4)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
