### PR TITLE
(refactor) Use react hook form's isSubmitting state

### DIFF
--- a/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
@@ -32,7 +32,6 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const memoizedPatientUuid = useMemo(() => ({ patientUuid }), [patientUuid]);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const { causesOfDeath, isLoading: isLoadingCausesOfDeath } = useCausesOfDeath();
   const { freeTextFieldConceptUuid } = useConfig<ChartConfig>();
@@ -74,7 +73,7 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
 
   const {
     control,
-    formState: { errors },
+    formState: { errors, isSubmitting },
     handleSubmit,
     watch,
   } = useForm<MarkPatientDeceasedFormSchema>({
@@ -91,7 +90,6 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
 
   const onSubmit: SubmitHandler<MarkPatientDeceasedFormSchema> = useCallback(
     (data) => {
-      setIsSubmitting(true);
       const { causeOfDeath, deathDate, nonCodedCauseOfDeath } = data;
 
       markPatientDeceased(deathDate, patientUuid, causeOfDeath, nonCodedCauseOfDeath)
@@ -106,9 +104,6 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
             subtitle: error?.message,
             title: t('errorMarkingPatientDeceased', 'Error marking patient deceased'),
           });
-        })
-        .finally(() => {
-          setIsSubmitting(false);
         });
     },
     [closeWorkspace, patientUuid, t],

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -53,8 +53,7 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
   promptBeforeClosing,
 }) => {
   const { t } = useTranslation();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const { immunizationsConfig } = useConfig() as ConfigObject;
+  const { immunizationsConfig } = useConfig<ConfigObject>();
   const currentUser = useSession();
   const { currentVisit } = useVisit(patientUuid);
   const isTablet = useLayoutType() === 'tablet';
@@ -103,7 +102,7 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
     control,
     handleSubmit,
     reset,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, isSubmitting },
     watch,
   } = formProps;
 
@@ -140,7 +139,6 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
 
   const onSubmit = useCallback(
     (data: ImmunizationFormInputData) => {
-      setIsSubmitting(true);
       const {
         vaccineUuid,
         vaccinationDate,
@@ -188,7 +186,6 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
         abortController,
       ).then(
         () => {
-          setIsSubmitting(false);
           closeWorkspaceWithSavedChanges();
           mutate();
           showSnackbar({
@@ -198,7 +195,6 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
           });
         },
         (err) => {
-          setIsSubmitting(false);
           showSnackbar({
             title: t('errorSaving', 'Error saving vaccination'),
             kind: 'error',

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
@@ -112,7 +112,6 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
   const memoizedState = useMemo(() => ({ patientUuid }), [patientUuid]);
   const { clinicianEncounterRole, encounterNoteTextConceptUuid, encounterTypeUuid, formConceptUuid } =
     config.visitNoteConfig;
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoadingPrimaryDiagnoses, setIsLoadingPrimaryDiagnoses] = useState(false);
   const [isLoadingSecondaryDiagnoses, setIsLoadingSecondaryDiagnoses] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
@@ -149,7 +148,14 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
     [visitNoteFormSchema, selectedPrimaryDiagnoses, t],
   );
 
-  const { control, handleSubmit, watch, setValue, formState, clearErrors } = useForm<VisitNotesFormData>({
+  const {
+    clearErrors,
+    control,
+    formState: { errors, isDirty, isSubmitting },
+    handleSubmit,
+    setValue,
+    watch,
+  } = useForm<VisitNotesFormData>({
     mode: 'onSubmit',
     resolver: customResolver,
     defaultValues: {
@@ -157,8 +163,6 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
       noteDate: new Date(),
     },
   });
-
-  const { isDirty } = formState;
 
   useEffect(() => {
     promptBeforeClosing(() => isDirty);
@@ -317,10 +321,8 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
   const onSubmit = useCallback(
     (data: VisitNotesFormData) => {
       const { noteDate, clinicalNote, images } = data;
-      setIsSubmitting(true);
 
       if (!selectedPrimaryDiagnoses.length) {
-        setIsSubmitting(false);
         return;
       }
 
@@ -413,9 +415,6 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
             isLowContrast: false,
             subtitle: err?.message,
           });
-        })
-        .finally(() => {
-          setIsSubmitting(false);
         });
     },
     [
@@ -524,7 +523,7 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
                 labelText={t('enterPrimaryDiagnoses', 'Enter Primary diagnoses')}
                 placeholder={t('primaryDiagnosisInputPlaceholder', 'Choose a primary diagnosis')}
                 handleSearch={handleSearch}
-                error={formState?.errors?.primaryDiagnosisSearch}
+                error={errors?.primaryDiagnosisSearch}
                 setIsSearching={setIsSearching}
               />
               {error ? (

--- a/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
@@ -33,7 +33,6 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
 }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [showErrorNotification, setShowErrorNotification] = useState(false);
   const { mutate } = usePatientOrders(patientUuid);
 
@@ -57,7 +56,7 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
   const {
     control,
     handleSubmit,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, isSubmitting },
   } = useForm<CancelOrderFormData>({
     mode: 'all',
     resolver: zodResolver(cancelOrderSchema),
@@ -77,7 +76,6 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
     (data: CancelOrderFormData) => {
       const formData = data;
       setShowErrorNotification(false);
-      setIsSubmitting(true);
 
       const payload = {
         fulfillerStatus: 'DECLINED',
@@ -86,7 +84,6 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
 
       cancelOrder(order, payload).then(
         (res) => {
-          setIsSubmitting(false);
           closeWorkspace();
           mutate();
 
@@ -99,7 +96,6 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
           });
         },
         (err) => {
-          setIsSubmitting(false);
           showSnackbar({
             isLowContrast: true,
             title: t('errorCancellingOrder', 'Error cancelling order'),

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
@@ -88,7 +88,6 @@ const VitalsAndBiometricsForm: React.FC<DefaultPatientWorkspaceProps> = ({
   const { currentVisit } = useVisit(patientUuid);
   const { data: conceptUnits, conceptMetadata, conceptRanges, isLoading } = useVitalsConceptMetadata();
   const [hasInvalidVitals, setHasInvalidVitals] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [muacColorCode, setMuacColorCode] = useState('');
   const [showErrorNotification, setShowErrorNotification] = useState(false);
   const [showErrorMessage, setShowErrorMessage] = useState(false);
@@ -98,7 +97,7 @@ const VitalsAndBiometricsForm: React.FC<DefaultPatientWorkspaceProps> = ({
     handleSubmit,
     watch,
     setValue,
-    formState: { isDirty },
+    formState: { isDirty, isSubmitting },
   } = useForm<VitalsBiometricsFormData>({
     mode: 'all',
     resolver: zodResolver(VitalsAndBiometricFormSchema),
@@ -181,7 +180,6 @@ const VitalsAndBiometricsForm: React.FC<DefaultPatientWorkspaceProps> = ({
         .every(([key, value]) => isValueWithinReferenceRange(conceptMetadata, config.concepts[`${key}Uuid`], value));
 
       if (allFieldsAreValid) {
-        setIsSubmitting(true);
         setShowErrorMessage(false);
         const abortController = new AbortController();
 
@@ -209,8 +207,7 @@ const VitalsAndBiometricsForm: React.FC<DefaultPatientWorkspaceProps> = ({
               });
             }
           })
-          .catch((err) => {
-            setIsSubmitting(false);
+          .catch(() => {
             createErrorHandler();
             showSnackbar({
               title: t('vitalsAndBiometricsSaveError', 'Error saving vitals and biometrics'),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Refactors submit state management logic in several forms to use react hook form's `isSubmitting` state. React hook form's [formState](https://react-hook-form.com/docs/useform/formstate#formState.isSubmitting) API provides a built-in `isSubmitting` state that can be used to manage the submit state of a form. This is a more reliable and easier to manage approach than using a custom state variable.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
