### PR TITLE
(chore) Scope testing-library plugin to lint tests only

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,14 +2,22 @@
   "env": {
     "node": true
   },
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:jest-dom/recommended",
-    "plugin:testing-library/react"
-  ],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:jest-dom/recommended"],
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "import", "jest-dom", "react-hooks", "testing-library"],
+  "overrides": [
+    {
+      "files": ["**/*.test.tsx"],
+      "extends": ["plugin:testing-library/react"]
+    },
+    {
+      "files": ["e2e/**/*.spec.ts"],
+      "extends": ["plugin:playwright/recommended"],
+      "rules": {
+        "testing-library/prefer-screen-queries": "off"
+      }
+    }
+  ],
   "rules": {
     "react-hooks/exhaustive-deps": "warn",
     "react-hooks/rules-of-hooks": "error",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR optimizes our ESLint configuration by only applying testing-library rules to test files. This fixes an issue where Playwright tests were being linted with Testing Library rules, which caused a lot of redundant lint errors. The specific changes are:

- Moving testing-library plugin to the `overrides` section of the ESLint config for `.test.tsx` files.
- Adding playwright plugin config for e2e tests.
- Disabling the prefer screen queries rule for e2e tests.
 
## Screenshots

### Before 

Squiggly red lines on the main branch

![CleanShot 2024-12-13 at 12  36 32@2x](https://github.com/user-attachments/assets/059c5ffb-4ae0-4f5e-af5e-fce2ed20aa4a)

### After

Squiggly red lines begone

![CleanShot 2024-12-13 at 12  35 28@2x](https://github.com/user-attachments/assets/1c1e3071-c0a2-47a5-b1f1-33c1b25b4714)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
