### PR TITLE
(refactor) O3-4610: Improve type safety in test results app

### DIFF
--- a/packages/esm-patient-tests-app/src/test-results/filter/filter-context.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/filter/filter-context.tsx
@@ -160,6 +160,7 @@ const FilterProvider = ({ roots, children }: FilterProviderProps) => {
         ...state,
         timelineData,
         tableData,
+        trendlineData: null,
         activeTests,
         someChecked,
         totalResultsCount,

--- a/packages/esm-patient-tests-app/src/test-results/filter/filter-types.ts
+++ b/packages/esm-patient-tests-app/src/test-results/filter/filter-types.ts
@@ -1,4 +1,5 @@
 import { type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
+import { type GroupedObservation } from '../../types';
 
 interface Observation {
   display: string;
@@ -101,13 +102,14 @@ export interface TimelineData {
 
 export interface FilterContextProps extends ReducerState {
   timelineData: TimelineData;
-  tableData?: any;
+  tableData: GroupedObservation[] | null;
+  trendlineData: TreeNode | null;
   activeTests: string[];
   someChecked: boolean;
   totalResultsCount: number;
-  initialize: any;
-  toggleVal: any;
-  updateParent: any;
+  initialize: (trees: Array<TreeNode>) => void;
+  toggleVal: (name: string) => void;
+  updateParent: (name: string) => void;
   resetTree: () => void;
 }
 

--- a/packages/esm-patient-tests-app/src/test-results/grouped-timeline/grouped-timeline.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/grouped-timeline/grouped-timeline.test.tsx
@@ -13,6 +13,8 @@ describe('GroupedTimeline', () => {
   const mockFilterContext: FilterContextProps = {
     activeTests: ['Bloodwork-Chemistry', 'Bloodwork'],
     timelineData: mockGroupedResults.timelineData,
+    tableData: null,
+    trendlineData: null,
     parents: mockGroupedResults.parents,
     checkboxes: { Bloodwork: false, Chemistry: true },
     someChecked: false,

--- a/packages/esm-patient-tests-app/src/test-results/tree-view/tree-view-wrapper.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/tree-view/tree-view-wrapper.test.tsx
@@ -36,6 +36,8 @@ const mockProps = {
 const mockFilterContext: FilterContextProps = {
   activeTests: ['Bloodwork-Chemistry', 'Bloodwork'],
   timelineData: mockGroupedResults.timelineData,
+  tableData: null,
+  trendlineData: null,
   parents: mockGroupedResults.parents,
   checkboxes: { Bloodwork: false, Chemistry: true },
   someChecked: true,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Fixed multiple TypeScript issues in the test-results package. The main problems were:

The missing `trendlineData` property in the `FilterContext.Provider` implementation, which was required by the interface definition
Several function types in the `FilterContextProps` interface that were using the generic `any` type instead of proper TypeScript types

For the functions, replaced the `any` types with specific type signatures:

`initialize: (trees: Array<TreeNode>) => void`
`toggleVal: (name: string) => void`
`updateParent: (name: string) => void`
`resetTree: () => void`

Also fixed the `tableData` type to be `GroupedObservation[] | null` instead of `any`.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4610
## Other
<!-- Anything not covered above -->
