### PR TITLE
(feat)O3-2971: Changes in order to add error conformation modal for empty form

### DIFF
--- a/packages/esm-form-engine-app/package.json
+++ b/packages/esm-form-engine-app/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/openmrs/openmrs-esm-patient-chart/issues"
   },
   "dependencies": {
-    "@carbon/react": "^1.47.0",
+    "@carbon/react": ">1.47.0 <1.50.0",
     "@openmrs/esm-form-engine-lib": "latest",
     "lodash-es": "^4.17.21",
     "react-error-boundary": "^4.0.13"

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -57,6 +57,21 @@ const FormRenderer: React.FC<FormRendererProps> = ({
     });
   }, []);
 
+  const handleEmptyFormSubmission = useCallback(() => {
+    return new Promise<void>((resolve, reject) => {
+      const dispose = showModal('form-engine-empty-form-confirm-modal', {
+        onCancel() {
+          dispose();
+          reject();
+        },
+        onConfirm() {
+          dispose();
+          resolve();
+        },
+      });
+    });
+  }, []);
+
   const handleMarkFormAsDirty = useCallback(
     (isDirty: boolean) => promptBeforeClosing(() => isDirty),
     [promptBeforeClosing],
@@ -86,6 +101,7 @@ const FormRenderer: React.FC<FormRendererProps> = ({
           formJson={schema}
           handleClose={handleCloseForm}
           handleConfirmQuestionDeletion={handleConfirmQuestionDeletion}
+          handleEmptyFormSubmission={handleEmptyFormSubmission}
           markFormAsDirty={handleMarkFormAsDirty}
           mode={additionalProps?.mode}
           formSessionIntent={formSessionIntent}

--- a/packages/esm-form-engine-app/src/form-renderer/repeat/empty-form.modal.scss
+++ b/packages/esm-form-engine-app/src/form-renderer/repeat/empty-form.modal.scss
@@ -1,0 +1,11 @@
+@use '@carbon/react/scss/colors';
+
+.customModal {
+  :global(.cds--modal-close) {
+    position: fixed;
+  }
+
+  :global(.cds--btn--primary) {
+    background-color: transparent;
+  }
+}

--- a/packages/esm-form-engine-app/src/form-renderer/repeat/empty-form.modal.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/repeat/empty-form.modal.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ModalHeader, ModalBody, ModalFooter, Button } from '@carbon/react';
+import styles from './empty-form.modal.scss';
+
+interface EmptyFormModalProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const EmptyFormModal: React.FC<EmptyFormModalProps> = ({ onConfirm, onCancel }) => {
+  const { t } = useTranslation();
+
+  return (
+    <React.Fragment>
+      <ModalHeader closeModal={onCancel} title={t('emptyForm', 'Empty Form')} className={styles.customModal} />
+      <ModalBody>
+        <p>{t('emptyFormConfirmation', 'All fields are Empty. Are you sure you want to submit the form?')}</p>
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={onCancel}>
+          {t('cancel', 'Cancel')}
+        </Button>
+        <Button kind="danger" onClick={onConfirm}>
+          {t('confirm', 'Confirm')}
+        </Button>
+      </ModalFooter>
+    </React.Fragment>
+  );
+};
+
+export default EmptyFormModal;

--- a/packages/esm-form-engine-app/src/index.ts
+++ b/packages/esm-form-engine-app/src/index.ts
@@ -29,6 +29,8 @@ export const deleteQuestionModal = getAsyncLifecycle(
   options,
 );
 
+export const emptyFormModal = getAsyncLifecycle(() => import('./form-renderer/repeat/empty-form.modal'), options);
+
 /**
  * DO NOT REMOVE THIS COMMENT
  * THE TRANSLATION KEYS AND VALUES USED IN THE FORM ENGINE LIB ARE WRITTEN HERE

--- a/packages/esm-form-engine-app/src/routes.json
+++ b/packages/esm-form-engine-app/src/routes.json
@@ -19,6 +19,10 @@
     {
       "name": "form-engine-delete-question-confirm-modal",
       "component": "deleteQuestionModal"
+    },
+    {
+      "name": "form-engine-empty-form-confirm-modal",
+      "component": "emptyFormModal"
     }
   ],
   "pages": []

--- a/packages/esm-form-engine-app/translations/en.json
+++ b/packages/esm-form-engine-app/translations/en.json
@@ -15,6 +15,8 @@
   "deleteQuestion": "Delete question",
   "deleteQuestionConfirmation": "Are you sure you want to delete this question?",
   "deleteQuestionExplainerText": "This action cannot be undone.",
+  "emptyFormConfirmation": "All fields are Empty. Are you sure you want to submit the form?",
+  "emptyForm": "Empty Form",
   "errorLoadingFormSchema": "Error loading form schema",
   "errorLoadingInitialValues": "Error loading initial values",
   "errorRenderingField": "Error rendering field",


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [X] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [X] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds a feature which triggers a conformation modal when User submits an empty form.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
