### PR TITLE
(feat) Switch to TabsVertical and TabListVertical components in chart views

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.scss
+++ b/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.scss
@@ -42,27 +42,11 @@
   display: inline-block;
 }
 
-.verticalTabs {
-  margin: layout.$spacing-05 0;
-  scroll-behavior: smooth;
-
-  > ul {
-    flex-direction: column !important;
-  }
-
-  :global(.cds--tabs--scrollable .cds--tabs--scrollable__nav-item + .cds--tabs--scrollable__nav-item) {
-    margin-left: 0;
-  }
-
-  :global(.cds--tabs--scrollable .cds--tabs--scrollable__nav-link) {
-    border-bottom: 0 !important;
-    border-left: layout.$spacing-01 solid $color-gray-30;
-  }
-}
-
 .tab {
   outline: 0;
   outline-offset: 0;
+  min-height: layout.$spacing-07 !important;
+  block-size: layout.$spacing-05 !important;
 
   &:active,
   &:focus {
@@ -70,7 +54,7 @@
   }
 
   &[aria-selected='true'] {
-    border-left: 3px solid var(--brand-03);
+    box-shadow: inset 4px 0 0 0 var(--brand-03) !important;
     border-bottom: none;
     font-weight: 600;
     margin-left: 0 !important;
@@ -80,17 +64,5 @@
     border-bottom: none;
     border-left: layout.$spacing-01 solid $ui-03;
     margin-left: 0 !important;
-  }
-}
-
-.tablist {
-  :global(.cds--tab--list) {
-    flex-direction: column;
-    max-height: fit-content;
-    overflow-x: visible;
-  }
-
-  > button :global(.cds--tabs .cds--tabs__nav-link) {
-    border-bottom: none;
   }
 }

--- a/packages/esm-patient-tests-app/src/test-results/trendline/trendline.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/trendline/trendline.component.tsx
@@ -1,7 +1,7 @@
 import React, { type ComponentProps, useState, useCallback, useMemo, useLayoutEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, InlineLoading, SkeletonText } from '@carbon/react';
-import { LineChart } from '@carbon/charts-react';
+import { LineChart, ScaleTypes, TickRotations } from '@carbon/charts-react';
 import { ArrowLeftIcon, ConfigurableLink, formatDate } from '@openmrs/esm-framework';
 import { EmptyState, type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import { useObstreeData } from './trendline-resource';
@@ -9,19 +9,6 @@ import { testResultsBasePath } from '../helpers';
 import CommonDataTable from '../overview/common-datatable.component';
 import RangeSelector from './range-selector.component';
 import styles from './trendline.scss';
-
-enum ScaleTypes {
-  TIME = 'time',
-  LINEAR = 'linear',
-  LOG = 'log',
-  LABELS = 'labels',
-}
-
-enum TickRotations {
-  ALWAYS = 'always',
-  AUTO = 'auto',
-  NEVER = 'never',
-}
 
 interface TrendlineProps {
   patientUuid: string;

--- a/packages/esm-patient-tests-app/src/test-results/trendline/trendline.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/trendline/trendline.test.tsx
@@ -6,6 +6,21 @@ import Trendline from './trendline.component';
 
 const mockUseObstreeData = jest.mocked(useObstreeData);
 
+jest.mock('@carbon/charts-react', () => ({
+  LineChart: () => <div data-testid="line-chart">Line Chart</div>,
+  ScaleTypes: {
+    TIME: 'time',
+    LINEAR: 'linear',
+    LOG: 'log',
+    LABELS: 'labels',
+  },
+  TickRotations: {
+    ALWAYS: 'always',
+    AUTO: 'auto',
+    NEVER: 'never',
+  },
+}));
+
 jest.mock('./trendline-resource', () => ({
   ...jest.requireActual('./trendline-resource'),
   useObstreeData: jest.fn(),

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-base.component.tsx
@@ -7,9 +7,9 @@ import { CardHeader, EmptyState, ErrorState, useVisitOrOfflineVisit } from '@ope
 import { launchVitalsAndBiometricsForm } from '../utils';
 import { useVitalsConceptMetadata, useVitalsAndBiometrics, withUnit } from '../common';
 import { type ConfigObject } from '../config-schema';
+import type { BiometricsTableHeader, BiometricsTableRow } from './types';
 import BiometricsChart from './biometrics-chart.component';
 import PaginatedBiometrics from './paginated-biometrics.component';
-import type { BiometricsTableHeader, BiometricsTableRow } from './types';
 import styles from './biometrics-base.scss';
 
 interface BiometricsBaseProps {
@@ -86,8 +86,14 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({ patientUuid, pageSize, 
     [biometrics],
   );
 
-  if (isLoading) return <DataTableSkeleton role="progressbar" />;
-  if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
+  if (isLoading) {
+    return <DataTableSkeleton role="progressbar" />;
+  }
+
+  if (error) {
+    return <ErrorState error={error} headerTitle={headerTitle} />;
+  }
+
   if (biometrics?.length) {
     return (
       <div className={styles.widgetCard}>

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.scss
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.scss
@@ -23,47 +23,17 @@
   padding-right: layout.$spacing-05;
 }
 
-.biometricsChartArea {
-  flex-grow: 4;
-  padding: 0 layout.$spacing-05 layout.$spacing-09;
-
-  :global(.cds--cc--layout-row) {
-    height: 0;
-  }
-
-  :global(.layout-child) {
-    margin-top: layout.$spacing-03;
-  }
-}
-
 .biometricLabel {
   @extend .label01;
   margin-bottom: layout.$spacing-05;
   display: inline-block;
 }
 
-.verticalTabs {
-  margin: layout.$spacing-05 0;
-  scroll-behavior: smooth;
-
-  > ul {
-    flex-direction: column !important;
-  }
-
-  :global(.cds--tabs--scrollable .cds--tabs--scrollable__nav-item + .cds--tabs--scrollable__nav-item) {
-    margin-left: 0;
-  }
-
-  :global(.cds--tabs--scrollable .cds--tabs--scrollable__nav-link) {
-    border-bottom: 0 !important;
-    border-left: layout.$spacing-01 solid $color-gray-30;
-  }
-}
-
 .tab {
   outline: 0;
   outline-offset: 0;
-  min-height: layout.$spacing-07;
+  min-height: layout.$spacing-07 !important;
+  block-size: layout.$spacing-05 !important;
 
   &:active,
   &:focus {
@@ -71,7 +41,7 @@
   }
 
   &[aria-selected='true'] {
-    border-left: 3px solid var(--brand-03);
+    box-shadow: inset 4px 0 0 0 var(--brand-03) !important;
     border-bottom: none;
     font-weight: 600;
     margin-left: 0 !important;
@@ -81,17 +51,5 @@
     border-bottom: none;
     border-left: layout.$spacing-01 solid $ui-03;
     margin-left: 0 !important;
-  }
-}
-
-.tablist {
-  :global(.cds--tab--list) {
-    flex-direction: column;
-    max-height: fit-content;
-    overflow-x: visible;
-  }
-
-  > button :global(.cds--tabs .cds--tabs__nav-link) {
-    border-bottom: none;
   }
 }

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
@@ -17,6 +17,22 @@ const testProps = {
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
 const mockUseVitalsAndBiometrics = jest.mocked(useVitalsAndBiometrics);
 
+jest.mock('@carbon/charts-react', () => ({
+  LineChart: () => <div data-testid="line-chart">Line Chart</div>,
+  ScaleTypes: {
+    TIME: 'time',
+    LINEAR: 'linear',
+    LOG: 'log',
+    LABELS: 'labels',
+    LABELS_RATIO: 'labels-ratio',
+  },
+  TickRotations: {
+    ALWAYS: 'always',
+    AUTO: 'auto',
+    NEVER: 'never',
+  },
+}));
+
 jest.mock('../common', () => {
   const originalModule = jest.requireActual('../common');
 

--- a/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import {
   DataTable,
-  type DataTableRow,
   Table,
   TableCell,
   TableContainer,
@@ -12,8 +11,8 @@ import {
 } from '@carbon/react';
 import { useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
-import styles from './paginated-biometrics.scss';
 import type { BiometricsTableHeader, BiometricsTableRow } from './types';
+import styles from './paginated-biometrics.scss';
 
 interface PaginatedBiometricsProps {
   tableRows: Array<BiometricsTableRow>;
@@ -73,14 +72,14 @@ const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
   return (
     <>
       <DataTable
-        rows={paginatedBiometrics}
         headers={tableHeaders}
-        size={isTablet ? 'lg' : 'sm'}
-        useZebraStyles
-        sortRow={handleSorting}
         isSortable
+        rows={paginatedBiometrics}
+        size={isTablet ? 'lg' : 'sm'}
+        sortRow={handleSorting}
+        useZebraStyles
       >
-        {({ rows, headers, getHeaderProps, getTableProps }) => (
+        {({ getHeaderProps, getTableProps, headers, rows }) => (
           <TableContainer className={styles.tableContainer}>
             <Table aria-label="biometrics" className={styles.table} {...getTableProps()}>
               <TableHead>
@@ -111,13 +110,13 @@ const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
         )}
       </DataTable>
       <PatientChartPagination
-        pageNumber={currentPage}
-        totalItems={tableRows.length}
         currentItems={paginatedBiometrics.length}
-        pageSize={pageSize}
-        onPageNumberChange={({ page }) => goTo(page)}
-        dashboardLinkUrl={pageUrl}
         dashboardLinkLabel={urlLabel}
+        dashboardLinkUrl={pageUrl}
+        onPageNumberChange={({ page }) => goTo(page)}
+        pageNumber={currentPage}
+        pageSize={pageSize}
+        totalItems={tableRows.length}
       />
     </>
   );

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
@@ -1,20 +1,12 @@
-import React, { useId, useMemo } from 'react';
+import React, { useId, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { Tab, Tabs, TabList } from '@carbon/react';
-import { LineChart } from '@carbon/charts-react';
+import { Tab, TabListVertical, TabPanel, TabPanels, TabsVertical } from '@carbon/react';
+import { LineChart, ScaleTypes } from '@carbon/charts-react';
 import { formatDate, parseDate } from '@openmrs/esm-framework';
 import { type ConfigObject } from '../config-schema';
 import { withUnit, type PatientVitalsAndBiometrics } from '../common';
 import styles from './vitals-chart.scss';
-
-enum ScaleTypes {
-  LABELS = 'labels',
-  LABELS_RATIO = 'labels-ratio',
-  LINEAR = 'linear',
-  LOG = 'log',
-  TIME = 'time',
-}
 
 interface VitalsChartProps {
   conceptUnits: Map<string, string>;
@@ -30,7 +22,7 @@ interface VitalsChartData {
 const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, config }) => {
   const { t } = useTranslation();
   const id = useId();
-  const [selectedVitalSign, setSelectedVitalsSign] = React.useState<VitalsChartData>({
+  const [selectedVitalsSign, setSelectedVitalsSign] = useState<VitalsChartData>({
     title: `${t('bp', 'BP')} (${conceptUnits.get(config.concepts.systolicBloodPressureUuid)})`,
     value: 'systolic',
   });
@@ -65,40 +57,39 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
 
   const chartData = useMemo(() => {
     return patientVitals
-      .filter((vitals) => vitals[selectedVitalSign.value])
-      .splice(0, 10)
+      .filter((vitals) => vitals[selectedVitalsSign.value])
+      .slice(0, 10)
       .sort((vitalA, vitalB) => new Date(vitalA.date).getTime() - new Date(vitalB.date).getTime())
       .map((vitals) => {
-        if (vitals[selectedVitalSign.value]) {
-          if (['systolic', 'diastolic'].includes(selectedVitalSign.value)) {
-            return [
-              {
-                group: 'Systolic blood pressure',
-                key: formatDate(parseDate(vitals.date.toString()), { year: false }),
-                value: vitals.systolic,
-                date: vitals.date,
-              },
-              {
-                group: 'Diastolic blood pressure',
-                key: formatDate(parseDate(vitals.date.toString()), { year: false }),
-                value: vitals.diastolic,
-                date: vitals.date,
-              },
-            ];
-          } else {
-            return {
-              group: selectedVitalSign.title,
-              key: formatDate(parseDate(vitals.date.toString()), { year: false }),
-              value: vitals[selectedVitalSign.value],
+        const formattedDate = formatDate(parseDate(vitals.date.toString()), { year: false });
+
+        if (['systolic', 'diastolic'].includes(selectedVitalsSign.value)) {
+          return [
+            {
+              group: 'Systolic blood pressure',
+              key: formattedDate,
+              value: vitals.systolic,
               date: vitals.date,
-            };
-          }
+            },
+            {
+              group: 'Diastolic blood pressure',
+              key: formattedDate,
+              value: vitals.diastolic,
+              date: vitals.date,
+            },
+          ];
         }
+        return {
+          group: selectedVitalsSign.value,
+          key: formattedDate,
+          value: vitals[selectedVitalsSign.value],
+          date: vitals.date,
+        };
       });
-  }, [patientVitals, selectedVitalSign]);
+  }, [patientVitals, selectedVitalsSign]);
 
   const chartOptions = {
-    title: selectedVitalSign.title,
+    title: selectedVitalsSign.title,
     axes: {
       bottom: {
         title: t('date', 'Date'),
@@ -107,7 +98,7 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
       },
       left: {
         mapsTo: 'value',
-        title: selectedVitalSign.title,
+        title: selectedVitalsSign.title,
         scaleType: ScaleTypes.LINEAR,
         includeZero: false,
       },
@@ -117,7 +108,7 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
     },
     color: {
       scale: {
-        [selectedVitalSign.title]: '#6929c4',
+        [selectedVitalsSign.title]: '#6929c4',
       },
     },
     tooltip: {
@@ -136,30 +127,41 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
         <label className={styles.vitalsSignLabel} htmlFor={`${id}-tab`}>
           {t('vitalSignDisplayed', 'Vital sign displayed')}
         </label>
-        <Tabs className={styles.verticalTabs}>
-          <TabList className={styles.tablist} aria-label="Vitals tabs">
-            {vitalSigns.map(({ id, title, value }) => {
-              return (
-                <Tab
-                  className={classNames(styles.tab, { [styles.selectedTab]: selectedVitalSign.title === title })}
-                  id={`${id}-tab`}
-                  key={id}
-                  onClick={() =>
-                    setSelectedVitalsSign({
-                      title: title,
-                      value: value,
-                    })
-                  }
-                >
-                  {title}
-                </Tab>
-              );
-            })}
-          </TabList>
-        </Tabs>
-      </div>
-      <div className={styles.vitalsChartArea}>
-        <LineChart data={chartData.flat()} options={chartOptions} />
+        <TabsVertical>
+          <TabListVertical aria-label="Vitals tabs">
+            {vitalSigns.map(({ id, title, value }) => (
+              <Tab
+                className={classNames(styles.tab, { [styles.selectedTab]: selectedVitalsSign.title === title })}
+                id={`${id}-tab`}
+                key={id}
+                onClick={() =>
+                  setSelectedVitalsSign({
+                    title: title,
+                    value: value,
+                  })
+                }
+              >
+                {title}
+              </Tab>
+            ))}
+          </TabListVertical>
+          <TabPanels>
+            {vitalSigns.map(({ id, title, value }) => (
+              <TabPanel key={id}>
+                <LineChart
+                  data={chartData
+                    .flat()
+                    .filter((data) =>
+                      value === 'systolic'
+                        ? data.group === 'Systolic blood pressure' || data.group === 'Diastolic blood pressure'
+                        : data.group === value,
+                    )}
+                  options={chartOptions}
+                />
+              </TabPanel>
+            ))}
+          </TabPanels>
+        </TabsVertical>
       </div>
     </div>
   );

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.scss
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.scss
@@ -23,47 +23,17 @@
   padding-right: layout.$spacing-05;
 }
 
-.vitalsChartArea {
-  flex-grow: 4;
-  padding: 0 layout.$spacing-05 layout.$spacing-09;
-
-  :global(.cds--cc--layout-row) {
-    height: 0;
-  }
-
-  :global(.layout-child) {
-    margin-top: layout.$spacing-03;
-  }
-}
-
 .vitalsSignLabel {
   @extend .label01;
   margin-bottom: layout.$spacing-05;
   display: inline-block;
 }
 
-.verticalTabs {
-  margin: layout.$spacing-05 0;
-  scroll-behavior: smooth;
-
-  > ul {
-    flex-direction: column !important;
-  }
-
-  :global(.cds--tabs--scrollable .cds--tabs--scrollable__nav-item + .cds--tabs--scrollable__nav-item) {
-    margin-left: 0;
-  }
-
-  :global(.cds--tabs--scrollable .cds--tabs--scrollable__nav-link) {
-    border-bottom: 0 !important;
-    border-left: layout.$spacing-01 solid $color-gray-30;
-  }
-}
-
 .tab {
   outline: 0;
   outline-offset: 0;
-  min-height: layout.$spacing-07;
+  min-height: layout.$spacing-07 !important;
+  block-size: layout.$spacing-05 !important;
 
   &:active,
   &:focus {
@@ -71,7 +41,7 @@
   }
 
   &[aria-selected='true'] {
-    border-left: 3px solid var(--brand-03);
+    box-shadow: inset 4px 0 0 0 var(--brand-03) !important;
     border-bottom: none;
     font-weight: 600;
     margin-left: 0 !important;
@@ -81,17 +51,5 @@
     border-bottom: none;
     border-left: layout.$spacing-01 solid $ui-03;
     margin-left: 0 !important;
-  }
-}
-
-.tablist {
-  :global(.cds--tab--list) {
-    flex-direction: column;
-    max-height: fit-content;
-    overflow-x: visible;
-  }
-
-  > button :global(.cds--tabs .cds--tabs__nav-link) {
-    border-bottom: none;
   }
 }

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -25,6 +25,22 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   disconnect: jest.fn(),
 }));
 
+jest.mock('@carbon/charts-react', () => ({
+  LineChart: () => <div data-testid="line-chart">Line Chart</div>,
+  ScaleTypes: {
+    TIME: 'time',
+    LINEAR: 'linear',
+    LOG: 'log',
+    LABELS: 'labels',
+    LABELS_RATIO: 'labels-ratio',
+  },
+  TickRotations: {
+    ALWAYS: 'always',
+    AUTO: 'auto',
+    NEVER: 'never',
+  },
+}));
+
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
 

--- a/tools/setup-tests.ts
+++ b/tools/setup-tests.ts
@@ -25,3 +25,9 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: jest.fn(),
   })),
 });
+
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR follows up on #2124 by refactoring chart views in the Patient Chart component to use the new [TabsVertical and TabListVertical Carbon components](https://react.carbondesignsystem.com/?path=/docs/components-tabs--overview#vertical-tabs). Previously, without proper vertical tabs support from Carbon, we relied on CSS hacks to render navigation tablists vertically. With the recent Carbon migration, we can now use the proper components for vertical tab layouts.

Other changes in this diff include:

- Improved type safety and code organization
- Optimized chart data handling
- Removed unused styles
- Replaced hard-coded enums with scale types and tick rotations from @carbon/charts-react

## Screenshots

Note the presence of a scrollbar in the before screenshots.

### Tablet

#### Before

![CleanShot 2025-04-02 at 9  50 18@2x](https://github.com/user-attachments/assets/8ecff3e4-c867-4ce6-ad01-a6042f61049c)

#### After

![CleanShot 2025-04-02 at 9  50 32@2x](https://github.com/user-attachments/assets/a6e5de4a-ef8d-459a-8092-89a3ea7b2bb6)

### Desktop

#### Before

![CleanShot 2025-04-02 at 9  51 33@2x](https://github.com/user-attachments/assets/97d28e35-5f84-40b7-b8c1-2b8020d945d1)

#### After

![CleanShot 2025-04-02 at 9  51 09@2x](https://github.com/user-attachments/assets/426576e0-12d6-42b1-be1b-fd3695017f04)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other


The current visual difference after switching to the new tab components is that they use the `contained` variant by default, which gives them a gray background instead of the previous white background. Rather than using styling hacks to override this, we should keep it as is. Carbon will likely add support for the [default variant](https://react.carbondesignsystem.com/?path=/story/components-tabs--default) with white background in the near future.