### PR TITLE
(test) O3-4440: Update results viewer spec to use correct assertion

### DIFF
--- a/e2e/specs/results-viewer.spec.ts
+++ b/e2e/specs/results-viewer.spec.ts
@@ -353,18 +353,14 @@ test('Record and edit test results', async ({ page }) => {
     for (const { resultsPageReference, updatedValue } of completeBloodCountData) {
       await test.step(resultsPageReference, async () => {
         const row = page.locator(`tr:has-text("${resultsPageReference}"):has(td:has-text("${updatedValue}"))`).first();
-        const valueCell = row.locator('td:nth-child(2)');
-
-        await expect(valueCell).toContainText(updatedValue);
+        await expect(row).toBeVisible();
       });
     }
 
     for (const { resultsPageReference, updatedValue } of chemistryResultsData) {
       await test.step(resultsPageReference, async () => {
         const row = page.locator(`tr:has-text("${resultsPageReference}"):has(td:has-text("${updatedValue}"))`).first();
-        const valueCell = row.locator('td:nth-child(2)');
-
-        await expect(valueCell).toContainText(updatedValue);
+        await expect(row).toBeVisible();
       });
     }
   });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The results viewer spec e2e test searches for the element of a relevant test record by using the value and then validates if the element has the test result value which is redundant. This PR instead checks if the element is visible.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4440

## Other
<!-- Anything not covered above -->
