### PR TITLE
(refactor) Use concept resource for conditions search

### DIFF
--- a/__mocks__/conditions.mock.ts
+++ b/__mocks__/conditions.mock.ts
@@ -337,13 +337,6 @@ export const mockFhirConditionsResponse = {
 export const searchedCondition = [
   {
     display: 'Headache',
-    concept: {
-      uuid: '139084AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-      display: 'Headache',
-    },
-    conceptName: {
-      uuid: '38867BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
-      display: 'Headache',
-    },
+    uuid: '139084AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   },
 ];

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -110,8 +110,8 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
 
     const payload: FormFields = {
       clinicalStatus: getValues('clinicalStatus'),
-      conceptId: selectedCondition?.concept?.uuid,
-      display: selectedCondition?.concept?.display,
+      conceptId: selectedCondition?.uuid,
+      display: selectedCondition?.display,
       abatementDateTime: getValues('abatementDateTime') ? dayjs(getValues('abatementDateTime')).format() : null,
       onsetDateTime: getValues('onsetDateTime') ? dayjs(getValues('onsetDateTime')).format() : null,
       patientId: patientUuid,
@@ -196,7 +196,9 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
     searchInputRef?.current?.focus();
   };
 
-  const handleSearchTermChange = (event: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(event.target.value);
+  const handleSearchTermChange = (searchTerm: string) => {
+    setSearchTerm(searchTerm);
+  };
 
   useEffect(() => {
     if (errors?.conditionName) {
@@ -233,9 +235,10 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
                       disabled={isEditing}
                       id="conditionsSearch"
                       labelText={t('enterCondition', 'Enter condition')}
-                      onChange={(e) => {
-                        onChange(e);
-                        handleSearchTermChange(e);
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        onChange(value);
+                        handleSearchTermChange(value);
                       }}
                       onClear={() => {
                         setSearchTerm('');
@@ -376,7 +379,7 @@ function SearchResults({
         {searchResults?.map((searchResult) => (
           <li
             className={styles.condition}
-            key={searchResult?.concept?.uuid}
+            key={searchResult?.uuid}
             onClick={() => onConditionChange(searchResult)}
             role="menuitem"
           >

--- a/packages/esm-patient-conditions-app/src/conditions/conditions.resource.ts
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions.resource.ts
@@ -25,15 +25,8 @@ export interface ConditionDataTableRow {
 }
 
 export type CodedCondition = {
-  concept: {
-    uuid: string;
-    display: string;
-  };
-  conceptName: {
-    uuid: string;
-    display: string;
-  };
   display: string;
+  uuid: string;
 };
 
 type CreatePayload = {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions.resource.ts
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions.resource.ts
@@ -106,7 +106,8 @@ export function useConditions(patientUuid: string) {
 export function useConditionsSearch(conditionToLookup: string) {
   const config = useConfig();
   const conditionConceptClassUuid = config?.conditionConceptClassUuid;
-  const conditionsSearchUrl = `${restBaseUrl}/conceptsearch?conceptClasses=${conditionConceptClassUuid}&q=${conditionToLookup}`;
+  const conditionsSearchUrl = `${restBaseUrl}/concept?name=${conditionToLookup}&searchType=fuzzy&class=${conditionConceptClassUuid}&v=custom:(uuid,display)`;
+
   const { data, error, isLoading } = useSWR<{ data: { results: Array<CodedCondition> } }, Error>(
     conditionToLookup ? conditionsSearchUrl : null,
     openmrsFetch,
@@ -114,7 +115,7 @@ export function useConditionsSearch(conditionToLookup: string) {
 
   return {
     searchResults: data?.data?.results ?? [],
-    error: error,
+    error,
     isSearching: isLoading,
   };
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Presently, we are using the [conceptsearch resource](https://github.com/openmrs/openmrs-esm-patient-chart/blob/main/packages/esm-patient-conditions-app/src/conditions/conditions.resource.ts#L109) to do a lookup for conditions in the Conditions form. This is different from what we do in the Visit note form’s diagnosis search fields where we use the [concept resource](https://github.com/openmrs/openmrs-esm-patient-chart/blob/main/packages/esm-patient-notes-app/src/notes/visit-notes.resource.ts#L106) with a fuzzy search.

One undesired side effect of using conceptsearch as we’re currently using it is that cross-locale searches don’t work. If the locale is set to fr for example, you can only search using the french names for a condition. So searching for malaria in the Condition search field won’t return anything, you’d have to search for paludisme.

We should use the concept resource with a fuzzy search for the Conditions form as well for a consistent search experience.

## Screenshots

https://github.com/user-attachments/assets/d2f3fa99-86ac-4d87-8e48-468520587946

### Rendering bug when clearing the input

https://github.com/user-attachments/assets/58078643-da07-41d9-aa2e-96891262b864

### Fix

https://github.com/user-attachments/assets/e7e70160-f713-4f7d-9259-5ff251cf1ef4

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
