### PR TITLE
(chore) Form engine app must use `latest` form-engine-lib versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "openmrs develop --sources packages/esm-patient-chart-app/",
     "ci:publish": "yarn workspaces foreach --all --topological --exclude @openmrs/esm-patient-chart npm publish --access public --tag latest",
     "ci:prepublish": "yarn workspaces foreach --all --topological --exclude @openmrs/esm-patient-chart npm publish --access public --tag next",
-    "ci:bump-form-engine-lib": "yarn up @openmrs/esm-form-engine-lib@next",
+    "ci:bump-form-engine-lib": "yarn up @openmrs/esm-form-engine-lib@latest",
     "release": "yarn workspaces foreach --all --topological version",
     "verify": "turbo run lint typescript test --color --concurrency=5",
     "postinstall": "husky install",

--- a/packages/esm-form-engine-app/package.json
+++ b/packages/esm-form-engine-app/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@carbon/react": "^1.47.0",
-    "@openmrs/esm-form-engine-lib": "next",
+    "@openmrs/esm-form-engine-lib": "latest",
     "lodash-es": "^4.17.21",
     "react-error-boundary": "^4.0.13"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5661,7 +5661,7 @@ __metadata:
   resolution: "@openmrs/esm-form-engine-app@workspace:packages/esm-form-engine-app"
   dependencies:
     "@carbon/react": "npm:^1.47.0"
-    "@openmrs/esm-form-engine-lib": "npm:next"
+    "@openmrs/esm-form-engine-lib": "npm:latest"
     "@openmrs/esm-patient-common-lib": "workspace:*"
     lodash-es: "npm:^4.17.21"
     react-error-boundary: "npm:^4.0.13"
@@ -5677,9 +5677,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-form-engine-lib@npm:next":
-  version: 3.1.0-pre.1684
-  resolution: "@openmrs/esm-form-engine-lib@npm:3.1.0-pre.1684"
+"@openmrs/esm-form-engine-lib@npm:latest":
+  version: 3.1.1
+  resolution: "@openmrs/esm-form-engine-lib@npm:3.1.1"
   dependencies:
     "@carbon/react": "npm:>1.47.0 <1.50.0"
     classnames: "npm:^2.5.1"
@@ -5697,7 +5697,7 @@ __metadata:
     react: 18.x
     react-i18next: 11.x
     swr: 2.x
-  checksum: 10/f25c7699c06cfb547954704c624089aa726858620a26b1a383afee95eada26836e348fb4fef2cb7c62f8f461e6d9832ff8f44bf5e0e269336c36ce172edfe547
+  checksum: 10/afb11bbcf73bffce13ff83b4a76d7af8a24031a699e7c33c4f763ba1b57ccd45b608a95f8f072117da4721bd927deb740d20b94b210cdeb4c6ffd218d9b209c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
The form engine app must use the `latest` (not `next`) released versions of the form engine app

## Screenshots
None

## Related Issue
None

## Other
<!-- Anything not covered above -->
