### PR TITLE
(fix) O3-4410: Revert the form workspaces' size to `wider`

### DIFF
--- a/packages/esm-patient-forms-app/src/routes.json
+++ b/packages/esm-patient-forms-app/src/routes.json
@@ -52,7 +52,7 @@
       "type": "clinical-form",
       "canMaximize": true,
       "canHide": true,
-      "width": "extra-wide"
+      "width": "wider"
     },
     {
       "name": "ward-patient-form-entry-workspace",
@@ -61,9 +61,7 @@
       "type": "ward-patient-clinical-form",
       "canMaximize": true,
       "canHide": false,
-      "width": "wider",
-      "hasOwnSidebar": true,
-      "sidebarFamily": "ward-patient"
+      "width": "wider"
     },
     {
       "name": "patient-html-form-entry-workspace",
@@ -72,7 +70,7 @@
       "type": "clinical-form",
       "canMaximize": true,
       "canHide": false,
-      "width": "extra-wide"
+      "width": "wider"
     },
     {
       "name": "ward-patient-html-form-entry-workspace",
@@ -81,9 +79,7 @@
       "type": "ward-patient-clinical-form",
       "canMaximize": true,
       "canHide": false,
-      "width": "extra-wide",
-      "hasOwnSidebar": true,
-      "sidebarFamily": "ward-patient"
+      "width": "wider"
     },
     {
       "name": "clinical-forms-workspace",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR makes a change to revert the changes done in https://github.com/openmrs/openmrs-esm-patient-chart/pull/2142 . This PR follows the UI improvements done in Form Engine Lib, respective PR: https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/461

## Screenshots
### Before

![image](https://github.com/user-attachments/assets/e6cdfb39-28d9-475a-b6c9-bdc2ebb36652)

### After

![image](https://github.com/user-attachments/assets/e81687ee-bd9c-48a5-a8c2-7a9221fab4fa)


## Related Issue
https://issues.openmrs.org/browse/O3-4410

## Other
Dependent on https://github.com/openmrs/openmrs-esm-patient-chart/pull/2220
