### PR TITLE
(fix) O3-4302: Hide voided diagnoses in patient chart visits widget

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -33,6 +33,7 @@ interface DiagnosisItem {
   diagnosis: string;
   rank: number;
   type: string;
+  voided?: boolean;
 }
 
 interface VisitSummaryProps {
@@ -74,14 +75,17 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
       // Check if there is a diagnosis associated with this encounter
       if (enc.hasOwnProperty('diagnoses')) {
         if (enc.diagnoses.length > 0) {
-          enc.diagnoses.forEach((diagnosis: Diagnosis) => {
-            // Putting all the diagnoses in a single array.
-            diagnoses.push({
-              diagnosis: diagnosis.display,
-              type: diagnosis.rank === 1 ? 'red' : 'blue',
-              rank: diagnosis.rank,
+          enc.diagnoses
+            .filter((diagnosis) => !diagnosis.voided)
+            .forEach((diagnosis: Diagnosis) => {
+              // Putting all the diagnoses in a single array.
+              diagnoses.push({
+                diagnosis: diagnosis.display,
+                type: diagnosis.rank === 1 ? 'red' : 'blue',
+                rank: diagnosis.rank,
+                voided: diagnosis.voided,
+              });
             });
-          });
         }
       }
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -75,17 +75,15 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
       // Check if there is a diagnosis associated with this encounter
       if (enc.hasOwnProperty('diagnoses')) {
         if (enc.diagnoses.length > 0) {
-          enc.diagnoses
-            .filter((diagnosis) => !diagnosis.voided)
-            .forEach((diagnosis: Diagnosis) => {
-              // Putting all the diagnoses in a single array.
-              diagnoses.push({
-                diagnosis: diagnosis.display,
-                type: diagnosis.rank === 1 ? 'red' : 'blue',
-                rank: diagnosis.rank,
-                voided: diagnosis.voided,
-              });
-            });
+          const validDiagnoses = enc.diagnoses
+            .filter((diagnosis: Diagnosis) => !diagnosis.voided)
+            .map((diagnosis: Diagnosis) => ({
+              diagnosis: diagnosis.display,
+              type: diagnosis.rank === 1 ? 'red' : 'blue',
+              rank: diagnosis.rank,
+              voided: diagnosis.voided,
+            }));
+          diagnoses.push(...validDiagnoses);
         }
       }
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -3,30 +3,29 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Tab, TabList, TabPanel, TabPanels, Tabs, Tag } from '@carbon/react';
 import {
-  type AssignedExtension,
   Extension,
   ExtensionSlot,
   formatTime,
   parseDate,
+  useAssignedExtensions,
   useConfig,
-  useConnectedExtensions,
   useLayoutType,
   type Visit,
 } from '@openmrs/esm-framework';
+import type { ExternalOverviewProps } from '@openmrs/esm-patient-common-lib';
 import {
+  mapEncounters,
   type Diagnosis,
   type Encounter,
-  mapEncounters,
   type Note,
   type Observation,
   type Order,
   type OrderItem,
 } from '../visit.resource';
-import VisitsTable from './visits-table/visits-table.component';
 import MedicationSummary from './medications-summary.component';
 import NotesSummary from './notes-summary.component';
 import TestsSummary from './tests-summary.component';
-import type { ExternalOverviewProps } from '@openmrs/esm-patient-common-lib';
+import VisitsTable from './visits-table/visits-table.component';
 import styles from './visit-summary.scss';
 
 interface DiagnosisItem {
@@ -46,8 +45,8 @@ const visitSummaryPanelSlot = 'visit-summary-panels';
 const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
   const config = useConfig();
   const { t } = useTranslation();
+  const extensions = useAssignedExtensions(visitSummaryPanelSlot);
   const layout = useLayoutType();
-  const extensions = useConnectedExtensions(visitSummaryPanelSlot) as AssignedExtension[];
 
   const [diagnoses, notes, medications]: [Array<DiagnosisItem>, Array<Note>, Array<OrderItem>] = useMemo(() => {
     // Medication Tab
@@ -57,9 +56,7 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
     // Notes Tab
     const notes: Array<Note> = [];
 
-    // Iterating through every Encounter
     visit?.encounters?.forEach((enc: Encounter) => {
-      // Orders of every encounter put in a single array.
       if (enc.hasOwnProperty('orders')) {
         medications.push(
           ...enc.orders.map((order: Order) => ({
@@ -113,7 +110,7 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
   }, [config.notesConceptUuids, visit?.encounters]);
 
   const testsFilter = useMemo<ExternalOverviewProps['filter']>(() => {
-    const encounterIds = visit?.encounters.map((e) => `Encounter/${e.uuid}`);
+    const encounterIds = visit?.encounters?.map((e) => `Encounter/${e.uuid}`);
     return ([entry]) => {
       return encounterIds.includes(entry.encounter?.reference);
     };

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -13,7 +13,7 @@ import { type ChartConfig } from '../../config-schema';
 export function useInfiniteVisits(patientUuid: string) {
   const config = useConfig<ChartConfig>();
   const customRepresentation =
-    'custom:(uuid,location,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis),form:(uuid,display),encounterDatetime,orders:full,obs:(uuid,concept:(uuid,display,conceptClass:(uuid,display)),display,groupMembers:(uuid,concept:(uuid,display),value:(uuid,display),display),value,obsDatetime),encounterType:(uuid,display,viewPrivilege,editPrivilege),encounterProviders:(uuid,display,encounterRole:(uuid,display),provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient,attributes:(attributeType:ref,display,uuid,value)';
+    'custom:(uuid,location,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis,voided),form:(uuid,display),encounterDatetime,orders:full,obs:(uuid,concept:(uuid,display,conceptClass:(uuid,display)),display,groupMembers:(uuid,concept:(uuid,display),value:(uuid,display),display),value,obsDatetime),encounterType:(uuid,display,viewPrivilege,editPrivilege),encounterProviders:(uuid,display,encounterRole:(uuid,display),provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient,attributes:(attributeType:ref,display,uuid,value)';
 
   const getKey = (pageIndex, previousPageData) => {
     const pageSize = config.numberOfVisitsToLoad;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Hide voided diagnosis in visits widget on patient chart

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1722" alt="Screenshot 2025-01-06 at 13 54 42" src="https://github.com/user-attachments/assets/5fa63d04-62b8-4ac3-828c-1394b3b3dc3f" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
