### PR TITLE
(refactor) O3-4336: Same theme colors for all order types

### DIFF
--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
@@ -4,9 +4,9 @@
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
 .desktopTile {
-  border-left: layout.$spacing-02 solid colors.$cyan-20;
+  border-left: layout.$spacing-02 solid colors.$purple-70;
   background-color: $ui-02;
-  border-top: 1px solid colors.$cyan-20;
+  border-top: 1px solid colors.$purple-20;
   border-right: none;
   padding: 0;
 }

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-panel.scss
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-panel.scss
@@ -4,9 +4,9 @@
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
 .desktopTile {
-  border-left: layout.$spacing-02 solid colors.$cyan-20;
+  border-left: layout.$spacing-02 solid colors.$purple-70;
   background-color: $ui-02;
-  border-top: 1px solid colors.$cyan-20;
+  border-top: 1px solid colors.$purple-20;
   border-right: none;
   padding: 0;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR keeps the same theme for all order types. Since new order types can be added via configuration, it keeps the colors same for configuration added order types.

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/6c637bed-d689-4822-a500-8a8fee2903aa)

### After
![image](https://github.com/user-attachments/assets/b80584c9-a389-437a-a147-99cd80424cfc)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
