### PR TITLE
(fix) O3-4260 fix error when starting a visit immediately after ending one

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
@@ -9,9 +9,12 @@ import styles from './end-visit-dialog.scss';
 interface EndVisitDialogProps {
   patientUuid: string;
   closeModal: () => void;
+
+  // for test mock only
+  stopDatetime?: Date;
 }
 
-const EndVisitDialog: React.FC<EndVisitDialogProps> = ({ patientUuid, closeModal }) => {
+const EndVisitDialog: React.FC<EndVisitDialogProps> = ({ patientUuid, closeModal, stopDatetime = new Date() }) => {
   const { t } = useTranslation();
   const { currentVisit, currentVisitIsRetrospective, mutate } = useVisit(patientUuid);
   const { queueEntry } = useVisitQueueEntry(patientUuid, currentVisit?.uuid);
@@ -21,9 +24,9 @@ const EndVisitDialog: React.FC<EndVisitDialogProps> = ({ patientUuid, closeModal
       setCurrentVisit(null, null);
       closeModal();
     } else {
-      const endVisitPayload = {
-        stopDatetime: new Date(),
-      };
+      const stopDatetimeTruncated = new Date(stopDatetime);
+      stopDatetimeTruncated.setSeconds(0, 0);
+      const endVisitPayload = { stopDatetime: stopDatetimeTruncated };
 
       const abortController = new AbortController();
 

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
@@ -5,10 +5,6 @@ import { showSnackbar, updateVisit, useVisit, type Visit, type FetchResponse } f
 import { mockCurrentVisit } from '__mocks__';
 import EndVisitDialog from './end-visit-dialog.component';
 
-const endVisitPayload = {
-  stopDatetime: expect.any(Date),
-};
-
 const mockCloseModal = jest.fn();
 const mockMutate = jest.fn();
 const mockShowSnackbar = jest.mocked(showSnackbar);
@@ -30,7 +26,8 @@ describe('End visit dialog', () => {
 
   test('displays a success snackbar when the visit is ended successfully', async () => {
     const user = userEvent.setup();
-
+    const mockCurrentTime = new Date('2024-12-11T01:20:25.1234');
+    const mockCurrentTimeTruncated = new Date('2024-12-11T01:20:00');
     mockUpdateVisit.mockResolvedValue({
       status: 200,
       data: {
@@ -40,7 +37,13 @@ describe('End visit dialog', () => {
       },
     } as unknown as FetchResponse<Visit>);
 
-    render(<EndVisitDialog patientUuid="some-patient-uuid" closeModal={mockCloseModal} />);
+    const expectedEndVisitPayload = {
+      stopDatetime: mockCurrentTimeTruncated,
+    };
+
+    render(
+      <EndVisitDialog patientUuid="some-patient-uuid" closeModal={mockCloseModal} stopDatetime={mockCurrentTime} />,
+    );
 
     const closeModalButton = screen.getByRole('button', { name: /close/i });
     const cancelButton = screen.getByRole('button', { name: /cancel/i });
@@ -60,7 +63,7 @@ describe('End visit dialog', () => {
 
     await user.click(endVisitButton);
 
-    expect(updateVisit).toHaveBeenCalledWith(mockCurrentVisit.uuid, endVisitPayload, expect.anything());
+    expect(updateVisit).toHaveBeenCalledWith(mockCurrentVisit.uuid, expectedEndVisitPayload, expect.anything());
 
     expect(mockShowSnackbar).toHaveBeenCalledWith({
       isLowContrast: true,
@@ -81,6 +84,10 @@ describe('End visit dialog', () => {
       },
     };
 
+    const expectedEndVisitPayload = {
+      stopDatetime: expect.any(Date),
+    };
+
     mockUpdateVisit.mockRejectedValue(error);
 
     render(<EndVisitDialog patientUuid="some-patient-uuid" closeModal={mockCloseModal} />);
@@ -96,7 +103,7 @@ describe('End visit dialog', () => {
 
     await user.click(endVisitButton);
 
-    expect(updateVisit).toHaveBeenCalledWith(mockCurrentVisit.uuid, endVisitPayload, new AbortController());
+    expect(updateVisit).toHaveBeenCalledWith(mockCurrentVisit.uuid, expectedEndVisitPayload, new AbortController());
     expect(mockShowSnackbar).toHaveBeenCalledWith({
       subtitle: 'Internal error message',
       kind: 'error',


### PR DESCRIPTION
…g one

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
In O3, when we start a visit, we truncate the start time’s seconds field to 0. However, when we end a visit, we do not do the same truncation. Hence, when we try to start another visit within the same minute, we get a This visit overlaps with another visit of the same patient error. 

This PR fix this by making the end time truncate the seconds field to 0 as well when ending a visit, 

Note that, however, there is still an issue with starting a visit, then ending the visit, and then starting a new visit, all within the same minute, as the backend will still think that the new visit conflicts with the old one. We’ll have to change the [backend logic](https://github.com/openmrs/openmrs-core/blob/723fb0c65a6aca9a9a7fc522f7db1c3a9f0231fb/api/src/main/java/org/openmrs/validator/VisitValidator.java#L137) (and probably also remove the seconds truncation logic when we start and stop visits) if we want to fix that as well.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4260
## Other
<!-- Anything not covered above -->
