### PR TITLE
(refactor) O3-4612: Improve type safety in patient chart clinical views 

### DIFF
--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list.component.tsx
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list.component.tsx
@@ -10,14 +10,6 @@ import { useEncounterRows, useFormsJson } from '../hooks';
 import type { TableRow, Encounter, Mode, ColumnValue, FormattedColumn } from '../types';
 import styles from './encounter-list.scss';
 
-
-export interface EncounterListColumn {
-  key: string;
-  header: string;
-  getValue: (encounter: Encounter) => ColumnValue;
-  link?: any;
-}
-
 export interface EncounterListProps {
   patientUuid: string;
   encounterType: string;

--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-list/table.component.tsx
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-list/table.component.tsx
@@ -9,21 +9,15 @@ import {
   TableHeader,
   TableRow,
 } from '@carbon/react';
-
+import { type TableHeaderType, type TableRow as TableRowType } from '../types';
 import styles from './table.scss';
-import { type TableRow as TableRowType } from '../types';
 
-type TableHeaderType = {
-  key: string;
-  header: string;
-};
-
-interface TableProps {
-  tableHeaders: TableHeaderType[];
-  tableRows: TableRowType[];
+interface EncounterListDataTableProps {
+  tableHeaders: Array<TableHeaderType>;
+  tableRows: Array<TableRowType>;
 }
 
-export const EncounterListDataTable: React.FC<TableProps> = ({ tableHeaders, tableRows }) => {
+export const EncounterListDataTable: React.FC<EncounterListDataTableProps> = ({ tableHeaders, tableRows }) => {
   return (
     <TableContainer>
       <DataTable rows={tableRows} headers={tableHeaders} isSortable={true} size="md">

--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-list/table.component.tsx
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-list/table.component.tsx
@@ -11,10 +11,16 @@ import {
 } from '@carbon/react';
 
 import styles from './table.scss';
+import { type TableRow as TableRowType } from '../types';
+
+type TableHeaderType = {
+  key: string;
+  header: string;
+};
 
 interface TableProps {
-  tableHeaders: any;
-  tableRows: any;
+  tableHeaders: TableHeaderType[];
+  tableRows: TableRowType[];
 }
 
 export const EncounterListDataTable: React.FC<TableProps> = ({ tableHeaders, tableRows }) => {

--- a/packages/esm-patient-chart-app/src/clinical-views/types.ts
+++ b/packages/esm-patient-chart-app/src/clinical-views/types.ts
@@ -1,5 +1,10 @@
-import { type OpenmrsResource } from '@openmrs/esm-framework';
 import { type ReactElement } from 'react';
+import { type OpenmrsResource } from '@openmrs/esm-framework';
+
+export type TableHeaderType = {
+  key: string;
+  header: string;
+};
 
 export interface Encounter extends OpenmrsResource {
   encounterDatetime: Date;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounters-table/encounters-table.component.tsx
@@ -20,7 +20,7 @@ import {
   TableToolbarSearch,
   Tile,
 } from '@carbon/react';
-import { formatDatetime, parseDate, useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { formatDatetime, parseDate, useLayoutType, usePagination, type Obs } from '@openmrs/esm-framework';
 import { ErrorState, EmptyState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import EncounterObservations from '../encounter-observations';
 import { useEncounters } from '../visit.resource';
@@ -28,21 +28,14 @@ import styles from './encounters-table.scss';
 
 interface Encounter {
   datetime?: string;
-  [key: string]: any;
+  obs?: Array<Obs>;
+  [key: string]: unknown | string | Array<Obs>;
 }
 
 interface EncountersTableProps {
   encounters: Array<Encounter>;
   showAllEncounters?: boolean;
 }
-
-type FilterProps = {
-  rowIds: Array<string>;
-  headers: Array<typeof DataTableHeader>;
-  cellsById: any;
-  inputValue: string;
-  getCellId: (row, key) => string;
-};
 
 const transformEncounters = (inData) => {
   if (!inData) return [];

--- a/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-view.component.tsx
@@ -44,14 +44,6 @@ interface FormViewProps {
   mutateForms?: () => void;
 }
 
-interface FilterProps {
-  rowIds: Array<string>;
-  headers: Array<Record<string, string>>;
-  cellsById: any;
-  inputValue: string;
-  getCellId: (row, key) => string;
-}
-
 const FormView: React.FC<FormViewProps> = ({
   category,
   forms,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This issue cleans up some of the older, loosely typed code in the patient chart and forms apps. I removed a few redundant interfaces (like `EncounterListColumn` and `FilterProps`) and replaced a bunch of `any` types with more meaningful, strongly typed ones like `FormattedColumn`, `TableRow`, and `Obs`.
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4612
## Other
<!-- Anything not covered above -->
