### PR TITLE
(fix) Allergies form should not change value to undefined

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,5 +3,5 @@
 
 set -e  # die on error
 
-npx lint-staged
+yarn lint-staged
 yarn turbo run extract-translations


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

In the E2E tests, when Playwright clicks on the allergen, two __item_clicked__ state changes are fired by Downshift (the library Carbon uses to implement the ComboBox). The first time this is fired, the selectedItem property is properly set to a value, but the second time it's set to `undefined`. Here we catch any attempts to set the value to `undefined` in the ComboBox onChange() handler and don't update the form state. However, clicking the button to clear the entry appears to send `null`, so this still works. This does lose the functionality where clicking on an already-selected item deselects that item (since that sets the current value to `undefined`), but that feels like a reasonable tradeoff.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
There's a lot of small refactorings here and there. For one things, I missed the extension slot here when pushing the patient "everywhere". Mostly, though, I've just added a lot of memoization, especially where functions call other functions or arrays are passed down as props.
