### PR TITLE
(test) Assert that form labels get translated to the system language

### DIFF
--- a/e2e/commands/index.ts
+++ b/e2e/commands/index.ts
@@ -1,2 +1,3 @@
 export * from './patient-operations';
 export * from './visit-operations';
+export * from './user-operations';

--- a/e2e/commands/user-operations.ts
+++ b/e2e/commands/user-operations.ts
@@ -1,0 +1,15 @@
+import { type APIRequestContext } from '@playwright/test';
+
+export const restoreLanguage = async (api: APIRequestContext, userUuid: string) => {
+  await api.post(`user/${userUuid}`, {
+    data: {
+      defaultLocale: 'en',
+    },
+  });
+};
+
+export async function getCurrentUserUuid(api: APIRequestContext): Promise<string> {
+  const response = await api.get('/ws/rest/v1/session');
+  const session = await response.json();
+  return session.user.uuid;
+}

--- a/e2e/pages/home-page.ts
+++ b/e2e/pages/home-page.ts
@@ -1,0 +1,14 @@
+import { type Page } from '@playwright/test';
+
+export class HomePage {
+  constructor(readonly page: Page) {}
+
+  readonly myAccountButton = () => this.page.getByRole('button', { name: /my account/i });
+
+  readonly changeLanguageButton = () =>
+    this.page.getByLabel(/change language/i).getByRole('button', { name: /change/i });
+
+  async goTo() {
+    await this.page.goto('/openmrs/spa/home');
+  }
+}

--- a/e2e/specs/allergies.spec.ts
+++ b/e2e/specs/allergies.spec.ts
@@ -130,7 +130,7 @@ test('Add, edit and delete an allergy', async ({ page }) => {
   });
 
   await test.step('And I should not see the deleted allergy in the list', async () => {
-    await expect(page.getByText(/bee stings/i)).not.toBeVisible();
+    await expect(page.getByText(/bee stings/i)).toBeHidden();
   });
 
   await test.step('And the allergy table should be empty', async () => {

--- a/e2e/specs/attachments.spec.ts
+++ b/e2e/specs/attachments.spec.ts
@@ -30,7 +30,7 @@ test('Add and remove an attachment', async ({ page }) => {
   });
 
   await test.step('And I choose the attachment file to upload', async () => {
-    await page.on('filechooser', async (fileChooser) => {
+    page.on('filechooser', async (fileChooser) => {
       await fileChooser.setFiles(filePath);
     });
     await page.click('.cds--file-browse-btn');
@@ -78,7 +78,7 @@ test('Add and remove an attachment', async ({ page }) => {
   });
 
   await test.step('And I should not see the deleted attachment in the list', async () => {
-    await expect(page.getByRole('button', { name: /brainScan/i })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: /brainScan/i })).toBeHidden();
   });
 
   await test.step('And the attachments table should be empty', async () => {

--- a/e2e/specs/clinical-forms.spec.ts
+++ b/e2e/specs/clinical-forms.spec.ts
@@ -1,8 +1,17 @@
 import { expect } from '@playwright/test';
 import { type Visit } from '@openmrs/esm-framework';
 import { test } from '../core';
-import { generateRandomPatient, deletePatient, type Patient, startVisit, endVisit } from '../commands';
+import {
+  generateRandomPatient,
+  deletePatient,
+  type Patient,
+  startVisit,
+  endVisit,
+  getCurrentUserUuid,
+  restoreLanguage,
+} from '../commands';
 import { ChartPage, VisitsPage } from '../pages';
+import { HomePage } from '../pages/home-page';
 
 let patient: Patient;
 let visit: Visit;
@@ -11,6 +20,10 @@ const subjectiveFindings = `I've had a headache for the last two days`;
 const objectiveFindings = `General appearance is healthy. No signs of distress. Head exam shows no abnormalities, no tenderness on palpation. Neurological exam is normal; cranial nerves intact, normal gait and coordination.`;
 const assessment = `Diagnosis: Tension-type headache. Differential Diagnoses: Migraine, sinusitis, refractive error.`;
 const plan = `Advise use of over-the-counter ibuprofen as needed for headache pain. Educate about proper posture during reading and screen time; discuss healthy sleep hygiene. Schedule a follow-up appointment in 2 weeks or sooner if the headache becomes more frequent or severe.`;
+
+test.use({
+  locale: 'en',
+});
 
 test.beforeEach(async ({ api }) => {
   patient = await generateRandomPatient(api);
@@ -164,7 +177,7 @@ test('Fill a form with a browser slightly ahead of time', async ({ page }) => {
   });
 
   await test.step('And I should not see any error messages', async () => {
-    await expect(page.getByText('error')).not.toBeVisible();
+    await expect(page.getByText('error')).toBeHidden();
   });
 });
 
@@ -272,7 +285,97 @@ test('Form state is retained when minimizing a form in the workspace', async ({ 
   });
 });
 
-test.afterEach(async ({ api }) => {
+test('Form labels should be translated to the system language', async ({ page }) => {
+  const chartPage = new ChartPage(page);
+  const homePage = new HomePage(page);
+
+  await test.step('When I visit the home page', async () => {
+    await homePage.goTo();
+  });
+
+  await test.step('Then I change the system language to French', async () => {
+    await homePage.myAccountButton().click();
+    await homePage.changeLanguageButton().click();
+    await page.locator('label').filter({ hasText: 'Français' }).locator('span').first().click();
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: /change/i })
+      .click();
+  });
+
+  await test.step('Then I visit the chart summary page', async () => {
+    await chartPage.goTo(patient.uuid);
+  });
+
+  await test.step('And I click the `Clinical forms` button on the siderail', async () => {
+    await page.getByRole('button', { name: /formulaires cliniques/i, exact: true }).click();
+  });
+
+  await test.step('Then I should see the `Adult HIV Return Visit` form listed in the clinical forms workspace', async () => {
+    await expect(page.getByRole('cell', { name: /adult hiv return visit/i, exact: true })).toBeVisible();
+  });
+
+  await test.step('And when I click the `Adult HIV Return Visit` link to launch the form', async () => {
+    await page.getByText(/adult hiv return visit/i).click();
+  });
+
+  await test.step('Then I should see the `Adult HIV Return Visit` form launch in the workspace', async () => {
+    await expect(page.getByText(/adult hiv return visit/i)).toBeVisible();
+  });
+
+  await test.step('And I should see all the form labels translated to French', async () => {
+    await expect(page.getByRole('paragraph').filter({ hasText: /détails de la rencontre/i })).toBeVisible();
+    await expect(page.getByRole('paragraph').filter({ hasText: /examen préclinique/i })).toBeVisible();
+    await expect(page.getByRole('paragraph').filter({ hasText: /histoire clinique/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^enregistrer$/i, exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: /annuler/i, exact: true })).toBeVisible();
+    await expect(page.getByText(/réduire tout/i, { exact: true })).toBeVisible();
+  });
+
+  await test.step('And when I change the system language back to English', async () => {
+    await homePage.goTo();
+    await page.getByRole('button', { name: /mon compte/i, exact: true }).click();
+    await page
+      .getByLabel(/changer de langue/i)
+      .getByRole('button', { name: /modifier/i })
+      .click();
+    await page
+      .locator('label')
+      .filter({ hasText: /^english$/i })
+      .locator('span')
+      .first()
+      .click();
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: /modifier/i })
+      .click();
+  });
+
+  await test.step('Then I visit the chart summary page', async () => {
+    await chartPage.goTo(patient.uuid);
+  });
+
+  await test.step('And I click the `Clinical forms` button on the siderail', async () => {
+    await page.getByRole('button', { name: /clinical forms/i, exact: true }).click();
+  });
+
+  await test.step('Then I click the `Adult HIV Return Visit` link to launch the form', async () => {
+    await page.getByText(/adult hiv return visit/i).click();
+  });
+
+  await test.step('Then I should see the form labels updated to English', async () => {
+    await expect(page.getByRole('paragraph').filter({ hasText: /encounter details/i })).toBeVisible();
+  });
+});
+
+test.afterEach(async ({ api, page }) => {
+  try {
+    const userUuid = await getCurrentUserUuid(api);
+    await restoreLanguage(api, userUuid);
+    await page.reload();
+  } catch (e) {
+    console.error('Failed to reset language to English:', e);
+  }
   await endVisit(api, visit);
   await deletePatient(api, patient.uuid);
 });

--- a/e2e/specs/conditions.spec.ts
+++ b/e2e/specs/conditions.spec.ts
@@ -119,7 +119,7 @@ test('Record, edit and delete a condition', async ({ page }) => {
   });
 
   await test.step('And I should not see the deleted condition in the list', async () => {
-    await expect(conditionsPage.page.getByText(/mental status change/i)).not.toBeVisible();
+    await expect(conditionsPage.page.getByText(/mental status change/i)).toBeHidden();
     await expect(conditionsPage.page.getByText(/there are no conditions to display for this patient/i)).toBeVisible();
   });
 });

--- a/e2e/specs/drug-orders.spec.ts
+++ b/e2e/specs/drug-orders.spec.ts
@@ -92,7 +92,7 @@ test('Record, edit and discontinue a drug order', async ({ page }) => {
   });
 
   await test.step('Then the order status should be changed to `New`', async () => {
-    await expect(orderBasket.getByText(/incomplete/i)).not.toBeVisible();
+    await expect(orderBasket.getByText(/incomplete/i)).toBeHidden();
     await expect(orderBasket.getByText(/new/i)).toBeVisible();
   });
 
@@ -183,7 +183,7 @@ test('Record, edit and discontinue a drug order', async ({ page }) => {
   });
 
   await test.step('Then the order status should be changed to `Modify`', async () => {
-    await expect(orderBasket.getByText(/new/i)).not.toBeVisible();
+    await expect(orderBasket.getByText(/new/i)).toBeHidden();
     await expect(orderBasket.getByText(/modify/i)).toBeVisible();
   });
 

--- a/e2e/specs/lab-orders.spec.ts
+++ b/e2e/specs/lab-orders.spec.ts
@@ -104,7 +104,7 @@ test.describe.serial('Running laboratory order tests sequentially', () => {
     });
 
     await test.step('Then the order status should be changed to `Modify`', async () => {
-      await expect(page.getByRole('status', { name: /new/i })).not.toBeVisible();
+      await expect(page.getByRole('status', { name: /new/i })).toBeHidden();
       await expect(page.getByRole('status', { name: /modify/i })).toBeVisible();
     });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Adds an e2e test to assert that clinical form labels get translated when the user changes the system language. This helps guard against regressions in how i18n is implemented in the form engine.

Other unrelated changes include:

- Replacing `expect().not.toBeVisible()` with `expect().toBeHidden()` in assertions as suggested by the Playwright ESLint plugin.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
