### PR TITLE
(refactor) O3-3846: Replace Carbon datepickers with reusable `OpenmrsDatePicker`

### DIFF
--- a/e2e/commands/visit-operations.ts
+++ b/e2e/commands/visit-operations.ts
@@ -2,10 +2,12 @@ import { type APIRequestContext, expect } from '@playwright/test';
 import { type Visit } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 
+export const visitStartDatetime = dayjs().subtract(1, 'D');
+
 export const startVisit = async (api: APIRequestContext, patientId: string): Promise<Visit> => {
   const visitRes = await api.post('visit', {
     data: {
-      startDatetime: dayjs().subtract(1, 'D').format('YYYY-MM-DDTHH:mm:ss.SSSZZ'),
+      startDatetime: visitStartDatetime.format('YYYY-MM-DDTHH:mm:ss.SSSZZ'),
       patient: patientId,
       location: process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
       visitType: '7b0f5697-27e3-40c4-8bae-f4049abfb4ed',

--- a/e2e/specs/conditions.spec.ts
+++ b/e2e/specs/conditions.spec.ts
@@ -35,8 +35,14 @@ test('Record, edit and delete a condition', async ({ page }) => {
   });
 
   await test.step('And I set `10/07/2023` as the onset date', async () => {
-    await page.getByLabel(/onset date/i).fill('10/07/2023');
-    await page.getByLabel(/onset date/i).press('Tab');
+    const onsetDateInput = page.getByTestId('onsetDate');
+    const onsetDateDayInput = onsetDateInput.getByRole('spinbutton', { name: /day/i });
+    const onsetDateMonthInput = onsetDateInput.getByRole('spinbutton', { name: /month/i });
+    const onsetDateYearInput = onsetDateInput.getByRole('spinbutton', { name: /year/i });
+    await onsetDateDayInput.fill('10');
+    await onsetDateMonthInput.fill('07');
+    await onsetDateYearInput.fill('2023');
+    await page.getByRole('radio', { name: /active/i }).focus();
   });
 
   await test.step('And I set the clinical status to `Active`', async () => {
@@ -80,9 +86,13 @@ test('Record, edit and delete a condition', async ({ page }) => {
   });
 
   await test.step('And I change the on onset date to `11/07/2023`', async () => {
-    await page.getByLabel(/onset date/i).clear();
-    await page.getByLabel(/onset date/i).fill('11/07/2023');
-    await page.getByLabel(/onset date/i).press('Tab');
+    const onsetDateInput = page.getByTestId('onsetDate');
+    const onsetDateDayInput = onsetDateInput.getByRole('spinbutton', { name: /day/i });
+    const onsetDateMonthInput = onsetDateInput.getByRole('spinbutton', { name: /month/i });
+    const onsetDateYearInput = onsetDateInput.getByRole('spinbutton', { name: /year/i });
+    await onsetDateDayInput.fill('11');
+    await onsetDateMonthInput.fill('07');
+    await onsetDateYearInput.fill('2023');
   });
 
   await test.step('And I click on the `Save & close` button', async () => {
@@ -119,7 +129,7 @@ test('Record, edit and delete a condition', async ({ page }) => {
   });
 
   await test.step('And I should not see the deleted condition in the list', async () => {
-    await expect(conditionsPage.page.getByText(/mental status change/i)).not.toBeVisible();
+    await expect(conditionsPage.page.getByText(/mental status change/i)).toBeHidden();
     await expect(conditionsPage.page.getByText(/there are no conditions to display for this patient/i)).toBeVisible();
   });
 });

--- a/e2e/specs/conditions.spec.ts
+++ b/e2e/specs/conditions.spec.ts
@@ -42,7 +42,6 @@ test('Record, edit and delete a condition', async ({ page }) => {
     await onsetDateDayInput.fill('10');
     await onsetDateMonthInput.fill('07');
     await onsetDateYearInput.fill('2023');
-    await page.getByRole('radio', { name: /active/i }).focus();
   });
 
   await test.step('And I set the clinical status to `Active`', async () => {

--- a/e2e/specs/edit-existing-visit.spec.ts
+++ b/e2e/specs/edit-existing-visit.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { type Visit } from '@openmrs/esm-framework';
-import { deletePatient, generateRandomPatient, type Patient, startVisit } from '../commands';
+import { deletePatient, generateRandomPatient, type Patient, startVisit, visitStartDatetime } from '../commands';
 import { test } from '../core';
 import { ChartPage, VisitsPage } from '../pages';
 
@@ -28,13 +28,22 @@ test('Edit an existing visit', async ({ page }) => {
   await test.step('Then I should see the `Edit Visit` form launch in the workspace', async () => {
     await expect(chartPage.page.getByText(/visit start date and time/i)).toBeVisible();
 
-    const startDateInput = chartPage.page.locator('input#visitStartDateInput');
+    const startDateInput = chartPage.page.getByTestId('visitStartDateInput');
+    const startDateDayInput = startDateInput.getByRole('spinbutton', { name: /day/i });
+    const startDateMonthInput = startDateInput.getByRole('spinbutton', { name: /month/i });
+    const startDateYearInput = startDateInput.getByRole('spinbutton', { name: /year/i });
     const startTimeInput = chartPage.page.locator('input#visitStartTime');
 
     await expect(startDateInput).toBeVisible();
-    const dateValue = await startDateInput.inputValue();
-    expect(dateValue).not.toBe('');
-    expect(dateValue).toMatch(/^\d{2}\/\d{2}\/\d{4}$/);
+    const startDateDayInputValue = await startDateDayInput.textContent();
+    expect(startDateDayInputValue).toBe(visitStartDatetime.format('DD'));
+    const startDateMonthInputValue = await startDateMonthInput.textContent();
+    expect(startDateMonthInputValue).toBe(visitStartDatetime.format('MM'));
+    const startDateYearInputValue = await startDateYearInput.textContent();
+    expect(startDateYearInputValue).toBe(visitStartDatetime.format('YYYY'));
+
+    // expect(dateValue).not.toBe('');
+    // expect(dateValue).toMatch(/^\d{2}\/\d{2}\/\d{4}$/);
 
     await expect(startTimeInput).toBeVisible();
     const timeValue = await startTimeInput.inputValue();

--- a/e2e/specs/immunizations.spec.ts
+++ b/e2e/specs/immunizations.spec.ts
@@ -31,9 +31,13 @@ test('Add an immunization', async ({ page }) => {
   });
 
   await test.step('When I set `08/03/2024` as the vaccination date', async () => {
-    await page.getByLabel(/vaccination date/i).clear();
-    await page.getByLabel(/vaccination date/i).fill('08/03/2024');
-    await page.getByLabel(/vaccination date/i).press('Tab');
+    const vaccinationDateInput = page.getByTestId('vaccinationDate');
+    const vaccinationDateDayInput = vaccinationDateInput.getByRole('spinbutton', { name: /day/i });
+    const vaccinationDateMonthInput = vaccinationDateInput.getByRole('spinbutton', { name: /month/i });
+    const vaccinationDateYearInput = vaccinationDateInput.getByRole('spinbutton', { name: /year/i });
+    await vaccinationDateDayInput.fill('08');
+    await vaccinationDateMonthInput.fill('03');
+    await vaccinationDateYearInput.fill('2024');
   });
 
   await test.step('And I set `Hepatitis B vaccination` as the immunization', async () => {

--- a/e2e/specs/program-enrollment.spec.ts
+++ b/e2e/specs/program-enrollment.spec.ts
@@ -41,8 +41,14 @@ test('Add and edit a program enrollment', async ({ page }) => {
   });
 
   await test.step('And I set `05/07/2023` as the completion date', async () => {
-    await page.locator('#completionDateInput').fill('05/07/2023');
-    await page.locator('#completionDateInput').press('Tab');
+    const completionDateInput = page.getByTestId('completionDate');
+    const completionDateDayInput = completionDateInput.getByRole('spinbutton', { name: /day/i });
+    const completionDateMonthInput = completionDateInput.getByRole('spinbutton', { name: /month/i });
+    const completionDateYearInput = completionDateInput.getByRole('spinbutton', { name: /year/i });
+    await completionDateDayInput.fill('05');
+    await completionDateMonthInput.fill('07');
+    await completionDateYearInput.fill('2023');
+    await page.locator('#location').focus();
   });
 
   await test.step('And I select `Outpatient Clinic` as the enrollment location', async () => {
@@ -88,9 +94,14 @@ test('Add and edit a program enrollment', async ({ page }) => {
   });
 
   await test.step('And I change the completion date to `04/07/2023`', async () => {
-    await page.locator('#completionDateInput').clear();
-    await page.locator('#completionDateInput').fill('04/07/2023');
-    await page.locator('#completionDateInput').press('Tab');
+    const completionDateInput = page.getByTestId('completionDate');
+    const completionDateDayInput = completionDateInput.getByRole('spinbutton', { name: /day/i });
+    const completionDateMonthInput = completionDateInput.getByRole('spinbutton', { name: /month/i });
+    const completionDateYearInput = completionDateInput.getByRole('spinbutton', { name: /year/i });
+    await completionDateDayInput.fill('04');
+    await completionDateMonthInput.fill('07');
+    await completionDateYearInput.fill('2023');
+    await page.locator('#location').focus();
   });
 
   await test.step('And I change the enrollment location to `Community Outreach`', async () => {

--- a/e2e/specs/program-enrollment.spec.ts
+++ b/e2e/specs/program-enrollment.spec.ts
@@ -31,7 +31,13 @@ test('Add and edit a program enrollment', async ({ page }) => {
   });
 
   await test.step('And I set `04/07/2023` as the enrollment date', async () => {
-    await page.locator('#enrollmentDateInput').fill('04/07/2023');
+    const enrollmentDateInput = page.getByTestId('enrollmentDate');
+    const enrollmentDateDayInput = enrollmentDateInput.getByRole('spinbutton', { name: /day/i });
+    const enrollmentDateMonthInput = enrollmentDateInput.getByRole('spinbutton', { name: /month/i });
+    const enrollmentDateYearInput = enrollmentDateInput.getByRole('spinbutton', { name: /year/i });
+    await enrollmentDateDayInput.fill('04');
+    await enrollmentDateMonthInput.fill('07');
+    await enrollmentDateYearInput.fill('2023');
   });
 
   await test.step('And I set `05/07/2023` as the completion date', async () => {
@@ -72,8 +78,13 @@ test('Add and edit a program enrollment', async ({ page }) => {
   });
 
   await test.step('When I change the enrollment date to `03/07/2023`', async () => {
-    await page.locator('#enrollmentDateInput').clear();
-    await page.locator('#enrollmentDateInput').fill('03/07/2023');
+    const enrollmentDateInput = page.getByTestId('enrollmentDate');
+    const enrollmentDateDayInput = enrollmentDateInput.getByRole('spinbutton', { name: /day/i });
+    const enrollmentDateMonthInput = enrollmentDateInput.getByRole('spinbutton', { name: /month/i });
+    const enrollmentDateYearInput = enrollmentDateInput.getByRole('spinbutton', { name: /year/i });
+    await enrollmentDateDayInput.fill('03');
+    await enrollmentDateMonthInput.fill('07');
+    await enrollmentDateYearInput.fill('2023');
   });
 
   await test.step('And I change the completion date to `04/07/2023`', async () => {

--- a/e2e/specs/start-and-end-visit.spec.ts
+++ b/e2e/specs/start-and-end-visit.spec.ts
@@ -22,7 +22,7 @@ test('Start and end a visit', async ({ page }) => {
 
   await test.step('Then I should see the `Start Visit` form launch in the workspace', async () => {
     await expect(chartPage.page.getByText(/visit start date and time/i)).toBeVisible();
-    await expect(chartPage.page.getByPlaceholder(/dd\/mm\/yyyy/i)).toBeVisible();
+    await expect(chartPage.page.getByTestId('visitStartDateInput')).toBeVisible();
     await expect(chartPage.page.getByPlaceholder(/hh\:mm/i)).toBeVisible();
     await expect(chartPage.page.getByRole('combobox', { name: /select a location/i })).toBeVisible();
     await expect(chartPage.page.getByText(/visit type/i)).toBeVisible();

--- a/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.test.tsx
@@ -24,14 +24,6 @@ jest.mock('../data.resource.ts', () => ({
   useCausesOfDeath: jest.fn(),
 }));
 
-jest.mock('@openmrs/esm-framework', () => {
-  const actual = jest.requireActual('@openmrs/esm-framework');
-  return {
-    ...actual,
-    OpenmrsDatePicker: jest.fn(),
-  };
-});
-
 mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
   return (
     <>

--- a/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
-import { OpenmrsDatePicker, getDefaultsFromConfigSchema, showSnackbar, useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, showSnackbar, useConfig } from '@openmrs/esm-framework';
 import { esmPatientChartSchema, type ChartConfig } from '../config-schema';
 import { mockPatient } from 'tools';
 import { markPatientDeceased, useCausesOfDeath } from '../data.resource';
 import MarkPatientDeceasedForm from './mark-patient-deceased-form.workspace';
-import dayjs from 'dayjs';
 
 const originalLocation = window.location;
 delete window.location;
@@ -17,30 +16,11 @@ const mockUseCausesOfDeath = jest.mocked(useCausesOfDeath);
 const mockUseConfig = jest.mocked(useConfig<ChartConfig>);
 const mockShowSnackbar = jest.mocked(showSnackbar);
 const mockCloseWorkspace = jest.fn();
-const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
 
 jest.mock('../data.resource.ts', () => ({
   markPatientDeceased: jest.fn().mockResolvedValue({}),
   useCausesOfDeath: jest.fn(),
 }));
-
-mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
-  return (
-    <>
-      <label htmlFor={id}>{labelText}</label>
-      <input
-        aria-label={labelText.toString()}
-        id={id}
-        onChange={(evt) => {
-          onChange(dayjs(evt.target.value).toDate());
-        }}
-        type="text"
-        // @ts-ignore
-        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
-      />
-    </>
-  );
-});
 
 describe('MarkPatientDeceasedForm', () => {
   const freeTextFieldConceptUuid = '1234e218-6c8a-4ca3-8edb-9f6d9c8c8c7f';
@@ -55,10 +35,26 @@ describe('MarkPatientDeceasedForm', () => {
   };
 
   const codedCausesOfDeath = [
-    { display: 'Traumatic injury', uuid: '8b64f45e-1d5f-4894-b77c-4e1d840e2c99', name: 'Traumatic injury' },
-    { display: 'Neoplasm/cancer', uuid: 'c4e8d03c-f09b-48d1-8d93-7d84d463f865', name: 'Neoplasm/cancer' },
-    { display: 'Infectious disease', uuid: 'b7c1c30f-5b9e-4a3d-b943-7f4b3f740e6c', name: 'Infectious disease' },
-    { display: 'Other', uuid: freeTextFieldConceptUuid, name: 'Other' },
+    {
+      display: 'Traumatic injury',
+      uuid: '8b64f45e-1d5f-4894-b77c-4e1d840e2c99',
+      name: 'Traumatic injury',
+    },
+    {
+      display: 'Neoplasm/cancer',
+      uuid: 'c4e8d03c-f09b-48d1-8d93-7d84d463f865',
+      name: 'Neoplasm/cancer',
+    },
+    {
+      display: 'Infectious disease',
+      uuid: 'b7c1c30f-5b9e-4a3d-b943-7f4b3f740e6c',
+      name: 'Infectious disease',
+    },
+    {
+      display: 'Other',
+      uuid: freeTextFieldConceptUuid,
+      name: 'Other',
+    },
   ];
 
   beforeEach(() => {
@@ -87,7 +83,7 @@ describe('MarkPatientDeceasedForm', () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/cause of death/i)).toBeInTheDocument();
     expect(screen.getByRole('searchbox')).toBeInTheDocument();
-    expect(screen.getByLabelText(/date/i)).toBeInTheDocument();
+    expect(screen.getByTestId(/deceasedDate/i)).toBeInTheDocument();
     codedCausesOfDeath.forEach((codedCauseOfDeath) => {
       expect(screen.getByRole('radio', { name: codedCauseOfDeath.display })).toBeInTheDocument();
     });

--- a/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
@@ -138,26 +138,18 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
                 <Controller
                   name="deathDate"
                   control={control}
-                  render={({ field: { onChange, value } }) => (
-                    <div role="textbox">
-                      <OpenmrsDatePicker
-                        className={styles.datePicker}
-                        id="deceasedDate"
-                        aria-invalid={!!errors?.deathDate}
-                        aria-describedby={errors?.deathDate ? 'deceasedDate-error' : undefined}
-                        aria-label={t('date', 'Date')}
-                        maxDate={new Date().toISOString()}
-                        onChange={(date) => onChange(date)}
-                        value={value}
-                      />
-                    </div>
+                  render={({ field, fieldState }) => (
+                    <OpenmrsDatePicker
+                      {...field}
+                      className={styles.datePicker}
+                      id="deceasedDate"
+                      labelText={t('date', 'Date')}
+                      maxDate={new Date()}
+                      invalid={Boolean(fieldState?.error?.message)}
+                      invalidText={fieldState?.error?.message}
+                    />
                   )}
                 />
-                {errors?.deathDate && (
-                  <p id="deceasedDate-error" role="alert" className={styles.errorMessage}>
-                    {errors?.deathDate?.message}
-                  </p>
-                )}
               </ResponsiveWrapper>
             ) : (
               <DatePickerSkeleton />

--- a/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
@@ -144,7 +144,7 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
                       id="deceasedDate"
                       isInvalid={!!errors?.deathDate}
                       invalidText={errors?.deathDate?.message}
-                      labelText={t('dateOfDeath', 'Date of death')}
+                      labelText={t('date', 'Date')}
                       maxDate={new Date().toISOString()}
                       onChange={(date) => onChange(date)}
                       value={value}

--- a/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
@@ -5,8 +5,6 @@ import { useTranslation } from 'react-i18next';
 import {
   Button,
   ButtonSet,
-  DatePicker,
-  DatePickerInput,
   DatePickerSkeleton,
   Form,
   InlineLoading,
@@ -23,7 +21,14 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { WarningFilled } from '@carbon/react/icons';
 import { EmptyState, type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
-import { ExtensionSlot, useLayoutType, showSnackbar, ResponsiveWrapper, useConfig } from '@openmrs/esm-framework';
+import {
+  ExtensionSlot,
+  useLayoutType,
+  showSnackbar,
+  ResponsiveWrapper,
+  useConfig,
+  OpenmrsDatePicker,
+} from '@openmrs/esm-framework';
 import { markPatientDeceased, useCausesOfDeath } from '../data.resource';
 import { type ChartConfig } from '../config-schema';
 import styles from './mark-patient-deceased-form.scss';
@@ -134,22 +139,13 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
                   name="deathDate"
                   control={control}
                   render={({ field: { onChange, value } }) => (
-                    <DatePicker
+                    <OpenmrsDatePicker
                       className={styles.datePicker}
-                      dateFormat="d/m/Y"
-                      datePickerType="single"
                       id="deceasedDate"
                       maxDate={new Date().toISOString()}
-                      onChange={([date]) => onChange(date)}
+                      onChange={(date) => onChange(date)}
                       value={value}
-                    >
-                      <DatePickerInput
-                        id="deceasedDateInput"
-                        labelText={t('date', 'Date')}
-                        placeholder="dd/mm/yyyy"
-                        style={{ width: '100%' }}
-                      />
-                    </DatePicker>
+                    />
                   )}
                 />
                 {errors?.deathDate && <p className={styles.errorMessage}>{errors?.deathDate?.message}</p>}

--- a/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
@@ -143,6 +143,7 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
                       {...field}
                       className={styles.datePicker}
                       id="deceasedDate"
+                      data-testid="deceasedDate"
                       labelText={t('date', 'Date')}
                       maxDate={new Date()}
                       invalid={Boolean(fieldState?.error?.message)}

--- a/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
@@ -142,6 +142,9 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
                     <OpenmrsDatePicker
                       className={styles.datePicker}
                       id="deceasedDate"
+                      isInvalid={!!errors?.deathDate}
+                      invalidText={errors?.deathDate?.message}
+                      labelText={t('dateOfDeath', 'Date of death')}
                       maxDate={new Date().toISOString()}
                       onChange={(date) => onChange(date)}
                       value={value}

--- a/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/mark-patient-deceased/mark-patient-deceased-form.workspace.tsx
@@ -139,19 +139,25 @@ const MarkPatientDeceasedForm: React.FC<DefaultPatientWorkspaceProps> = ({ close
                   name="deathDate"
                   control={control}
                   render={({ field: { onChange, value } }) => (
-                    <OpenmrsDatePicker
-                      className={styles.datePicker}
-                      id="deceasedDate"
-                      isInvalid={!!errors?.deathDate}
-                      invalidText={errors?.deathDate?.message}
-                      labelText={t('date', 'Date')}
-                      maxDate={new Date().toISOString()}
-                      onChange={(date) => onChange(date)}
-                      value={value}
-                    />
+                    <div role="textbox">
+                      <OpenmrsDatePicker
+                        className={styles.datePicker}
+                        id="deceasedDate"
+                        aria-invalid={!!errors?.deathDate}
+                        aria-describedby={errors?.deathDate ? 'deceasedDate-error' : undefined}
+                        aria-label={t('date', 'Date')}
+                        maxDate={new Date().toISOString()}
+                        onChange={(date) => onChange(date)}
+                        value={value}
+                      />
+                    </div>
                   )}
                 />
-                {errors?.deathDate && <p className={styles.errorMessage}>{errors?.deathDate?.message}</p>}
+                {errors?.deathDate && (
+                  <p id="deceasedDate-error" role="alert" className={styles.errorMessage}>
+                    {errors?.deathDate?.message}
+                  </p>
+                )}
               </ResponsiveWrapper>
             ) : (
               <DatePickerSkeleton />

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useId, useMemo } from 'react';
 import {
   Checkbox,
-  DatePicker,
-  DatePickerInput,
   NumberInput,
   Select,
   SelectItem,
@@ -14,7 +12,7 @@ import {
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { Controller, type ControllerRenderProps, useFormContext } from 'react-hook-form';
-import { useConfig } from '@openmrs/esm-framework';
+import { OpenmrsDatePicker, useConfig } from '@openmrs/esm-framework';
 import { type ChartConfig } from '../../config-schema';
 import { useConceptAnswersForVisitAttributeType, useVisitAttributeType } from '../hooks/useVisitAttributeType';
 import { type VisitFormData } from './visit-form.resource';
@@ -204,21 +202,13 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
         );
       case 'org.openmrs.customdatatype.datatype.DateDatatype':
         return (
-          <DatePicker
+          <OpenmrsDatePicker
             {...fieldProps}
-            dateFormat="d/m/Y"
-            datePickerType="single"
-            onChange={([date]) => onChange(dayjs(date).format('YYYY-MM-DD'))}
-          >
-            <DatePickerInput
-              id="date-picker-default-id"
-              placeholder="dd/mm/yyyy"
-              labelText={labelText}
-              type="text"
-              invalid={!!errors.visitAttributes?.[uuid]}
-              invalidText={errors.visitAttributes?.[uuid]?.message}
-            />
-          </DatePicker>
+            onChange={(date) => onChange(dayjs(date).format('YYYY-MM-DD'))}
+            labelText={labelText}
+            invalid={!!errors.visitAttributes?.[uuid]}
+            invalidText={errors.visitAttributes?.[uuid]?.message}
+          />
         );
       default:
         return (

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
@@ -205,9 +205,9 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
           <OpenmrsDatePicker
             {...fieldProps}
             onChange={(date) => onChange(dayjs(date).format('YYYY-MM-DD'))}
-            id="date-picker-default-id"
+            id={`date-picker-${uuid}`}
             labelText={labelText}
-            invalid={!!errors.visitAttributes?.[uuid]}
+            aria-invalid={!!errors.visitAttributes?.[uuid]}
             invalidText={errors.visitAttributes?.[uuid]?.message}
           />
         );

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
@@ -11,7 +11,7 @@ import {
 } from '@carbon/react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
-import { Controller, type ControllerRenderProps, useFormContext } from 'react-hook-form';
+import { Controller, type ControllerFieldState, type ControllerRenderProps, useFormContext } from 'react-hook-form';
 import { OpenmrsDatePicker, useConfig } from '@openmrs/esm-framework';
 import { type ChartConfig } from '../../config-schema';
 import { useConceptAnswersForVisitAttributeType, useVisitAttributeType } from '../hooks/useVisitAttributeType';
@@ -67,12 +67,13 @@ const VisitAttributeTypeFields: React.FC<VisitAttributeTypeFieldsProps> = ({ set
                 key={attributeType.uuid}
                 name={`visitAttributes.${attributeType.uuid}`}
                 control={control}
-                render={({ field }) => (
+                render={({ field, fieldState }) => (
                   <AttributeTypeField
                     key={attributeType.uuid}
                     attributeType={attributeType}
                     setErrorFetchingResources={setErrorFetchingResources}
                     fieldProps={field}
+                    fieldState={fieldState}
                   />
                 )}
               />
@@ -88,6 +89,7 @@ const VisitAttributeTypeFields: React.FC<VisitAttributeTypeFieldsProps> = ({ set
 
 interface AttributeTypeFieldProps {
   fieldProps: ControllerRenderProps<VisitFormData, `visitAttributes.${string}`>;
+  fieldState: ControllerFieldState;
   attributeType: {
     uuid: string;
     required: boolean;
@@ -103,6 +105,7 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
   attributeType,
   setErrorFetchingResources,
   fieldProps,
+  fieldState,
 }) => {
   const { uuid, required } = attributeType;
   const { data, isLoading, error: errorFetchingVisitAttributeType } = useVisitAttributeType(uuid);
@@ -128,7 +131,6 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
   }, [errorFetchingVisitAttributeAnswers, errorFetchingVisitAttributeType, required, setErrorFetchingResources]);
 
   const fieldToRender = useMemo(() => {
-    const { onChange } = fieldProps;
     if (isLoading) {
       return <></>;
     }
@@ -152,8 +154,8 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
             id={`select-${id}`}
             {...fieldProps}
             labelText={labelText}
-            invalid={!!errors.visitAttributes?.[uuid]}
-            invalidText={errors.visitAttributes?.[uuid]?.message}
+            invalid={!!fieldState?.error?.message}
+            invalidText={fieldState?.error?.message}
           >
             <SelectItem text={t('selectAnOption', 'Select an option')} value={''} />
             {answers.map((ans, indx) => (
@@ -167,8 +169,8 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
             {...fieldProps}
             label={labelText}
             hideSteppers
-            invalid={!!errors.visitAttributes?.[uuid]}
-            invalidText={errors.visitAttributes?.[uuid]?.message}
+            invalid={!!fieldState?.error?.message}
+            invalidText={fieldState?.error?.message}
           />
         );
       case 'org.openmrs.customdatatype.datatype.FreeTextDatatype':
@@ -178,8 +180,8 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
             id={uuid}
             labelText={labelText}
             placeholder={labelText}
-            invalid={!!errors.visitAttributes?.[uuid]}
-            invalidText={errors.visitAttributes?.[uuid]?.message}
+            invalid={!!fieldState?.error?.message}
+            invalidText={fieldState?.error?.message}
           />
         );
       case 'org.openmrs.customdatatype.datatype.LongFreeTextDatatype':
@@ -187,8 +189,8 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
           <TextArea
             {...fieldProps}
             labelText={labelText}
-            invalid={!!errors.visitAttributes?.[uuid]}
-            invalidText={errors.visitAttributes?.[uuid]?.message}
+            invalid={!!fieldState?.error?.message}
+            invalidText={fieldState?.error?.message}
           />
         );
       case 'org.openmrs.customdatatype.datatype.BooleanDatatype':
@@ -196,19 +198,18 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
           <Checkbox
             {...fieldProps}
             labelText={labelText}
-            invalid={!!errors.visitAttributes?.[uuid]}
-            invalidText={errors.visitAttributes?.[uuid]?.message}
+            invalid={!!fieldState?.error?.message}
+            invalidText={fieldState?.error?.message}
           />
         );
       case 'org.openmrs.customdatatype.datatype.DateDatatype':
         return (
           <OpenmrsDatePicker
             {...fieldProps}
-            onChange={(date) => onChange(dayjs(date).format('YYYY-MM-DD'))}
             id={`date-picker-${uuid}`}
             labelText={labelText}
-            aria-invalid={!!errors.visitAttributes?.[uuid]}
-            invalidText={errors.visitAttributes?.[uuid]?.message}
+            aria-invalid={!!fieldState?.error?.message}
+            invalidText={fieldState?.error?.message}
           />
         );
       default:
@@ -216,24 +217,24 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
           <TextInput
             {...fieldProps}
             labelText={labelText}
-            invalid={!!errors.visitAttributes?.[uuid]}
-            invalidText={errors.visitAttributes?.[uuid]?.message}
+            invalid={!!fieldState?.error?.message}
+            invalidText={fieldState?.error?.message}
           />
         );
     }
   }, [
-    uuid,
-    answers,
-    data,
     isLoading,
-    isLoadingAnswers,
-    labelText,
-    t,
     errorFetchingVisitAttributeType,
+    data?.datatypeClassname,
+    isLoadingAnswers,
     errorFetchingVisitAttributeAnswers,
-    fieldProps,
-    errors.visitAttributes,
     id,
+    fieldProps,
+    labelText,
+    fieldState?.error?.message,
+    t,
+    answers,
+    uuid,
   ]);
 
   if (isLoading) {

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-attribute-type.component.tsx
@@ -205,6 +205,7 @@ const AttributeTypeField: React.FC<AttributeTypeFieldProps> = ({
           <OpenmrsDatePicker
             {...fieldProps}
             onChange={(date) => onChange(dayjs(date).format('YYYY-MM-DD'))}
+            id="date-picker-default-id"
             labelText={labelText}
             invalid={!!errors.visitAttributes?.[uuid]}
             invalidText={errors.visitAttributes?.[uuid]?.message}

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -53,6 +53,7 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
                 {...field}
                 className={styles.datePicker}
                 id={`${dateFieldName}Input`}
+                data-testid={`${dateFieldName}Input`}
                 maxDate={maxDateObj}
                 minDate={minDateObj}
                 labelText={t('date', 'Date')}

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -59,6 +59,9 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
                 labelText={t('date', 'Date')}
                 invalid={Boolean(errors[dateFieldName])}
                 invalidText={errors[dateFieldName]?.message}
+                aria-labelledby={`${dateFieldName}Label`}
+                aria-describedby={errors[dateFieldName] ? `${dateFieldName}Error` : undefined}
+                aria-invalid={Boolean(errors[dateFieldName]) ? 'true' : 'false'}
               />
             </ResponsiveWrapper>
           )}

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -47,21 +47,17 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
         <Controller
           name={dateFieldName}
           control={control}
-          render={({ field: { onChange, value } }) => (
+          render={({ field, fieldState }) => (
             <ResponsiveWrapper>
               <OpenmrsDatePicker
+                {...field}
                 className={styles.datePicker}
                 id={`${dateFieldName}Input`}
                 maxDate={maxDateObj}
                 minDate={minDateObj}
-                onChange={onChange}
-                value={value ? dayjs(value).format('DD/MM/YYYY') : null}
                 labelText={t('date', 'Date')}
-                invalid={Boolean(errors[dateFieldName])}
-                invalidText={errors[dateFieldName]?.message}
-                aria-labelledby={`${dateFieldName}Label`}
-                aria-describedby={errors[dateFieldName] ? `${dateFieldName}Error` : undefined}
-                aria-invalid={Boolean(errors[dateFieldName]) ? 'true' : 'false'}
+                invalid={Boolean(fieldState?.error?.message)}
+                invalidText={fieldState?.error?.message}
               />
             </ResponsiveWrapper>
           )}

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -37,7 +37,7 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
   // Since we have the separate date and time fields, the final validation needs to be done at the form
   // submission, hence just using the min date with hours/ minutes/ seconds set to 0 and max date set to
   // last second of the day. We want to just compare dates and not time.
-  const minDateObj = minDate ? dayjs(new Date(minDate).setHours(0, 0, 0, 0)).format('DD/MM/YYYY') : null;
+  const minDateObj = minDate ? dayjs(new Date(minDate).setHours(0, 0, 0, 0)) : null;
   const maxDateObj = maxDate ? dayjs(new Date(maxDate).setHours(23, 59, 59, 59)).format('DD/MM/YYYY') : null;
 
   return (

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
-import { DatePicker, DatePickerInput, SelectItem, TimePicker, TimePickerSelect } from '@carbon/react';
+import { SelectItem, TimePicker, TimePickerSelect } from '@carbon/react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { ResponsiveWrapper } from '@openmrs/esm-framework';
+import { OpenmrsDatePicker, ResponsiveWrapper } from '@openmrs/esm-framework';
 import { type amPm } from '@openmrs/esm-patient-common-lib';
 import { type VisitFormData } from './visit-form.resource';
 import styles from './visit-form.scss';
@@ -49,25 +49,17 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
           control={control}
           render={({ field: { onChange, value } }) => (
             <ResponsiveWrapper>
-              <DatePicker
+              <OpenmrsDatePicker
                 className={styles.datePicker}
-                dateFormat="d/m/Y"
-                datePickerType="single"
                 id={dateFieldName}
                 maxDate={maxDateObj}
                 minDate={minDateObj}
-                onChange={([date]) => onChange(date)}
+                onChange={onChange}
                 value={value ? dayjs(value).format('DD/MM/YYYY') : null}
-              >
-                <DatePickerInput
-                  id={`${dateFieldName}Input`}
-                  invalid={Boolean(errors[dateFieldName])}
-                  invalidText={errors[dateFieldName]?.message}
-                  labelText={t('date', 'Date')}
-                  placeholder="dd/mm/yyyy"
-                  style={{ width: '100%' }}
-                />
-              </DatePicker>
+                labelText={t('date', 'Date')}
+                invalid={Boolean(errors[dateFieldName])}
+                invalidText={errors[dateFieldName]?.message}
+              />
             </ResponsiveWrapper>
           )}
         />

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -51,7 +51,7 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
             <ResponsiveWrapper>
               <OpenmrsDatePicker
                 className={styles.datePicker}
-                id={dateFieldName}
+                id={`${dateFieldName}Input`}
                 maxDate={maxDateObj}
                 minDate={minDateObj}
                 onChange={onChange}

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -8,6 +8,7 @@ import {
   useLocations,
   useVisitTypes,
   type Visit,
+  OpenmrsDatePicker,
 } from '@openmrs/esm-framework';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -168,6 +169,26 @@ jest.mock('./visit-form.resource', () => {
     updateVisitAttribute: jest.fn(),
     deleteVisitAttribute: jest.fn(),
   };
+});
+
+const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
+
+mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
+  return (
+    <>
+      <label htmlFor={id}>{labelText}</label>
+      <input
+        aria-label={labelText.toString()}
+        id={id}
+        onChange={(evt) => {
+          onChange(dayjs(evt.target.value).toDate());
+        }}
+        type="text"
+        // @ts-ignore
+        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
+      />
+    </>
+  );
 });
 
 mockSaveVisit.mockResolvedValue({

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -8,7 +8,6 @@ import {
   useLocations,
   useVisitTypes,
   type Visit,
-  OpenmrsDatePicker,
 } from '@openmrs/esm-framework';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -171,26 +170,6 @@ jest.mock('./visit-form.resource', () => {
   };
 });
 
-const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
-
-mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
-  return (
-    <>
-      <label htmlFor={id}>{labelText}</label>
-      <input
-        aria-label={labelText.toString()}
-        id={id}
-        onChange={(evt) => {
-          onChange(dayjs(evt.target.value).toDate());
-        }}
-        type="text"
-        // @ts-ignore
-        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
-      />
-    </>
-  );
-});
-
 mockSaveVisit.mockResolvedValue({
   status: 201,
   data: {
@@ -233,7 +212,7 @@ describe('Visit form', () => {
   it('renders the Start Visit form with all the relevant fields and values', async () => {
     renderVisitForm();
 
-    expect(screen.getByRole('textbox', { name: /Date/i })).toBeInTheDocument();
+    expect(screen.getByTestId('visitStartDateInput')).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /Time/i })).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: /Time/i })).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: /Select a location/i })).toBeInTheDocument();

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import dayjs from 'dayjs';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@testing-library/react';
-import { type FetchResponse, openmrsFetch, showSnackbar } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, showSnackbar, OpenmrsDatePicker } from '@openmrs/esm-framework';
 import { mockFhirConditionsResponse, searchedCondition } from '__mocks__';
 import { getByTextWithMarkup, mockPatient } from 'tools';
 import { createCondition, useConditionsSearch } from './conditions.resource';
@@ -38,6 +38,34 @@ jest.mock('./conditions.resource', () => ({
   useConditionsSearch: jest.fn(),
 }));
 
+jest.mock('@openmrs/esm-framework', () => {
+  const actualFramework = jest.requireActual('@openmrs/esm-framework');
+  return {
+    ...actualFramework,
+    OpenmrsDatePicker: jest.fn(),
+  };
+});
+
+const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
+
+mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
+  return (
+    <>
+      <label htmlFor={id}>{labelText}</label>
+      <input
+        aria-label={labelText.toString()}
+        id={id}
+        onChange={(evt) => {
+          onChange(dayjs(evt.target.value).toDate());
+        }}
+        type="text"
+        // @ts-ignore
+        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
+      />
+    </>
+  );
+});
+
 mockOpenmrsFetch.mockResolvedValue({ data: [] } as FetchResponse);
 mockUseConditionsSearch.mockReturnValue({
   searchResults: [],
@@ -68,7 +96,6 @@ describe('Conditions form', () => {
     expect(cancelButton).toBeEnabled();
     expect(submitButton).toBeInTheDocument();
   });
-
   it('closes the form and the workspace when the cancel button is clicked', async () => {
     const user = userEvent.setup();
     renderConditionsForm();

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
@@ -158,10 +158,14 @@ describe('Conditions form', () => {
     await user.click(activeStatusInput);
     await user.click(submitButton);
 
-    expect(mockShowSnackbar).toHaveBeenCalledWith({
-      kind: 'success',
-      subtitle: 'It is now visible on the Conditions page',
-      title: 'Condition saved',
+    jest.clearAllMocks();
+
+    await waitFor(() => {
+      expect(mockShowSnackbar).toHaveBeenCalledWith({
+        kind: 'success',
+        subtitle: 'It is now visible on the Conditions page',
+        title: 'Condition saved',
+      });
     });
   });
 

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from '@testing-library/react';
-import { type FetchResponse, openmrsFetch, showSnackbar, OpenmrsDatePicker } from '@openmrs/esm-framework';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { type FetchResponse, openmrsFetch, showSnackbar } from '@openmrs/esm-framework';
 import { mockFhirConditionsResponse, searchedCondition } from '__mocks__';
 import { getByTextWithMarkup, mockPatient } from 'tools';
 import { createCondition, useConditionsSearch } from './conditions.resource';
@@ -38,26 +38,6 @@ jest.mock('./conditions.resource', () => ({
   useConditionsSearch: jest.fn(),
 }));
 
-const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
-
-mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
-  return (
-    <>
-      <label htmlFor={id}>{labelText}</label>
-      <input
-        aria-label={labelText.toString()}
-        id={id}
-        onChange={(evt) => {
-          onChange(dayjs(evt.target.value).toDate());
-        }}
-        type="text"
-        // @ts-ignore
-        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
-      />
-    </>
-  );
-});
-
 mockOpenmrsFetch.mockResolvedValue({ data: [] } as FetchResponse);
 mockUseConditionsSearch.mockReturnValue({
   searchResults: [],
@@ -72,7 +52,7 @@ describe('Conditions form', () => {
     renderConditionsForm();
 
     expect(screen.getByRole('group', { name: /condition/i })).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /onset date/i })).toBeInTheDocument();
+    expect(screen.getByTestId('onsetDate')).toBeInTheDocument();
     expect(screen.getByRole('group', { name: /clinical status/i })).toBeInTheDocument();
     expect(screen.getByRole('searchbox', { name: /enter condition/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /clear search input/i })).toBeInTheDocument();
@@ -88,6 +68,7 @@ describe('Conditions form', () => {
     expect(cancelButton).toBeEnabled();
     expect(submitButton).toBeInTheDocument();
   });
+
   it('closes the form and the workspace when the cancel button is clicked', async () => {
     const user = userEvent.setup();
     renderConditionsForm();
@@ -102,10 +83,10 @@ describe('Conditions form', () => {
     renderConditionsForm();
 
     await user.click(screen.getByLabelText(/^active/i));
-    expect(screen.queryByLabelText(/end date/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('endDate')).not.toBeInTheDocument();
 
     await user.click(screen.getByLabelText(/inactive/i));
-    expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
+    expect(screen.getByTestId('endDate')).toBeInTheDocument();
   });
 
   it('renders a list of matching conditions when the user types a query into the searchbox', async () => {
@@ -151,21 +132,29 @@ describe('Conditions form', () => {
     const submitButton = screen.getByRole('button', { name: /save & close/i });
     const activeStatusInput = screen.getByRole('radio', { name: 'Active' });
     const conditionSearchInput = screen.getByRole('searchbox', { name: /enter condition/i });
+    const onsetDateInput = screen.getByTestId('onsetDate');
+    const onsetDateDayInput = within(onsetDateInput).getByRole('spinbutton', { name: /day/i });
+    const onsetDateMonthInput = within(onsetDateInput).getByRole('spinbutton', { name: /month/i });
+    const onsetDateYearInput = within(onsetDateInput).getByRole('spinbutton', { name: /year/i });
+
     expect(cancelButton).toBeEnabled();
 
     await user.type(conditionSearchInput, 'Headache');
     await user.click(screen.getByRole('menuitem', { name: /headache/i }));
     await user.click(activeStatusInput);
+    // await user.type(onsetDateInput, '2020-05-05');
+    await user.type(onsetDateDayInput, '05');
+    await user.type(onsetDateMonthInput, '05');
+    await user.type(onsetDateYearInput, '2020');
     await user.click(submitButton);
 
-    jest.clearAllMocks();
-
     await waitFor(() => {
-      expect(mockShowSnackbar).toHaveBeenCalledWith({
-        kind: 'success',
-        subtitle: 'It is now visible on the Conditions page',
-        title: 'Condition saved',
-      });
+      expect(mockShowSnackbar).toHaveBeenCalled();
+    });
+    expect(mockShowSnackbar).toHaveBeenCalledWith({
+      kind: 'success',
+      subtitle: 'It is now visible on the Conditions page',
+      title: 'Condition saved',
     });
   });
 
@@ -183,7 +172,10 @@ describe('Conditions form', () => {
     const submitButton = screen.getByRole('button', { name: /save & close/i });
     const activeStatusInput = screen.getByRole('radio', { name: 'Active' });
     const conditionSearchInput = screen.getByRole('searchbox', { name: /enter condition/i });
-    const onsetDateInput = screen.getByRole('textbox', { name: /onset date/i });
+    const onsetDateInput = screen.getByTestId('onsetDate');
+    const onsetDateDayInput = within(onsetDateInput).getByRole('spinbutton', { name: /day/i });
+    const onsetDateMonthInput = within(onsetDateInput).getByRole('spinbutton', { name: /month/i });
+    const onsetDateYearInput = within(onsetDateInput).getByRole('spinbutton', { name: /year/i });
 
     const error = {
       message: 'Internal Server Error',
@@ -196,7 +188,9 @@ describe('Conditions form', () => {
     mockCreateCondition.mockRejectedValue(error);
     await user.type(conditionSearchInput, 'Headache');
     await user.click(screen.getByRole('menuitem', { name: /Headache/i }));
-    await user.type(onsetDateInput, '2020-05-05');
+    await user.type(onsetDateDayInput, '05');
+    await user.type(onsetDateMonthInput, '05');
+    await user.type(onsetDateYearInput, '2020');
     await user.click(activeStatusInput);
     expect(activeStatusInput).toBeChecked();
     expect(submitButton).toBeEnabled();

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.test.tsx
@@ -38,14 +38,6 @@ jest.mock('./conditions.resource', () => ({
   useConditionsSearch: jest.fn(),
 }));
 
-jest.mock('@openmrs/esm-framework', () => {
-  const actualFramework = jest.requireActual('@openmrs/esm-framework');
-  return {
-    ...actualFramework,
-    OpenmrsDatePicker: jest.fn(),
-  };
-});
-
 const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
 
 mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
@@ -159,18 +151,13 @@ describe('Conditions form', () => {
     const submitButton = screen.getByRole('button', { name: /save & close/i });
     const activeStatusInput = screen.getByRole('radio', { name: 'Active' });
     const conditionSearchInput = screen.getByRole('searchbox', { name: /enter condition/i });
-    const onsetDateInput = screen.getByRole('textbox', { name: /onset date/i });
     expect(cancelButton).toBeEnabled();
 
     await user.type(conditionSearchInput, 'Headache');
     await user.click(screen.getByRole('menuitem', { name: /headache/i }));
     await user.click(activeStatusInput);
-    await user.type(onsetDateInput, '2020-05-05');
     await user.click(submitButton);
 
-    await waitFor(() => {
-      expect(mockShowSnackbar).toHaveBeenCalled();
-    });
     expect(mockShowSnackbar).toHaveBeenCalledWith({
       kind: 'success',
       subtitle: 'It is now visible on the Conditions page',

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -282,6 +282,9 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
                   onBlur={onBlur}
                   value={value}
                   labelText={t('onsetDate', 'Onset date')}
+                  aria-label={t('onsetDate', 'Onset date')}
+                  aria-required="true"
+                  aria-describedby="onsetDateHelper"
                 />
               </ResponsiveWrapper>
             )}
@@ -324,6 +327,9 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
                       onBlur={onBlur}
                       value={value}
                       labelText={t('endDate', 'End date')}
+                      aria-label={t('endDate', 'End date')}
+                      aria-required="true"
+                      aria-describedby="endDateDescription"
                     />
                   </ResponsiveWrapper>
                 </>

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -278,6 +278,7 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
                 <OpenmrsDatePicker
                   {...field}
                   id="onsetDate"
+                  data-testid="onsetDate"
                   maxDate={new Date()}
                   labelText={t('onsetDate', 'Onset date')}
                   invalid={Boolean(fieldState?.error?.message)}
@@ -319,6 +320,7 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
                     <OpenmrsDatePicker
                       {...field}
                       id="endDate"
+                      data-testid="endDate"
                       minDate={new Date(watch('onsetDateTime'))}
                       maxDate={new Date()}
                       labelText={t('endDate', 'End date')}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -4,8 +4,6 @@ import classNames from 'classnames';
 import dayjs from 'dayjs';
 import 'dayjs/plugin/utc';
 import {
-  DatePicker,
-  DatePickerInput,
   FormGroup,
   FormLabel,
   InlineLoading,
@@ -18,7 +16,7 @@ import {
 } from '@carbon/react';
 import { WarningFilled } from '@carbon/react/icons';
 import { useFormContext, Controller } from 'react-hook-form';
-import { showSnackbar, useDebounce, useSession, ResponsiveWrapper } from '@openmrs/esm-framework';
+import { showSnackbar, useDebounce, useSession, ResponsiveWrapper, OpenmrsDatePicker } from '@openmrs/esm-framework';
 import { type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import {
   type CodedCondition,
@@ -277,18 +275,14 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
             control={control}
             render={({ field: { onChange, onBlur, value } }) => (
               <ResponsiveWrapper>
-                <DatePicker
+                <OpenmrsDatePicker
                   id="onsetDate"
-                  datePickerType="single"
-                  dateFormat="d/m/Y"
                   maxDate={dayjs().utc().format()}
-                  placeholder="dd/mm/yyyy"
-                  onChange={([date]) => onChange(date)}
+                  onChange={onChange}
                   onBlur={onBlur}
                   value={value}
-                >
-                  <DatePickerInput id="onsetDateInput" labelText={t('onsetDate', 'Onset date')} />
-                </DatePicker>
+                  labelText={t('onsetDate', 'Onset date')}
+                />
               </ResponsiveWrapper>
             )}
           />
@@ -322,19 +316,15 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
               render={({ field: { onBlur, onChange, value } }) => (
                 <>
                   <ResponsiveWrapper>
-                    <DatePicker
+                    <OpenmrsDatePicker
                       id="endDate"
-                      datePickerType="single"
-                      dateFormat="d/m/Y"
                       minDate={new Date(watch('onsetDateTime')).toISOString()}
                       maxDate={dayjs().utc().format()}
-                      placeholder="dd/mm/yyyy"
-                      onChange={([date]) => onChange(date)}
+                      onChange={onChange}
                       onBlur={onBlur}
                       value={value}
-                    >
-                      <DatePickerInput id="abatementDateTime" labelText={t('endDate', 'End date')} />
-                    </DatePicker>
+                      labelText={t('endDate', 'End date')}
+                    />
                   </ResponsiveWrapper>
                 </>
               )}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -273,18 +273,15 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
           <Controller
             name="onsetDateTime"
             control={control}
-            render={({ field: { onChange, onBlur, value } }) => (
+            render={({ field, fieldState }) => (
               <ResponsiveWrapper>
                 <OpenmrsDatePicker
+                  {...field}
                   id="onsetDate"
-                  maxDate={dayjs().utc().format()}
-                  onChange={onChange}
-                  onBlur={onBlur}
-                  value={value}
+                  maxDate={new Date()}
                   labelText={t('onsetDate', 'Onset date')}
-                  aria-label={t('onsetDate', 'Onset date')}
-                  aria-required="true"
-                  aria-describedby="onsetDateHelper"
+                  invalid={Boolean(fieldState?.error?.message)}
+                  invalidText={fieldState?.error?.message}
                 />
               </ResponsiveWrapper>
             )}
@@ -316,20 +313,17 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
             <Controller
               name="abatementDateTime"
               control={control}
-              render={({ field: { onBlur, onChange, value } }) => (
+              render={({ field, fieldState }) => (
                 <>
                   <ResponsiveWrapper>
                     <OpenmrsDatePicker
+                      {...field}
                       id="endDate"
-                      minDate={new Date(watch('onsetDateTime')).toISOString()}
-                      maxDate={dayjs().utc().format()}
-                      onChange={onChange}
-                      onBlur={onBlur}
-                      value={value}
+                      minDate={new Date(watch('onsetDateTime'))}
+                      maxDate={new Date()}
                       labelText={t('endDate', 'End date')}
-                      aria-label={t('endDate', 'End date')}
-                      aria-required="true"
-                      aria-describedby="endDateDescription"
+                      invalid={Boolean(fieldState?.error?.message)}
+                      invalidText={fieldState?.error?.message}
                     />
                   </ResponsiveWrapper>
                 </>

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import {
   getDefaultsFromConfigSchema,
   showSnackbar,
@@ -10,7 +10,6 @@ import {
   useConfig,
   useSession,
   useVisit,
-  OpenmrsDatePicker,
 } from '@openmrs/esm-framework';
 import { configSchema } from '../config-schema';
 import { type ImmunizationWidgetConfigObject } from '../types/fhir-immunization-domain';
@@ -31,25 +30,6 @@ const mockUseVisit = jest.mocked(useVisit);
 const mockMutate = jest.fn();
 const mockToOmrsIsoString = jest.mocked(toOmrsIsoString);
 const mockToDateObjectStrict = jest.mocked(toDateObjectStrict);
-const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
-
-mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
-  return (
-    <>
-      <label htmlFor={id}>{labelText}</label>
-      <input
-        aria-label={labelText.toString()}
-        id={id}
-        onChange={(evt) => {
-          onChange(dayjs(evt.target.value).toDate());
-        }}
-        type="text"
-        // @ts-ignore
-        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
-      />
-    </>
-  );
-});
 
 jest.mock('../hooks/useImmunizationsConceptSet', () => ({
   useImmunizationsConceptSet: jest.fn(() => ({
@@ -140,7 +120,7 @@ describe('Immunizations Form', () => {
   it('should render ImmunizationsForm component', () => {
     render(<ImmunizationsForm {...testProps} />);
 
-    expect(screen.getByRole('textbox', { name: /Vaccination Date/i })).toBeInTheDocument();
+    expect(screen.getByTestId('vaccinationDate')).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /Time/i })).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: /Time/i })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /AM/i })).toBeInTheDocument();
@@ -148,7 +128,7 @@ describe('Immunizations Form', () => {
     expect(screen.getByRole('combobox', { name: /Immunization/i })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /Manufacturer/i })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /Lot Number/i })).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /Expiration Date/i })).toBeInTheDocument();
+    expect(screen.getByTestId('vaccinationExpiration')).toBeInTheDocument();
   });
 
   it('should render dose field appropriately', async () => {
@@ -266,23 +246,35 @@ describe('Immunizations Form', () => {
 
     render(<ImmunizationsForm {...testProps} />);
 
-    const vaccinationDateField = screen.getByRole('textbox', { name: /Vaccination Date/i });
+    const vaccinationDateField = screen.getByTestId('vaccinationDate');
+    const vaccinationDateDayInput = within(vaccinationDateField).getByRole('spinbutton', { name: /day/i });
+    const vaccinationDateMonthInput = within(vaccinationDateField).getByRole('spinbutton', { name: /month/i });
+    const vaccinationDateYearInput = within(vaccinationDateField).getByRole('spinbutton', { name: /year/i });
     const vaccinationTimeField = screen.getByRole('textbox', { name: /Time/i });
     const vaccineField = screen.getByRole('combobox', { name: /Immunization/i });
     const doseField = screen.getByRole('spinbutton', { name: /Dose number within series/i });
     const lotField = screen.getByRole('textbox', { name: /Lot number/i });
     const manufacturerField = screen.getByRole('textbox', { name: /Manufacturer/i });
-    const expirationDateField = screen.getByRole('textbox', { name: /Expiration Date/i });
+    const expirationDateField = screen.getByTestId('vaccinationExpiration');
+    const expirationDateDayInput = within(expirationDateField).getByRole('spinbutton', { name: /day/i });
+    const expirationDateMonthInput = within(expirationDateField).getByRole('spinbutton', { name: /month/i });
+    const expirationDateYearInput = within(expirationDateField).getByRole('spinbutton', { name: /year/i });
     const saveButton = screen.getByRole('button', { name: /Save/i });
 
     // verify the form values
-    expect(vaccinationDateField).toHaveValue('03/01/2024');
+    expect(vaccinationDateDayInput.innerHTML).toBe('03');
+    expect(vaccinationDateMonthInput.innerHTML).toBe('01');
+    expect(vaccinationDateYearInput.innerHTML).toBe('2024');
+
     expect(vaccinationTimeField).toHaveValue('03:44');
     expect(vaccineField.title).toBe('Bacillus Calmette–Guérin vaccine');
     expect(doseField).toHaveValue(24);
     expect(lotField).toHaveValue('A123456');
     expect(manufacturerField).toHaveValue('Merck & Co., Inc.');
-    expect(expirationDateField).toHaveValue('19/05/2024');
+    // expect(expirationDateField).toHaveValue('19/05/2024');
+    expect(expirationDateDayInput.innerHTML).toBe('19');
+    expect(expirationDateMonthInput.innerHTML).toBe('05');
+    expect(expirationDateYearInput.innerHTML).toBe('2024');
 
     // edit the form
     await selectOption(vaccineField, 'Hepatitis B vaccination');

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
@@ -10,6 +10,7 @@ import {
   useConfig,
   useSession,
   useVisit,
+  OpenmrsDatePicker,
 } from '@openmrs/esm-framework';
 import { configSchema } from '../config-schema';
 import { type ImmunizationWidgetConfigObject } from '../types/fhir-immunization-domain';
@@ -30,6 +31,25 @@ const mockUseVisit = jest.mocked(useVisit);
 const mockMutate = jest.fn();
 const mockToOmrsIsoString = jest.mocked(toOmrsIsoString);
 const mockToDateObjectStrict = jest.mocked(toDateObjectStrict);
+const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
+
+mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
+  return (
+    <>
+      <label htmlFor={id}>{labelText}</label>
+      <input
+        aria-label={labelText.toString()}
+        id={id}
+        onChange={(evt) => {
+          onChange(dayjs(evt.target.value).toDate());
+        }}
+        type="text"
+        // @ts-ignore
+        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
+      />
+    </>
+  );
+});
 
 jest.mock('../hooks/useImmunizationsConceptSet', () => ({
   useImmunizationsConceptSet: jest.fn(() => ({

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -43,8 +43,6 @@ interface ResponsiveWrapperProps {
   isTablet: boolean;
 }
 
-const datePickerFormat = 'd/m/Y';
-
 const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
   patientUuid,
   closeWorkspace,

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -4,8 +4,6 @@ import dayjs from 'dayjs';
 import {
   Button,
   ButtonSet,
-  DatePicker,
-  DatePickerInput,
   Dropdown,
   Form,
   InlineNotification,
@@ -24,6 +22,7 @@ import {
   toDateObjectStrict,
   showSnackbar,
   ResponsiveWrapper,
+  OpenmrsDatePicker,
 } from '@openmrs/esm-framework';
 import { useForm, Controller, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -229,25 +228,16 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
                   name="vaccinationDate"
                   control={control}
                   render={({ field: { onChange, value } }) => (
-                    <DatePicker
+                    <OpenmrsDatePicker
                       id="vaccinationDate"
                       maxDate={new Date().toISOString()}
-                      dateFormat={datePickerFormat}
-                      datePickerType="single"
                       value={value}
-                      onChange={([date]) => onChange(date)}
-                      style={{ paddingBottom: '1rem' }}
-                    >
-                      <DatePickerInput
-                        id="vaccinationDateInput"
-                        placeholder="dd/mm/yyyy"
-                        labelText={t('vaccinationDate', 'Vaccination date')}
-                        type="text"
-                        invalid={!!errors['vaccinationDate']}
-                        invalidText={errors['vaccinationDate']?.message}
-                        style={{ width: '100%' }}
-                      />
-                    </DatePicker>
+                      onChange={(date) => onChange(date)}
+                      style={{ paddingBottom: '1rem', width: '100%' }}
+                      invalid={!!errors['vaccinationDate']}
+                      invalidText={errors['vaccinationDate']?.message}
+                      labelText={t('vaccinationDate', 'Vaccination date')}
+                    />
                   )}
                 />
               </ResponsiveWrapper>
@@ -380,22 +370,14 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
                 control={control}
                 render={({ field: { onChange, value } }) => (
                   <div className={styles.row}>
-                    <DatePicker
+                    <OpenmrsDatePicker
                       id="vaccinationExpiration"
                       className="vaccinationExpiration"
                       minDate={immunizationToEditMeta ? null : new Date().toISOString()}
-                      dateFormat={datePickerFormat}
-                      datePickerType="single"
                       value={value}
-                      onChange={([date]) => onChange(date)}
-                    >
-                      <DatePickerInput
-                        id="date-picker-calendar-id"
-                        placeholder="dd/mm/yyyy"
-                        labelText={t('expirationDate', 'Expiration date')}
-                        type="text"
-                      />
-                    </DatePicker>
+                      onChange={(date) => onChange(date)}
+                      labelText={t('expirationDate', 'Expiration date')}
+                    />
                   </div>
                 )}
               />

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -229,6 +229,7 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
                     <OpenmrsDatePicker
                       {...field}
                       id="vaccinationDate"
+                      data-testid="vaccinationDate"
                       maxDate={new Date()}
                       style={{ paddingBottom: '1rem', width: '100%' }}
                       labelText={t('vaccinationDate', 'Vaccination date')}
@@ -370,6 +371,7 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
                     <OpenmrsDatePicker
                       {...field}
                       id="vaccinationExpiration"
+                      data-testid="vaccinationExpiration"
                       className="vaccinationExpiration"
                       minDate={immunizationToEditMeta ? null : new Date()}
                       labelText={t('expirationDate', 'Expiration date')}

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -234,9 +234,9 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
                       value={value}
                       onChange={(date) => onChange(date)}
                       style={{ paddingBottom: '1rem', width: '100%' }}
+                      labelText={t('vaccinationDate', 'Vaccination date')}
                       invalid={!!errors['vaccinationDate']}
                       invalidText={errors['vaccinationDate']?.message}
-                      labelText={t('vaccinationDate', 'Vaccination date')}
                     />
                   )}
                 />

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -225,16 +225,15 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
                 <Controller
                   name="vaccinationDate"
                   control={control}
-                  render={({ field: { onChange, value } }) => (
+                  render={({ field, fieldState }) => (
                     <OpenmrsDatePicker
+                      {...field}
                       id="vaccinationDate"
-                      maxDate={new Date().toISOString()}
-                      value={value}
-                      onChange={(date) => onChange(date)}
+                      maxDate={new Date()}
                       style={{ paddingBottom: '1rem', width: '100%' }}
                       labelText={t('vaccinationDate', 'Vaccination date')}
-                      invalid={!!errors['vaccinationDate']}
-                      invalidText={errors['vaccinationDate']?.message}
+                      invalid={Boolean(fieldState?.error?.message)}
+                      invalidText={fieldState?.error?.message}
                     />
                   )}
                 />
@@ -366,18 +365,16 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
               <Controller
                 name="expirationDate"
                 control={control}
-                render={({ field: { onChange, value } }) => (
+                render={({ field, fieldState }) => (
                   <div className={styles.row}>
                     <OpenmrsDatePicker
+                      {...field}
                       id="vaccinationExpiration"
                       className="vaccinationExpiration"
-                      minDate={immunizationToEditMeta ? null : new Date().toISOString()}
-                      value={value}
-                      onChange={(date) => onChange(date)}
+                      minDate={immunizationToEditMeta ? null : new Date()}
                       labelText={t('expirationDate', 'Expiration date')}
-                      aria-label={t('expirationDate', 'Expiration date')}
-                      aria-required="true"
-                      aria-describedby="vaccinationExpirationHelper"
+                      invalid={Boolean(fieldState?.error?.message)}
+                      invalidText={fieldState?.error?.message}
                     />
                   </div>
                 )}

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -375,6 +375,9 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
                       value={value}
                       onChange={(date) => onChange(date)}
                       labelText={t('expirationDate', 'Expiration date')}
+                      aria-label={t('expirationDate', 'Expiration date')}
+                      aria-required="true"
+                      aria-describedby="vaccinationExpirationHelper"
                     />
                   </div>
                 )}

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
@@ -10,10 +10,11 @@ import {
   mockPatientDrugOrdersApiData,
   mockSessionDataResponse,
 } from '__mocks__';
-import { closeWorkspace, useSession } from '@openmrs/esm-framework';
+import { closeWorkspace, useSession, OpenmrsDatePicker } from '@openmrs/esm-framework';
 import { type PostDataPrepFunction, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { _resetOrderBasketStore } from '@openmrs/esm-patient-common-lib/src/orders/store';
 import AddDrugOrderWorkspace from './add-drug-order.workspace';
+import dayjs from 'dayjs';
 
 const mockCloseWorkspace = closeWorkspace as jest.Mock;
 const mockLaunchPatientWorkspace = jest.fn();
@@ -21,6 +22,7 @@ const mockUseSession = jest.mocked(useSession);
 const mockUseDrugSearch = jest.mocked(useDrugSearch);
 const mockUseDrugTemplate = jest.mocked(useDrugTemplate);
 const usePatientOrdersMock = jest.fn();
+const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
 
 mockCloseWorkspace.mockImplementation((name, { onWorkspaceClose }) => onWorkspaceClose());
 mockUseSession.mockReturnValue(mockSessionDataResponse.data);
@@ -53,6 +55,24 @@ jest.mock('../api/api', () => ({
     .fn()
     .mockReturnValue({ requireOutpatientQuantity: false, error: null, isLoading: false }),
 }));
+
+mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
+  return (
+    <>
+      <label htmlFor={id}>{labelText}</label>
+      <input
+        aria-label={labelText.toString()}
+        id={id}
+        onChange={(evt) => {
+          onChange(dayjs(evt.target.value).toDate());
+        }}
+        type="text"
+        // @ts-ignore
+        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
+      />
+    </>
+  );
+});
 
 describe('AddDrugOrderWorkspace drug search', () => {
   beforeEach(() => {

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
@@ -10,11 +10,10 @@ import {
   mockPatientDrugOrdersApiData,
   mockSessionDataResponse,
 } from '__mocks__';
-import { closeWorkspace, useSession, OpenmrsDatePicker } from '@openmrs/esm-framework';
+import { closeWorkspace, useSession } from '@openmrs/esm-framework';
 import { type PostDataPrepFunction, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { _resetOrderBasketStore } from '@openmrs/esm-patient-common-lib/src/orders/store';
 import AddDrugOrderWorkspace from './add-drug-order.workspace';
-import dayjs from 'dayjs';
 
 const mockCloseWorkspace = closeWorkspace as jest.Mock;
 const mockLaunchPatientWorkspace = jest.fn();
@@ -22,7 +21,6 @@ const mockUseSession = jest.mocked(useSession);
 const mockUseDrugSearch = jest.mocked(useDrugSearch);
 const mockUseDrugTemplate = jest.mocked(useDrugTemplate);
 const usePatientOrdersMock = jest.fn();
-const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
 
 mockCloseWorkspace.mockImplementation((name, { onWorkspaceClose }) => onWorkspaceClose());
 mockUseSession.mockReturnValue(mockSessionDataResponse.data);
@@ -55,24 +53,6 @@ jest.mock('../api/api', () => ({
     .fn()
     .mockReturnValue({ requireOutpatientQuantity: false, error: null, isLoading: false }),
 }));
-
-mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
-  return (
-    <>
-      <label htmlFor={id}>{labelText}</label>
-      <input
-        aria-label={labelText.toString()}
-        id={id}
-        onChange={(evt) => {
-          onChange(dayjs(evt.target.value).toDate());
-        }}
-        type="text"
-        // @ts-ignore
-        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
-      />
-    </>
-  );
-});
 
 describe('AddDrugOrderWorkspace drug search', () => {
   beforeEach(() => {

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -612,6 +612,9 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                           onChange={(newStartDate) => onChange(newStartDate)}
                           onBlur={onBlur}
                           ref={ref}
+                          id="startDatePicker"
+                          labelText={t('startDate', 'Start date')}
+                          size={isTablet ? 'lg' : 'sm'}
                         />
                       )}
                     />

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -7,8 +7,6 @@ import {
   Checkbox,
   Column,
   ComboBox,
-  DatePicker,
-  DatePickerInput,
   IconButton,
   Form,
   FormGroup,
@@ -30,6 +28,7 @@ import {
   ExtensionSlot,
   formatDate,
   getPatientName,
+  OpenmrsDatePicker,
   parseDate,
   useConfig,
   useLayoutType,
@@ -607,21 +606,13 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                       name="startDate"
                       control={control}
                       render={({ field: { onBlur, value, onChange, ref } }) => (
-                        <DatePicker
-                          datePickerType="single"
+                        <OpenmrsDatePicker
                           maxDate={new Date().toISOString()}
                           value={value}
-                          onChange={([newStartDate]) => onChange(newStartDate)}
+                          onChange={(newStartDate) => onChange(newStartDate)}
                           onBlur={onBlur}
                           ref={ref}
-                        >
-                          <DatePickerInput
-                            id="startDatePicker"
-                            placeholder="dd/mm/yyyy"
-                            labelText={t('startDate', 'Start date')}
-                            size={isTablet ? 'lg' : 'sm'}
-                          />
-                        </DatePicker>
+                        />
                       )}
                     />
                   </InputWrapper>

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -615,6 +615,8 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                           id="startDatePicker"
                           labelText={t('startDate', 'Start date')}
                           size={isTablet ? 'lg' : 'sm'}
+                          aria-labelledby="startDatePickerLabel"
+                          aria-describedby="startDatePickerDescription"
                         />
                       )}
                     />

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -605,18 +605,15 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                     <Controller
                       name="startDate"
                       control={control}
-                      render={({ field: { onBlur, value, onChange, ref } }) => (
+                      render={({ field, fieldState }) => (
                         <OpenmrsDatePicker
-                          maxDate={new Date().toISOString()}
-                          value={value}
-                          onChange={(newStartDate) => onChange(newStartDate)}
-                          onBlur={onBlur}
-                          ref={ref}
+                          {...field}
+                          maxDate={new Date()}
                           id="startDatePicker"
                           labelText={t('startDate', 'Start date')}
                           size={isTablet ? 'lg' : 'sm'}
-                          aria-labelledby="startDatePickerLabel"
-                          aria-describedby="startDatePickerDescription"
+                          invalid={Boolean(fieldState?.error?.message)}
+                          invalidText={fieldState?.error?.message}
                         />
                       )}
                     />

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render } from '@testing-library/react';
-import {
-  OpenmrsDatePicker,
-  getDefaultsFromConfigSchema,
-  showSnackbar,
-  useConfig,
-  useSession,
-} from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, showSnackbar, useConfig, useSession } from '@openmrs/esm-framework';
 import { fetchDiagnosisConceptsByName, saveVisitNote } from './visit-notes.resource';
 import {
   ConfigMock,
@@ -19,27 +13,6 @@ import {
 import { configSchema, type ConfigObject } from '../config-schema';
 import { mockPatient, getByTextWithMarkup } from 'tools';
 import VisitNotesForm from './visit-notes-form.workspace';
-import dayjs from 'dayjs';
-
-const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
-
-mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
-  return (
-    <>
-      <label htmlFor={id}>{labelText}</label>
-      <input
-        aria-label={labelText.toString()}
-        id={id}
-        onChange={(evt) => {
-          onChange(dayjs(evt.target.value).toDate());
-        }}
-        type="text"
-        // @ts-ignore
-        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
-      />
-    </>
-  );
-});
 
 const defaultProps = {
   patientUuid: mockPatient.id,
@@ -90,7 +63,7 @@ test('renders the visit notes form with all the relevant fields and values', () 
 
   renderVisitNotesForm();
 
-  expect(screen.getByRole('textbox', { name: /visit date/i })).toBeInTheDocument();
+  expect(screen.getByTestId('visitDateTimePicker')).toBeInTheDocument();
   expect(screen.getByRole('textbox', { name: /write your notes/i })).toBeInTheDocument();
   expect(screen.getByRole('searchbox', { name: /enter primary diagnoses/i })).toBeInTheDocument();
   expect(screen.getByRole('searchbox', { name: /enter secondary diagnoses/i })).toBeInTheDocument();

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render } from '@testing-library/react';
-import { getDefaultsFromConfigSchema, showSnackbar, useConfig, useSession } from '@openmrs/esm-framework';
+import {
+  OpenmrsDatePicker,
+  getDefaultsFromConfigSchema,
+  showSnackbar,
+  useConfig,
+  useSession,
+} from '@openmrs/esm-framework';
 import { fetchDiagnosisConceptsByName, saveVisitNote } from './visit-notes.resource';
 import {
   ConfigMock,
@@ -13,6 +19,27 @@ import {
 import { configSchema, type ConfigObject } from '../config-schema';
 import { mockPatient, getByTextWithMarkup } from 'tools';
 import VisitNotesForm from './visit-notes-form.workspace';
+import dayjs from 'dayjs';
+
+const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
+
+mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
+  return (
+    <>
+      <label htmlFor={id}>{labelText}</label>
+      <input
+        aria-label={labelText.toString()}
+        id={id}
+        onChange={(evt) => {
+          onChange(dayjs(evt.target.value).toDate());
+        }}
+        type="text"
+        // @ts-ignore
+        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
+      />
+    </>
+  );
+});
 
 const defaultProps = {
   patientUuid: mockPatient.id,

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
@@ -458,6 +458,7 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
                     maxDate={new Date().toISOString()}
                     value={value}
                     onChange={(date) => onChange(date)}
+                    id="visitDateTimePicker"
                     labelText={t('visitDate', 'Visit date')}
                   />
                 </ResponsiveWrapper>

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
@@ -460,6 +460,8 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
                     onChange={(date) => onChange(date)}
                     id="visitDateTimePicker"
                     labelText={t('visitDate', 'Visit date')}
+                    aria-label={t('visitDate', 'Visit date')}
+                    aria-describedby="visitDateHelpText"
                   />
                 </ResponsiveWrapper>
               )}

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
@@ -458,6 +458,7 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
                     {...field}
                     maxDate={new Date()}
                     id="visitDateTimePicker"
+                    data-testid="visitDateTimePicker"
                     labelText={t('visitDate', 'Visit date')}
                     invalid={Boolean(fieldState?.error?.message)}
                     invalidText={fieldState?.error?.message}

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
@@ -11,8 +11,6 @@ import {
   Button,
   ButtonSet,
   Column,
-  DatePicker,
-  DatePickerInput,
   Form,
   FormGroup,
   InlineLoading,
@@ -38,6 +36,7 @@ import {
   useConfig,
   useLayoutType,
   useSession,
+  OpenmrsDatePicker,
 } from '@openmrs/esm-framework';
 import { type DefaultPatientWorkspaceProps, useAllowedFileExtensions } from '@openmrs/esm-patient-common-lib';
 import type { ConfigObject } from '../config-schema';
@@ -455,19 +454,12 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
               control={control}
               render={({ field: { onChange, value } }) => (
                 <ResponsiveWrapper>
-                  <DatePicker
-                    dateFormat="d/m/Y"
-                    datePickerType="single"
+                  <OpenmrsDatePicker
                     maxDate={new Date().toISOString()}
                     value={value}
-                    onChange={([date]) => onChange(date)}
-                  >
-                    <DatePickerInput
-                      id="visitDateTimePicker"
-                      labelText={t('visitDate', 'Visit date')}
-                      placeholder="dd/mm/yyyy"
-                    />
-                  </DatePicker>
+                    onChange={(date) => onChange(date)}
+                    labelText={t('visitDate', 'Visit date')}
+                  />
                 </ResponsiveWrapper>
               )}
             />

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
@@ -452,16 +452,15 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
             <Controller
               name="noteDate"
               control={control}
-              render={({ field: { onChange, value } }) => (
+              render={({ field, fieldState }) => (
                 <ResponsiveWrapper>
                   <OpenmrsDatePicker
-                    maxDate={new Date().toISOString()}
-                    value={value}
-                    onChange={(date) => onChange(date)}
+                    {...field}
+                    maxDate={new Date()}
                     id="visitDateTimePicker"
                     labelText={t('visitDate', 'Visit date')}
-                    aria-label={t('visitDate', 'Visit date')}
-                    aria-describedby="visitDateHelpText"
+                    invalid={Boolean(fieldState?.error?.message)}
+                    invalidText={fieldState?.error?.message}
                   />
                 </ResponsiveWrapper>
               )}

--- a/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
@@ -44,15 +44,6 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   };
 });
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    OpenmrsDatePicker: jest.fn(),
-  };
-});
-
 mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
   return (
     <>

--- a/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
@@ -2,14 +2,12 @@ import React from 'react';
 import { useReactToPrint } from 'react-to-print';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import dayjs from 'dayjs';
 import {
   type ConfigObject,
   getDefaultsFromConfigSchema,
   openmrsFetch,
   useConfig,
   useSession,
-  OpenmrsDatePicker,
 } from '@openmrs/esm-framework';
 import { useOrderTypes, usePatientOrders } from '@openmrs/esm-patient-common-lib';
 import { configSchema } from '../config-schema';
@@ -23,7 +21,6 @@ const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockSession = jest.mocked(useSession);
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
 const mockUseReactToPrint = jest.mocked(useReactToPrint);
-const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
 
 mockSession.mockReturnValue(mockSessionDataResponse.data);
 mockOpenmrsFetch.mockImplementation(jest.fn());
@@ -42,24 +39,6 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
     useOrderTypes: jest.fn(),
     usePatient: jest.fn(),
   };
-});
-
-mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
-  return (
-    <>
-      <label htmlFor={id}>{labelText}</label>
-      <input
-        aria-label={labelText.toString()}
-        id={id}
-        onChange={(evt) => {
-          onChange(dayjs(evt.target.value).toDate());
-        }}
-        type="text"
-        // @ts-ignore
-        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
-      />
-    </>
-  );
 });
 
 describe('OrderDetailsTable', () => {

--- a/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { useReactToPrint } from 'react-to-print';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import dayjs from 'dayjs';
 import {
   type ConfigObject,
   getDefaultsFromConfigSchema,
   openmrsFetch,
   useConfig,
   useSession,
+  OpenmrsDatePicker,
 } from '@openmrs/esm-framework';
 import { useOrderTypes, usePatientOrders } from '@openmrs/esm-patient-common-lib';
 import { configSchema } from '../config-schema';
@@ -21,6 +23,7 @@ const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockSession = jest.mocked(useSession);
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
 const mockUseReactToPrint = jest.mocked(useReactToPrint);
+const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
 
 mockSession.mockReturnValue(mockSessionDataResponse.data);
 mockOpenmrsFetch.mockImplementation(jest.fn());
@@ -39,6 +42,33 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
     useOrderTypes: jest.fn(),
     usePatient: jest.fn(),
   };
+});
+
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+
+  return {
+    ...originalModule,
+    OpenmrsDatePicker: jest.fn(),
+  };
+});
+
+mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
+  return (
+    <>
+      <label htmlFor={id}>{labelText}</label>
+      <input
+        aria-label={labelText.toString()}
+        id={id}
+        onChange={(evt) => {
+          onChange(dayjs(evt.target.value).toDate());
+        }}
+        type="text"
+        // @ts-ignore
+        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
+      />
+    </>
+  );
 });
 
 describe('OrderDetailsTable', () => {

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { useReactToPrint } from 'react-to-print';
 import {
   Button,
+  DatePicker,
+  DatePickerInput,
   DataTable,
   DataTableSkeleton,
   Dropdown,
@@ -47,7 +49,6 @@ import {
   formatDate,
   getCoreTranslation,
   getPatientName,
-  OpenmrsDatePicker,
   PrinterIcon,
   useConfig,
   useLayoutType,
@@ -361,21 +362,27 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({
           />
         </div>
         <span className={styles.rangeLabel}>{t('dateRange', 'Date range')}:</span>
-        <OpenmrsDatePicker
-          id="startDatePickerInput"
-          aria-labelledby="dateRangeLabel startDatePickerLabel"
-          aria-label={t('startDate', 'Start Date')}
+        <DatePicker
+          datePickerType="range"
+          dateFormat={'d/m/Y'}
           value={''}
-          onChange={(date: Date) => {
-            handleDateFilterChange([date, date]);
+          onChange={([startDate, endDate]) => {
+            handleDateFilterChange([startDate, endDate]);
           }}
-        />
-
-        <OpenmrsDatePicker
-          id="endDatePickerInput"
-          aria-labelledby="dateRangeLabel endDatePickerLabel"
-          aria-label={t('endDate', 'End Date')}
-        />
+        >
+          <DatePickerInput
+            id="startDatePickerInput"
+            data-testid="startDatePickerInput"
+            labelText=""
+            placeholder="dd/mm/yyyy"
+          />
+          <DatePickerInput
+            id="endDatePickerInput"
+            data-testid="endDatePickerInput"
+            labelText=""
+            placeholder="dd/mm/yyyy"
+          />
+        </DatePicker>
       </div>
 
       {(() => {

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -6,8 +6,6 @@ import {
   Button,
   DataTable,
   DataTableSkeleton,
-  DatePicker,
-  DatePickerInput,
   Dropdown,
   InlineLoading,
   Layer,
@@ -49,6 +47,7 @@ import {
   formatDate,
   getCoreTranslation,
   getPatientName,
+  OpenmrsDatePicker,
   PrinterIcon,
   useConfig,
   useLayoutType,
@@ -362,27 +361,13 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({
           />
         </div>
         <span className={styles.rangeLabel}>{t('dateRange', 'Date range')}:</span>
-        <DatePicker
-          datePickerType="range"
-          dateFormat={'d/m/Y'}
+        <OpenmrsDatePicker
           value={''}
-          onChange={([startDate, endDate]) => {
-            handleDateFilterChange([startDate, endDate]);
+          onChange={(date: Date) => {
+            handleDateFilterChange([date, date]);
           }}
-        >
-          <DatePickerInput
-            id="startDatePickerInput"
-            data-testid="startDatePickerInput"
-            labelText=""
-            placeholder="dd/mm/yyyy"
-          />
-          <DatePickerInput
-            id="endDatePickerInput"
-            data-testid="endDatePickerInput"
-            labelText=""
-            placeholder="dd/mm/yyyy"
-          />
-        </DatePicker>
+          labelText={t('dateRange', 'Select Date')}
+        />
       </div>
 
       {(() => {

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -362,11 +362,22 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({
         </div>
         <span className={styles.rangeLabel}>{t('dateRange', 'Date range')}:</span>
         <OpenmrsDatePicker
+          id="startDatePickerInput"
+          data-testid="startDatePickerInput"
+          labelText="Start Date"
           value={''}
           onChange={(date: Date) => {
             handleDateFilterChange([date, date]);
           }}
-          labelText={t('dateRange', 'Select Date')}
+        />
+
+        <OpenmrsDatePicker
+          id="endDatePickerInput"
+          data-testid="endDatePickerInput"
+          labelText="End Date"
+          onChange={(date: Date) => {
+            handleDateFilterChange([date, date]);
+          }}
         />
       </div>
 

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -363,15 +363,19 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({
         <span className={styles.rangeLabel}>{t('dateRange', 'Date range')}:</span>
         <OpenmrsDatePicker
           id="startDatePickerInput"
-          data-testid="startDatePickerInput"
-          labelText=""
+          aria-labelledby="dateRangeLabel startDatePickerLabel"
+          aria-label={t('startDate', 'Start Date')}
           value={''}
           onChange={(date: Date) => {
             handleDateFilterChange([date, date]);
           }}
         />
 
-        <OpenmrsDatePicker id="endDatePickerInput" data-testid="endDatePickerInput" labelText="" />
+        <OpenmrsDatePicker
+          id="endDatePickerInput"
+          aria-labelledby="dateRangeLabel endDatePickerLabel"
+          aria-label={t('endDate', 'End Date')}
+        />
       </div>
 
       {(() => {

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -364,21 +364,14 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({
         <OpenmrsDatePicker
           id="startDatePickerInput"
           data-testid="startDatePickerInput"
-          labelText="Start Date"
+          labelText=""
           value={''}
           onChange={(date: Date) => {
             handleDateFilterChange([date, date]);
           }}
         />
 
-        <OpenmrsDatePicker
-          id="endDatePickerInput"
-          data-testid="endDatePickerInput"
-          labelText="End Date"
-          onChange={(date: Date) => {
-            handleDateFilterChange([date, date]);
-          }}
-        />
+        <OpenmrsDatePicker id="endDatePickerInput" data-testid="endDatePickerInput" labelText="" />
       </div>
 
       {(() => {

--- a/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
@@ -112,12 +112,12 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
                 <div className={styles.row}>
                   <OpenmrsDatePicker
                     id="cancellationDate"
-                    minDate={dayjs().startOf('day')}
+                    minDate={dayjs().startOf('day').toDate()}
                     value={value}
                     onChange={(date) => onChange(date)}
+                    label={t('cancellationDate', 'Cancellation date')}
                     invalid={!!errors['cancellationDate']}
                     invalidText={errors['cancellationDate']?.message}
-                    label={t('cancellationDate', 'Cancellation date')}
                   />
                 </div>
               )}

--- a/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
@@ -4,19 +4,8 @@ import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import {
-  Button,
-  TextArea,
-  ButtonSet,
-  Column,
-  Form,
-  InlineNotification,
-  Stack,
-  DatePicker,
-  DatePickerInput,
-  InlineLoading,
-} from '@carbon/react';
-import { showSnackbar, useLayoutType } from '@openmrs/esm-framework';
+import { Button, TextArea, ButtonSet, Column, Form, InlineNotification, Stack, InlineLoading } from '@carbon/react';
+import { OpenmrsDatePicker, showSnackbar, useLayoutType } from '@openmrs/esm-framework';
 import { type DefaultPatientWorkspaceProps, usePatientOrders, type Order } from '@openmrs/esm-patient-common-lib';
 import { cancelOrder } from './cancel-order.resource';
 import styles from './cancel-order-form.scss';
@@ -121,24 +110,15 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
               control={control}
               render={({ field: { onChange, value } }) => (
                 <div className={styles.row}>
-                  <DatePicker
+                  <OpenmrsDatePicker
                     id="cancellationDate"
                     minDate={dayjs().startOf('day')}
-                    dateFormat="d/m/Y"
-                    datePickerType="single"
                     value={value}
-                    onChange={([date]) => onChange(date)}
-                    autocomplete="off"
-                  >
-                    <DatePickerInput
-                      id="date-picker-calendar-id"
-                      placeholder="dd/mm/yyyy"
-                      labelText={t('cancellationDate', 'Cancellation date')}
-                      type="text"
-                      invalid={!!errors['cancellationDate']}
-                      invalidText={!!errors['cancellationDate'] && errors['cancellationDate'].message}
-                    />
-                  </DatePicker>
+                    onChange={(date) => onChange(date)}
+                    invalid={!!errors['cancellationDate']}
+                    invalidText={errors['cancellationDate']?.message}
+                    label={t('cancellationDate', 'Cancellation date')}
+                  />
                 </div>
               )}
             />

--- a/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
@@ -116,8 +116,9 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
                     value={value}
                     onChange={(date) => onChange(date)}
                     labelText={t('cancellationDate', 'Cancellation date')}
-                    invalid={!!errors['cancellationDate']}
-                    invalidText={errors['cancellationDate']?.message}
+                    aria-label={t('cancellationDate', 'Cancellation date')}
+                    aria-invalid={!!errors['cancellationDate']}
+                    aria-describedby={errors['cancellationDate'] ? 'cancellationDate-error' : undefined}
                   />
                 </div>
               )}

--- a/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
@@ -112,10 +112,10 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
                 <div className={styles.row}>
                   <OpenmrsDatePicker
                     id="cancellationDate"
-                    minDate={dayjs().startOf('day').toDate()}
+                    minDate={dayjs().startOf('day')}
                     value={value}
                     onChange={(date) => onChange(date)}
-                    label={t('cancellationDate', 'Cancellation date')}
+                    labelText={t('cancellationDate', 'Cancellation date')}
                     invalid={!!errors['cancellationDate']}
                     invalidText={errors['cancellationDate']?.message}
                   />

--- a/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-cancellation-form/cancel-order-form.component.tsx
@@ -108,17 +108,15 @@ const OrderCancellationForm: React.FC<OrderCancellationFormProps> = ({
             <Controller
               name="cancellationDate"
               control={control}
-              render={({ field: { onChange, value } }) => (
+              render={({ field, fieldState }) => (
                 <div className={styles.row}>
                   <OpenmrsDatePicker
+                    {...field}
                     id="cancellationDate"
                     minDate={dayjs().startOf('day')}
-                    value={value}
-                    onChange={(date) => onChange(date)}
                     labelText={t('cancellationDate', 'Cancellation date')}
-                    aria-label={t('cancellationDate', 'Cancellation date')}
-                    aria-invalid={!!errors['cancellationDate']}
-                    aria-describedby={errors['cancellationDate'] ? 'cancellationDate-error' : undefined}
+                    invalid={Boolean(fieldState?.error?.message)}
+                    invalidText={fieldState?.error?.message}
                   />
                 </div>
               )}

--- a/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
@@ -92,23 +92,21 @@ mockCreateProgramEnrollment.mockResolvedValue({
 } as unknown as FetchResponse);
 
 describe('ProgramsForm', () => {
+  const inpatientWardUuid = 'b1a8b05e-3542-4037-bbd3-998ee9c40574';
+  const oncologyScreeningProgramUuid = '11b129ca-a5e7-4025-84bf-b92a173e20de';
+
   it('renders a success toast notification upon successfully recording a program enrollment', async () => {
     const user = userEvent.setup();
-
-    const inpatientWardUuid = 'b1a8b05e-3542-4037-bbd3-998ee9c40574';
-    const oncologyScreeningProgramUuid = '11b129ca-a5e7-4025-84bf-b92a173e20de';
 
     renderProgramsForm();
 
     const programNameInput = screen.getByRole('combobox', { name: /program name/i });
-    const enrollmentDateInput = screen.getByRole('textbox', { name: /date enrolled/i });
     const enrollmentLocationInput = screen.getByRole('combobox', { name: /enrollment location/i });
     const enrollButton = screen.getByRole('button', { name: /save and close/i });
 
     await user.click(enrollButton);
     expect(screen.getByText(/program is required/i)).toBeInTheDocument();
 
-    await user.type(enrollmentDateInput, '2020-05-05');
     await user.selectOptions(programNameInput, [oncologyScreeningProgramUuid]);
     await user.selectOptions(enrollmentLocationInput, [inpatientWardUuid]);
     expect(screen.getByRole('option', { name: /Inpatient Ward/i })).toBeInTheDocument();
@@ -140,25 +138,25 @@ describe('ProgramsForm', () => {
 
     renderProgramsForm(mockEnrolledProgramsResponse[0].uuid);
 
+    const enrollmentLocationInput = screen.getByRole('combobox', { name: /enrollment location/i });
     const enrollButton = screen.getByRole('button', { name: /save and close/i });
-    const completionDateInput = screen.getByRole('textbox', { name: /date completed/i });
 
     mockUpdateProgramEnrollment.mockResolvedValue({
       status: 200,
       statusText: 'OK',
     } as unknown as FetchResponse);
 
-    await user.type(completionDateInput, '05/05/2020');
-    await user.tab();
+    await user.click(enrollmentLocationInput);
+    await user.selectOptions(enrollmentLocationInput, [inpatientWardUuid]);
     await user.click(enrollButton);
 
     expect(mockUpdateProgramEnrollment).toHaveBeenCalledTimes(1);
     expect(mockUpdateProgramEnrollment).toHaveBeenCalledWith(
       mockEnrolledProgramsResponse[0].uuid,
       expect.objectContaining({
-        dateCompleted: expect.stringMatching(/^2020-05-05/),
+        dateCompleted: null,
         dateEnrolled: expect.stringMatching(/^2020-01-16/),
-        location: mockEnrolledProgramsResponse[0].location.uuid,
+        location: inpatientWardUuid,
         patient: mockPatient.id,
         program: mockEnrolledProgramsResponse[0].program.uuid,
       }),

--- a/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
+import dayjs from 'dayjs';
 import {
   type FetchResponse,
   showSnackbar,
   useLocations,
   useConfig,
   getDefaultsFromConfigSchema,
+  OpenmrsDatePicker,
 } from '@openmrs/esm-framework';
 import { mockCareProgramsResponse, mockEnrolledProgramsResponse, mockLocationsResponse } from '__mocks__';
 import { mockPatient } from 'tools';
@@ -29,6 +31,25 @@ const mockCloseWorkspace = jest.fn();
 const mockCloseWorkspaceWithSavedChanges = jest.fn();
 const mockPromptBeforeClosing = jest.fn();
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
+
+const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
+mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
+  return (
+    <>
+      <label htmlFor={id}>{labelText}</label>
+      <input
+        aria-label={labelText.toString()}
+        id={id}
+        onChange={(evt) => {
+          onChange(dayjs(evt.target.value).toDate());
+        }}
+        type="text"
+        // @ts-ignore
+        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
+      />
+    </>
+  );
+});
 
 const testProps = {
   closeWorkspace: mockCloseWorkspace,

--- a/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
-import dayjs from 'dayjs';
+import { render, screen, within } from '@testing-library/react';
 import {
   type FetchResponse,
   showSnackbar,
   useLocations,
   useConfig,
   getDefaultsFromConfigSchema,
-  OpenmrsDatePicker,
 } from '@openmrs/esm-framework';
 import { mockCareProgramsResponse, mockEnrolledProgramsResponse, mockLocationsResponse } from '__mocks__';
 import { mockPatient } from 'tools';
@@ -31,25 +29,6 @@ const mockCloseWorkspace = jest.fn();
 const mockCloseWorkspaceWithSavedChanges = jest.fn();
 const mockPromptBeforeClosing = jest.fn();
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
-
-const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
-mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange }) => {
-  return (
-    <>
-      <label htmlFor={id}>{labelText}</label>
-      <input
-        aria-label={labelText.toString()}
-        id={id}
-        onChange={(evt) => {
-          onChange(dayjs(evt.target.value).toDate());
-        }}
-        type="text"
-        // @ts-ignore
-        value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
-      />
-    </>
-  );
-});
 
 const testProps = {
   closeWorkspace: mockCloseWorkspace,
@@ -92,21 +71,28 @@ mockCreateProgramEnrollment.mockResolvedValue({
 } as unknown as FetchResponse);
 
 describe('ProgramsForm', () => {
-  const inpatientWardUuid = 'b1a8b05e-3542-4037-bbd3-998ee9c40574';
-  const oncologyScreeningProgramUuid = '11b129ca-a5e7-4025-84bf-b92a173e20de';
-
   it('renders a success toast notification upon successfully recording a program enrollment', async () => {
     const user = userEvent.setup();
+
+    const inpatientWardUuid = 'b1a8b05e-3542-4037-bbd3-998ee9c40574';
+    const oncologyScreeningProgramUuid = '11b129ca-a5e7-4025-84bf-b92a173e20de';
 
     renderProgramsForm();
 
     const programNameInput = screen.getByRole('combobox', { name: /program name/i });
+    const enrollmentDateInput = screen.getByTestId('enrollmentDate');
+    const enrollmentDateDayInput = within(enrollmentDateInput).getByRole('spinbutton', { name: /day/i });
+    const enrollmentDateMonthInput = within(enrollmentDateInput).getByRole('spinbutton', { name: /month/i });
+    const enrollmentDateYearInput = within(enrollmentDateInput).getByRole('spinbutton', { name: /year/i });
     const enrollmentLocationInput = screen.getByRole('combobox', { name: /enrollment location/i });
     const enrollButton = screen.getByRole('button', { name: /save and close/i });
 
     await user.click(enrollButton);
     expect(screen.getByText(/program is required/i)).toBeInTheDocument();
 
+    await user.type(enrollmentDateDayInput, '05');
+    await user.type(enrollmentDateMonthInput, '05');
+    await user.type(enrollmentDateYearInput, '2020');
     await user.selectOptions(programNameInput, [oncologyScreeningProgramUuid]);
     await user.selectOptions(enrollmentLocationInput, [inpatientWardUuid]);
     expect(screen.getByRole('option', { name: /Inpatient Ward/i })).toBeInTheDocument();
@@ -120,6 +106,7 @@ describe('ProgramsForm', () => {
         location: inpatientWardUuid,
         patient: mockPatient.id,
         program: oncologyScreeningProgramUuid,
+        dateEnrolled: expect.stringMatching(/^2020-05-05/),
       }),
       new AbortController(),
     );
@@ -138,25 +125,30 @@ describe('ProgramsForm', () => {
 
     renderProgramsForm(mockEnrolledProgramsResponse[0].uuid);
 
-    const enrollmentLocationInput = screen.getByRole('combobox', { name: /enrollment location/i });
     const enrollButton = screen.getByRole('button', { name: /save and close/i });
+    const completionDateInput = screen.getByTestId('completionDate');
+    const completionDateDayInput = within(completionDateInput).getByRole('spinbutton', { name: /day/i });
+    const completionDateMonthInput = within(completionDateInput).getByRole('spinbutton', { name: /month/i });
+    const completionDateYearInput = within(completionDateInput).getByRole('spinbutton', { name: /year/i });
 
     mockUpdateProgramEnrollment.mockResolvedValue({
       status: 200,
       statusText: 'OK',
     } as unknown as FetchResponse);
 
-    await user.click(enrollmentLocationInput);
-    await user.selectOptions(enrollmentLocationInput, [inpatientWardUuid]);
+    await user.type(completionDateDayInput, '05');
+    await user.type(completionDateMonthInput, '05');
+    await user.type(completionDateYearInput, '2020');
+    await user.tab();
     await user.click(enrollButton);
 
     expect(mockUpdateProgramEnrollment).toHaveBeenCalledTimes(1);
     expect(mockUpdateProgramEnrollment).toHaveBeenCalledWith(
       mockEnrolledProgramsResponse[0].uuid,
       expect.objectContaining({
-        dateCompleted: null,
+        dateCompleted: expect.stringMatching(/^2020-05-05/),
         dateEnrolled: expect.stringMatching(/^2020-01-16/),
-        location: inpatientWardUuid,
+        location: mockEnrolledProgramsResponse[0].location.uuid,
         patient: mockPatient.id,
         program: mockEnrolledProgramsResponse[0].program.uuid,
       }),

--- a/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
@@ -204,12 +204,13 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
       control={control}
       render={({ field: { onChange, value } }) => (
         <OpenmrsDatePicker
-          aria-label="enrollment date"
+          aria-label={t('dateEnrolled', 'Date enrolled')}
           id="enrollmentDate"
           maxDate={new Date().toISOString()}
           onChange={onChange}
           value={value}
           labelText={t('dateEnrolled', 'Date enrolled')}
+          aria-required="true"
         />
       )}
     />
@@ -221,13 +222,14 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
       control={control}
       render={({ field: { onChange, value } }) => (
         <OpenmrsDatePicker
-          aria-label="completion date"
+          aria-label={t('dateCompleted', 'Date completed')}
           id="completionDate"
           minDate={new Date(watch('enrollmentDate')).toISOString()}
           maxDate={new Date().toISOString()}
           onChange={onChange}
           value={value}
           labelText={t('dateCompleted', 'Date completed')}
+          aria-required="true"
         />
       )}
     />

--- a/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
@@ -5,8 +5,6 @@ import dayjs from 'dayjs';
 import {
   Button,
   ButtonSet,
-  DatePicker,
-  DatePickerInput,
   Form,
   FormGroup,
   FormLabel,
@@ -20,7 +18,15 @@ import {
 import { z } from 'zod';
 import { useForm, Controller, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { parseDate, showSnackbar, useConfig, useLayoutType, useLocations, useSession } from '@openmrs/esm-framework';
+import {
+  OpenmrsDatePicker,
+  parseDate,
+  showSnackbar,
+  useConfig,
+  useLayoutType,
+  useLocations,
+  useSession,
+} from '@openmrs/esm-framework';
 import { type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import { type ConfigObject } from '../config-schema';
 import {
@@ -197,18 +203,14 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
       name="enrollmentDate"
       control={control}
       render={({ field: { onChange, value } }) => (
-        <DatePicker
+        <OpenmrsDatePicker
           aria-label="enrollment date"
           id="enrollmentDate"
-          datePickerType="single"
-          dateFormat="d/m/Y"
           maxDate={new Date().toISOString()}
-          placeholder="dd/mm/yyyy"
-          onChange={([date]) => onChange(date)}
+          onChange={onChange}
           value={value}
-        >
-          <DatePickerInput id="enrollmentDateInput" labelText={t('dateEnrolled', 'Date enrolled')} />
-        </DatePicker>
+          labelText={t('dateEnrolled', 'Date enrolled')}
+        />
       )}
     />
   );
@@ -218,19 +220,15 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
       name="completionDate"
       control={control}
       render={({ field: { onChange, value } }) => (
-        <DatePicker
+        <OpenmrsDatePicker
           aria-label="completion date"
           id="completionDate"
-          datePickerType="single"
-          dateFormat="d/m/Y"
           minDate={new Date(watch('enrollmentDate')).toISOString()}
           maxDate={new Date().toISOString()}
-          placeholder="dd/mm/yyyy"
-          onChange={([date]) => onChange(date)}
+          onChange={onChange}
           value={value}
-        >
-          <DatePickerInput id="completionDateInput" labelText={t('dateCompleted', 'Date completed')} />
-        </DatePicker>
+          labelText={t('dateCompleted', 'Date completed')}
+        />
       )}
     />
   );

--- a/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
@@ -202,15 +202,14 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
     <Controller
       name="enrollmentDate"
       control={control}
-      render={({ field: { onChange, value } }) => (
+      render={({ field, fieldState }) => (
         <OpenmrsDatePicker
-          aria-label={t('dateEnrolled', 'Date enrolled')}
+          {...field}
           id="enrollmentDate"
-          maxDate={new Date().toISOString()}
-          onChange={onChange}
-          value={value}
+          maxDate={new Date()}
           labelText={t('dateEnrolled', 'Date enrolled')}
-          aria-required="true"
+          invalid={Boolean(fieldState?.error?.message)}
+          invalidText={fieldState?.error?.message}
         />
       )}
     />
@@ -220,16 +219,15 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
     <Controller
       name="completionDate"
       control={control}
-      render={({ field: { onChange, value } }) => (
+      render={({ field, fieldState }) => (
         <OpenmrsDatePicker
-          aria-label={t('dateCompleted', 'Date completed')}
+          {...field}
           id="completionDate"
-          minDate={new Date(watch('enrollmentDate')).toISOString()}
-          maxDate={new Date().toISOString()}
-          onChange={onChange}
-          value={value}
+          minDate={new Date(watch('enrollmentDate'))}
+          maxDate={new Date()}
           labelText={t('dateCompleted', 'Date completed')}
-          aria-required="true"
+          invalid={Boolean(fieldState?.error?.message)}
+          invalidText={fieldState?.error?.message}
         />
       )}
     />

--- a/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
@@ -206,6 +206,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
         <OpenmrsDatePicker
           {...field}
           id="enrollmentDate"
+          data-testid="enrollmentDate"
           maxDate={new Date()}
           labelText={t('dateEnrolled', 'Date enrolled')}
           invalid={Boolean(fieldState?.error?.message)}
@@ -223,6 +224,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
         <OpenmrsDatePicker
           {...field}
           id="completionDate"
+          data-testid="completionDate"
           minDate={new Date(watch('enrollmentDate'))}
           maxDate={new Date()}
           labelText={t('dateCompleted', 'Date completed')}

--- a/packages/esm-patient-tests-app/src/test-results/print-modal/print-modal.extension.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/print-modal/print-modal.extension.tsx
@@ -126,6 +126,8 @@ function PrintModal({
               onChange={setSelectedFromDate}
               value={selectedFromDate}
               labelText={t('startDate', 'Start date')}
+              aria-required="true"
+              data-testid="start-date-picker"
             />
             <OpenmrsDatePicker
               className={styles.datePicker}
@@ -134,6 +136,8 @@ function PrintModal({
               onChange={setSelectedToDate}
               value={selectedToDate}
               labelText={t('endDate', 'End date')}
+              aria-required="true"
+              data-testid="end-date-picker"
             />
           </div>
         </ResponsiveWrapper>

--- a/packages/esm-patient-tests-app/src/test-results/print-modal/print-modal.extension.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/print-modal/print-modal.extension.tsx
@@ -126,7 +126,6 @@ function PrintModal({
               onChange={setSelectedFromDate}
               value={selectedFromDate}
               labelText={t('startDate', 'Start date')}
-              style={{ width: '100%' }}
             />
             <OpenmrsDatePicker
               className={styles.datePicker}
@@ -135,7 +134,6 @@ function PrintModal({
               onChange={setSelectedToDate}
               value={selectedToDate}
               labelText={t('endDate', 'End date')}
-              style={{ width: '100%' }}
             />
           </div>
         </ResponsiveWrapper>

--- a/packages/esm-patient-tests-app/src/test-results/print-modal/print-modal.extension.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/print-modal/print-modal.extension.tsx
@@ -3,8 +3,6 @@ import { useTranslation } from 'react-i18next';
 import {
   Button,
   DataTable,
-  DatePicker,
-  DatePickerInput,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -30,6 +28,7 @@ import {
   useSession,
   ResponsiveWrapper,
   getCoreTranslation,
+  OpenmrsDatePicker,
 } from '@openmrs/esm-framework';
 import usePanelData from '../panel-view/usePanelData';
 import styles from './print-modal.scss';
@@ -58,8 +57,6 @@ function PrintModal({
     externalModuleName: '@openmrs/esm-patient-banner-app',
   });
   const headerTitle = t('testResults_title', 'Test Results');
-  const datePickerPlaceHolder = 'dd/mm/yyyy';
-  const datePickerFormat = 'd/m/Y';
 
   const tableHeaders = [
     { key: 'testType', header: 'Test Type' },
@@ -123,35 +120,21 @@ function PrintModal({
       <ModalBody className={styles.modalBody}>
         <ResponsiveWrapper>
           <div className={styles.datePickerContainers}>
-            <DatePicker
+            <OpenmrsDatePicker
               className={styles.datePicker}
-              dateFormat={datePickerFormat}
-              datePickerType="single"
               maxDate={new Date().toISOString()}
-              onChange={([date]) => setSelectedFromDate(date)}
+              onChange={setSelectedFromDate}
               value={selectedFromDate}
-            >
-              <DatePickerInput
-                labelText={t('startDate', 'Start date')}
-                placeholder={datePickerPlaceHolder}
-                style={{ width: '100%' }}
-              />
-            </DatePicker>
-            <DatePicker
+              labelText={t('startDate', 'Start date')}
+            />
+            <OpenmrsDatePicker
               className={styles.datePicker}
-              dateFormat={datePickerFormat}
-              datePickerType="single"
               minDate={selectedFromDate}
               maxDate={new Date().toISOString()}
-              onChange={([date]) => setSelectedToDate(date)}
+              onChange={setSelectedToDate}
               value={selectedToDate}
-            >
-              <DatePickerInput
-                labelText={t('endDate', 'End date')}
-                placeholder={datePickerPlaceHolder}
-                style={{ width: '100%' }}
-              />
-            </DatePicker>
+              labelText={t('endDate', 'End date')}
+            />
           </div>
         </ResponsiveWrapper>
         <div className={styles.printContainer} ref={printContainerRef}>

--- a/packages/esm-patient-tests-app/src/test-results/print-modal/print-modal.extension.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/print-modal/print-modal.extension.tsx
@@ -132,12 +132,10 @@ function PrintModal({
             <OpenmrsDatePicker
               className={styles.datePicker}
               minDate={selectedFromDate}
-              maxDate={new Date().toISOString()}
+              maxDate={new Date()}
               onChange={setSelectedToDate}
               value={selectedToDate}
               labelText={t('endDate', 'End date')}
-              aria-required="true"
-              data-testid="end-date-picker"
             />
           </div>
         </ResponsiveWrapper>

--- a/packages/esm-patient-tests-app/src/test-results/print-modal/print-modal.extension.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/print-modal/print-modal.extension.tsx
@@ -126,6 +126,7 @@ function PrintModal({
               onChange={setSelectedFromDate}
               value={selectedFromDate}
               labelText={t('startDate', 'Start date')}
+              style={{ width: '100%' }}
             />
             <OpenmrsDatePicker
               className={styles.datePicker}
@@ -134,6 +135,7 @@ function PrintModal({
               onChange={setSelectedToDate}
               value={selectedToDate}
               labelText={t('endDate', 'End date')}
+              style={{ width: '100%' }}
             />
           </div>
         </ResponsiveWrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5701,9 +5701,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-api@npm:6.1.1-pre.2723"
+"@openmrs/esm-api@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-api@npm:6.2.1-pre.2750"
   dependencies:
     "@types/fhir": "npm:0.0.31"
     lodash-es: "npm:^4.17.21"
@@ -5712,17 +5712,17 @@ __metadata:
     "@openmrs/esm-error-handling": 6.x
     "@openmrs/esm-navigation": 6.x
     "@openmrs/esm-offline": 6.x
-  checksum: 10/da621c2f362dc7feac330d8ee921c52ecefad667f12bbc1d18c3976f972c495158f8ac35b597418c5d352eda70249b74ad8a91bae7eb409731fc0f27733dae76
+  checksum: 10/6534307459e0a6465fbe1c9acd243eb7abb2944650d81be71abf92560479e2f1dfc261dabbdb4874ed38f98f27ea49206766171241304da05bb44c65713a23f0
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-app-shell@npm:6.1.1-pre.2723"
+"@openmrs/esm-app-shell@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-app-shell@npm:6.2.1-pre.2750"
   dependencies:
     "@carbon/react": "npm:~1.37.0"
-    "@openmrs/esm-framework": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-styleguide": "npm:6.1.1-pre.2723"
+    "@openmrs/esm-framework": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-styleguide": "npm:6.2.1-pre.2750"
     dayjs: "npm:^1.10.4"
     dexie: "npm:^3.0.3"
     html-webpack-plugin: "npm:^5.5.0"
@@ -5747,13 +5747,13 @@ __metadata:
     workbox-strategies: "npm:^6.1.5"
     workbox-webpack-plugin: "npm:^6.1.5"
     workbox-window: "npm:^6.1.5"
-  checksum: 10/ce9e7a913047a70560c5ecbb78b3bf1b2d66e7ad9877c981236fc8cffebb72754ecd574574ef5b676d6beb508f07dff9113e8720d2314a6bd30cc6288edf118b
+  checksum: 10/5fa8e3eda001e9a2e75c76b5c8348753e8855cbc963ca4c5977eb479b23d6477e2b33a5a2552d01a2a3f4a15eab4d9ee3b196d3d18501ed8ea5c5e6bad4b70e8
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-config@npm:6.1.1-pre.2723"
+"@openmrs/esm-config@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-config@npm:6.2.1-pre.2750"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
@@ -5761,44 +5761,44 @@ __metadata:
     "@openmrs/esm-state": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/ba7910687830965b28737188f345cbed843812b4651e4dae0db9c271b3e92e5d0d60be7b758a0e306c63cca2a25e530c3889e618851ad786d358ec27a9df0a68
+  checksum: 10/1bae04e68286bb6e64bf99d7d2d87af1d8f2910adb1a7f8350efb7e5bd56497ec88a67a622ba3c26b2937efb2808471f8ce2303504e18bf716e71e98e0af7fa3
   languageName: node
   linkType: hard
 
-"@openmrs/esm-context@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-context@npm:6.1.1-pre.2723"
+"@openmrs/esm-context@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-context@npm:6.2.1-pre.2750"
   dependencies:
     immer: "npm:^10.0.4"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
-  checksum: 10/0d625f91243087760bb222fb9628ef59af8b4047254dac4d52d21c189c29e37bed3af4076e43d2f1883416ec6fc009e6be8aa9da1348477f2f3c3ee5e1ec5224
+  checksum: 10/c5f519190b787e1619620d050bf1b4f0296ef5272708b42b4482faa2461df1dbf3a8f67b151f72b90ad333b8db382e8dcdad604cb5247e1b9e77a84ce1afb7dd
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-dynamic-loading@npm:6.1.1-pre.2723"
+"@openmrs/esm-dynamic-loading@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-dynamic-loading@npm:6.2.1-pre.2750"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-translations": 6.x
-  checksum: 10/b0470e15c4442e4e4293a69a0405cda4e2139f03fde0d5eef845c74f48abcad0ad53f955c3ea8cf851122f3c2873ed8b336cc0238f408c86fec81a324b64da80
+  checksum: 10/20a493dd907408405dee0d4431636c1599eb95c688798892cec3b7bb66aeedd7cbde34e80562ab458237076593390b7e5da6c25827159b1688aee07259c6cfaa
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-error-handling@npm:6.1.1-pre.2723"
+"@openmrs/esm-error-handling@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-error-handling@npm:6.2.1-pre.2750"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
-  checksum: 10/066361aa2a63efce622db359b1c4359f3c3f0001e8123b6ae3fb1be37fcb5fbe28c0d48091e95bb0441dc24f5023fe970e23fe0dfac907a04034418bc0fe8f5b
+  checksum: 10/33763bcf7ad2ec6b9634f8b05c21e460c851254ebede80dcef0129aee8c4e393bdbd1e48a9d8373e61e2dc057a1e200b4dd9d6201c7f4a2b6262899e4f2a292c
   languageName: node
   linkType: hard
 
-"@openmrs/esm-expression-evaluator@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-expression-evaluator@npm:6.1.1-pre.2723"
+"@openmrs/esm-expression-evaluator@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-expression-evaluator@npm:6.2.1-pre.2750"
   dependencies:
     "@jsep-plugin/arrow": "npm:^1.0.5"
     "@jsep-plugin/new": "npm:^1.0.3"
@@ -5807,13 +5807,13 @@ __metadata:
     "@jsep-plugin/template": "npm:^1.0.4"
     "@jsep-plugin/ternary": "npm:^1.1.3"
     jsep: "npm:^1.3.9"
-  checksum: 10/a1ba857fc966228a53db549146a119925cd394c010c7068c5ee3e2781437eeb8ba81a57b3a05c4d6323342c4249b6bb01487eec064eaa6ac76089989a2b191c9
+  checksum: 10/2f4cc328dfbc97fed84fe5ad8f3819d981c746697ee7d06cac443730be1dd7970af1b2509467a624eabe1d9a9036dad8e92045be3972616de61c5d764a0b02a0
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-extensions@npm:6.1.1-pre.2723"
+"@openmrs/esm-extensions@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-extensions@npm:6.2.1-pre.2750"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -5824,20 +5824,20 @@ __metadata:
     "@openmrs/esm-state": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/32912d946e2f50bf279c0789c400a39ff1f5c2a37185c9da0212fb5d8343089355d7f1765014621cb1b8314cef819c618e7b39df7b0d5827a56f379cbdc25104
+  checksum: 10/c1d7e991edb9a0e1ff0615e6c6592fde7c8cc31e3c5af81fd860075db4d2e904aa57b982f3ff0ef498ec1fd03c45e633c841381f080ed127f9b4cd2d1697586f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-feature-flags@npm:6.1.1-pre.2723"
+"@openmrs/esm-feature-flags@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-feature-flags@npm:6.2.1-pre.2750"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
     single-spa: 6.x
-  checksum: 10/614e42d34057b43011390ae58ca63c07d5b2df053fcd0fc907d3bac28083eccbf318adb7940cd79e4e2827380e61e4ae91934d14f4685b6361e05eb071a8e860
+  checksum: 10/345b8729ef8b475bdc3900c5f1e6b6f874492a8ddcbf861b7fae00b2cca0166bbb6aa50ffabe9fed3fb2e04e47100c14a1730c655937979d52e863fa85366025
   languageName: node
   linkType: hard
 
@@ -5954,27 +5954,27 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-framework@npm:6.1.1-pre.2723, @openmrs/esm-framework@npm:next":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-framework@npm:6.1.1-pre.2723"
+"@openmrs/esm-framework@npm:6.2.1-pre.2750, @openmrs/esm-framework@npm:next":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-framework@npm:6.2.1-pre.2750"
   dependencies:
-    "@openmrs/esm-api": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-config": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-context": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-dynamic-loading": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-error-handling": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-expression-evaluator": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-extensions": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-feature-flags": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-globals": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-navigation": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-offline": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-react-utils": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-routes": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-state": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-styleguide": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-translations": "npm:6.1.1-pre.2723"
-    "@openmrs/esm-utils": "npm:6.1.1-pre.2723"
+    "@openmrs/esm-api": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-config": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-context": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-dynamic-loading": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-error-handling": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-expression-evaluator": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-extensions": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-feature-flags": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-globals": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-navigation": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-offline": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-react-utils": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-routes": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-state": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-styleguide": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-translations": "npm:6.2.1-pre.2750"
+    "@openmrs/esm-utils": "npm:6.2.1-pre.2750"
     dayjs: "npm:^1.10.7"
   peerDependencies:
     dayjs: 1.x
@@ -5985,7 +5985,7 @@ __metadata:
     rxjs: 6.x
     single-spa: 6.x
     swr: 2.x
-  checksum: 10/7fe5f6170fcf51eb6edda60a7e2588cf082d5922b113ae72a28719c7759c84f4e4f9d40ffc006dc0b735964a1fcb5cfbcae097cf9d7a4c1311f560f460886f33
+  checksum: 10/c486928c25160187d757591bc412f3887db90654a9f37ce4151adfa0f697ab3e30eef7b76699e478ef78064b3154726b63238c188d518c0a4ab3b8eb5e1ff0fa
   languageName: node
   linkType: hard
 
@@ -6011,31 +6011,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-globals@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-globals@npm:6.1.1-pre.2723"
+"@openmrs/esm-globals@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-globals@npm:6.2.1-pre.2750"
   dependencies:
     "@types/fhir": "npm:0.0.31"
   peerDependencies:
     single-spa: 6.x
-  checksum: 10/c352395a774d323425d7bb0a29e64b8344a48a042b01cdd8ebd2e8d6b6b9219ba7379cc5f32b24c1c5c7a9588f28228b77ca13c651be2787ad1b341e8df28c26
+  checksum: 10/87ea8b5c5c44dea326b13af8903c2cb0aa589d7097c630aad36309aa81334c20e2861f523f0363ad56f21045d2ca415c37a4080517fe5bbc8d058e566759d9c6
   languageName: node
   linkType: hard
 
-"@openmrs/esm-navigation@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-navigation@npm:6.1.1-pre.2723"
+"@openmrs/esm-navigation@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-navigation@npm:6.2.1-pre.2750"
   dependencies:
     path-to-regexp: "npm:6.1.0"
   peerDependencies:
     "@openmrs/esm-state": 6.x
-  checksum: 10/63a7c849b3bc06db4541433c1cbdaea0280fdbd8e01d6c00d331e0d15f0feada04ca72b22836836c34ece01e496e66dc72d0f4a507507066877228ac11b40e4f
+  checksum: 10/7060884dd29603a281841f64abba6b2f6abcf221e8cfd43fe8e422c091aab30358636994a27a758a7473c4fec0f60af7d41757ff873d8b4a266851f83d8d9ffe
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-offline@npm:6.1.1-pre.2723"
+"@openmrs/esm-offline@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-offline@npm:6.2.1-pre.2750"
   dependencies:
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -6046,7 +6046,7 @@ __metadata:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
     rxjs: 6.x
-  checksum: 10/b692ed55cc66943fbf3b1bfb5e93a86e629c7531a1e5774deb05f91a9c46c9a7e1de6328c1708df5c81b0cc5d9b2e38a314440970342c2f0134079b9e176a0fb
+  checksum: 10/c4d7f36aebddaf551005f69ef8beefda71d5cd011c4d56e6363ddabd96f854cc5e1d2bd40cb178d2afe30123ddfbea549b52bec99474b5400cb8f918b40aefb1
   languageName: node
   linkType: hard
 
@@ -6443,9 +6443,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-react-utils@npm:6.1.1-pre.2723"
+"@openmrs/esm-react-utils@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-react-utils@npm:6.2.1-pre.2750"
   dependencies:
     lodash-es: "npm:^4.17.21"
     single-spa-react: "npm:^6.0.2"
@@ -6466,13 +6466,13 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 10/080717986bb77c7950b8b0595ba14c025ea421a633996eaaf53d575586dea442bae7fcf7979c01d72fa6ac617e330da76abbca8c7b7ea71fdcfcdf08355338e8
+  checksum: 10/4d530784d48387837920e2eba7de19c63d72309abaec88eebffacf02fa96c922fdfe36966b06e50b65737ce0f74ecaf54596e99771c275be6f99c1b60dac8c3f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-routes@npm:6.1.1-pre.2723"
+"@openmrs/esm-routes@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-routes@npm:6.2.1-pre.2750"
   peerDependencies:
     "@openmrs/esm-config": 6.x
     "@openmrs/esm-dynamic-loading": 6.x
@@ -6481,25 +6481,25 @@ __metadata:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/04270827b21908f028ad07faef6beaf38790f30e1006fdd2e2c93d55c97355e18ba94bd5e505bee76a709bdf5366f596e26383b2c7cbc17bb34bfd637aca0e83
+  checksum: 10/6bb96a71782add604a17bc11d1227466ed8b9505947c442b9e0af9cd9c75c5453d6d6f5770b80f523782a9b8b160c1d8cefdb7b344ba6c12aced5029395fd8f7
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-state@npm:6.1.1-pre.2723"
+"@openmrs/esm-state@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-state@npm:6.2.1-pre.2750"
   dependencies:
     zustand: "npm:^4.5.5"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-utils": 6.x
-  checksum: 10/2d1fad380d8b5e296bc5b3cea96f2220183ee2c8eaeb03ef1028a3c0c722c36075c71a94723ce818e83ca4ebf815b51527e0297705ccb8cef6f85d12b91fa5d1
+  checksum: 10/37db4eeb301a1f27c5a475ab4c341a8504428ed0b48675e3fa277f94b33f0c0a0e214e9addc8ca69ea19ffe9a49268b7d241f6131777c0b4f675596de17e9a3c
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-styleguide@npm:6.1.1-pre.2723"
+"@openmrs/esm-styleguide@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-styleguide@npm:6.2.1-pre.2750"
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
     "@carbon/react": "npm:~1.37.0"
@@ -6523,24 +6523,24 @@ __metadata:
     react-dom: 18.x
     react-i18next: 11.x
     rxjs: 6.x
-  checksum: 10/8cec0c36eb872cec4da69fbd196b296adb56f69f0fd6d0a0d43e3bb33759d4ea2f51569a1e3616815258e17668a9c98e35c80f0dc11f99ca873cca096c2decb9
+  checksum: 10/ec67aa36783c7a26ee08eec3e6cf474df40ca1d0503e34967e32515ddbd0876d887a35063131280aae0cd9afddad29267db07afa878fb838f4f932fd8a4c86f9
   languageName: node
   linkType: hard
 
-"@openmrs/esm-translations@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-translations@npm:6.1.1-pre.2723"
+"@openmrs/esm-translations@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-translations@npm:6.2.1-pre.2750"
   dependencies:
     i18next: "npm:21.10.0"
   peerDependencies:
     i18next: 21.x
-  checksum: 10/c720f382a6f1638715b2304a1736400b4c0e50651e64d448e8f584f42f561b4b79df3ae94304944f580b5c0d026408df52700f88f0bd040d09234c9691cd8371
+  checksum: 10/e141491d7c9daf604a31d2625337e54d217caa4bc9120ff9741b6d104185a5ba2488485c914308a01b1260266b91d03fc77ab4943cd8cb9e09097791df87d7cf
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/esm-utils@npm:6.1.1-pre.2723"
+"@openmrs/esm-utils@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/esm-utils@npm:6.2.1-pre.2750"
   dependencies:
     "@formatjs/intl-durationformat": "npm:^0.2.4"
     "@internationalized/date": "npm:^3.7.0"
@@ -6550,7 +6550,7 @@ __metadata:
     dayjs: 1.x
     i18next: 21.x
     rxjs: 6.x
-  checksum: 10/c3333fcefe62dd3f694811b0b19b6eb81ff6a98de3b11dc27dd66c7f1e8c301b209be952d683e41298faf7743a9f230575d457a602df5b3e78ad04751584ddce
+  checksum: 10/c1c8b68109b73af79e6086364c973414ad4b0760d8c42e6520799910fe7e04c4b2d344f4863cc9061a10250332154158a0f37e5c67ba55a14f4e2b948a04080f
   languageName: node
   linkType: hard
 
@@ -6601,9 +6601,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:6.1.1-pre.2723":
-  version: 6.1.1-pre.2723
-  resolution: "@openmrs/webpack-config@npm:6.1.1-pre.2723"
+"@openmrs/webpack-config@npm:6.2.1-pre.2750":
+  version: 6.2.1-pre.2750
+  resolution: "@openmrs/webpack-config@npm:6.2.1-pre.2750"
   dependencies:
     "@swc/core": "npm:^1.3.58"
     clean-webpack-plugin: "npm:^4.0.0"
@@ -6621,7 +6621,7 @@ __metadata:
     webpack-stats-plugin: "npm:^1.0.3"
   peerDependencies:
     webpack: 5.x
-  checksum: 10/f53de3e9bee8276ba3387a0a2145ca0e190efadb8a6cfc815e02bb8a06909811cec298bd27614654a378738e2d604ab0a71fa4de88e0f0066a0b11f4ad621d78
+  checksum: 10/57a4efec6c0c27fe6bf0f0a511ff18fc6347e54ce62ec3e5f5af764c85fbeb4003c48c8dc110ebe387cc8901b4ff66a79b72e00e75121bd7dbf569eb13184c78
   languageName: node
   linkType: hard
 
@@ -21601,11 +21601,11 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 6.1.1-pre.2723
-  resolution: "openmrs@npm:6.1.1-pre.2723"
+  version: 6.2.1-pre.2750
+  resolution: "openmrs@npm:6.2.1-pre.2750"
   dependencies:
-    "@openmrs/esm-app-shell": "npm:6.1.1-pre.2723"
-    "@openmrs/webpack-config": "npm:6.1.1-pre.2723"
+    "@openmrs/esm-app-shell": "npm:6.2.1-pre.2750"
+    "@openmrs/webpack-config": "npm:6.2.1-pre.2750"
     "@pnpm/npm-conf": "npm:^2.1.0"
     "@swc/core": "npm:^1.3.58"
     autoprefixer: "npm:^10.4.20"
@@ -21644,7 +21644,7 @@ __metadata:
     yargs: "npm:^17.6.2"
   bin:
     openmrs: ./dist/cli.js
-  checksum: 10/fec7046524d59240dfd2a76f0512c1bcfa1cd4f9319872c32738360db17d000cd90b4a01797d2b563133a3328e509c202467ec42296239e65f083abe6f430538
+  checksum: 10/cf7a7c3faf1c2824a58cb47bd220a7ce0ed322b08f28d35d931c63bcf9fceeca67ef546b349cc46b3c1fd2075856873b42af79c9abad138d9d50b888d576b53d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR replaces usages of the Carbon [DatePicker](https://react.carbondesignsystem.com/?path=/docs/components-datepicker--overview) component with our custom reusable [OpenmrsDatePicker](https://github.com/openmrs/openmrs-esm-core/pull/1041) component.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3846

## Other
<!-- Anything not covered above -->
