### PR TITLE
(fix) Conditions list not updating after deleting a condition

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
@@ -204,7 +204,7 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patientUuid }) 
                           <TableCell key={cell.id}>{cell.value?.content ?? cell.value}</TableCell>
                         ))}
                         <TableCell className="cds--table-column-menu">
-                          <ConditionsActionMenu condition={row} />
+                          <ConditionsActionMenu condition={row} patientUuid={patientUuid} />
                         </TableCell>
                       </TableRow>
                     ))}

--- a/packages/esm-patient-conditions-app/src/conditions/delete-condition.modal.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/delete-condition.modal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, InlineLoading, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import { showSnackbar } from '@openmrs/esm-framework';
 import { deleteCondition, useConditions } from './conditions.resource';
+import styles from './delete-condition.scss';
 
 interface DeleteConditionModalProps {
   closeDeleteModal: () => void;
@@ -19,17 +20,15 @@ const DeleteConditionModal: React.FC<DeleteConditionModalProps> = ({ closeDelete
     setIsDeleting(true);
 
     try {
-      const res = await deleteCondition(conditionId);
+      await deleteCondition(conditionId);
+      await mutate();
 
-      if (res.status === 200) {
-        mutate();
-        closeDeleteModal();
-        showSnackbar({
-          isLowContrast: true,
-          kind: 'success',
-          title: t('conditionDeleted', 'Condition deleted'),
-        });
-      }
+      closeDeleteModal();
+      showSnackbar({
+        isLowContrast: true,
+        kind: 'success',
+        title: t('conditionDeleted', 'Condition deleted'),
+      });
     } catch (error) {
       console.error('Error deleting condition: ', error);
 
@@ -52,7 +51,7 @@ const DeleteConditionModal: React.FC<DeleteConditionModalProps> = ({ closeDelete
         <Button kind="secondary" onClick={closeDeleteModal}>
           {t('cancel', 'Cancel')}
         </Button>
-        <Button kind="danger" onClick={handleDelete} disabled={isDeleting}>
+        <Button className={styles.deleteButton} kind="danger" onClick={handleDelete} disabled={isDeleting}>
           {isDeleting ? (
             <InlineLoading description={t('deleting', 'Deleting') + '...'} />
           ) : (

--- a/packages/esm-patient-conditions-app/src/conditions/delete-condition.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/delete-condition.scss
@@ -1,0 +1,7 @@
+@use '@carbon/layout';
+
+.deleteButton {
+  :global(.cds--inline-loading) {
+    min-height: layout.$spacing-05;
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Presently, deleting a condition from the conditions overview tile in the Patient Summary page does not update the conditions list. Whilst the mutate function is getting called, the actual revalidation request is not being made. Because the `useConditions` hook takes in a `patientUuid` parameter, SWR uses that to invalidate the cache. The underlying issue here is that the `ConditionsActionMenu` component invoked in the `ConditionsOverview` component does not pass in the `patientUuid` parameter. This PR fixes that and gets the conditions list to update after deleting a condition.

## Screenshots

https://github.com/user-attachments/assets/c3716a8a-e79e-4123-966a-10b649ccf603

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
