### PR TITLE
(fix) Fix RangeError when selecting a date in the visit form

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-date-time.component.tsx
@@ -38,7 +38,7 @@ const VisitDateTimeField: React.FC<VisitDateTimeFieldProps> = ({
   // submission, hence just using the min date with hours/ minutes/ seconds set to 0 and max date set to
   // last second of the day. We want to just compare dates and not time.
   const minDateObj = minDate ? dayjs(new Date(minDate).setHours(0, 0, 0, 0)) : null;
-  const maxDateObj = maxDate ? dayjs(new Date(maxDate).setHours(23, 59, 59, 59)).format('DD/MM/YYYY') : null;
+  const maxDateObj = maxDate ? dayjs(new Date(maxDate).setHours(23, 59, 59, 59)) : null;
 
   return (
     <section>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

While the [OpenmrsDatePicker](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L107) component's type definitions suggest it accepts [strings](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L79) for `minDate` and `maxDate` props, the implementation appears to have issues with formatted date strings in "DD/MM/YYYY" format. This is currently manifesting in a regression in the Start Visit form where clicking the datepicker yields a `RangeError: date value is not finite in DateTimeFormat.formatRange()` error. 

[Repro of the bug when starting a visit](https://github.com/user-attachments/assets/d1d13731-a7de-422f-9b89-e7333e92382f)

This error specifically occurs when starting a new visit, but not when editing existing visits, likely because existing visits already have properly formatted date objects. Removing the explicit date formatting from the `minDate` and `maxDate` object constructions resolves the RangeError by passing dayjs objects directly instead of formatted strings.

## Screenshots

### RangeError fixed
https://github.com/user-attachments/assets/ba50db5e-2304-43bb-9c61-5d3d9e65cc06

## Related Issue
https://openmrs.atlassian.net/browse/O3-4538

## Other
<!-- Anything not covered above -->
