### PR TITLE
(fix)O3-4494:  Patient Chart Visit tab's "All Encounters" table does not show all encounters

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button, InlineLoading, Tab, Tabs, TabList, TabPanel, TabPanels } from '@carbon/react';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { formatDatetime, parseDate, useConfig, ExtensionSlot } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import type { ChartConfig } from '../../config-schema';
-import { mapEncounters, useInfiniteVisits } from './visit.resource';
+import { mapEncounters, useInfiniteVisits, useEncounters } from './visit.resource';
 import VisitsTable from './past-visits-components/visits-table';
 import VisitSummary from './past-visits-components/visit-summary.component';
 import styles from './visit-detail-overview.scss';
@@ -17,8 +17,10 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
   const { t } = useTranslation();
   const { visits, error, hasMore, isLoading, isValidating, mutateVisits, setSize, size } =
     useInfiniteVisits(patientUuid);
+  const { encounters } = useEncounters(patientUuid);
   const { showAllEncountersTab } = useConfig<ChartConfig>();
   const shouldLoadMore = size !== visits?.length;
+  const [visitSummarySize, setVisitSummarySize] = useState(size);
 
   const visitsWithEncounters = visits
     ?.filter((visit) => visit?.encounters?.length)
@@ -30,11 +32,25 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
     <div className={styles.tabs}>
       <Tabs>
         <TabList aria-label="Visit detail tabs" className={styles.tabList}>
-          <Tab className={styles.tab} id="visit-summaries-tab">
+          <Tab
+            className={styles.tab}
+            id="visit-summaries-tab"
+            onClick={() => {
+              setSize(visitSummarySize);
+            }}
+          >
             {t('visitSummaries', 'Visit summaries')}
           </Tab>
-          {showAllEncountersTab ? (
-            <Tab className={styles.tab} id="all-encounters-tab">
+          {showAllEncountersTab && !isLoading ? (
+            <Tab
+              className={styles.tab}
+              id="all-encounters-tab"
+              onClick={() => {
+                setVisitSummarySize(size);
+                const newSize = Math.floor((encounters?.length + 19) / 20);
+                setSize(newSize);
+              }}
+            >
               {t('allEncounters', 'All encounters')}
             </Tab>
           ) : (

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Button, InlineLoading, Tab, Tabs, TabList, TabPanel, TabPanels } from '@carbon/react';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { formatDatetime, parseDate, useConfig, ExtensionSlot } from '@openmrs/esm-framework';


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.  
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).  
- [x] My work includes tests or is validated by existing tests.  

## Summary  

The "All Encounters" tab in the Visits section was not displaying all patient encounters. Instead, it only showed encounters from the visits that were already loaded in the "Visit Summaries" tab.  

The issue was resolved by fetching the total number of encounters related to the patient. The `useEncounters(patientUuid)` hook provides all encounters, so we used it to determine the total count (`encounters.length`). Since the API request size is 20 encounters per request, we calculated how many requests were needed (`newSize = Math.floor((encounters.length + 19) / 20)`) and adjusted the size and called the API with (`setSize(newSize)`) when the "All Encounters" tab is clicked. Additionally, we introduced `visitSummarySize` to track the number of visits loaded in the "Visit Summaries" tab, preventing all visits from loading automatically when switching tabs.  

This ensures that all encounters are displayed correctly while maintaining the expected behavior of visit summaries.  

## Recordings
Before:-

https://github.com/user-attachments/assets/cbe123ea-874b-4fee-9f24-dc29d502bec0

After:-

https://github.com/user-attachments/assets/c24f2266-03b6-4d5e-9c43-a78a9f086a1c



## Related Issue  
https://openmrs.atlassian.net/browse/O3-4494  

