### PR TITLE
(test): Fix non-decimal concept having a decimal value

### DIFF
--- a/e2e/specs/results-viewer.spec.ts
+++ b/e2e/specs/results-viewer.spec.ts
@@ -152,7 +152,7 @@ test('Record and edit test results', async ({ page }) => {
     {
       label: 'Total Protein (g/dL)',
       resultsPageReference: 'Total Protein',
-      value: '7.0',
+      value: '7',
       updatedValue: '8',
     },
     {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR updates the value of `Total Protein` to be a non-decimal value, since its concept doesn't allow decimal values. Although this previously wasn't an issue, the backend now [no-longer accepts non-decimal values ](https://openmrs.atlassian.net/browse/TRUNK-6244).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
This needs to be merged to [fix the failing e2e in the PR that bumps the initializer and core version](https://github.com/openmrs/openmrs-distro-referenceapplication/pull/888).
