### PR TITLE
(fix) O3-4598 add visit context switcher to 'Add vitals' workspace

### DIFF
--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/add-test-order.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/add-test-order.test.tsx
@@ -4,6 +4,7 @@ import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import { _resetOrderBasketStore } from '@openmrs/esm-patient-common-lib/src/orders/store';
 import { type PostDataPrepLabOrderFunction } from '../api';
 import {
+  age,
   closeWorkspace,
   getDefaultsFromConfigSchema,
   useConfig,
@@ -218,7 +219,7 @@ describe('AddLabOrder', () => {
     renderAddLabOrderWorkspace();
     expect(screen.getByText(/john wilson/i)).toBeInTheDocument();
     expect(screen.getByText(/male/i)).toBeInTheDocument();
-    expect(screen.getByText(/52 yrs/i)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(age(mockPatient.birthDate), 'i'))).toBeInTheDocument();
     expect(screen.getByText('04 — Apr — 1972')).toBeInTheDocument();
   });
 

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-base.component.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ContentSwitcher, DataTableSkeleton, IconSwitch, InlineLoading } from '@carbon/react';
 import { Add, Analytics, Table } from '@carbon/react/icons';
 import { formatDatetime, parseDate, useConfig, useLayoutType } from '@openmrs/esm-framework';
-import { CardHeader, EmptyState, ErrorState, useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
-import { launchVitalsAndBiometricsForm } from '../utils';
+import { CardHeader, EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
+import { useLaunchVitalsAndBiometricsForm } from '../utils';
 import { useVitalsConceptMetadata, useVitalsAndBiometrics, withUnit } from '../common';
 import { type ConfigObject } from '../config-schema';
 import type { BiometricsTableHeader, BiometricsTableRow } from './types';
@@ -30,12 +30,7 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({ patientUuid, pageSize, 
   const { bmiUnit } = config.biometrics;
   const { data: biometrics, isLoading, error, isValidating } = useVitalsAndBiometrics(patientUuid, 'biometrics');
   const { data: conceptUnits } = useVitalsConceptMetadata();
-  const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
-
-  const launchBiometricsForm = useCallback(
-    () => launchVitalsAndBiometricsForm(currentVisit, config),
-    [config, currentVisit],
-  );
+  const launchBiometricsForm = useLaunchVitalsAndBiometricsForm();
 
   const tableHeaders: Array<BiometricsTableHeader> = [
     {

--- a/packages/esm-patient-vitals-app/src/utils.ts
+++ b/packages/esm-patient-vitals-app/src/utils.ts
@@ -1,39 +1,32 @@
-import { type Visit } from '@openmrs/esm-framework';
-import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
+import { useConfig } from '@openmrs/esm-framework';
+import { useLaunchWorkspaceRequiringVisit } from '@openmrs/esm-patient-common-lib';
 import { type ConfigObject } from './config-schema';
 import { patientVitalsBiometricsFormWorkspace } from './constants';
 import { invalidateCachedVitalsAndBiometrics } from './common';
-
-/**
- * Launches the for entry workspace with the custom form
- *
- * @param formUuid The form to use
- * @param encounterUuid The current encounter, if any
- * @param formName The name of the form to use
- */
-export function launchFormEntry(formUuid: string, encounterUuid?: string, formName?: string) {
-  launchPatientWorkspace('patient-form-entry-workspace', {
-    workspaceTitle: formName,
-    formInfo: { formUuid, encounterUuid },
-    mutateForm: invalidateCachedVitalsAndBiometrics,
-  });
-}
+import { useCallback } from 'react';
 
 /**
  * Launches the appropriate workspace based on the current visit and configuration.
  * @param currentVisit - The current visit.
  * @param config - The configuration object.
  */
-export function launchVitalsAndBiometricsForm(currentVisit: Visit, config: ConfigObject) {
-  if (!currentVisit) {
-    launchStartVisitPrompt();
-    return;
-  }
+export function useLaunchVitalsAndBiometricsForm() {
+  const config = useConfig<ConfigObject>();
+  const { useFormEngine, formName, formUuid } = config.vitals;
+  const launchVitalsAndBiometricsForm = useLaunchWorkspaceRequiringVisit(
+    useFormEngine ? 'patient-form-entry-workspace' : patientVitalsBiometricsFormWorkspace,
+  );
 
-  if (config.vitals.useFormEngine) {
-    const { formUuid, formName } = config.vitals;
-    launchFormEntry(formUuid, '', formName);
-  } else {
-    launchPatientWorkspace(patientVitalsBiometricsFormWorkspace);
-  }
+  const launchVitalsAndBiometricsFormNoParams = useCallback(() => {
+    const workspaceProps = useFormEngine
+      ? {
+          workspaceTitle: formName,
+          formInfo: { formUuid, encounterUuid: '' },
+          mutateForm: invalidateCachedVitalsAndBiometrics,
+        }
+      : {};
+    launchVitalsAndBiometricsForm(workspaceProps);
+  }, [useFormEngine, formName, formUuid, launchVitalsAndBiometricsForm]);
+
+  return launchVitalsAndBiometricsFormNoParams;
 }

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
@@ -18,7 +18,7 @@ import {
   useVitalsConceptMetadata,
 } from '../common';
 import { type ConfigObject } from '../config-schema';
-import { launchVitalsAndBiometricsForm as launchForm } from '../utils';
+import { useLaunchVitalsAndBiometricsForm } from '../utils';
 import VitalsHeaderItem from './vitals-header-item.component';
 import styles from './vitals-header.scss';
 
@@ -43,13 +43,14 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, hideLinks = fa
   const { workspaces } = useWorkspaces();
 
   const isWorkspaceOpen = useCallback(() => Boolean(workspaces?.length), [workspaces]);
+  const launchForm = useLaunchVitalsAndBiometricsForm();
 
   const launchVitalsAndBiometricsForm = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.stopPropagation();
-      launchForm(currentVisit, config);
+      launchForm();
     },
-    [config, currentVisit],
+    [launchForm],
   );
 
   if (isLoading) {

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
@@ -274,6 +274,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
   if (isLoadingConceptMetadata || isLoadingInitialValues) {
     return (
       <Form className={styles.form}>
+        <ExtensionSlot name="visit-context-header-slot" state={{ patientUuid }} />
         <div className={styles.grid}>
           <Stack>
             <Column>
@@ -305,6 +306,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
 
   return (
     <Form className={styles.form} data-openmrs-role="Vitals and Biometrics Form">
+      <ExtensionSlot name="visit-context-header-slot" state={{ patientUuid }} />
       <div className={styles.grid}>
         <Stack>
           <Column>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.component.tsx
@@ -1,9 +1,9 @@
-import React, { type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { type ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useReactToPrint } from 'react-to-print';
 import { Button, ContentSwitcher, DataTableSkeleton, IconSwitch, InlineLoading } from '@carbon/react';
 import { Analytics, Table } from '@carbon/react/icons';
-import { CardHeader, EmptyState, ErrorState, useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import {
   AddIcon,
   PrinterIcon,
@@ -15,7 +15,7 @@ import {
   useLayoutType,
 } from '@openmrs/esm-framework';
 import type { ConfigObject } from '../config-schema';
-import { launchVitalsAndBiometricsForm } from '../utils';
+import { useLaunchVitalsAndBiometricsForm } from '../utils';
 import { useVitalsAndBiometrics, useVitalsConceptMetadata, withUnit } from '../common';
 import type { VitalsTableHeader, VitalsTableRow } from './types';
 import PaginatedVitals from './paginated-vitals.component';
@@ -37,19 +37,15 @@ const VitalsOverview: React.FC<VitalsOverviewProps> = ({ patientUuid, patient, p
   const config = useConfig<ConfigObject>();
   const headerTitle = t('vitals', 'Vitals');
   const [chartView, setChartView] = useState(false);
-  const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
   const isTablet = useLayoutType() === 'tablet';
   const [isPrinting, setIsPrinting] = useState(false);
   const contentToPrintRef = useRef(null);
+  const launchVitalsBiometricsForm = useLaunchVitalsAndBiometricsForm();
 
   const { excludePatientIdentifierCodeTypes } = useConfig();
   const { data: vitals, error, isLoading, isValidating } = useVitalsAndBiometrics(patientUuid);
   const { data: conceptUnits } = useVitalsConceptMetadata();
   const showPrintButton = config.vitals.showPrintButton && !chartView;
-
-  const launchVitalsBiometricsForm = useCallback(() => {
-    launchVitalsAndBiometricsForm(currentVisit, config);
-  }, [config, currentVisit]);
 
   useEncounterVitalsAndBiometrics('771bbc44-8d45-4ac3-af6e-059814dd7cde');
   const patientDetails = useMemo(() => {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
When 'rde' feature flag is enabled, the `useLaunchWorkspaceRequiringVisit` to show the visit context switcher if not visit is in context. This PR makes change to use that hook for launching the vitals form as well. It also adds the visit context header to the workspace.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/c4615b9a-6550-4da6-8e0f-7bdf7c407f2a


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4598

## Other
<!-- Anything not covered above -->
