### PR TITLE
(fix) O3-4403: Unable to record allergy in non-English locale

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.workspace.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.workspace.tsx
@@ -77,12 +77,28 @@ function AllergyForm(props: AllergyFormProps) {
   const { concepts } = useConfig();
   const isTablet = useLayoutType() === 'tablet';
 
-  const severityLevels = [t('mild', 'Mild'), t('moderate', 'Moderate'), t('severe', 'Severe')];
-  const patientState = useMemo(() => ({ patientUuid }), [patientUuid]);
   const { mildReactionUuid, severeReactionUuid, moderateReactionUuid, otherConceptUuid } = useMemo(
     () => concepts,
     [concepts],
   );
+  const severityLevels = [
+    {
+      uuid: mildReactionUuid,
+      key: 'mild',
+      display: t('mild', 'Mild'),
+    },
+    {
+      uuid: moderateReactionUuid,
+      key: 'moderate',
+      display: t('moderate', 'Moderate'),
+    },
+    {
+      uuid: severeReactionUuid,
+      key: 'severe',
+      display: t('severe', 'Severe'),
+    },
+  ];
+  const patientState = useMemo(() => ({ patientUuid }), [patientUuid]);
   const { allergicReactions, isLoading } = useAllergicReactions();
   const { allergens } = useAllergens();
   const [isDisabled, setIsDisabled] = useState(true);
@@ -377,24 +393,8 @@ function AllergyForm(props: AllergyFormProps) {
                     valueSelected={value}
                     onBlur={onBlur}
                   >
-                    {severityLevels.map((severity, index) => (
-                      <RadioButton
-                        id={severity.toLowerCase() + 'Severity'}
-                        key={`severity-${index}`}
-                        labelText={severity}
-                        value={(() => {
-                          switch (severity.toLowerCase()) {
-                            case 'mild':
-                              return mildReactionUuid;
-                            case 'moderate':
-                              return moderateReactionUuid;
-                            case 'severe':
-                              return severeReactionUuid;
-                            default:
-                              return '';
-                          }
-                        })()}
-                      />
+                    {severityLevels.map(({ key, display, uuid }, index) => (
+                      <RadioButton id={key} key={key} labelText={display} value={uuid} />
                     ))}
                   </RadioButtonGroup>
                 )}

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.workspace.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-form/allergy-form.workspace.tsx
@@ -393,7 +393,7 @@ function AllergyForm(props: AllergyFormProps) {
                     valueSelected={value}
                     onBlur={onBlur}
                   >
-                    {severityLevels.map(({ key, display, uuid }, index) => (
+                    {severityLevels.map(({ key, display, uuid }) => (
                       <RadioButton id={key} key={key} labelText={display} value={uuid} />
                     ))}
                   </RadioButtonGroup>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

- Resolved an issue where severity levels were translated before being used as keys in logic, causing errors in non-English locales.
- Replaced the severityLevels array with an object structure containing uuid, key, and display.
- Updated the rendering logic to use the new structure, simplifying the rendering logic.


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4403


