### PR TITLE
(fix)O3-4433:Prescription date should allow future selection while placing a drug order

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -599,7 +599,6 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                       render={({ field: { onBlur, value, onChange, ref } }) => (
                         <DatePicker
                           datePickerType="single"
-                          maxDate={new Date().toISOString()}
                           value={value}
                           onChange={([newStartDate]) => onChange(newStartDate)}
                           onBlur={onBlur}


### PR DESCRIPTION
…order.

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR updates the prescription start date functionality to allow future date selections when placing a drug order. By removing the maxDate property from the DatePicker component, clinicians can now schedule prescriptions to start on any future date, enabling greater flexibility in aligning drug orders with patient care plans and specific clinical scenarios.

## Screenshots
<!-- Required if you are making UI changes. -->
![Screenshot 2025-02-07 015508](https://github.com/user-attachments/assets/83f02a75-dec4-4b41-8d5a-00a31e9e0248)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4433

## Other
<!-- Anything not covered above -->
