### PR TITLE
(fix) O3-4480: Fix default content switcher index in visit detail overview page

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.component.tsx
@@ -48,7 +48,7 @@ function VisitDetailOverviewComponent({ patientUuid }: VisitOverviewComponentPro
         <TabPanels>
           <TabPanel>
             <div className={styles.contentSwitcherContainer}>
-              <ContentSwitcher onChange={(event) => setVisitSummaryMode(event.name)}>
+              <ContentSwitcher selectedIndex={1} onChange={(event) => setVisitSummaryMode(event.name)}>
                 <Switch name="table" text={t('table', 'Table')} />
                 <Switch name="cards" text={t('summaryCards', 'Summary cards')} />
               </ContentSwitcher>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The visit overview's content switcher initial index is not properly set to the 'card' tab. This PR fixes it.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![image](https://github.com/user-attachments/assets/95f5301c-0db2-48b4-aa5d-129988861afb)

After:
![image](https://github.com/user-attachments/assets/078e85b5-bad2-4145-ae87-a0cb3f8322ae)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
