### PR TITLE
(fix) Make the order fields nullish in the order forms

### DIFF
--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-form/general-order-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-form/general-order-form.component.tsx
@@ -58,11 +58,11 @@ export function OrderForm({
   const OrderFormSchema = useMemo(
     () =>
       z.object({
-        instructions: z.string().optional(),
+        instructions: z.string().nullish(),
         urgency: z.string().refine((value) => value !== '', {
           message: translateFrom(moduleName, 'addLabOrderPriorityRequired', 'Priority is required'),
         }),
-        accessionNumber: z.string().optional(),
+        accessionNumber: z.string().nullish(),
         concept: z.object(
           { display: z.string(), uuid: z.string() },
           {

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-form/general-order-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-form/general-order-form.component.tsx
@@ -8,7 +8,7 @@ import {
   useOrderType,
   priorityOptions,
 } from '@openmrs/esm-patient-common-lib';
-import { translateFrom, useLayoutType, useSession, useConfig, ExtensionSlot } from '@openmrs/esm-framework';
+import { translateFrom, useLayoutType, useSession, ExtensionSlot } from '@openmrs/esm-framework';
 import {
   Button,
   ButtonSet,
@@ -26,9 +26,8 @@ import { Controller, type FieldErrors, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { moduleName } from '@openmrs/esm-patient-chart-app/src/constants';
-import styles from './general-order-form.scss';
-import type { ConfigObject } from '../../../config-schema';
 import { ordersEqual, prepOrderPostData } from '../resources';
+import styles from './general-order-form.scss';
 
 export interface OrderFormProps extends DefaultPatientWorkspaceProps {
   initialOrder: OrderBasketItem;

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
@@ -62,11 +62,11 @@ export function LabOrderForm({
   const labOrderFormSchema = useMemo(
     () =>
       z.object({
-        instructions: z.string().optional(),
+        instructions: z.string().nullish(),
         urgency: z.string().refine((value) => value !== '', {
           message: translateFrom(moduleName, 'addLabOrderPriorityRequired', 'Priority is required'),
         }),
-        accessionNumber: z.string().nullable(),
+        accessionNumber: z.string().nullish(),
         testType: z.object(
           { label: z.string(), conceptUuid: z.string() },
           {

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
@@ -27,8 +27,8 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { moduleName } from '@openmrs/esm-patient-chart-app/src/constants';
 import { type ConfigObject } from '../../config-schema';
+import { type TestOrderBasketItem } from '../../types';
 import styles from './test-order-form.scss';
-import type { TestOrderBasketItem } from '../../types';
 
 export interface LabOrderFormProps extends DefaultPatientWorkspaceProps {
   initialOrder: TestOrderBasketItem;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR makes the reference field and Additional instructions fields in the order forms `nullish`. Currently, the `optional` allows `undefined` field value, but if the value of the field is `null`, it throws the `invalid_type` error. As per docs, [nullish](https://zod.dev/?id=nullish) will accept both `undefined` and `null` values for the fields.

## Screenshots
### Before
https://github.com/user-attachments/assets/5f7fd14b-a4f4-4895-b721-e3a8f0c07544

###After

https://github.com/user-attachments/assets/f86bd967-6450-4872-a8bc-99ba47ae31a3


## Related Issue
None

## Other
<!-- Anything not covered above -->
