### PR TITLE
Minor: Refactored inline type to `DoseTypesProps`

### DIFF
--- a/packages/esm-patient-immunizations-app/src/immunizations/components/dose-input.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/components/dose-input.component.tsx
@@ -1,15 +1,11 @@
 import React, { useMemo } from 'react';
-import { type ImmunizationSequenceDefinition } from '../../types/fhir-immunization-domain';
+import { type DoseInputProps } from '../../types/fhir-immunization-domain';
 import { useController, type Control } from 'react-hook-form';
 import { Dropdown, NumberInput } from '@carbon/react';
 import styles from './../immunizations-form.scss';
 import { useTranslation } from 'react-i18next';
 
-export const DoseInput: React.FC<{
-  vaccine: string;
-  sequences: ImmunizationSequenceDefinition[];
-  control: Control;
-}> = ({ vaccine, sequences, control }) => {
+export const DoseInput: React.FC<DoseInputProps> = ({ vaccine, sequences, control }) => {
   const { t } = useTranslation();
   const { field } = useController({ name: 'doseNumber', control });
 

--- a/packages/esm-patient-immunizations-app/src/types/fhir-immunization-domain.ts
+++ b/packages/esm-patient-immunizations-app/src/types/fhir-immunization-domain.ts
@@ -1,3 +1,5 @@
+import { type Control } from 'react-hook-form';
+
 export type OpenmrsConcept = {
   uuid: string;
   display: string;
@@ -84,4 +86,10 @@ export type ImmunizationData = {
   vaccineUuid: string;
   existingDoses: Array<ImmunizationDoseData>;
   sequences?: Array<ImmunizationSequence>;
+};
+
+export type DoseInputProps = {
+  vaccine: string;
+  sequences: ImmunizationSequenceDefinition[];
+  control: Control;
 };


### PR DESCRIPTION
This PR has a title that briefly describes the work done.

My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
My work includes tests or is validated by existing tests.

Summary:
My PR is just to add modularity in code by refactoring inline type definition with a type definition DoseInputProps in 

Screenshots:
There is no UI Change.

Related Issue:
No related issues.

Other:
It is an idea just to align the codebase with the OpenMRS 3.0 StyleGuide while, I was dwelling in the esm-patient-immunizations-app for putting a step towards GSoC.
