### PR TITLE
(fix) O3-4584: Validate against future onset dates in the conditions form

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.workspace.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.workspace.tsx
@@ -31,7 +31,12 @@ const createSchema = (formContext: 'creating' | 'editing', t: TFunction) => {
     abatementDateTime: z.date().optional().nullable(),
     clinicalStatus: clinicalStatusValidation,
     conditionName: conditionNameValidation,
-    onsetDateTime: z.date().nullable(),
+    onsetDateTime: z
+      .date()
+      .nullable()
+      .refine((onsetDateTime) => onsetDateTime <= new Date(), {
+        message: t('onsetDateCannotBeFuture', 'Onset date cannot be in the future'),
+      }),
   });
 };
 

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.workspace.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.workspace.tsx
@@ -35,7 +35,7 @@ const createSchema = (formContext: 'creating' | 'editing', t: TFunction) => {
       .date()
       .nullable()
       .refine((onsetDateTime) => onsetDateTime <= new Date(), {
-        message: t('onsetDateCannotBeFuture', 'Onset date cannot be in the future'),
+        message: t('onsetDateCannotBeInTheFuture', 'Onset date cannot be in the future'),
       }),
   });
 };

--- a/packages/esm-patient-conditions-app/translations/en.json
+++ b/packages/esm-patient-conditions-app/translations/en.json
@@ -29,6 +29,7 @@
   "noConditionsToDisplay": "No conditions to display",
   "noResultsFor": "No results for",
   "onsetDate": "Onset date",
+  "onsetDateCannotBeFuture": "Onset date cannot be in the future",
   "recordCondition": "Record a Condition",
   "required": "Required",
   "saveAndClose": "Save & close",

--- a/packages/esm-patient-conditions-app/translations/en.json
+++ b/packages/esm-patient-conditions-app/translations/en.json
@@ -29,7 +29,7 @@
   "noConditionsToDisplay": "No conditions to display",
   "noResultsFor": "No results for",
   "onsetDate": "Onset date",
-  "onsetDateCannotBeFuture": "Onset date cannot be in the future",
+  "onsetDateCannotBeInTheFuture": "Onset date cannot be in the future",
   "recordCondition": "Record a Condition",
   "required": "Required",
   "saveAndClose": "Save & close",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The system allows saving a condition with an onset date. The system should display a validation error preventing the user from entering a future onset date

## Screenshots
<!-- Required if you are making UI changes. -->
## Before 
<img width="426" alt="Screenshot 2025-04-02 at 7 59 08 PM" src="https://github.com/user-attachments/assets/6b0c1a47-e8ba-4b88-8471-44bc9a458fc5" />

## After
<img width="417" alt="Screenshot 2025-04-02 at 7 48 40 PM" src="https://github.com/user-attachments/assets/e4c25bbd-f809-44bf-a661-e30600a2a89b" />
<img width="427" alt="Screenshot 2025-04-02 at 7 49 31 PM" src="https://github.com/user-attachments/assets/64b751ce-bed5-443a-a17b-da3056b42c55" />



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[ticket link](https://openmrs.atlassian.net/browse/O3-4584)

## Other
<!-- Anything not covered above -->
