### PR TITLE
(feat) O3-4334: Add scheduled date field for scheduled orders

### DIFF
--- a/packages/esm-patient-common-lib/src/orders/types/order.ts
+++ b/packages/esm-patient-common-lib/src/orders/types/order.ts
@@ -70,6 +70,7 @@ export interface OrderBasketItem {
   previousOrder?: string;
   orderType?: string;
   orderNumber?: string;
+  scheduledDate?: Date;
 }
 
 export type OrderUrgency = 'ROUTINE' | 'STAT' | 'ON_SCHEDULED_DATE';
@@ -96,6 +97,7 @@ export interface OrderPost {
   instructions?: string;
   accessionNumber?: string;
   orderType?: string;
+  scheduledDate?: string;
 }
 
 export interface DrugOrderPost extends OrderPost {

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-form/general-order-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-form/general-order-form.component.tsx
@@ -1,9 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
-import { useTranslation } from 'react-i18next';
-import { Controller, type FieldErrors, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
+import {
+  type OrderBasketItem,
+  type DefaultPatientWorkspaceProps,
+  launchPatientWorkspace,
+  useOrderBasket,
+  useOrderType,
+  priorityOptions,
+} from '@openmrs/esm-patient-common-lib';
+import { useLayoutType, useSession, useConfig, ExtensionSlot, OpenmrsDatePicker } from '@openmrs/esm-framework';
 import {
   Button,
   ButtonSet,
@@ -17,15 +22,10 @@ import {
   TextArea,
   TextInput,
 } from '@carbon/react';
-import {
-  launchPatientWorkspace,
-  priorityOptions,
-  type DefaultPatientWorkspaceProps,
-  type OrderBasketItem,
-  useOrderBasket,
-  useOrderType,
-} from '@openmrs/esm-patient-common-lib';
-import { useLayoutType, useSession, ExtensionSlot, useConfig } from '@openmrs/esm-framework';
+import { useTranslation } from 'react-i18next';
+import { Controller, type FieldErrors, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 import { ordersEqual, prepOrderPostData } from '../resources';
 import styles from './general-order-form.scss';
 import { type ConfigObject } from '../../../config-schema';
@@ -57,20 +57,26 @@ export function OrderForm({
 
   const OrderFormSchema = useMemo(
     () =>
-      z.object({
-        instructions: z.string().nullish(),
-        urgency: z.string().refine((value) => value !== '', {
-          message: t('priorityRequired', 'Priority is required'),
+      z
+        .object({
+          instructions: z.string().nullish(),
+          urgency: z.string().refine((value) => value !== '', {
+            message: t('priorityRequired', 'Priority is required'),
+          }),
+          accessionNumber: z.string().nullish(),
+          concept: z.object(
+            { display: z.string(), uuid: z.string() },
+            {
+              required_error: t('orderableConceptRequired', 'Orderable concept is required'),
+              invalid_type_error: t('orderableConceptRequired', 'Orderable concept is required'),
+            },
+          ),
+          scheduledDate: z.date().nullish(),
+        })
+        .refine((data) => data.urgency !== 'ON_SCHEDULED_DATE' || data.scheduledDate, {
+          message: t('scheduledDateRequired', 'Scheduled date is required'),
+          path: ['scheduledDate'],
         }),
-        accessionNumber: z.string().nullish(),
-        concept: z.object(
-          { display: z.string(), uuid: z.string() },
-          {
-            required_error: t('orderableConceptRequired', 'Orderable concept is required'),
-            invalid_type_error: t('orderableConceptRequired', 'Orderable concept is required'),
-          },
-        ),
-      }),
     [t],
   );
 
@@ -78,6 +84,7 @@ export function OrderForm({
     control,
     handleSubmit,
     formState: { errors, defaultValues, isDirty },
+    watch,
   } = useForm<OrderBasketItem>({
     mode: 'all',
     resolver: zodResolver(OrderFormSchema),
@@ -85,6 +92,8 @@ export function OrderForm({
       ...initialOrder,
     },
   });
+
+  const isScheduledDateRequired = watch('urgency') === 'ON_SCHEDULED_DATE';
 
   const filterItemsByName = useCallback((menu) => {
     return menu?.item?.value?.toLowerCase().includes(menu?.inputValue?.toLowerCase());
@@ -97,6 +106,9 @@ export function OrderForm({
         ...data,
       };
       finalizedOrder.orderer = session.currentProvider.uuid;
+      if (finalizedOrder.urgency !== 'ON_SCHEDULED_DATE') {
+        finalizedOrder.scheduledDate = null;
+      }
 
       const newOrders = [...orders];
       const existingOrder = orders.find((order) => ordersEqual(order, finalizedOrder));
@@ -202,6 +214,29 @@ export function OrderForm({
               </InputWrapper>
             </Column>
           </Grid>
+          {isScheduledDateRequired && (
+            <Grid className={styles.gridRow}>
+              <Column lg={8} md={8} sm={4}>
+                <InputWrapper>
+                  <Controller
+                    name="scheduledDate"
+                    control={control}
+                    render={({ field, fieldState }) => (
+                      <OpenmrsDatePicker
+                        labelText={t('scheduledDate', 'Scheduled date')}
+                        id="scheduledDate"
+                        {...field}
+                        invalid={Boolean(fieldState?.error?.message)}
+                        invalidText={fieldState?.error?.message}
+                        minDate={new Date()}
+                        size={responsiveSize}
+                      />
+                    )}
+                  />
+                </InputWrapper>
+              </Column>
+            </Grid>
+          )}
           <Grid className={styles.gridRow}>
             <Column lg={16} md={8} sm={4}>
               <InputWrapper>

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/resources.ts
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/resources.ts
@@ -1,4 +1,10 @@
-import { type FetchResponse, openmrsFetch, type OpenmrsResource, restBaseUrl } from '@openmrs/esm-framework';
+import {
+  type FetchResponse,
+  openmrsFetch,
+  type OpenmrsResource,
+  restBaseUrl,
+  toOmrsIsoString,
+} from '@openmrs/esm-framework';
 import {
   type OrderBasketItem,
   priorityOptions,
@@ -41,6 +47,7 @@ export function prepOrderPostData(
       // orderReason: order.orderReason,
       accessionNumber: order.accessionNumber,
       urgency: order.urgency,
+      scheduledDate: order.scheduledDate ? toOmrsIsoString(order.scheduledDate) : null,
     };
   } else if (order.action === 'REVISE') {
     return {
@@ -55,6 +62,7 @@ export function prepOrderPostData(
       previousOrder: order.previousOrder,
       accessionNumber: order.accessionNumber,
       urgency: order.urgency,
+      scheduledDate: order.scheduledDate ? toOmrsIsoString(order.scheduledDate) : null,
     };
   } else if (order.action === 'DISCONTINUE') {
     return {
@@ -68,6 +76,7 @@ export function prepOrderPostData(
       previousOrder: order.previousOrder,
       accessionNumber: order.accessionNumber,
       urgency: order.urgency,
+      scheduledDate: order.scheduledDate ? toOmrsIsoString(order.scheduledDate) : null,
     };
   } else {
     throw new Error(`Unknown order action: ${order.action}.`);

--- a/packages/esm-patient-orders-app/src/utils/index.ts
+++ b/packages/esm-patient-orders-app/src/utils/index.ts
@@ -87,6 +87,7 @@ export function buildLabOrder(order: Order, action?: OrderAction) {
     concept: order.concept,
     orderType: order.orderType.uuid,
     specimenSource: null,
+    scheduledDate: order.scheduledDate ? new Date(order.scheduledDate) : null,
   };
 }
 
@@ -106,5 +107,6 @@ export function buildGeneralOrder(order: Order, action?: OrderAction): OrderBask
     concept: order.concept,
     orderNumber: order.orderNumber,
     orderType: order.orderType.uuid,
+    scheduledDate: order.scheduledDate ? new Date(order.scheduledDate) : null,
   };
 }

--- a/packages/esm-patient-orders-app/translations/en.json
+++ b/packages/esm-patient-orders-app/translations/en.json
@@ -93,6 +93,8 @@
   "saveLabResults": "Save lab results",
   "saveOrder": "Save order",
   "saving": "Saving",
+  "scheduledDate": "Scheduled date",
+  "scheduledDateRequired": "Scheduled date is required",
   "searchAgain": "search again",
   "searchFieldOrder": "Search for {{orderType}} order",
   "searchOrderables": "Search orderables",

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
@@ -3,12 +3,11 @@ import classNames from 'classnames';
 import {
   type DefaultPatientWorkspaceProps,
   launchPatientWorkspace,
+  priorityOptions,
   useOrderBasket,
   useOrderType,
-  priorityOptions,
 } from '@openmrs/esm-patient-common-lib';
-import { ExtensionSlot, useConfig, useLayoutType, useSession } from '@openmrs/esm-framework';
-import { prepTestOrderPostData, useOrderReasons } from '../api';
+import { ExtensionSlot, OpenmrsDatePicker, useConfig, useLayoutType, useSession } from '@openmrs/esm-framework';
 import {
   Button,
   ButtonSet,
@@ -23,10 +22,11 @@ import {
   TextArea,
   TextInput,
 } from '@carbon/react';
-import { useTranslation } from 'react-i18next';
-import { ordersEqual } from './test-order';
 import { Controller, type FieldErrors, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
+import { prepTestOrderPostData, useOrderReasons } from '../api';
+import { ordersEqual } from './test-order';
 import { z } from 'zod';
 import { type ConfigObject } from '../../config-schema';
 import { type TestOrderBasketItem } from '../../types';
@@ -63,27 +63,33 @@ export function LabOrderForm({
 
   const labOrderFormSchema = useMemo(
     () =>
-      z.object({
-        instructions: z.string().nullish(),
-        urgency: z.string().refine((value) => value !== '', {
-          message: t('priorityRequired', 'Priority is required'),
+      z
+        .object({
+          instructions: z.string().nullish(),
+          urgency: z.string().refine((value) => value !== '', {
+            message: t('priorityRequired', 'Priority is required'),
+          }),
+          accessionNumber: z.string().nullish(),
+          testType: z.object(
+            { label: z.string(), conceptUuid: z.string() },
+            {
+              required_error: t('testTypeRequired', 'Test type is required'),
+              invalid_type_error: t('testTypeRequired', 'Test type is required'),
+            },
+          ),
+          orderReason: orderReasonRequired
+            ? z
+                .string({
+                  required_error: t('orderReasonRequired', 'Order reason is required'),
+                })
+                .refine((value) => !!value, t('orderReasonRequired', 'Order reason is required'))
+            : z.string().optional(),
+          scheduledDate: z.date({}).nullish(),
+        })
+        .refine((data) => data.urgency !== 'ON_SCHEDULED_DATE' || Boolean(data.scheduledDate), {
+          message: t('scheduledDateRequired', 'Scheduled date is required'),
+          path: ['scheduledDate'],
         }),
-        accessionNumber: z.string().nullish(),
-        testType: z.object(
-          { label: z.string(), conceptUuid: z.string() },
-          {
-            required_error: t('testTypeRequired', 'Test type is required'),
-            invalid_type_error: t('testTypeRequired', 'Test type is required'),
-          },
-        ),
-        orderReason: orderReasonRequired
-          ? z
-              .string({
-                required_error: t('orderReasonRequired', 'Order reason is required'),
-              })
-              .refine((value) => !!value, t('orderReasonRequired', 'Order reason is required'))
-          : z.string().optional(),
-      }),
     [orderReasonRequired, t],
   );
 
@@ -91,6 +97,7 @@ export function LabOrderForm({
     control,
     handleSubmit,
     formState: { errors, defaultValues, isDirty },
+    watch,
   } = useForm<TestOrderBasketItem>({
     mode: 'all',
     resolver: zodResolver(labOrderFormSchema),
@@ -99,6 +106,8 @@ export function LabOrderForm({
       ...initialOrder,
     },
   });
+
+  const isScheduledDateRequired = watch('urgency') === 'ON_SCHEDULED_DATE';
 
   const orderReasonUuids =
     (config.labTestsWithOrderReasons?.find((c) => c.labTestUuid === defaultValues?.testType?.conceptUuid) || {})
@@ -117,6 +126,9 @@ export function LabOrderForm({
         ...data,
       };
       finalizedOrder.orderer = session.currentProvider.uuid;
+      if (finalizedOrder.urgency !== 'ON_SCHEDULED_DATE') {
+        finalizedOrder.scheduledDate = null;
+      }
 
       const newOrders = [...orders];
       const existingOrder = orders.find((order) => ordersEqual(order, finalizedOrder));
@@ -160,109 +172,33 @@ export function LabOrderForm({
   const responsiveSize = isTablet ? 'lg' : 'sm';
 
   return (
-    <>
-      <Form className={styles.orderForm} onSubmit={handleSubmit(handleFormSubmission, onError)} id="drugOrderForm">
-        <div className={styles.form}>
-          <ExtensionSlot name="top-of-lab-order-form-slot" state={{ order: initialOrder }} />
-          <Grid className={styles.gridRow}>
-            <Column lg={16} md={8} sm={4}>
-              <InputWrapper>
-                <label className={styles.testTypeLabel}>{t('testType', 'Test type')}</label>
-                <p className={styles.testType}>{initialOrder?.testType?.label}</p>
-              </InputWrapper>
-            </Column>
-          </Grid>
-          {config.showReferenceNumberField ? (
-            <Grid className={styles.gridRow}>
-              <Column lg={16} md={8} sm={4}>
-                <InputWrapper>
-                  <Controller
-                    name="accessionNumber"
-                    control={control}
-                    render={({ field: { onChange, onBlur, value } }) => (
-                      <TextInput
-                        id="labReferenceNumberInput"
-                        invalid={!!errors.accessionNumber}
-                        invalidText={errors.accessionNumber?.message}
-                        labelText={t('referenceNumber', 'Reference number', {
-                          orderType: orderType?.display,
-                        })}
-                        maxLength={150}
-                        onBlur={onBlur}
-                        onChange={onChange}
-                        size={responsiveSize}
-                        value={value}
-                      />
-                    )}
-                  />
-                </InputWrapper>
-              </Column>
-            </Grid>
-          ) : null}
-          <Grid className={styles.gridRow}>
-            <Column lg={8} md={8} sm={4}>
-              <InputWrapper>
-                <Controller
-                  name="urgency"
-                  control={control}
-                  render={({ field, fieldState }) => (
-                    <Select
-                      id="priorityInput"
-                      {...field}
-                      invalid={Boolean(fieldState?.error?.message)}
-                      invalidText={fieldState?.error?.message}
-                      labelText={t('priority', 'Priority')}
-                    >
-                      {priorityOptions.map((option) => (
-                        <SelectItem key={option.value} value={option.value} text={option.label} />
-                      ))}
-                    </Select>
-                  )}
-                />
-              </InputWrapper>
-            </Column>
-          </Grid>
-          {orderReasons.length > 0 && (
-            <Grid className={styles.gridRow}>
-              <Column lg={16} md={8} sm={4}>
-                <InputWrapper>
-                  <Controller
-                    name="orderReason"
-                    control={control}
-                    render={({ field: { onBlur, onChange } }) => (
-                      <ComboBox
-                        id="orderReasonInput"
-                        invalid={!!errors.orderReason}
-                        invalidText={errors.orderReason?.message}
-                        items={orderReasons}
-                        itemToString={(item) => item?.display}
-                        onBlur={onBlur}
-                        onChange={({ selectedItem }) => onChange(selectedItem?.uuid || '')}
-                        selectedItem={''}
-                        shouldFilterItem={filterItemsByName}
-                        size={responsiveSize}
-                        titleText={t('orderReason', 'Order reason')}
-                      />
-                    )}
-                  />
-                </InputWrapper>
-              </Column>
-            </Grid>
-          )}
+    <Form className={styles.orderForm} onSubmit={handleSubmit(handleFormSubmission, onError)} id="drugOrderForm">
+      <div className={styles.form}>
+        <ExtensionSlot name="top-of-lab-order-form-slot" state={{ order: initialOrder }} />
+        <Grid className={styles.gridRow}>
+          <Column lg={16} md={8} sm={4}>
+            <InputWrapper>
+              <label className={styles.testTypeLabel}>{t('testType', 'Test type')}</label>
+              <p className={styles.testType}>{initialOrder?.testType?.label}</p>
+            </InputWrapper>
+          </Column>
+        </Grid>
+        {config.showReferenceNumberField ? (
           <Grid className={styles.gridRow}>
             <Column lg={16} md={8} sm={4}>
               <InputWrapper>
                 <Controller
-                  name="instructions"
+                  name="accessionNumber"
                   control={control}
                   render={({ field: { onChange, onBlur, value } }) => (
-                    <TextArea
-                      enableCounter
-                      id="additionalInstructionsInput"
-                      invalid={!!errors.instructions}
-                      invalidText={errors.instructions?.message}
-                      labelText={t('additionalInstructions', 'Additional instructions')}
-                      maxCount={500}
+                    <TextInput
+                      id="labReferenceNumberInput"
+                      invalid={!!errors.accessionNumber}
+                      invalidText={errors.accessionNumber?.message}
+                      labelText={t('referenceNumber', 'Reference number', {
+                        orderType: orderType?.display,
+                      })}
+                      maxLength={150}
                       onBlur={onBlur}
                       onChange={onChange}
                       size={responsiveSize}
@@ -273,31 +209,128 @@ export function LabOrderForm({
               </InputWrapper>
             </Column>
           </Grid>
-        </div>
-        <div>
-          {showErrorNotification && (
-            <Column className={styles.errorContainer}>
-              <InlineNotification
-                lowContrast
-                onClose={() => setShowErrorNotification(false)}
-                subtitle={t('pleaseRequiredFields', 'Please fill all required fields') + '.'}
-                title={t('error', 'Error')}
+        ) : null}
+        <Grid className={styles.gridRow}>
+          <Column lg={8} md={8} sm={4}>
+            <InputWrapper>
+              <Controller
+                name="urgency"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <Select
+                    id="priorityInput"
+                    {...field}
+                    invalid={Boolean(fieldState?.error?.message)}
+                    invalidText={fieldState?.error?.message}
+                    labelText={t('priority', 'Priority')}
+                  >
+                    {priorityOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value} text={option.label} />
+                    ))}
+                  </Select>
+                )}
               />
+            </InputWrapper>
+          </Column>
+        </Grid>
+        {isScheduledDateRequired && (
+          <Grid className={styles.gridRow}>
+            <Column lg={8} md={8} sm={4}>
+              <InputWrapper>
+                <Controller
+                  name="scheduledDate"
+                  control={control}
+                  render={({ field, fieldState }) => (
+                    <OpenmrsDatePicker
+                      labelText={t('scheduledDate', 'Scheduled date')}
+                      id="scheduledDate"
+                      {...field}
+                      invalid={Boolean(fieldState?.error?.message)}
+                      invalidText={fieldState?.error?.message}
+                      minDate={new Date()}
+                      size={responsiveSize}
+                    />
+                  )}
+                />
+              </InputWrapper>
             </Column>
-          )}
-          <ButtonSet
-            className={classNames(styles.buttonSet, isTablet ? styles.tabletButtonSet : styles.desktopButtonSet)}
-          >
-            <Button className={styles.button} kind="secondary" onClick={cancelOrder} size="xl">
-              {t('discard', 'Discard')}
-            </Button>
-            <Button className={styles.button} kind="primary" size="xl" type="submit">
-              {t('saveOrder', 'Save order')}
-            </Button>
-          </ButtonSet>
-        </div>
-      </Form>
-    </>
+          </Grid>
+        )}
+        {orderReasons.length > 0 && (
+          <Grid className={styles.gridRow}>
+            <Column lg={16} md={8} sm={4}>
+              <InputWrapper>
+                <Controller
+                  name="orderReason"
+                  control={control}
+                  render={({ field: { onBlur, onChange } }) => (
+                    <ComboBox
+                      id="orderReasonInput"
+                      invalid={!!errors.orderReason}
+                      invalidText={errors.orderReason?.message}
+                      items={orderReasons}
+                      itemToString={(item) => item?.display}
+                      onBlur={onBlur}
+                      onChange={({ selectedItem }) => onChange(selectedItem?.uuid || '')}
+                      selectedItem={''}
+                      shouldFilterItem={filterItemsByName}
+                      size={responsiveSize}
+                      titleText={t('orderReason', 'Order reason')}
+                    />
+                  )}
+                />
+              </InputWrapper>
+            </Column>
+          </Grid>
+        )}
+        <Grid className={styles.gridRow}>
+          <Column lg={16} md={8} sm={4}>
+            <InputWrapper>
+              <Controller
+                name="instructions"
+                control={control}
+                render={({ field: { onChange, onBlur, value } }) => (
+                  <TextArea
+                    enableCounter
+                    id="additionalInstructionsInput"
+                    invalid={!!errors.instructions}
+                    invalidText={errors.instructions?.message}
+                    labelText={t('additionalInstructions', 'Additional instructions')}
+                    maxCount={500}
+                    onBlur={onBlur}
+                    onChange={onChange}
+                    size={responsiveSize}
+                    value={value}
+                  />
+                )}
+              />
+            </InputWrapper>
+          </Column>
+        </Grid>
+      </div>
+      <div>
+        {showErrorNotification && (
+          <Column className={styles.errorContainer}>
+            <InlineNotification
+              lowContrast
+              onClose={() => setShowErrorNotification(false)}
+              subtitle={t('pleaseRequiredFields', 'Please fill all required fields') + '.'}
+              title={t('error', 'Error')}
+            />
+          </Column>
+        )}
+        <ButtonSet
+          className={classNames(styles.buttonSet, isTablet ? styles.tabletButtonSet : styles.desktopButtonSet)}
+        >
+          <Button className={styles.button} kind="secondary" onClick={cancelOrder} size="xl">
+            {t('discard', 'Discard')}
+          </Button>
+          <Button className={styles.button} kind="primary" size="xl" type="submit">
+            {t('saveOrder', 'Save order')}
+          </Button>
+        </ButtonSet>
+      </div>
+    </Form>
   );
 }
 

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { type ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import {
   type DefaultPatientWorkspaceProps,
   launchPatientWorkspace,
+  type OrderUrgency,
   priorityOptions,
   useOrderBasket,
   useOrderType,
@@ -22,7 +23,7 @@ import {
   TextArea,
   TextInput,
 } from '@carbon/react';
-import { Controller, type FieldErrors, useForm } from 'react-hook-form';
+import { Controller, type ControllerRenderProps, type FieldErrors, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from 'react-i18next';
 import { prepTestOrderPostData, useOrderReasons } from '../api';
@@ -97,6 +98,7 @@ export function LabOrderForm({
     control,
     handleSubmit,
     formState: { errors, defaultValues, isDirty },
+    setValue,
     watch,
   } = useForm<TestOrderBasketItem>({
     mode: 'all',
@@ -126,9 +128,6 @@ export function LabOrderForm({
         ...data,
       };
       finalizedOrder.orderer = session.currentProvider.uuid;
-      if (finalizedOrder.urgency !== 'ON_SCHEDULED_DATE') {
-        finalizedOrder.scheduledDate = null;
-      }
 
       const newOrders = [...orders];
       const existingOrder = orders.find((order) => ordersEqual(order, finalizedOrder));
@@ -163,6 +162,16 @@ export function LabOrderForm({
     if (errors) {
       setShowErrorNotification(true);
     }
+  };
+
+  const handleUpdateUrgency = (fieldOnChange: ControllerRenderProps['onChange']) => {
+    return (e: ChangeEvent<HTMLSelectElement>) => {
+      const value = e.target.value as OrderUrgency;
+      if (value !== 'ON_SCHEDULED_DATE') {
+        setValue('scheduledDate', null);
+      }
+      fieldOnChange(e);
+    };
   };
 
   useEffect(() => {
@@ -220,6 +229,7 @@ export function LabOrderForm({
                   <Select
                     id="priorityInput"
                     {...field}
+                    onChange={handleUpdateUrgency(field.onChange)}
                     invalid={Boolean(fieldState?.error?.message)}
                     invalidText={fieldState?.error?.message}
                     labelText={t('priority', 'Priority')}

--- a/packages/esm-patient-tests-app/src/test-orders/api.ts
+++ b/packages/esm-patient-tests-app/src/test-orders/api.ts
@@ -4,7 +4,14 @@ import useSWR, { mutate } from 'swr';
 import useSWRImmutable from 'swr/immutable';
 import type { OrderPost, PatientOrderFetchResponse, TestOrderPost } from '@openmrs/esm-patient-common-lib';
 import type { TestOrderBasketItem } from '../types';
-import { type FetchResponse, openmrsFetch, restBaseUrl, showSnackbar, useConfig } from '@openmrs/esm-framework';
+import {
+  type FetchResponse,
+  openmrsFetch,
+  restBaseUrl,
+  showSnackbar,
+  toOmrsIsoString,
+  useConfig,
+} from '@openmrs/esm-framework';
 import { type ConfigObject } from '../config-schema';
 
 export const careSettingUuid = '6f0c9a92-6f24-11e3-af88-005056821db0';
@@ -95,6 +102,7 @@ export function prepTestOrderPostData(
       orderReason: order.orderReason,
       accessionNumber: order.accessionNumber,
       urgency: order.urgency,
+      scheduledDate: order.scheduledDate ? toOmrsIsoString(order.scheduledDate) : null,
     };
   } else if (order.action === 'REVISE') {
     return {
@@ -110,6 +118,7 @@ export function prepTestOrderPostData(
       previousOrder: order.previousOrder,
       accessionNumber: order.accessionNumber,
       urgency: order.urgency,
+      scheduledDate: order.scheduledDate ? toOmrsIsoString(order.scheduledDate) : null,
     };
   } else if (order.action === 'DISCONTINUE') {
     return {
@@ -124,6 +133,7 @@ export function prepTestOrderPostData(
       previousOrder: order.previousOrder,
       accessionNumber: order.accessionNumber,
       urgency: order.urgency,
+      scheduledDate: order.scheduledDate ? toOmrsIsoString(order.scheduledDate) : null,
     };
   } else {
     throw new Error(`Unknown order action: ${order.action}.`);

--- a/packages/esm-patient-tests-app/translations/en.json
+++ b/packages/esm-patient-tests-app/translations/en.json
@@ -72,6 +72,8 @@
   "returnToOrderBasket": "Return to order basket",
   "returnToTimeline": "Return to timeline",
   "saveOrder": "Save order",
+  "scheduledDate": "Scheduled date",
+  "scheduledDateRequired": "Scheduled date is required",
   "search": "Search",
   "searchAgain": "search again",
   "searchByTestName": "Search by test name",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
The orders need to have a scheduled date if the priority/ urgency of the order is set to `ON_SCHEDULED_DATE`. This PR adds a date field to define a `scheduled date` for an order.

## Screenshots
https://github.com/user-attachments/assets/a009aea6-6799-418b-ab36-46bc13db1bb1

## Related Issue
https://openmrs.atlassian.net/browse/O3-4334

## Other
<!-- Anything not covered above -->
