### PR TITLE
(fix) O3-4398: Invalidate lab orders after submitting test results form

### DIFF
--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
@@ -21,9 +21,11 @@ import {
 import { useLabResultsFormSchema } from './useLabResultsFormSchema';
 import ResultFormField from './lab-results-form-field.component';
 import styles from './lab-results-form.scss';
+import { cache } from 'swr/_internal';
 
 export interface LabResultsFormProps extends DefaultPatientWorkspaceProps {
   order: Order;
+  mutateLabOrders?: () => void;
 }
 
 const LabResultsForm: React.FC<LabResultsFormProps> = ({
@@ -31,6 +33,7 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
   closeWorkspaceWithSavedChanges,
   order,
   promptBeforeClosing,
+  mutateLabOrders,
 }) => {
   const { t } = useTranslation();
   const abortController = useAbortController();
@@ -179,8 +182,9 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
         abortController,
       );
       closeWorkspaceWithSavedChanges();
-      mutateResults();
       mutateOrderData();
+      mutateResults();
+      mutateLabOrders();
       showNotification(
         'success',
         t('successfullySavedLabResults', 'Lab results for {{orderNumber}} have been successfully updated', {

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
@@ -21,7 +21,6 @@ import {
 import { useLabResultsFormSchema } from './useLabResultsFormSchema';
 import ResultFormField from './lab-results-form-field.component';
 import styles from './lab-results-form.scss';
-import { cache } from 'swr/_internal';
 
 export interface LabResultsFormProps extends DefaultPatientWorkspaceProps {
   order: Order;

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
@@ -24,7 +24,7 @@ import styles from './lab-results-form.scss';
 
 export interface LabResultsFormProps extends DefaultPatientWorkspaceProps {
   order: Order;
-  mutateLabOrders?: () => void;
+  invalidateLabOrders?: () => void;
 }
 
 const LabResultsForm: React.FC<LabResultsFormProps> = ({
@@ -32,7 +32,11 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
   closeWorkspaceWithSavedChanges,
   order,
   promptBeforeClosing,
-  mutateLabOrders,
+  /* Callback to refresh lab orders in the Laboratory app after results are saved.
+   * This ensures the orders list stays in sync across the different tabs in the Laboratory app.
+   * @see https://github.com/openmrs/openmrs-esm-laboratory-app/pull/117
+   */
+  invalidateLabOrders,
 }) => {
   const { t } = useTranslation();
   const abortController = useAbortController();
@@ -180,10 +184,12 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
         orderDiscontinuationPayload,
         abortController,
       );
+
       closeWorkspaceWithSavedChanges();
       mutateOrderData();
       mutateResults();
-      mutateLabOrders();
+      invalidateLabOrders?.();
+
       showNotification(
         'success',
         t('successfullySavedLabResults', 'Lab results for {{orderNumber}} have been successfully updated', {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR adds a new optional prop `invalidateLabOrders` that enables the invalidation of lab orders in the Laboratory app after entering test results using the Test Results form.

## Screenshots

This is an example of a use case where this will help in the labs ESM.

https://github.com/user-attachments/assets/b85c1fd1-c090-479c-b170-00f6760e9792

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4398
## Other
<!-- Anything not covered above -->
An accompanying PR on the labs app can be found [here](https://github.com/openmrs/openmrs-esm-laboratory-app/pull/117).