### PR TITLE
(feat) order-basket: Improve a11y and styling of status tags

### DIFF
--- a/e2e/specs/lab-orders.spec.ts
+++ b/e2e/specs/lab-orders.spec.ts
@@ -50,8 +50,12 @@ test.describe.serial('Running laboratory order tests sequentially', () => {
       await page.getByLabel(/additional instructions/i).fill(' N/A');
     });
 
-    await test.step('Add I save the lab order form', async () => {
+    await test.step('And I save the lab order form', async () => {
       await page.getByRole('button', { name: /save order/i }).click();
+    });
+
+    await test.step('And I click the `Sign and close` button', async () => {
+      await expect(page.getByRole('status', { name: /new/i })).toBeVisible();
       await page.getByRole('button', { name: /sign and close/i }).click();
     });
 
@@ -70,7 +74,6 @@ test.describe.serial('Running laboratory order tests sequentially', () => {
 
   test('Modify a lab order', async ({ page }) => {
     const ordersPage = new OrdersPage(page);
-    const orderBasket = page.locator('[data-extension-slot-name="order-basket-slot"]');
 
     await test.step('When I visit the orders page', async () => {
       await ordersPage.goTo(patient.uuid);
@@ -101,8 +104,8 @@ test.describe.serial('Running laboratory order tests sequentially', () => {
     });
 
     await test.step('Then the order status should be changed to `Modify`', async () => {
-      await expect(orderBasket.getByText(/new/i)).not.toBeVisible();
-      await expect(orderBasket.getByText(/modify/i)).toBeVisible();
+      await expect(page.getByRole('status', { name: /new/i })).not.toBeVisible();
+      await expect(page.getByRole('status', { name: /modify/i })).toBeVisible();
     });
 
     await test.step('When I click on the `Sign and close` button', async () => {
@@ -116,7 +119,6 @@ test.describe.serial('Running laboratory order tests sequentially', () => {
 
   test('Discontinue a lab order', async ({ page }) => {
     const ordersPage = new OrdersPage(page);
-    const orderBasket = page.locator('[data-extension-slot-name="order-basket-slot"]');
 
     await test.step('When I visit the orders page', async () => {
       await ordersPage.goTo(patient.uuid);
@@ -138,7 +140,7 @@ test.describe.serial('Running laboratory order tests sequentially', () => {
     });
 
     await test.step('Then the order status should be changed to `Discontinue`', async () => {
-      await expect(orderBasket.getByText(/discontinue/i)).toBeVisible();
+      await expect(page.getByRole('status', { name: /discontinue/i })).toBeVisible();
     });
 
     await test.step('And I click on the `Sign and close` button', async () => {

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.component.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.component.tsx
@@ -126,18 +126,58 @@ function OrderActionLabel({ orderBasketItem }: { orderBasketItem: DrugOrderBaske
   const { t } = useTranslation();
 
   if (orderBasketItem.isOrderIncomplete) {
-    return <span className={styles.orderActionIncompleteLabel}>{t('orderActionIncomplete', 'Incomplete')}</span>;
+    return (
+      <span
+        className={styles.orderActionIncompleteLabel}
+        role="status"
+        aria-atomic
+        aria-label={t('orderActionIncomplete', 'Incomplete')}
+      >
+        {t('orderActionIncomplete', 'Incomplete')}
+      </span>
+    );
   }
 
   switch (orderBasketItem.action) {
     case 'NEW':
-      return <span className={styles.orderActionNewLabel}>{t('orderActionNew', 'New')}</span>;
+      return (
+        <span className={styles.orderActionNewLabel} role="status" aria-atomic aria-label={t('orderActionNew', 'New')}>
+          {t('orderActionNew', 'New')}
+        </span>
+      );
     case 'RENEW':
-      return <span className={styles.orderActionRenewLabel}>{t('orderActionRenew', 'Renew')}</span>;
+      return (
+        <span
+          className={styles.orderActionRenewLabel}
+          role="status"
+          aria-atomic
+          aria-label={t('orderActionRenew', 'Renew')}
+        >
+          {t('orderActionRenew', 'Renew')}
+        </span>
+      );
     case 'REVISE':
-      return <span className={styles.orderActionRevisedLabel}>{t('orderActionRevise', 'Modify')}</span>;
+      return (
+        <span
+          className={styles.orderActionReviseLabel}
+          role="status"
+          aria-atomic
+          aria-label={t('orderActionRevise', 'Modify')}
+        >
+          {t('orderActionRevise', 'Modify')}
+        </span>
+      );
     case 'DISCONTINUE':
-      return <span className={styles.orderActionDiscontinueLabel}>{t('orderActionDiscontinue', 'Discontinue')}</span>;
+      return (
+        <span
+          className={styles.orderActionDiscontinueLabel}
+          role="status"
+          aria-atomic
+          aria-label={t('orderActionDiscontinue', 'Discontinue')}
+        >
+          {t('orderActionDiscontinue', 'Discontinue')}
+        </span>
+      );
     default:
       return <></>;
   }

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.scss
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.scss
@@ -1,3 +1,4 @@
+@use '@carbon/colors';
 @use '@carbon/layout';
 @use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
@@ -27,29 +28,27 @@
 
 .orderActionNewLabel {
   @extend .label;
-  color: $support-02;
-}
-
-.orderActionRenewLabel {
-  @extend .label;
-  color: $support-02;
-}
-
-.orderActionRevisedLabel {
-  @extend .label;
-  color: #943d00;
-}
-
-.orderActionDiscontinueLabel {
-  @extend .label;
-  color: $danger;
+  background-color: colors.$green-10-hover;
+  padding: 0 layout.$spacing-02;
 }
 
 .orderActionIncompleteLabel {
-  @extend .label;
+  @extend .orderActionNewLabel;
+  background-color: colors.$red-60;
   color: white;
-  background-color: $danger;
-  padding: 0 layout.$spacing-02;
+}
+
+.orderActionRenewLabel {
+  @extend .orderActionNewLabel;
+}
+
+.orderActionReviseLabel {
+  @extend .orderActionNewLabel;
+}
+
+.orderActionDiscontinueLabel {
+  @extend .orderActionNewLabel;
+  background-color: colors.$gray-20;
 }
 
 .orderErrorText {

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/order-basket-item-tile.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/order-basket-item-tile.component.tsx
@@ -78,18 +78,58 @@ function OrderActionLabel({ orderBasketItem }: { orderBasketItem: OrderBasketIte
   const { t } = useTranslation();
 
   if (orderBasketItem.isOrderIncomplete) {
-    return <span className={styles.orderActionIncompleteLabel}>{t('orderActionIncomplete', 'Incomplete')}</span>;
+    return (
+      <span
+        className={styles.orderActionIncompleteLabel}
+        role="status"
+        aria-atomic
+        aria-label={t('orderActionIncomplete', 'Incomplete')}
+      >
+        {t('orderActionIncomplete', 'Incomplete')}
+      </span>
+    );
   }
 
   switch (orderBasketItem.action) {
     case 'NEW':
-      return <span className={styles.orderActionNewLabel}>{t('orderActionNew', 'New')}</span>;
+      return (
+        <span className={styles.orderActionNewLabel} role="status" aria-atomic aria-label={t('orderActionNew', 'New')}>
+          {t('orderActionNew', 'New')}
+        </span>
+      );
     case 'RENEW':
-      return <span className={styles.orderActionRenewLabel}>{t('orderActionRenew', 'Renew')}</span>;
+      return (
+        <span
+          className={styles.orderActionRenewLabel}
+          role="status"
+          aria-atomic
+          aria-label={t('orderActionRenew', 'Renew')}
+        >
+          {t('orderActionRenew', 'Renew')}
+        </span>
+      );
     case 'REVISE':
-      return <span className={styles.orderActionRevisedLabel}>{t('orderActionRevise', 'Modify')}</span>;
+      return (
+        <span
+          className={styles.orderActionReviseLabel}
+          role="status"
+          aria-atomic
+          aria-label={t('orderActionRevise', 'Modify')}
+        >
+          {t('orderActionRevise', 'Modify')}
+        </span>
+      );
     case 'DISCONTINUE':
-      return <span className={styles.orderActionDiscontinueLabel}>{t('orderActionDiscontinue', 'Discontinue')}</span>;
+      return (
+        <span
+          className={styles.orderActionDiscontinueLabel}
+          role="status"
+          aria-atomic
+          aria-label={t('orderActionDiscontinue', 'Discontinue')}
+        >
+          {t('orderActionDiscontinue', 'Discontinue')}
+        </span>
+      );
     default:
       return <></>;
   }

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/order-basket-item-tile.scss
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/order-basket-item-tile.scss
@@ -1,3 +1,4 @@
+@use '@carbon/colors';
 @use '@carbon/layout';
 @use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
@@ -27,31 +28,27 @@
 
 .orderActionNewLabel {
   @extend .label;
-  color: black;
-  background-color: #c4f4cc;
+  background-color: colors.$green-10-hover;
   padding: 0 layout.$spacing-02;
 }
 
 .orderActionIncompleteLabel {
-  @extend .label;
+  @extend .orderActionNewLabel;
+  background-color: colors.$red-60;
   color: white;
-  background-color: $danger;
-  padding: 0 layout.$spacing-02;
 }
 
 .orderActionRenewLabel {
-  @extend .label;
-  color: $support-02;
+  @extend .orderActionNewLabel;
 }
 
-.orderActionRevisedLabel {
-  @extend .label;
-  color: #943d00;
+.orderActionReviseLabel {
+  @extend .orderActionNewLabel;
 }
 
 .orderActionDiscontinueLabel {
-  @extend .label;
-  color: $danger;
+  @extend .orderActionNewLabel;
+  background-color: colors.$gray-20;
 }
 
 .orderErrorText {

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/orderable-concept-search/orderable-concept-search.workspace.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/orderable-concept-search/orderable-concept-search.workspace.tsx
@@ -1,3 +1,6 @@
+import React, { type ComponentProps, useCallback, useMemo, useRef, useState } from 'react';
+import { Button, Search } from '@carbon/react';
+import { useTranslation } from 'react-i18next';
 import {
   ArrowLeftIcon,
   ResponsiveWrapper,
@@ -13,14 +16,11 @@ import {
   useOrderType,
   usePatientChartStore,
 } from '@openmrs/esm-patient-common-lib';
-import React, { type ComponentProps, useCallback, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import styles from './orderable-concept-search.scss';
-import { Button, Search } from '@carbon/react';
-import OrderableConceptSearchResults from './search-results.component';
-import { type ConfigObject } from '../../../config-schema';
 import { OrderForm } from '../general-order-form/general-order-form.component';
 import { prepOrderPostData } from '../resources';
+import { type ConfigObject } from '../../../config-schema';
+import OrderableConceptSearchResults from './search-results.component';
+import styles from './orderable-concept-search.scss';
 
 interface OrderableConceptSearchWorkspaceProps extends DefaultWorkspaceProps {
   order: OrderBasketItem;

--- a/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-item-tile.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-item-tile.component.tsx
@@ -93,18 +93,58 @@ function OrderActionLabel({ orderBasketItem }: { orderBasketItem: TestOrderBaske
   const { t } = useTranslation();
 
   if (orderBasketItem.isOrderIncomplete) {
-    return <span className={styles.orderActionIncompleteLabel}>{t('orderActionIncomplete', 'Incomplete')}</span>;
+    return (
+      <span
+        className={styles.orderActionIncompleteLabel}
+        role="status"
+        aria-atomic
+        aria-label={t('orderActionIncomplete', 'Incomplete')}
+      >
+        {t('orderActionIncomplete', 'Incomplete')}
+      </span>
+    );
   }
 
   switch (orderBasketItem.action) {
     case 'NEW':
-      return <span className={styles.orderActionNewLabel}>{t('orderActionNew', 'New')}</span>;
+      return (
+        <span className={styles.orderActionNewLabel} role="status" aria-atomic aria-label={t('orderActionNew', 'New')}>
+          {t('orderActionNew', 'New')}
+        </span>
+      );
     case 'RENEW':
-      return <span className={styles.orderActionRenewLabel}>{t('orderActionRenew', 'Renew')}</span>;
+      return (
+        <span
+          className={styles.orderActionRenewLabel}
+          role="status"
+          aria-atomic
+          aria-label={t('orderActionRenew', 'Renew')}
+        >
+          {t('orderActionRenew', 'Renew')}
+        </span>
+      );
     case 'REVISE':
-      return <span className={styles.orderActionRevisedLabel}>{t('orderActionRevise', 'Modify')}</span>;
+      return (
+        <span
+          className={styles.orderActionReviseLabel}
+          role="status"
+          aria-atomic
+          aria-label={t('orderActionRevise', 'Modify')}
+        >
+          {t('orderActionRevise', 'Modify')}
+        </span>
+      );
     case 'DISCONTINUE':
-      return <span className={styles.orderActionDiscontinueLabel}>{t('orderActionDiscontinue', 'Discontinue')}</span>;
+      return (
+        <span
+          className={styles.orderActionDiscontinueLabel}
+          role="status"
+          aria-atomic
+          aria-label={t('orderActionDiscontinue', 'Discontinue')}
+        >
+          {t('orderActionDiscontinue', 'Discontinue')}
+        </span>
+      );
     default:
       return <></>;
   }

--- a/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-item-tile.scss
+++ b/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-item-tile.scss
@@ -1,3 +1,4 @@
+@use '@carbon/colors';
 @use '@carbon/layout';
 @use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
@@ -27,31 +28,27 @@
 
 .orderActionNewLabel {
   @extend .label;
-  color: black;
-  background-color: #c4f4cc;
+  background-color: colors.$green-10-hover;
   padding: 0 layout.$spacing-02;
 }
 
 .orderActionIncompleteLabel {
-  @extend .label;
+  @extend .orderActionNewLabel;
+  background-color: colors.$red-60;
   color: white;
-  background-color: $danger;
-  padding: 0 layout.$spacing-02;
 }
 
 .orderActionRenewLabel {
-  @extend .label;
-  color: $support-02;
+  @extend .orderActionNewLabel;
 }
 
-.orderActionRevisedLabel {
-  @extend .label;
-  color: #943d00;
+.orderActionReviseLabel {
+  @extend .orderActionNewLabel;
 }
 
 .orderActionDiscontinueLabel {
-  @extend .label;
-  color: $danger;
+  @extend .orderActionNewLabel;
+  background-color: colors.$gray-20;
 }
 
 .orderErrorText {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This change improves the styling of status tags in the Order basket so that they are more consistent with the [designs](https://zeroheight.com/23a080e38/p/030b9a-order-item). It also adds a11y attributes to the status labels so that they are more accessible. A desired side effect of these changes is that using these a11y attributes will make the Order basket e2e tests more robust.

## Screenshots

![CleanShot 2024-12-13 at 11  58 39@2x](https://github.com/user-attachments/assets/492d1b2d-c12c-4e3a-a08f-4a9eb3517d78)

![CleanShot 2024-12-13 at 11  58 55@2x](https://github.com/user-attachments/assets/60f75efb-6230-41f4-b7a0-a8f16bac1590)

![CleanShot 2024-12-13 at 11  59 08@2x](https://github.com/user-attachments/assets/3c21cdfd-59bc-4c75-b85b-9f7b348b4f4f)

![CleanShot 2024-12-13 at 11  59 30@2x](https://github.com/user-attachments/assets/1dd53f5e-2954-4c21-9e2d-0ee8d30c50e5)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

It's a long-shot, but maybe this can help fix this [test failure](https://github.com/openmrs/openmrs-esm-core/actions/runs/12284171342/job/34282605146?pr=1235) on Core:

![CleanShot 2024-12-13 at 12  01 13@2x](https://github.com/user-attachments/assets/c7d12bbd-1f1c-4c42-bc8e-46d1c405e6d1)