### PR TITLE
(fix) O3-4348: Prevent adding same order into multiple groups

### DIFF
--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -74,7 +74,6 @@ interface OrderBasketItemActionsProps {
   openOrderForm: (additionalProps?: { order: MutableOrderBasketItem }) => void;
   orderItem: Order;
   responsiveSize: string;
-  setOrderItems: (orderType: string, items: Array<MutableOrderBasketItem>) => void;
 }
 
 interface OrderHeaderProps {
@@ -113,7 +112,6 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ patientUuid, showAddBu
   const patient = usePatient(patientUuid);
   const { excludePatientIdentifierCodeTypes } = useConfig();
   const [isPrinting, setIsPrinting] = useState(false);
-  const { setOrders } = useOrderBasket<MutableOrderBasketItem>();
   const { data: orderTypes } = useOrderTypes();
   const [selectedOrderTypeUuid, setSelectedOrderTypeUuid] = useState(null);
   const [selectedFromDate, setSelectedFromDate] = useState(null);
@@ -514,7 +512,6 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ patientUuid, showAddBu
                                                 openOrderBasket={launchOrderBasket}
                                                 openOrderForm={() => openOrderForm(matchingOrder)}
                                                 orderItem={matchingOrder}
-                                                setOrderItems={setOrders}
                                                 responsiveSize={responsiveSize}
                                               />
                                             ) : (
@@ -602,14 +599,13 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ patientUuid, showAddBu
 
 function OrderBasketItemActions({
   orderItem,
-  setOrderItems,
   openOrderBasket,
   openOrderForm,
   responsiveSize,
 }: OrderBasketItemActionsProps) {
   const { t } = useTranslation();
-  const { orders: items } = useOrderBasket<MutableOrderBasketItem>(orderItem.orderType.uuid);
-  const alreadyInBasket = items.some((x) => x.uuid === orderItem.uuid);
+  const { orders, setOrders } = useOrderBasket<MutableOrderBasketItem>(orderItem.orderType.uuid);
+  const alreadyInBasket = orders.some((x) => x.uuid === orderItem.uuid);
 
   const handleModifyClick = useCallback(() => {
     if (orderItem.type === 'drugorder') {
@@ -617,7 +613,7 @@ function OrderBasketItemActions({
         .then((res) => {
           const medicationOrder = res.data;
           const medicationItem = buildMedicationOrder(medicationOrder, 'REVISE');
-          setOrderItems(medicationsOrderBasket, [...items, medicationItem]);
+          setOrders([...orders, medicationItem]);
           openOrderForm({ order: medicationItem });
         })
         .catch((e) => {
@@ -625,14 +621,14 @@ function OrderBasketItemActions({
         });
     } else if (orderItem.type === 'testorder') {
       const labItem = buildLabOrder(orderItem, 'REVISE');
-      setOrderItems(orderItem.orderType.uuid, [...items, labItem]);
+      setOrders([...orders, labItem]);
       openOrderForm({ order: labItem });
     } else if (orderItem.type === 'order') {
       const order = buildGeneralOrder(orderItem, 'REVISE');
-      setOrderItems(orderItem.orderType.uuid, [...items, order]);
+      setOrders([...orders, order]);
       openOrderForm({ order });
     }
-  }, [orderItem, openOrderForm, items, setOrderItems]);
+  }, [orderItem, openOrderForm, orders, setOrders]);
 
   const handleAddResultsClick = useCallback(() => {
     launchPatientWorkspace('test-results-form-workspace', { order: orderItem });
@@ -642,19 +638,19 @@ function OrderBasketItemActions({
     if (orderItem.type === 'drugorder') {
       getDrugOrderByUuid(orderItem.uuid).then((res) => {
         let medicationOrder = res.data;
-        setOrderItems(medicationsOrderBasket, [...items, buildMedicationOrder(medicationOrder, 'DISCONTINUE')]);
+        setOrders([...orders, buildMedicationOrder(medicationOrder, 'DISCONTINUE')]);
         openOrderBasket();
       });
     } else if (orderItem.type === 'testorder') {
       const labItem = buildLabOrder(orderItem, 'DISCONTINUE');
-      setOrderItems(orderItem.orderType.uuid, [...items, labItem]);
+      setOrders([...orders, labItem]);
       openOrderBasket();
     } else {
       const order = buildGeneralOrder(orderItem, 'DISCONTINUE');
-      setOrderItems(orderItem.orderType.uuid, [...items, order]);
+      setOrders([...orders, order]);
       openOrderBasket();
     }
-  }, [orderItem, setOrderItems, items, openOrderBasket]);
+  }, [orderItem, setOrders, orders, openOrderBasket]);
 
   return (
     <Layer className={styles.layer}>

--- a/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/orders-details-table.component.tsx
@@ -70,7 +70,6 @@ interface OrderDetailsProps {
 }
 
 interface OrderBasketItemActionsProps {
-  items: Array<MutableOrderBasketItem>;
   openOrderBasket: () => void;
   openOrderForm: (additionalProps?: { order: MutableOrderBasketItem }) => void;
   orderItem: Order;
@@ -114,7 +113,7 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ patientUuid, showAddBu
   const patient = usePatient(patientUuid);
   const { excludePatientIdentifierCodeTypes } = useConfig();
   const [isPrinting, setIsPrinting] = useState(false);
-  const { orders, setOrders } = useOrderBasket<MutableOrderBasketItem>();
+  const { setOrders } = useOrderBasket<MutableOrderBasketItem>();
   const { data: orderTypes } = useOrderTypes();
   const [selectedOrderTypeUuid, setSelectedOrderTypeUuid] = useState(null);
   const [selectedFromDate, setSelectedFromDate] = useState(null);
@@ -512,7 +511,6 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ patientUuid, showAddBu
                                           <TableCell className="cds--table-column-menu">
                                             {isOmrsOrder(matchingOrder) ? (
                                               <OrderBasketItemActions
-                                                items={orders}
                                                 openOrderBasket={launchOrderBasket}
                                                 openOrderForm={() => openOrderForm(matchingOrder)}
                                                 orderItem={matchingOrder}
@@ -604,13 +602,13 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({ patientUuid, showAddBu
 
 function OrderBasketItemActions({
   orderItem,
-  items,
   setOrderItems,
   openOrderBasket,
   openOrderForm,
   responsiveSize,
 }: OrderBasketItemActionsProps) {
   const { t } = useTranslation();
+  const { orders: items } = useOrderBasket<MutableOrderBasketItem>(orderItem.orderType.uuid);
   const alreadyInBasket = items.some((x) => x.uuid === orderItem.uuid);
 
   const handleModifyClick = useCallback(() => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the following issue:

### Context

The order basket store handles the grouping of all orders depending on the `groupingKey`.
The `useOrderBasket` hook returns the different values of `orders` basked on the parameters passed to it.

In the following scenario
```
const {orders, setOrders} = useOrderBasket()
```
It'll return **all** the orders present for a patient and the `setOrders` function will be called with a `groupingKey` as first arg and `orders` to be set as the 2nd arg.

In the following scenario
```
const {orders, setOrders} = useOrderBasket(groupingKey)
```
It'll return **only** the orders associated with the `groupingKey` and the `setOrders` function doesn't need a `groupingKey` anymore, just the `orders` to be set in the 1st arg.

### Issue
When modifying/canceling an order, the `orders` from the 1st scenario (mentioned above) were being used to update the order basket state; hence, the already present orders were being re-added as new orders, this time as part of a new `grouping`. 

## Screenshots
### Before

https://github.com/user-attachments/assets/e0415026-33d4-4994-ad70-ec410277da72

P.S. All the form errors are already handled in the following PRs, the changes are not updated in the server the above video was shot on.

https://github.com/openmrs/openmrs-esm-patient-chart/pull/2180
https://github.com/openmrs/openmrs-esm-patient-chart/pull/2177
https://github.com/openmrs/openmrs-esm-patient-chart/pull/2179


### After

https://github.com/user-attachments/assets/bb89872a-ffe1-4ba6-a78f-a6ce56516ecd



## Related Issue
https://openmrs.atlassian.net/browse/O3-4348

## Other
<!-- Anything not covered above -->
