### PR TITLE
(fix) Use `isExpanded` prop from nav-group extension config

### DIFF
--- a/packages/esm-patient-chart-app/src/side-nav/generic-nav-group.component.tsx
+++ b/packages/esm-patient-chart-app/src/side-nav/generic-nav-group.component.tsx
@@ -13,11 +13,17 @@ export const genericNavGroupConfigSchema = {
     _description: 'The name of the slot to create, which links can be added to.',
     _default: 'my-group-nav-slot',
   },
+  isExpanded: {
+    _type: Type.Boolean,
+    _description: 'Whether the group should be expanded by default.',
+    _default: true,
+  },
 };
 
 export interface GenericNavGroupConfig {
   title: string;
   slotName: string;
+  isExpanded: boolean;
 }
 
 interface GenericNavGroupProps {
@@ -26,5 +32,12 @@ interface GenericNavGroupProps {
 
 export default function GenericNavGroup({ basePath }: GenericNavGroupProps) {
   const config = useConfig<GenericNavGroupConfig>();
-  return <DashboardGroupExtension title={config.title} slotName={config.slotName} basePath={basePath} />;
+  return (
+    <DashboardGroupExtension
+      title={config.title}
+      slotName={config.slotName}
+      isExpanded={config.isExpanded}
+      basePath={basePath}
+    />
+  );
 }


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Fixes an [issue](https://openmrs.slack.com/archives/CHP5QAE5R/p1742323868070499?thread_ts=1741936313.155169&cid=CHP5QAE5R) where the default collapse setting for nav groups was being ignored.

## Screenshots
<!-- Required if you are making UI changes. -->

After:

https://github.com/user-attachments/assets/26f0b0ea-5cb0-453f-9a89-32eab054f929


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
