### PR TITLE
(fix) Tweaks to the Edit program enrollments flow

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.scss
@@ -67,7 +67,7 @@
 }
 
 .conditionLabel {
-  @include type.type-style('label-02');
+  @include type.type-style('body-compact-02');
 }
 
 .errorContainer {

--- a/packages/esm-patient-programs-app/src/programs/programs-action-menu.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-action-menu.component.tsx
@@ -15,8 +15,13 @@ export const ProgramsActionMenu = ({ patientUuid, programEnrollmentId }: Program
   const isTablet = useLayoutType() === 'tablet';
 
   const launchEditProgramsForm = useCallback(
-    () => launchPatientWorkspace('programs-form-workspace', { programEnrollmentId }),
-    [programEnrollmentId],
+    () =>
+      launchPatientWorkspace('programs-form-workspace', {
+        workspaceTitle: t('editProgramEnrollment', 'Edit program enrollment'),
+        programEnrollmentId,
+        formContext: 'editing',
+      }),
+    [programEnrollmentId, t],
   );
 
   const launchDeleteProgramDialog = useCallback(() => {

--- a/packages/esm-patient-programs-app/src/programs/programs-action-menu.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-action-menu.component.tsx
@@ -19,7 +19,6 @@ export const ProgramsActionMenu = ({ patientUuid, programEnrollmentId }: Program
       launchPatientWorkspace('programs-form-workspace', {
         workspaceTitle: t('editProgramEnrollment', 'Edit program enrollment'),
         programEnrollmentId,
-        formContext: 'editing',
       }),
     [programEnrollmentId, t],
   );

--- a/packages/esm-patient-programs-app/src/programs/programs-action-menu.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-action-menu.test.tsx
@@ -52,7 +52,6 @@ describe('ProgramActionsMenu', () => {
     await user.click(screen.getByText('Edit'));
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
-      formContext: 'editing',
       programEnrollmentId: testProps.programEnrollmentId,
       workspaceTitle: 'Edit program enrollment',
     });

--- a/packages/esm-patient-programs-app/src/programs/programs-action-menu.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-action-menu.test.tsx
@@ -52,7 +52,9 @@ describe('ProgramActionsMenu', () => {
     await user.click(screen.getByText('Edit'));
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
+      formContext: 'editing',
       programEnrollmentId: testProps.programEnrollmentId,
+      workspaceTitle: 'Edit program enrollment',
     });
   });
 

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
@@ -92,7 +92,6 @@ describe('ProgramsDetailedSummary', () => {
     await user.click(screen.getByText('Edit'));
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
-      formContext: 'editing',
       programEnrollmentId: mockEnrolledProgramsResponse[0].uuid,
       workspaceTitle: 'Edit program enrollment',
     });

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
@@ -92,7 +92,9 @@ describe('ProgramsDetailedSummary', () => {
     await user.click(screen.getByText('Edit'));
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
+      formContext: 'editing',
       programEnrollmentId: mockEnrolledProgramsResponse[0].uuid,
+      workspaceTitle: 'Edit program enrollment',
     });
   });
 

--- a/packages/esm-patient-programs-app/src/programs/programs-form.scss
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.scss
@@ -49,3 +49,7 @@
   min-width: 100%;
   padding: 0;
 }
+
+.programName {
+  @include type.type-style('body-compact-02');
+}

--- a/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
+import classNames from 'classnames';
 import { type TFunction, useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
 import {
@@ -8,6 +9,7 @@ import {
   DatePickerInput,
   Form,
   FormGroup,
+  FormLabel,
   InlineLoading,
   InlineNotification,
   Layer,
@@ -20,6 +22,7 @@ import { useForm, Controller, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { parseDate, showSnackbar, useConfig, useLayoutType, useLocations, useSession } from '@openmrs/esm-framework';
 import { type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
+import { type ConfigObject } from '../config-schema';
 import {
   createProgramEnrollment,
   useAvailablePrograms,
@@ -57,7 +60,8 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
   const availableLocations = useLocations();
   const { data: availablePrograms } = useAvailablePrograms();
   const { data: enrollments, mutateEnrollments } = useEnrollments(patientUuid);
-  const { showProgramStatusField } = useConfig();
+  const { showProgramStatusField } = useConfig<ConfigObject>();
+  const inEditMode = Boolean(programEnrollmentId);
 
   const programsFormSchema = useMemo(() => createProgramsFormSchema(t), [t]);
 
@@ -77,10 +81,10 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
       });
 
   const getLocationUuid = () => {
-    if (!currentEnrollment?.location.uuid && session?.sessionLocation?.uuid) {
+    if (!currentEnrollment?.location?.uuid && session?.sessionLocation?.uuid) {
       return session?.sessionLocation?.uuid;
     }
-    return currentEnrollment?.location.uuid ?? null;
+    return currentEnrollment?.location?.uuid ?? null;
   };
 
   const currentState = currentEnrollment ? findLastState(currentEnrollment.states) : null;
@@ -156,30 +160,34 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
     [closeWorkspaceWithSavedChanges, currentEnrollment, currentState, mutateEnrollments, patientUuid, t],
   );
 
+  const programName = (
+    <FormGroup legendText={t('programName', 'Program name')}>
+      <FormLabel className={styles.programName}>{currentProgram?.display}</FormLabel>
+    </FormGroup>
+  );
+
   const programSelect = (
     <Controller
       name="selectedProgram"
       control={control}
       render={({ field: { onChange, value } }) => (
-        <>
-          <Select
-            aria-label="program name"
-            id="program"
-            invalid={!!errors?.selectedProgram}
-            invalidText={errors?.selectedProgram?.message}
-            labelText={t('programName', 'Program name')}
-            onChange={(event) => onChange(event.target.value)}
-            value={value}
-          >
-            <SelectItem text={t('chooseProgram', 'Choose a program')} value="" />
-            {eligiblePrograms?.length > 0 &&
-              eligiblePrograms.map((program) => (
-                <SelectItem key={program.uuid} text={program.display} value={program.uuid}>
-                  {program.display}
-                </SelectItem>
-              ))}
-          </Select>
-        </>
+        <Select
+          aria-label="program name"
+          id="program"
+          invalid={!!errors?.selectedProgram}
+          invalidText={errors?.selectedProgram?.message}
+          labelText={t('programName', 'Program name')}
+          onChange={(event) => onChange(event.target.value)}
+          value={value}
+        >
+          <SelectItem text={t('chooseProgram', 'Choose a program')} value="" />
+          {eligiblePrograms?.length > 0 &&
+            eligiblePrograms.map((program) => (
+              <SelectItem key={program.uuid} text={program.display} value={program.uuid}>
+                {program.display}
+              </SelectItem>
+            ))}
+        </Select>
       )}
     />
   );
@@ -263,34 +271,38 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
       name="selectedProgramStatus"
       control={control}
       render={({ field: { onChange, value } }) => (
-        <>
-          <Select
-            aria-label={t('programStatus', 'Program status')}
-            id="programStatus"
-            invalid={!!errors?.selectedProgramStatus}
-            invalidText={errors?.selectedProgramStatus?.message}
-            labelText={t('programStatus', 'Program status')}
-            onChange={(event) => onChange(event.target.value)}
-            value={value}
-          >
-            <SelectItem text={t('chooseStatus', 'Choose a program status')} value="" />
-            {workflowStates.map((state) => (
-              <SelectItem key={state.uuid} text={state.concept.display} value={state.uuid}>
-                {state.concept.display}
-              </SelectItem>
-            ))}
-          </Select>
-        </>
+        <Select
+          aria-label={t('programStatus', 'Program status')}
+          id="programStatus"
+          invalid={!!errors?.selectedProgramStatus}
+          invalidText={errors?.selectedProgramStatus?.message}
+          labelText={t('programStatus', 'Program status')}
+          onChange={(event) => onChange(event.target.value)}
+          value={value}
+        >
+          <SelectItem text={t('chooseStatus', 'Choose a program status')} value="" />
+          {workflowStates.map((state) => (
+            <SelectItem key={state.uuid} text={state.concept.display} value={state.uuid}>
+              {state.concept.display}
+            </SelectItem>
+          ))}
+        </Select>
       )}
     />
   );
 
   const formGroups = [
-    {
-      style: { maxWidth: isTablet && '50%' },
-      legendText: '',
-      value: programSelect,
-    },
+    inEditMode
+      ? {
+          style: { maxWidth: isTablet && '50%' },
+          legendText: '',
+          value: programName,
+        }
+      : {
+          style: { maxWidth: isTablet && '50%' },
+          legendText: '',
+          value: programSelect,
+        },
     {
       style: { maxWidth: '50%' },
       legendText: '',
@@ -334,7 +346,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
           </FormGroup>
         ))}
       </Stack>
-      <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
+      <ButtonSet className={classNames(isTablet ? styles.tablet : styles.desktop)}>
         <Button className={styles.button} kind="secondary" onClick={closeWorkspace}>
           {t('cancel', 'Cancel')}
         </Button>

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
@@ -92,7 +92,6 @@ describe('ProgramsOverview', () => {
     await user.click(screen.getByText('Edit'));
 
     expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
-      formContext: 'editing',
       programEnrollmentId: mockEnrolledProgramsResponse[0].uuid,
       workspaceTitle: 'Edit program enrollment',
     });

--- a/packages/esm-patient-programs-app/translations/en.json
+++ b/packages/esm-patient-programs-app/translations/en.json
@@ -18,6 +18,7 @@
   "deleting": "Deleting",
   "edit": "Edit",
   "editOrDeleteProgram": "Edit or delete program",
+  "editProgramEnrollment": "Edit program enrollment",
   "enrollmentLocation": "Enrollment location",
   "enrollmentNowVisible": "It is now visible in the Programs table",
   "enrollmentSaved": "Program enrollment saved",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR makes the following changes to the Edit program enrollments flow:

- Display a read-only program name field when editing an enrollment to prevent program name changes.
- Set the workspace title to "Edit program enrollment" when editing an enrollment.

A tangential change involves changing the styling of the condition name label in the Conditions form to use the [body-compact-02](https://carbondesignsystem.com/elements/typography/type-sets/#body-styles) type style when editing a condition.

## Screenshots

### Before

Notice the incorrect workspace title and the dropdown used for the program name:

![CleanShot 2025-02-03 at 3  38 14@2x](https://github.com/user-attachments/assets/22195d37-f877-4760-abf8-d94c800861a0)

### After

![CleanShot 2025-02-03 at 3  30 49@2x](https://github.com/user-attachments/assets/298a1fa9-2223-49e4-be6a-f4d598db7a5e)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
