### PR TITLE
(fix) Automatically revalidate visit data after submitting visit notes

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -49,8 +49,8 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
               <ErrorState headerTitle={t('visits', 'visits')} error={error} />
             ) : visits?.length ? (
               <>
-                {visits.map((visit, i) => (
-                  <div className={styles.container} key={i}>
+                {visits.map((visit) => (
+                  <div className={styles.container} key={visit.uuid}>
                     <div className={styles.header}>
                       <div className={styles.visitInfo}>
                         <div>

--- a/packages/esm-patient-notes-app/src/config-schema.ts
+++ b/packages/esm-patient-notes-app/src/config-schema.ts
@@ -2,21 +2,15 @@ import { Type } from '@openmrs/esm-framework';
 import notesConfigSchema, { type VisitNoteConfigObject } from './notes/visit-note-config-schema';
 
 export const configSchema = {
-  visitNoteConfig: notesConfigSchema,
-  numberOfVisitsToLoad: {
-    _type: Type.Number,
-    _description: 'The number of visits to load initially in the Visits Summary tab. Defaults to 5',
-    _default: 5,
-  },
   diagnosisConceptClass: {
-    _type: Type.UUID,
-    _description: 'The concept class to use for the diagnoses',
     _default: '8d4918b0-c2cc-11de-8d13-0010c6dffd0f',
+    _description: 'The concept class to use for the diagnoses',
+    _type: Type.UUID,
   },
+  visitNoteConfig: notesConfigSchema,
 };
 
 export interface ConfigObject {
-  visitNoteConfig: VisitNoteConfigObject;
-  numberOfVisitsToLoad: number;
   diagnosisConceptClass: string;
+  visitNoteConfig: VisitNoteConfigObject;
 }

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
@@ -170,7 +170,8 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
   const currentImages = watch('images');
 
   const { mutateVisitNotes } = useVisitNotes(patientUuid);
-  const { mutateVisits } = useInfiniteVisits(patientUuid);
+  const { mutateVisits: mutateInfiniteVisits } = useInfiniteVisits(patientUuid);
+
   const mutateAttachments = () =>
     mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/attachment`));
 
@@ -389,8 +390,8 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
           }
         })
         .then(() => {
+          mutateInfiniteVisits();
           mutateVisitNotes();
-          mutateVisits();
 
           if (images?.length) {
             mutateAttachments();
@@ -424,8 +425,8 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
       encounterTypeUuid,
       formConceptUuid,
       locationUuid,
+      mutateInfiniteVisits,
       mutateVisitNotes,
-      mutateVisits,
       patientUuid,
       providerUuid,
       selectedPrimaryDiagnoses.length,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Extends the changes made in #2278 to the Visit notes form so that submitting a visit note triggers a revalidation request for visit data. This ensures that the Visit summary page is kept in sync with the latest data updates.

## Screenshots

### Before 

https://github.com/user-attachments/assets/2a530472-3996-465a-8b2e-24d0d1cb3c81

### After

https://github.com/user-attachments/assets/b231f644-5d53-4787-9a2a-43b490d1db24

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
