### PR TITLE
(refactor) programs-form: Improve error handling and loading states

### DIFF
--- a/packages/esm-patient-programs-app/src/programs/programs-form.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.scss
@@ -15,6 +15,10 @@
   align-items: baseline;
   min-width: 50%;
 
+  :global(.cds--inline-loading) {
+    min-height: layout.$spacing-05 !important;
+  }
+
   :global(.cds--inline-loading__text) {
     @include type.type-style('body-01');
   }
@@ -38,12 +42,6 @@
   flex-direction: column;
   justify-content: space-between;
   height: 100%;
-}
-
-.errorMessage {
-  @include type.type-style('label-02');
-  margin-top: layout.$spacing-03;
-  color: $danger;
 }
 
 .notification {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Improves form validation in the Programs form by:

- Using React Hook Form's `isSubmitting` state instead of local state (should have been fixed in https://github.com/openmrs/openmrs-esm-patient-chart/pull/2141)
- Cleaning up styling for the submit button's loading state
- Replacing a custom error message solution with the `Select` component's `invalidText` prop. With this change, we don't need additional styling for the error message.

## Screenshots

### Validation error message (largely unchanged UI / UX)

![CleanShot 2024-12-17 at 11  53 16@2x](https://github.com/user-attachments/assets/98864a6e-4129-4593-8f3b-7ae33d9c03be)

### Submit button loading state

![CleanShot 2024-12-17 at 11  52 41@2x](https://github.com/user-attachments/assets/b4dce104-1138-48c6-a9c6-0257a4840a01)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
