### PR TITLE
(fix) O3-4570 : fix order basket failing to load in ward app due to missing patientUuid

### DIFF
--- a/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
@@ -9,6 +9,7 @@ import {
   postOrders,
   postOrdersOnNewEncounter,
   useOrderBasket,
+  usePatientChartStore,
   useVisitOrOfflineVisit,
 } from '@openmrs/esm-patient-common-lib';
 import { type ConfigObject } from '../config-schema';
@@ -17,11 +18,14 @@ import styles from './order-basket.scss';
 import GeneralOrderType from './general-order-type/general-order-type.component';
 
 const OrderBasket: React.FC<DefaultPatientWorkspaceProps> = ({
-  patientUuid,
+  patientUuid : patientUuidFromProps,
   closeWorkspace,
   closeWorkspaceWithSavedChanges,
   promptBeforeClosing,
 }) => {
+  const { patientUuid:patientUuidFromStore } = usePatientChartStore();
+  const patientUuid = patientUuidFromProps || patientUuidFromStore;
+
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const config = useConfig<ConfigObject>();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
See https://openmrs.atlassian.net/browse/O3-4570

## Screenshots
[Kapture 2025-03-27 at 15.04.13.webm](https://github.com/user-attachments/assets/83a7a120-b709-45cc-9231-635a51ef8065)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
