### PR TITLE
(fix) Restore generic patient widget

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/index.ts
+++ b/packages/esm-generic-patient-widgets-app/src/index.ts
@@ -1,4 +1,4 @@
-import { defineExtensionConfigSchema, getSyncLifecycle } from '@openmrs/esm-framework';
+import { defineConfigSchema, getSyncLifecycle } from '@openmrs/esm-framework';
 import { configSchema } from './config-schema';
 import obsSwitchableComponent from './obs-switchable/obs-switchable.component';
 
@@ -14,5 +14,5 @@ const options = {
 export const switchableObs = getSyncLifecycle(obsSwitchableComponent, options);
 
 export function startupApp() {
-  defineExtensionConfigSchema(moduleName, configSchema);
+  defineConfigSchema(moduleName, configSchema);
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

This fixes the generic-patient-widgets app. The functionality was broken in openmrs/openmrs-esm-core#898, which was solving an issue related to configurations being provided before their schema was loaded. Inadvertently, this _requires_ apps to call `defineConfigSchema()`is they use configuration anywhere. 

The generic-patient-widgets-app was using `defineExtensionConfigSchema()`, and using this call wrongly (since it passed the module name instead of the extension name). The goal of this function is to allow individual extensions to have config schemas separate from those that are in the app they define, not to provide the configuration schema for the module.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
