### PR TITLE
(fix) O3-4461: Remove view timeline button from individual test panels

### DIFF
--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
@@ -132,7 +132,7 @@ const IndividualResultsTable: React.FC<IndividualResultsTableProps> = ({ isLoadi
                   iconDescription="view timeline"
                   kind="ghost"
                   renderIcon={(props: ComponentProps<typeof ArrowRightIcon>) => <ArrowRightIcon size={16} {...props} />}
-                  onClick={() => launchResultsDialog(headerTitle, subRows[0]?.conceptUuid)}
+                  onClick={() => launchResultsDialog(headerTitle, subRows?.entries[0]?.conceptUuid)}
                   size="sm"
                 >
                   {t('viewTimeline', 'View timeline')}

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
@@ -127,16 +127,6 @@ const IndividualResultsTable: React.FC<IndividualResultsTableProps> = ({ isLoadi
               <h4 className={styles.resultType}>{headerTitle}</h4>
               <div className={styles.displayFlex}>
                 <span className={styles.date}>{formatDate(new Date(subRows.date), { mode: 'standard' })}</span>
-                <Button
-                  className={styles.viewTimeline}
-                  iconDescription="view timeline"
-                  kind="ghost"
-                  renderIcon={(props: ComponentProps<typeof ArrowRightIcon>) => <ArrowRightIcon size={16} {...props} />}
-                  onClick={() => launchResultsDialog(headerTitle, subRows?.entries[0]?.conceptUuid)}
-                  size="sm"
-                >
-                  {t('viewTimeline', 'View timeline')}
-                </Button>
               </div>
             </div>
             <Table className={styles.table} {...getTableProps()} size={isDesktop ? 'md' : 'sm'}>

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
@@ -1,8 +1,7 @@
-import React, { type ComponentProps, useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import {
-  Button,
   DataTable,
   DataTableSkeleton,
   Table,
@@ -13,10 +12,10 @@ import {
   TableHeader,
   TableRow,
 } from '@carbon/react';
-import { ArrowRightIcon, showModal, useLayoutType, isDesktop, formatDate } from '@openmrs/esm-framework';
+import { showModal, useLayoutType, formatDate } from '@openmrs/esm-framework';
 import { getPatientUuidFromStore, type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
-import styles from './individual-results-table.scss';
 import { type GroupedObservation } from '../../types';
+import styles from './individual-results-table.scss';
 
 interface IndividualResultsTableProps {
   isLoading: boolean;
@@ -116,7 +115,9 @@ const IndividualResultsTable: React.FC<IndividualResultsTableProps> = ({ isLoadi
     [index, subRows, launchResultsDialog],
   );
 
-  if (isLoading) return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;
+  if (isLoading) {
+    return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;
+  }
 
   if (subRows.entries?.length) {
     return (

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.scss
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.scss
@@ -102,16 +102,6 @@ p {
   justify-content: flex-start;
 }
 
-.viewTimeline {
-  display: flex;
-  margin-left: auto;
-  margin-top: -(layout.$spacing-02);
-
-  svg {
-    fill: colors.$blue-60 !important;
-  }
-}
-
 .cardTitle {
   background-color: white;
   padding: 0.5rem;

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import IndividualResultsTable from './individual-results-table.component';
 import { type GroupedObservation } from '../../types';
+import IndividualResultsTable from './individual-results-table.component';
 
 describe('IndividualResultsTable', () => {
   const mockSubRows = {

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.test.tsx
@@ -44,7 +44,6 @@ describe('IndividualResultsTable', () => {
     expect(screen.getByText(/15-Oct-2024/i)).toBeInTheDocument();
     expect(screen.getByText(/test name/i)).toBeInTheDocument();
     expect(screen.getByText(/reference range/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /view timeline/i })).toBeInTheDocument();
     expect(screen.getByRole('row', { name: /hiv viral load 45 copies\/ml -- copies\/ml/i })).toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-tests-app/translations/en.json
+++ b/packages/esm-patient-tests-app/translations/en.json
@@ -106,6 +106,5 @@
   "tryTo": "Try to",
   "usingADifferentTerm": "using a different term",
   "value": "Value",
-  "view": "View",
-  "viewTimeline": "View timeline"
+  "view": "View"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

- After discussion in  [slack](https://openmrs.slack.com/archives/CKS32D55G/p1741341149194779) about this ticket 
-  suggested to  remove the button (view timeline)


## Screenshots
<img width="1470" alt="Screenshot 2025-03-10 at 5 27 22 PM" src="https://github.com/user-attachments/assets/e8b1808c-2c7d-462b-b07f-b5d9f86dbbb9" />




## Related Issue
https://openmrs.atlassian.net/browse/O3-4461

## Other
<!-- Anything not covered above -->
