### PR TITLE
(fix) 03-4477: Workspace closes when form is cancelled and then shows the prompt

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -3,11 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { InlineLoading } from '@carbon/react';
 import { FormEngine } from '@openmrs/esm-form-engine-lib';
 import { showModal, type Visit } from '@openmrs/esm-framework';
-import {
-  clinicalFormsWorkspace,
-  type DefaultPatientWorkspaceProps,
-  launchPatientWorkspace,
-} from '@openmrs/esm-patient-common-lib';
+import { type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import FormError from './form-error.component';
 import useFormSchema from '../hooks/useFormSchema';
 import styles from './form-renderer.scss';
@@ -30,7 +26,6 @@ const FormRenderer: React.FC<FormRendererProps> = ({
   patientUuid,
   promptBeforeClosing,
   visit,
-  clinicalFormsWorkspaceName = clinicalFormsWorkspace,
 }) => {
   const { t } = useTranslation();
   const { schema, error, isLoading } = useFormSchema(formUuid);
@@ -39,8 +34,8 @@ const FormRenderer: React.FC<FormRendererProps> = ({
 
   const handleCloseForm = useCallback(() => {
     closeWorkspace();
-    !encounterUuid && openClinicalFormsWorkspaceOnFormClose && launchPatientWorkspace(clinicalFormsWorkspaceName);
-  }, [closeWorkspace, encounterUuid, openClinicalFormsWorkspaceOnFormClose, clinicalFormsWorkspaceName]);
+    !encounterUuid && openClinicalFormsWorkspaceOnFormClose;
+  }, [closeWorkspace, encounterUuid, openClinicalFormsWorkspaceOnFormClose]);
 
   const handleConfirmQuestionDeletion = useCallback(() => {
     return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
Previously when a user clicks the cancel button on the clinical forms in the workspace, the workspace closes and brings up a prompt. This fix addresses this issue and keeps the workspace open, until a user clicks the discard button in the prompt.

## Screenshots
Before
https://github.com/user-attachments/assets/0a47b269-8ac0-46da-9961-60c9afe6aa67

After

https://github.com/user-attachments/assets/b97005ab-251e-4b04-bcb1-aff355d19fcf




## Related Issue
https://openmrs.atlassian.net/browse/O3-4477


## Other
<!-- Anything not covered above -->
