### PR TITLE
(fix) Attempt to fix e2e test errors

### DIFF
--- a/e2e/commands/visit-operations.ts
+++ b/e2e/commands/visit-operations.ts
@@ -13,16 +13,16 @@ export const startVisit = async (api: APIRequestContext, patientId: string): Pro
     },
   });
 
-  await expect(visitRes.ok()).toBeTruthy();
+  expect(visitRes.ok()).toBeTruthy();
   return await visitRes.json();
 };
 
-export const endVisit = async (api: APIRequestContext, uuid: string) => {
-  const visitRes = await api.post(`visit/${uuid}`, {
+export const endVisit = async (api: APIRequestContext, visit: Visit) => {
+  const visitRes = await api.post(`visit/${visit.uuid}`, {
     data: {
-      location: process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
-      startDatetime: dayjs().subtract(1, 'D').format('YYYY-MM-DDTHH:mm:ss.SSSZZ'),
-      visitType: '7b0f5697-27e3-40c4-8bae-f4049abfb4ed',
+      location: visit.location.uuid,
+      startDatetime: visit.startDatetime,
+      visitType: visit.visitType.uuid,
       stopDatetime: dayjs().format('YYYY-MM-DDTHH:mm:ss.SSSZZ'),
     },
   });

--- a/e2e/specs/biometrics.spec.ts
+++ b/e2e/specs/biometrics.spec.ts
@@ -67,6 +67,6 @@ test('Record biometrics', async ({ page }) => {
 });
 
 test.afterEach(async ({ api }) => {
-  await endVisit(api, visit.uuid);
+  await endVisit(api, visit);
   await deletePatient(api, patient.uuid);
 });

--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -273,6 +273,6 @@ test('Form state is retained when minimizing a form in the workspace', async ({ 
 });
 
 test.afterEach(async ({ api }) => {
-  await endVisit(api, visit.uuid);
+  await endVisit(api, visit);
   await deletePatient(api, patient.uuid);
 });

--- a/e2e/specs/drug-orders.spec.ts
+++ b/e2e/specs/drug-orders.spec.ts
@@ -243,6 +243,6 @@ test('Record, edit and discontinue a drug order', async ({ page }) => {
 });
 
 test.afterEach(async ({ api }) => {
-  await endVisit(api, visit.uuid);
+  await endVisit(api, visit);
   await deletePatient(api, patient.uuid);
 });

--- a/e2e/specs/lab-orders.spec.ts
+++ b/e2e/specs/lab-orders.spec.ts
@@ -156,6 +156,6 @@ test.describe.serial('Running laboratory order tests sequentially', () => {
 });
 
 test.afterAll(async ({ api }) => {
-  await endVisit(api, visit.uuid);
+  await endVisit(api, visit);
   await deletePatient(api, patient.uuid);
 });

--- a/e2e/specs/results-viewer.spec.ts
+++ b/e2e/specs/results-viewer.spec.ts
@@ -364,6 +364,6 @@ test('Record and edit test results', async ({ page }) => {
 });
 
 test.afterEach(async ({ api }) => {
-  await endVisit(api, visit.uuid);
+  await endVisit(api, visit);
   await deletePatient(api, patient.uuid);
 });

--- a/e2e/specs/visit-note.spec.ts
+++ b/e2e/specs/visit-note.spec.ts
@@ -88,6 +88,6 @@ test('Add and delete a visit note', async ({ page }) => {
 });
 
 test.afterEach(async ({ api }) => {
-  await endVisit(api, visit.uuid);
+  await endVisit(api, visit);
   await deletePatient(api, patient.uuid);
 });

--- a/e2e/specs/vitals.spec.ts
+++ b/e2e/specs/vitals.spec.ts
@@ -80,6 +80,6 @@ test('Record vital signs', async ({ page }) => {
 });
 
 test.afterEach(async ({ api }) => {
-  await endVisit(api, visit.uuid);
+  await endVisit(api, visit);
   await deletePatient(api, patient.uuid);
 });

--- a/packages/esm-patient-common-lib/src/orders/postOrders.ts
+++ b/packages/esm-patient-common-lib/src/orders/postOrders.ts
@@ -71,8 +71,14 @@ export async function postOrders(encounterUuid: string, abortController: AbortCo
     const orders = patientItems[grouping];
     for (let i = 0; i < orders.length; i++) {
       const order = orders[i];
-      const dto = postDataPrepFunctions[grouping](order, patientUuid, encounterUuid);
-      await postOrder(dto, abortController).catch((error) => {
+      const dataPrepFn = postDataPrepFunctions[grouping];
+
+      if (typeof dataPrepFn !== 'function') {
+        console.warn(`The postDataPrep function registered for ${grouping} orders is not a function`);
+        continue;
+      }
+
+      await postOrder(dataPrepFn(order, patientUuid, encounterUuid), abortController).catch((error) => {
         erroredItems.push({
           ...order,
           orderError: error,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Semi-speculative attempt to fix failing e2e tests that are hard to reproduce:

1. Since `endVisit()` is called without the full existing visit, it used to always change the start date; this leads to hard-to-reproduce failures, where encounters are recorded "inside" the visit after, but close to the start date and so the attempt to stop the visit ends up rejected by the backend. Since we were already storing a reference to the visit, there's no reason we can't use that.
2. For some unknown reason—and apparently only in e2e tests—at least one entry in the `postDataPrepFunctions` winds up being not a function, which raises an error that isn't handled by the code. This PR introduces a simple check for this condition and skips the callback if it is not a function.

Hopefully, this fixes the issues with the e2e tests in GitHub Actions

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
