### PR TITLE
(fix) Remove redundant escapeValue override in visit form translations

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
@@ -158,9 +158,6 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
           },
           t('invalidVisitStartDate', 'Start date needs to be on or before {{firstEncounterDatetime}}', {
             firstEncounterDatetime: formatDatetime(new Date()),
-            interpolation: {
-              escapeValue: false,
-            },
           }),
         ),
         visitStartTime: z
@@ -293,9 +290,6 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
       setError('visitStartDate', {
         message: t('invalidVisitStartDate', 'Start date needs to be on or before {{firstEncounterDatetime}}', {
           firstEncounterDatetime: new Date(maxVisitStartDatetime).toLocaleString(),
-          interpolation: {
-            escapeValue: false,
-          },
         }),
       });
     }
@@ -321,9 +315,6 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
             'Stop date needs to be on or after {{lastEncounterDatetime}}',
             {
               lastEncounterDatetime: new Date(minVisitStopDatetime).toLocaleString(),
-              interpolation: {
-                escapeValue: false,
-              },
             },
           ),
         });


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes explicit `escapeValue: false` overrides in several translation interpolations in VisitForm workspace component. The overrides are unnecessary since the interpolated date values don't contain HTML that needs to be preserved. 

This hardening measure ensures any special characters in interpolated values are properly escaped by default.

## Screenshots

The interpolated translation strings for validations render in the UI as expected:

### en-US

![CleanShot 2025-02-06 at 12  34 11@2x](https://github.com/user-attachments/assets/e8c2162b-395b-48f3-99cf-30541b84b784)

### fr-FR

![CleanShot 2025-02-06 at 12  47 50@2x](https://github.com/user-attachments/assets/06e2baca-16a5-412b-b52b-eaf45f2ee597)

### es-ES

![CleanShot 2025-02-06 at 12  49 37@2x](https://github.com/user-attachments/assets/22bf3999-57dd-49cd-8125-b9ffbaba0a46)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
