### PR TITLE
(feat) O3-4370: Preserve search context when discarding visit form in queues app 

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
@@ -7,13 +7,17 @@ import { showSnackbar } from '@openmrs/esm-framework';
 interface StartVisitButtonProps {
   patientUuid: string;
   handleBackToSearchList?: () => void;
+  setIsPatientSearchOpen?: (isOpen: boolean) => void;
 }
 
-const StartVisitButton = ({ patientUuid, handleBackToSearchList }: StartVisitButtonProps) => {
+const StartVisitButton = ({ patientUuid, handleBackToSearchList, setIsPatientSearchOpen }: StartVisitButtonProps) => {
   const { t } = useTranslation();
   const startVisitWorkspaceForm = 'start-visit-workspace-form';
 
   const handleStartVisit = useCallback(() => {
+    if (setIsPatientSearchOpen) {
+      setIsPatientSearchOpen(false);
+    }
     try {
       launchPatientWorkspace(startVisitWorkspaceForm, {
         patientUuid,
@@ -30,7 +34,7 @@ const StartVisitButton = ({ patientUuid, handleBackToSearchList }: StartVisitBut
         subtitle: error.message ?? t('errorStartingVisitDescription', 'An error occurred while starting the visit'),
       });
     }
-  }, [patientUuid, t, handleBackToSearchList]);
+  }, [patientUuid, t, handleBackToSearchList, setIsPatientSearchOpen]);
 
   return (
     <Button aria-label={t('startVisit', 'Start visit')} kind="primary" onClick={handleStartVisit}>

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
@@ -6,9 +6,10 @@ import { showSnackbar } from '@openmrs/esm-framework';
 
 interface StartVisitButtonProps {
   patientUuid: string;
+  handleBackToSearchList: () => void;
 }
 
-const StartVisitButton = ({ patientUuid }: StartVisitButtonProps) => {
+const StartVisitButton = ({ patientUuid, handleBackToSearchList }: StartVisitButtonProps) => {
   const { t } = useTranslation();
   const startVisitWorkspaceForm = 'start-visit-workspace-form';
 
@@ -17,6 +18,7 @@ const StartVisitButton = ({ patientUuid }: StartVisitButtonProps) => {
       launchPatientWorkspace(startVisitWorkspaceForm, {
         patientUuid,
         openedFrom: 'patient-chart-start-visit',
+        handleBackToSearchList,
       });
     } catch (error) {
       console.error('Error launching visit form workspace:', error);
@@ -28,7 +30,7 @@ const StartVisitButton = ({ patientUuid }: StartVisitButtonProps) => {
         subtitle: error.message ?? t('errorStartingVisitDescription', 'An error occurred while starting the visit'),
       });
     }
-  }, [patientUuid, t]);
+  }, [patientUuid, t, handleBackToSearchList]);
 
   return (
     <Button aria-label={t('startVisit', 'Start visit')} kind="primary" onClick={handleStartVisit}>

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
@@ -6,23 +6,22 @@ import { showSnackbar } from '@openmrs/esm-framework';
 
 interface StartVisitButtonProps {
   patientUuid: string;
-  handleBackToSearchList?: () => void;
-  setIsPatientSearchOpen?: (isOpen: boolean) => void;
+  handleReturnToSearchList?: () => void;
+  hidePatientSearch?: () => void;
 }
 
-const StartVisitButton = ({ patientUuid, handleBackToSearchList, setIsPatientSearchOpen }: StartVisitButtonProps) => {
+const StartVisitButton = ({ patientUuid, handleReturnToSearchList, hidePatientSearch }: StartVisitButtonProps) => {
   const { t } = useTranslation();
   const startVisitWorkspaceForm = 'start-visit-workspace-form';
 
   const handleStartVisit = useCallback(() => {
-    if (setIsPatientSearchOpen) {
-      setIsPatientSearchOpen(false);
-    }
+    hidePatientSearch?.();
+
     try {
       launchPatientWorkspace(startVisitWorkspaceForm, {
         patientUuid,
         openedFrom: 'patient-chart-start-visit',
-        handleBackToSearchList,
+        handleReturnToSearchList,
       });
     } catch (error) {
       console.error('Error launching visit form workspace:', error);
@@ -34,7 +33,7 @@ const StartVisitButton = ({ patientUuid, handleBackToSearchList, setIsPatientSea
         subtitle: error.message ?? t('errorStartingVisitDescription', 'An error occurred while starting the visit'),
       });
     }
-  }, [patientUuid, t, handleBackToSearchList, setIsPatientSearchOpen]);
+  }, [patientUuid, t, handleReturnToSearchList, hidePatientSearch]);
 
   return (
     <Button aria-label={t('startVisit', 'Start visit')} kind="primary" onClick={handleStartVisit}>

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
@@ -6,7 +6,7 @@ import { showSnackbar } from '@openmrs/esm-framework';
 
 interface StartVisitButtonProps {
   patientUuid: string;
-  handleBackToSearchList: () => void;
+  handleBackToSearchList?: () => void;
 }
 
 const StartVisitButton = ({ patientUuid, handleBackToSearchList }: StartVisitButtonProps) => {

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.test.tsx
@@ -13,7 +13,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => ({
 
 describe('StartVisitButton', () => {
   it('renders the start visit button', () => {
-    render(<StartVisitButton patientUuid={mockPatient.id} handleBackToSearchList={() => {}} />);
+    render(<StartVisitButton patientUuid={mockPatient.id} />);
 
     expect(screen.getByRole('button', { name: /start visit/i })).toBeInTheDocument();
   });
@@ -21,7 +21,7 @@ describe('StartVisitButton', () => {
   it('clicking the button launches the start visit form', async () => {
     const user = userEvent.setup();
 
-    render(<StartVisitButton patientUuid={mockPatient.id} handleBackToSearchList={() => {}} />);
+    render(<StartVisitButton patientUuid={mockPatient.id} />);
 
     const startVisitButton = screen.getByRole('button', { name: /start visit/i });
     await user.click(startVisitButton);
@@ -30,7 +30,6 @@ describe('StartVisitButton', () => {
     expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('start-visit-workspace-form', {
       patientUuid: mockPatient.id,
       openedFrom: 'patient-chart-start-visit',
-      handleBackToSearchList: expect.any(Function),
     });
   });
 });

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.test.tsx
@@ -13,7 +13,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => ({
 
 describe('StartVisitButton', () => {
   it('renders the start visit button', () => {
-    render(<StartVisitButton patientUuid={mockPatient.id} />);
+    render(<StartVisitButton patientUuid={mockPatient.id} handleBackToSearchList={() => {}} />);
 
     expect(screen.getByRole('button', { name: /start visit/i })).toBeInTheDocument();
   });
@@ -21,7 +21,7 @@ describe('StartVisitButton', () => {
   it('clicking the button launches the start visit form', async () => {
     const user = userEvent.setup();
 
-    render(<StartVisitButton patientUuid={mockPatient.id} />);
+    render(<StartVisitButton patientUuid={mockPatient.id} handleBackToSearchList={() => {}} />);
 
     const startVisitButton = screen.getByRole('button', { name: /start visit/i });
     await user.click(startVisitButton);
@@ -30,6 +30,7 @@ describe('StartVisitButton', () => {
     expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('start-visit-workspace-form', {
       patientUuid: mockPatient.id,
       openedFrom: 'patient-chart-start-visit',
+      handleBackToSearchList: expect.any(Function),
     });
   });
 });

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
@@ -605,12 +605,12 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
   );
 
   const handleDiscard = useCallback(() => {
-    if (openedFrom === 'patient-chart-start-visit' && handleBackToSearchList) {
+    if (handleBackToSearchList) {
       handleBackToSearchList();
     } else {
       closeWorkspace();
     }
-  }, [openedFrom, handleBackToSearchList, closeWorkspace]);
+  }, [handleBackToSearchList, closeWorkspace]);
 
   const visitStartDate = getValues('visitStartDate') ?? new Date();
   minVisitStopDatetime = minVisitStopDatetime ?? Date.parse(visitStartDate.toLocaleString());

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
@@ -74,23 +74,23 @@ interface StartVisitFormProps extends DefaultPatientWorkspaceProps {
    * This string is passed into various extensions within the form to
    * affect how / if they should be rendered.
    */
+  handleReturnToSearchList?: () => void;
   openedFrom: string;
   showPatientHeader?: boolean;
   showVisitEndDateTimeFields: boolean;
   visitToEdit?: Visit;
-  handleBackToSearchList?: () => void;
 }
 
 const StartVisitForm: React.FC<StartVisitFormProps> = ({
   closeWorkspace,
+  handleReturnToSearchList,
+  openedFrom,
   patient,
   patientUuid,
   promptBeforeClosing,
   showPatientHeader = false,
   showVisitEndDateTimeFields,
   visitToEdit,
-  openedFrom,
-  handleBackToSearchList,
 }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
@@ -605,12 +605,12 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
   );
 
   const handleDiscard = useCallback(() => {
-    if (handleBackToSearchList) {
-      handleBackToSearchList();
+    if (handleReturnToSearchList) {
+      handleReturnToSearchList();
     } else {
       closeWorkspace();
     }
-  }, [handleBackToSearchList, closeWorkspace]);
+  }, [handleReturnToSearchList, closeWorkspace]);
 
   const visitStartDate = getValues('visitStartDate') ?? new Date();
   minVisitStopDatetime = minVisitStopDatetime ?? Date.parse(visitStartDate.toLocaleString());

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
@@ -78,6 +78,7 @@ interface StartVisitFormProps extends DefaultPatientWorkspaceProps {
   showPatientHeader?: boolean;
   showVisitEndDateTimeFields: boolean;
   visitToEdit?: Visit;
+  handleBackToSearchList?: () => void;
 }
 
 const StartVisitForm: React.FC<StartVisitFormProps> = ({
@@ -89,6 +90,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
   showVisitEndDateTimeFields,
   visitToEdit,
   openedFrom,
+  handleBackToSearchList,
 }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
@@ -602,6 +604,14 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
     ],
   );
 
+  const handleDiscard = useCallback(() => {
+    if (openedFrom === 'patient-chart-start-visit' && handleBackToSearchList) {
+      handleBackToSearchList();
+    } else {
+      closeWorkspace();
+    }
+  }, [openedFrom, handleBackToSearchList, closeWorkspace]);
+
   const visitStartDate = getValues('visitStartDate') ?? new Date();
   minVisitStopDatetime = minVisitStopDatetime ?? Date.parse(visitStartDate.toLocaleString());
   const minVisitStopDatetimeFallback = Date.parse(visitStartDate.toLocaleString());
@@ -791,7 +801,7 @@ const StartVisitForm: React.FC<StartVisitFormProps> = ({
             [styles.desktop]: !isTablet,
           })}
         >
-          <Button className={styles.button} kind="secondary" onClick={closeWorkspace}>
+          <Button className={styles.button} kind="secondary" onClick={handleDiscard}>
             {t('discard', 'Discard')}
           </Button>
           <Button


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary


Currently, when adding a patient to a queue from the service queues app, users are directed to a search pane in the workspace. After entering a search term, a list of matching patients is displayed. From this list, users can select a patient to add to the queue. For patients without an active visit, clicking the "Start Visit" button opens a form to start a new visit. However, if a user clicks the discard button on that form, the entire workspace closes. This forces users to restart the entire process of adding a patient to the queue.

This PR modifies the discard button behavior to keep the workspace open and return users to the search pane with their previous search results still visible. This allows users to easily select the same patient again or choose a different patient without repeating the queue addition process.

## Screenshots

### Before

https://github.com/user-attachments/assets/9ae6bc1e-bf68-4866-938d-caf4f82f53e9

### After

https://github.com/user-attachments/assets/2b5b5ff6-d128-4946-be00-53c5faf6f18b

## Related Issue

https://openmrs.atlassian.net/browse/O3-4370

## Other
<!-- Anything not covered above -->
