### PR TITLE
(fix) O3-4271 fix callback registration in visit form

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.resource.ts
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.resource.ts
@@ -28,11 +28,12 @@ export function useConditionalVisitTypes() {
 
   return visitTypesHook();
 }
+export interface VisitFormCallbacks {
+  onVisitCreatedOrUpdated: (visit: Visit) => Promise<any>;
+}
 
-export type OnVisitCreatedOrUpdatedCallback = (visit: Visit, patientUuid: string) => Promise<any>;
-
-export function useOnVisitCreatedOrUpdatedCallbacks() {
-  return useState<Map<string, OnVisitCreatedOrUpdatedCallback>>(new Map());
+export function useVisitFormCallbacks() {
+  return useState<Map<string, VisitFormCallbacks>>(new Map());
 }
 
 export function createVisitAttribute(visitUuid: string, attributeType: string, value: string) {

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -24,7 +24,7 @@ import {
   createVisitAttribute,
   deleteVisitAttribute,
   updateVisitAttribute,
-  useOnVisitCreatedOrUpdatedCallbacks,
+  useVisitFormCallbacks,
 } from './visit-form.resource';
 
 const visitUuid = 'test_visit_uuid';
@@ -76,9 +76,9 @@ const mockUseEmrConfiguration = jest.mocked(useEmrConfiguration);
 
 // from ./visit-form.resource
 const mockOnVisitCreatedOrUpdatedCallback = jest.fn();
-jest.mocked(useOnVisitCreatedOrUpdatedCallbacks).mockReturnValue([
-  new Map([['test-extension-id', mockOnVisitCreatedOrUpdatedCallback]]), // OnVisitCreatedOrUpdatedCallbacks
-  jest.fn(), // setOnVisitCreatedOrUpdatedCallbacks
+jest.mocked(useVisitFormCallbacks).mockReturnValue([
+  new Map([['test-extension-id', { onVisitCreatedOrUpdated: mockOnVisitCreatedOrUpdatedCallback }]]), // visitFormCallbacks
+  jest.fn(), // setVisitFormCallbacks
 ]);
 const mockCreateVisitAttribute = jest.mocked(createVisitAttribute).mockResolvedValue({} as unknown as FetchResponse);
 const mockUpdateVisitAttribute = jest.mocked(updateVisitAttribute).mockResolvedValue({} as unknown as FetchResponse);
@@ -164,7 +164,7 @@ jest.mock('./visit-form.resource', () => {
   const requireActual = jest.requireActual('./visit-form.resource');
   return {
     ...requireActual,
-    useOnVisitCreatedOrUpdatedCallbacks: jest.fn(),
+    useVisitFormCallbacks: jest.fn(),
     createVisitAttribute: jest.fn(),
     updateVisitAttribute: jest.fn(),
     deleteVisitAttribute: jest.fn(),


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
See also [corresponding PR](https://github.com/openmrs/openmrs-esm-patient-management/pull/1411) in patient-management.

This is a regression from [O3-4200](https://openmrs.atlassian.net/browse/O3-4200). In the service queues app, the form for creating a new queue entry for patient with existing visit is broken. The actual fix is in [corresponding PR](https://github.com/openmrs/openmrs-esm-patient-management/pull/1411) in patient management; this PR makes necessary change on how the visit form registers `onVisitCreatedOrUpdated` callbacks.

Root cause:

`[state, setState = useState<Function>()` is generally a bad idea, because `setState` is overloaded to take in either 1) the new state or 2) a lambda that returns the new state. When doing `setState(callback)`, JavaScript has no way to distinguish between the two, and erroneously treats it as case 2. The visit form, which stores `onVisitCreatedOrUpdated` callbacks in a `Map<string, Callbacks>`, doesn't actually have this problem, but the form for creating a new queue entry for patient with existing visit does.

This PR addresses this by wrapping the callback states in an object.

Unrelated, the visit form has a non-functional / performance issue with infinite state updates when the extensions in `VisitFormExtensionSlot` register callbacks. (Generally, the pattern of a child component updating the parent's state is dangerous if the state is an object.)  This PR address that with a combination of `useCallbacks`, `useMemo` and `memo` in various places. (It feels like it should be possible to reduce the use of these memoing functions, but I haven't been able to simplify it.)

## Screenshots
<!-- Required if you are making UI changes. -->
On submission on start visit form to: start a visit, update visit attributes, check-in appointment, create queue entry.
![image](https://github.com/user-attachments/assets/3ecc2351-3525-499c-9720-d21930079663)

On submission of form to create queue entry for patient with existing visit:
![image](https://github.com/user-attachments/assets/68e4861d-0ebe-44bf-a675-1c27a27f5701)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4271

## Other
<!-- Anything not covered above -->


[O3-4200]: https://openmrs.atlassian.net/browse/O3-4200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ