### PR TITLE
(chore) Extend version range support for stockmanagement backend module

### DIFF
--- a/packages/esm-patient-orders-app/src/routes.json
+++ b/packages/esm-patient-orders-app/src/routes.json
@@ -5,7 +5,7 @@
   },
   "optionalBackendDependencies": {
     "fhirproxy": "^1.0.0-SNAPSHOT",
-    "stockmanagement": "^2.0.2-SNAPSHOT",
+    "stockmanagement": ">=1.4.0 || ^2.0.0-SNAPSHOT",
     "billing": "^1.2.0-SNAPSHOT"
   },
   "extensions": [
@@ -25,7 +25,7 @@
       "name": "order-basket-action-menu",
       "component": "orderBasketActionMenu",
       "slots": [
-        "action-menu-patient-chart-items-slot", 
+        "action-menu-patient-chart-items-slot",
         "action-menu-ward-patient-items-slot"
       ]
     },

--- a/packages/esm-patient-orders-app/src/routes.json
+++ b/packages/esm-patient-orders-app/src/routes.json
@@ -5,7 +5,7 @@
   },
   "optionalBackendDependencies": {
     "fhirproxy": "^1.0.0-SNAPSHOT",
-    "stockmanagement": ">=1.4.0 || ^2.0.0-SNAPSHOT",
+    "stockmanagement": "^1.4.0 || ^2.0.0-SNAPSHOT",
     "billing": "^1.2.0-SNAPSHOT"
   },
   "extensions": [

--- a/packages/esm-patient-orders-app/src/routes.json
+++ b/packages/esm-patient-orders-app/src/routes.json
@@ -5,7 +5,7 @@
   },
   "optionalBackendDependencies": {
     "fhirproxy": "^1.0.0-SNAPSHOT",
-    "stockmanagement": "^1.4.0 || ^2.0.0-SNAPSHOT",
+    "stockmanagement": "^1.4.0 || ^2.0.0",
     "billing": "^1.2.0-SNAPSHOT"
   },
   "extensions": [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR provides support for both available versions of the `stockmanagement` backend dependency in the orders app . i.e. `v1.4.0` and `v2.0.0`. 

## Screenshots

<img width="2055" alt="image" src="https://github.com/user-attachments/assets/6da58c6c-292d-4ad4-935d-c33abfa437c4" />

<img width="2055" alt="image" src="https://github.com/user-attachments/assets/932cb11a-6534-41bf-8f8d-62c061cdca49" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
