### PR TITLE
(fix) O3-4452: Vitals header should not use `label` tags

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.component.tsx
@@ -23,7 +23,7 @@ const VitalsHeaderItem: React.FC<VitalsHeaderItemProps> = ({ interpretation, val
   const unitId = `omrs-patient-chart-unit-${unitName}-${generatedId}`;
 
   const displayValue =
-    Boolean(value) ? t('notAvailable', 'Not available') : value;
+    Boolean(value) ? value : t('notAvailable', 'Not available');
 
   return (
     <section className={styles.container}>

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.component.tsx
@@ -23,7 +23,7 @@ const VitalsHeaderItem: React.FC<VitalsHeaderItemProps> = ({ interpretation, val
   const unitId = `omrs-patient-chart-unit-${unitName}-${generatedId}`;
 
   const displayValue =
-    value === null || value === undefined || value === '' ? t('notAvailable', 'Not available') : value;
+    Boolean(value) ? t('notAvailable', 'Not available') : value;
 
   return (
     <section className={styles.container}>

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import type { ObservationInterpretation } from '../common';
@@ -16,6 +16,15 @@ const VitalsHeaderItem: React.FC<VitalsHeaderItemProps> = ({ interpretation, val
   const flaggedCritical = interpretation && interpretation.includes('critically');
   const flaggedAbnormal = interpretation && interpretation !== 'normal';
 
+  const generatedId = useId();
+
+  const labelId = `omrs-patient-chart-label-${unitName}-${generatedId}`;
+  const valueId = `omrs-patient-chart-value-${unitName}-${generatedId}`;
+  const unitId = `omrs-patient-chart-unit-${unitName}-${generatedId}`;
+
+  const displayValue =
+    value === null || value === undefined || value === '' ? t('notAvailable', 'Not available') : value;
+
   return (
     <section className={styles.container}>
       <div
@@ -25,16 +34,22 @@ const VitalsHeaderItem: React.FC<VitalsHeaderItemProps> = ({ interpretation, val
         })}
       >
         <div className={styles['label-container']}>
-          <label className={styles.label}>{unitName}</label>
+          <span id={labelId} className={styles.label}>
+            {unitName}
+          </span>
           {flaggedAbnormal ? (
             <span className={styles[interpretation.replace('_', '-')]} title={t('abnormalValue', 'Abnormal value')} />
           ) : null}
         </div>
         <div className={styles['value-container']}>
-          <label className={styles['pad-right']}>
-            <span className={styles.value}>{value || '-'} </span>
-            <span className={styles.units}>{value && unitSymbol}</span>
-          </label>
+          <div className={styles['pad-right']}>
+            <span id={valueId} aria-labelledby={`${labelId} ${unitId}`} className={styles.value}>
+              {displayValue}
+            </span>
+            <span id={unitId} className={styles.units}>
+              {value ? ` ${unitSymbol}` : ''}
+            </span>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes an accessibility and semantic issue in the vitals header component. Previously, label elements were misused for both the measurement header and value display. To address this, the component now:

- Generates a unique ID for the value container.

- Uses a label with an htmlFor attribute to properly reference the value container for the measurement header.

- Changes the label wrapping the actual value to a div ensuring that the visual styling remains unchanged.

## Screenshots
<!-- Required if you are making UI changes. -->
Before
![Screenshot 2025-02-17 182245](https://github.com/user-attachments/assets/fad40609-96a4-48c0-b911-0f87c8020a01)
After
![Screenshot 2025-02-17 182403](https://github.com/user-attachments/assets/5cd841ae-3665-4097-bf1a-e0e94830c2a8)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4452

## Other
<!-- Anything not covered above -->
