### PR TITLE
(fix) Handle undefined unit symbols in vitals header

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header-item.test.tsx
@@ -12,4 +12,20 @@ describe('VitalsHeaderItem', () => {
     expect(screen.getByText('°C')).toBeInTheDocument();
     expect(screen.getByText('36.5')).toBeInTheDocument();
   });
+
+  it('handles empty unit symbol gracefully', () => {
+    const propsWithEmptyUnit = { ...testProps, unitSymbol: '' };
+    render(<VitalsHeaderItem {...propsWithEmptyUnit} />);
+
+    expect(screen.getByText('Temp')).toBeInTheDocument();
+    expect(screen.getByText('36.5')).toBeInTheDocument();
+  });
+
+  it('handles undefined unit symbol gracefully', () => {
+    const propsWithUndefinedUnit = { ...testProps, unitSymbol: undefined };
+    render(<VitalsHeaderItem {...propsWithUndefinedUnit} />);
+
+    expect(screen.getByText('Temp')).toBeInTheDocument();
+    expect(screen.getByText('36.5')).toBeInTheDocument();
+  });
 });

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
@@ -203,7 +203,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, hideLinks = fa
             />
             <VitalsHeaderItem
               unitName={t('bmi', 'BMI')}
-              unitSymbol={latestVitals?.bmi && config.biometrics['bmiUnit']}
+              unitSymbol={(latestVitals?.bmi && config.biometrics['bmiUnit']) ?? ''}
               value={latestVitals?.bmi ?? '--'}
             />
             {latestVitals?.muac && (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR ensures consistent handling of undefined unit symbols across all vitals measurements. It updates the BMI unit symbol logic to use the nullish coalescing operator for consistency with other measurements, and adds tests to verify that VitalsHeaderItem handles both empty and undefined unit symbols gracefully.

## Screenshots

### Before

![CleanShot 2025-03-03 at 12  57 59@2x](https://github.com/user-attachments/assets/565a5c0b-0f98-4097-9944-ba79e7856768)

### After
![CleanShot 2025-03-03 at 12  58 29@2x](https://github.com/user-attachments/assets/4d4ba59b-aca1-484c-9c75-644551c4b6d0)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
