### PR TITLE
(fix) Enable more automatic visit data revalidations

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/hooks/useDeleteVisit.hook.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useDeleteVisit.hook.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { type Visit, showSnackbar, useVisit } from '@openmrs/esm-framework';
-import { deleteVisit, restoreVisit, useVisits } from '../visits-widget/visit.resource';
+import { deleteVisit, restoreVisit, useVisits, useInfiniteVisits } from '../visits-widget/visit.resource';
 
 export function useDeleteVisit(patientUuid: string, visit: Visit, onVisitDelete = () => {}, onVisitRestore = () => {}) {
   const { t } = useTranslation();
   const { mutateVisits } = useVisits(patientUuid);
   const { mutate: mutateCurrentVisit } = useVisit(patientUuid);
+  const { mutateVisits: mutateInfiniteVisits } = useInfiniteVisits(patientUuid);
   const [isDeletingVisit, setIsDeletingVisit] = useState(false);
 
   const restoreDeletedVisit = () => {
@@ -21,6 +22,7 @@ export function useDeleteVisit(patientUuid: string, visit: Visit, onVisitDelete 
         });
         mutateVisits();
         mutateCurrentVisit();
+        mutateInfiniteVisits();
         onVisitRestore?.();
       })
       .catch(() => {
@@ -42,6 +44,7 @@ export function useDeleteVisit(patientUuid: string, visit: Visit, onVisitDelete 
       .then(() => {
         mutateVisits();
         mutateCurrentVisit();
+        mutateInfiniteVisits();
 
         if (!isCurrentVisitDeleted) {
           showSnackbar({

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
@@ -50,7 +50,7 @@ import {
 import { type ChartConfig } from '../../config-schema';
 import { useDefaultVisitLocation } from '../hooks/useDefaultVisitLocation';
 import { useEmrConfiguration } from '../hooks/useEmrConfiguration';
-import { invalidateUseVisits, useInfiniteVisits, useVisits } from '../visits-widget/visit.resource';
+import { invalidateUseVisits, useInfiniteVisits } from '../visits-widget/visit.resource';
 import { useVisitAttributeTypes } from '../hooks/useVisitAttributeType';
 import { MemoizedRecommendedVisitType } from './recommended-visit-type.component';
 import {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -57,15 +57,15 @@ export function useVisits(patientUuid: string) {
   const customRepresentation =
     'custom:(uuid,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis),form:(uuid,display),encounterDatetime,orders:full,obs:(uuid,concept:(uuid,display,conceptClass:(uuid,display)),display,groupMembers:(uuid,concept:(uuid,display),value:(uuid,display),display),value,obsDatetime),encounterType:(uuid,display,viewPrivilege,editPrivilege),encounterProviders:(uuid,display,encounterRole:(uuid,display),provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient,attributes:(attributeType:ref,display,uuid,value)';
 
+  const apiUrl = patientUuid ? `${restBaseUrl}/visit?patient=${patientUuid}&v=${customRepresentation}` : null;
+
   const {
     data,
     error,
     isLoading,
     isValidating,
     mutate: localMutate,
-  } = useSWR(patientUuid ? ['visits', patientUuid] : null, () =>
-    openmrsFetch(`${restBaseUrl}/visit?patient=${patientUuid}&v=${customRepresentation}`),
-  );
+  } = useSWR(patientUuid ? ['visits', patientUuid] : null, () => openmrsFetch(apiUrl));
 
   return {
     visits: data ? data?.data?.results : null,


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This change fixes an issue where deleting or restoring a visit would not properly invalidate all visit data. This was particularly noticeable when using the Visit summary dashboard.

It does so by adding calls to mutateInfiniteVisits in the useDeleteVisit hook, ensuring that all visit data views are properly revalidated when a visit is deleted or restored.

Additionally, this change:
- Removes an unused useVisits import from the Visit Form workspace component
- Improves code clarity in visit.resource.tsx by extracting the API URL construction

This diff intentionally factors out the visit data revalidation logic into a smaller changeset before tackling the more complex task of unifying all visit revalidation logic into a single hook. This incremental approach will make the subsequent unification of visit revalidation logic more manageable.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
