### PR TITLE
(fix) O3-4329: Ensure start visit form launches when scheduling appointments

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@carbon/react';
-import { launchPatientChartWithWorkspaceOpen } from '@openmrs/esm-patient-common-lib';
+import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -7,17 +7,18 @@ const StartVisitButton = ({ patientUuid }) => {
   const { t } = useTranslation();
 
   const handleStartVisit = useCallback(() => {
-    launchPatientChartWithWorkspaceOpen({
-      patientUuid,
-      workspaceName: 'start-visit-workspace-form',
-      additionalProps: {
+    try {
+      launchPatientWorkspace('start-visit-workspace-form', {
+        patientUuid,
         openedFrom: 'patient-chart-start-visit',
-      },
-    });
+      });
+    } catch (error) {
+      console.error('Error launching Start Visit workspace:', error);
+    }
   }, [patientUuid]);
 
   return (
-    <Button kind="primary" onClick={handleStartVisit}>
+    <Button kind="primary" onClick={handleStartVisit} aria-label={t('startVisit', 'Start visit')}>
       {t('startVisit', 'Start visit')}
     </Button>
   );

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
@@ -1,24 +1,37 @@
-import { Button } from '@carbon/react';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import React, { useCallback } from 'react';
+import { Button } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
+import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { showSnackbar } from '@openmrs/esm-framework';
 
-const StartVisitButton = ({ patientUuid }) => {
+interface StartVisitButtonProps {
+  patientUuid: string;
+}
+
+const StartVisitButton = ({ patientUuid }: StartVisitButtonProps) => {
   const { t } = useTranslation();
+  const startVisitWorkspaceForm = 'start-visit-workspace-form';
 
   const handleStartVisit = useCallback(() => {
     try {
-      launchPatientWorkspace('start-visit-workspace-form', {
+      launchPatientWorkspace(startVisitWorkspaceForm, {
         patientUuid,
         openedFrom: 'patient-chart-start-visit',
       });
     } catch (error) {
-      console.error('Error launching Start Visit workspace:', error);
+      console.error('Error launching visit form workspace:', error);
+
+      showSnackbar({
+        isLowContrast: false,
+        kind: 'error',
+        title: t('errorStartingVisit', 'Error starting visit'),
+        subtitle: error.message ?? t('errorStartingVisitDescription', 'An error occurred while starting the visit'),
+      });
     }
-  }, [patientUuid]);
+  }, [patientUuid, t]);
 
   return (
-    <Button kind="primary" onClick={handleStartVisit} aria-label={t('startVisit', 'Start visit')}>
+    <Button aria-label={t('startVisit', 'Start visit')} kind="primary" onClick={handleStartVisit}>
       {t('startVisit', 'Start visit')}
     </Button>
   );

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { mockPatient } from 'tools';
+import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import StartVisitButton from './start-visit-button.component';
+
+const mockLaunchPatientWorkspace = jest.mocked(launchPatientWorkspace);
+
+jest.mock('@openmrs/esm-patient-common-lib', () => ({
+  launchPatientWorkspace: jest.fn(),
+}));
+
+describe('StartVisitButton', () => {
+  it('renders the start visit button', () => {
+    render(<StartVisitButton patientUuid={mockPatient.id} />);
+
+    expect(screen.getByRole('button', { name: /start visit/i })).toBeInTheDocument();
+  });
+
+  it('clicking the button launches the start visit form', async () => {
+    const user = userEvent.setup();
+
+    render(<StartVisitButton patientUuid={mockPatient.id} />);
+
+    const startVisitButton = screen.getByRole('button', { name: /start visit/i });
+    await user.click(startVisitButton);
+
+    expect(mockLaunchPatientWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('start-visit-workspace-form', {
+      patientUuid: mockPatient.id,
+      openedFrom: 'patient-chart-start-visit',
+    });
+  });
+});

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -65,6 +65,8 @@
   "errorMarkingPatientAlive": "Error marking patient alive",
   "errorMarkingPatientDeceased": "Error marking patient deceased",
   "errorOccuredDeletingVisit": "An error occured when deleting visit",
+  "errorStartingVisit": "Error starting visit",
+  "errorStartingVisitDescription": "An error occurred while starting the visit",
   "errorUpdatingVisitAttribute": "Could not update {{attributeName}} attribute",
   "errorUpdatingVisitDetails": "Error updating visit details",
   "errorWhenRestoringVisit": "Error occured when restoring {{visit}}",

--- a/packages/esm-patient-orders-app/translations/en.json
+++ b/packages/esm-patient-orders-app/translations/en.json
@@ -31,6 +31,7 @@
   "errorSavingLabResults": "Error saving lab results",
   "goToDrugOrderForm": "Order form",
   "indication": "Indication",
+  "labResultError": "Error loading lab results",
   "inStock": "In stock",
   "instructions": "Instructions",
   "labResultError": "Error loading lab results",

--- a/packages/esm-patient-orders-app/translations/en.json
+++ b/packages/esm-patient-orders-app/translations/en.json
@@ -31,7 +31,6 @@
   "errorSavingLabResults": "Error saving lab results",
   "goToDrugOrderForm": "Order form",
   "indication": "Indication",
-  "labResultError": "Error loading lab results",
   "inStock": "In stock",
   "instructions": "Instructions",
   "labResultError": "Error loading lab results",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue where the Start Visit form would not launch when attempting to start a visit for a patient before scheduling an appointment. It does so by changing the way the Start Visit form workspace gets launched. Instead of launching the Patient Chart and then launching the Start Visit form workspace, it launches the Start Visit form workspace directly from the Appointments app using the [launchPatientWorkspace](https://github.com/bharath-k-shetty/openmrs-esm-patient-chart/blob/main/packages/esm-patient-common-lib/src/workspaces.ts#L12) function. This function launches a workspace directly within the context of the present app without needing to launch the Patient Chart.

Additional improvements include:

- Adding test coverage for the StartVisitButton component.
- Improving error handling for cases where the StartVisit form workspace won't launch by showing an error snackbar explaining the reason why the form would not load.
- Improving a11y by adding an aria-label to the "Start visit" button.

## Screenshots

### Before

https://github.com/user-attachments/assets/e35badce-9a7b-473f-b0db-14b40a1582b1

### After

https://github.com/user-attachments/assets/4f527946-7c52-45d5-8d02-7b737d185c03

## Related Issue

https://openmrs.atlassian.net/browse/O3-4329

## Other
