### PR TITLE
(feat) Restore manual refresh data button in results viewer

### DIFF
--- a/packages/esm-patient-tests-app/src/test-results/results-viewer/results-viewer.extension.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/results-viewer/results-viewer.extension.tsx
@@ -4,7 +4,7 @@ import { type TFunction, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { ContentSwitcher, Switch, Button } from '@carbon/react';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
-import { navigate, useConfig, useLayoutType } from '@openmrs/esm-framework';
+import { navigate, RenewIcon, useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { type ConfigObject } from '../../config-schema';
 import { type viewOpts } from '../../types';
 import { FilterContext, FilterProvider } from '../filter';
@@ -109,7 +109,8 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
             totalResultsCount ? `(${totalResultsCount})` : ''
           }`}</h4>
           <div className={styles.leftHeaderActions}>
-            <p>{t('view', 'View')}: </p>
+            <RefreshDataButton isTablet={isTablet} t={t} />
+            <span className={styles.contentSwitcherLabel}>{t('view', 'View')}: </span>
             <ContentSwitcher
               selectedIndex={['panel', 'tree'].indexOf(selectedSection)}
               onChange={({ name }: { name: panelOpts }) => setSelectedSection(name)}
@@ -152,15 +153,15 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
 
   return (
     <div className={styles.resultsContainer}>
-      <div ref={headerRef} className={styles.headerSentinel} />
+      <div className={styles.headerSentinel} ref={headerRef} />
       <div className={classNames(styles.resultsHeader, { [styles.resultsHeaderScrolled]: !isHeaderVisible })}>
         <div className={classNames(styles.leftSection, styles.leftHeaderSection)}>
           <h4>{t('tests', 'Tests')}</h4>
           <Button
             className={styles.button}
             kind="ghost"
-            size={isTablet ? 'md' : 'sm'}
             onClick={resetTree} // TODO: Undo selections fix
+            size={isTablet ? 'md' : 'sm'}
           >
             <span>{t('reset', 'Reset')}</span>
           </Button>
@@ -170,16 +171,19 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
             <h4 className={styles.viewOptionsText}>{`${t('results', 'Results')} ${
               totalResultsCount ? `(${totalResultsCount})` : ''
             }`}</h4>
-            <p className={styles.viewOptionsSubHeading}>{t('view', 'View')}: </p>
-            <ContentSwitcher
-              className={styles.viewOptionsSwitcher}
-              onChange={({ name }: { name: viewOpts }) => setView(name)}
-              selectedIndex={isExpanded ? 1 : 0}
-              size={responsiveSize}
-            >
-              <Switch name="individual-test" text={t('individualTests', 'Individual tests')} disabled={loading} />
-              <Switch name="over-time" text={t('overTime', 'Over time')} disabled={loading} />
-            </ContentSwitcher>
+            <div className={styles.buttonsContainer}>
+              <RefreshDataButton isTablet={isTablet} t={t} />
+              <span className={styles.contentSwitcherLabel}>{t('view', 'View')}: </span>
+              <ContentSwitcher
+                className={styles.viewOptionsSwitcher}
+                onChange={({ name }: { name: viewOpts }) => setView(name)}
+                selectedIndex={isExpanded ? 1 : 0}
+                size={responsiveSize}
+              >
+                <Switch name="individual-test" text={t('individualTests', 'Individual tests')} disabled={loading} />
+                <Switch name="over-time" text={t('overTime', 'Over time')} disabled={loading} />
+              </ContentSwitcher>
+            </div>
           </div>
         </div>
       </div>
@@ -196,5 +200,19 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid, basePath, lo
     </div>
   );
 };
+
+function RefreshDataButton({ isTablet, t }: RefreshDataButtonProps) {
+  return (
+    <Button
+      className={styles.button}
+      kind="ghost"
+      onClick={() => window.location.reload()}
+      renderIcon={RenewIcon}
+      size={isTablet ? 'md' : 'sm'}
+    >
+      <span>{t('refreshData', 'Refresh data')}</span>
+    </Button>
+  );
+}
 
 export default RoutedResultsViewer;

--- a/packages/esm-patient-tests-app/src/test-results/results-viewer/results-viewer.scss
+++ b/packages/esm-patient-tests-app/src/test-results/results-viewer/results-viewer.scss
@@ -1,11 +1,7 @@
+@use '@carbon/colors';
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '@carbon/colors';
 @use '@openmrs/esm-styleguide/src/vars' as *;
-
-:global(.omrs-breakpoint-gt-small-desktop .-esm-patient-chart__patient-chart__widthContained___Ow0JH) {
-  max-width: 150rem;
-}
 
 @media (min-width: 1200px) {
   :global(.-esm-patient-chart__patient-chart__widthContained___Ow0JH) {
@@ -13,12 +9,8 @@
   }
 }
 
-:global(.cds--data-table td, .cds--data-table th) {
-  vertical-align: top;
-}
-
-:global(.cds--data-table--md td) {
-  padding-top: 0.1rem;
+:global(.omrs-breakpoint-gt-small-desktop .-esm-patient-chart__patient-chart__widthContained___Ow0JH) {
+  max-width: 150rem;
 }
 
 .resultsContainer {
@@ -27,6 +19,14 @@
   position: relative;
   grid-template-columns: repeat(12, minmax(0, 1fr));
   background-color: $ui-01;
+
+  :global(.cds--data-table td, .cds--data-table th) {
+    vertical-align: top;
+  }
+
+  :global(.cds--data-table--md td) {
+    padding-top: 0.1rem;
+  }
 }
 
 .flex {
@@ -83,9 +83,9 @@
   justify-self: start;
 }
 
-.viewOptionsSubHeading {
+.contentSwitcherLabel {
   white-space: nowrap;
-  align-self: center;
+  @include type.type-style('body-01');
 }
 
 .viewOptionsSwitcher {
@@ -184,21 +184,6 @@
   margin-bottom: layout.$spacing-07;
 }
 
-.button {
-  align-items: center;
-  margin-left: layout.$spacing-05;
-
-  svg {
-    order: 1;
-    margin-right: layout.$spacing-03;
-    margin-left: 0 !important;
-  }
-
-  span {
-    order: 2;
-  }
-}
-
 .border {
   border: 1px solid $ui-03;
   border-bottom: none;
@@ -207,5 +192,20 @@
 .groupPanelsTables {
   > div + div {
     margin-top: layout.$spacing-05;
+  }
+}
+
+.buttonsContainer {
+  display: flex;
+  align-items: center;
+  gap: layout.$spacing-03;
+}
+
+.button {
+  align-items: center;
+  margin-right: layout.$spacing-03;
+
+  svg {
+    fill: colors.$blue-60 !important;
   }
 }

--- a/packages/esm-patient-tests-app/translations/en.json
+++ b/packages/esm-patient-tests-app/translations/en.json
@@ -60,6 +60,7 @@
   "recentTestResults": "recent test results",
   "referenceNumber": "Reference number",
   "referenceRange": "Reference range",
+  "refreshData": "Refresh data",
   "removeFromBasket": "Remove from basket",
   "reset": "Reset",
   "resetTreeText": "Reset tree",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR restores the "Refresh Data" button in the test results viewer UI to allow manual data reloading. As a temporary solution until automatic data revalidation is implemented, the button calls `window.location.reload()` to refresh the page state.

## Screenshots

### Desktop

![CleanShot 2025-01-14 at 3  56 53@2x](https://github.com/user-attachments/assets/5ce84ad0-139b-413d-abee-e208e5c14214)

### Tablet

![CleanShot 2025-01-14 at 3  57 19@2x](https://github.com/user-attachments/assets/5b63c323-2a10-43c3-bee3-05778992c933)

## Related Issue

https://openmrs.atlassian.net/browse/O3-4346

## Other
<!-- Anything not covered above -->
