### PR TITLE
(fix) O3-4363 Fix context switcher modal name and order workspace height

### DIFF
--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -232,7 +232,7 @@ export const encounterListTableTabs = getAsyncLifecycle(
 
 export const visitContextSwitcherModal = getAsyncLifecycle(
   () => import('./visit/visits-widget/visit-context/visit-context-switcher.modal'),
-  { featureName: 'visit-context-switcher-modal', moduleName },
+  { featureName: 'visit-context-switcher', moduleName },
 );
 
 export const visitContextHeader = getAsyncLifecycle(

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/visit-context-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/visit-context-header.component.tsx
@@ -32,7 +32,7 @@ const VisitContextHeader: React.FC<VisitContextHeaderProps> = ({ patientUuid }) 
   }, [currentVisit, isLoading, setVisitContext, manuallySetVisitUuid, showVisitContextHeader]);
 
   const openVisitSwitcherModal = () => {
-    const dispose = showModal('visit-context-switcher-modal', {
+    const dispose = showModal('visit-context-switcher', {
       patientUuid,
       closeModal: () => dispose(),
       size: 'sm',

--- a/packages/esm-patient-common-lib/src/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces.ts
@@ -52,7 +52,7 @@ export function useLaunchWorkspaceRequiringVisit<T extends object>(workspaceName
         launchWorkspace(workspaceName, additionalProps);
       } else {
         if (isRdeEnabled) {
-          const dispose = showModal('visit-context-switcher-modal', {
+          const dispose = showModal('visit-context-switcher', {
             patientUuid,
             closeModal: () => dispose(),
             onAfterVisitSelected: () => launchPatientWorkspace(workspaceName, additionalProps),

--- a/packages/esm-patient-orders-app/src/order-basket/order-basket.scss
+++ b/packages/esm-patient-orders-app/src/order-basket/order-basket.scss
@@ -10,6 +10,7 @@
 
 .orderBasketContainer {
   margin: layout.$spacing-05;
+  flex: 1;
 }
 
 .orderBasketContainer :global(.cds--btn-set .cds--btn) {

--- a/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
@@ -120,8 +120,8 @@ const OrderBasket: React.FC<DefaultPatientWorkspaceProps> = ({
 
   return (
     <>
-      <ExtensionSlot name="visit-context-header-slot" state={{ patientUuid }} />
       <div className={styles.container}>
+        <ExtensionSlot name="visit-context-header-slot" state={{ patientUuid }} />
         <div className={styles.orderBasketContainer}>
           <ExtensionSlot
             className={classNames(styles.orderBasketSlot, {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Fix a couple things from https://github.com/openmrs/openmrs-esm-patient-chart/pull/2222:
- The `visit-context-switcher-modal` modal was renamed to `visit-context-switcher` in routes.json, but I forgot to make corresponding change in code.
- The Order basket workspace scroll height needs to be adjust with the Visit context rendered at the top
Before:
![image](https://github.com/user-attachments/assets/571abd8a-be44-44d0-b2a1-e532b852a17e)

After:
![image](https://github.com/user-attachments/assets/b48e42a3-bb83-452c-8943-97d8d3910769)

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
