### PR TITLE
(fix) O3-4363: Fix form container layout styling in Visit Notes and Vitals & Biometrics forms

### DIFF
--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -128,6 +128,7 @@
 
 .formContainer {
   margin: layout.$spacing-05;
+  flex: 1;
 }
 
 .form {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
@@ -435,209 +435,211 @@ const VisitNotesForm: React.FC<DefaultPatientWorkspaceProps> = ({
         </Row>
       )}
 
-      <Stack className={styles.formContainer} gap={2}>
-        {isTablet ? <h2 className={styles.heading}>{t('addVisitNote', 'Add a visit note')}</h2> : null}
-        <Row className={styles.row}>
-          <Column sm={1}>
-            <span className={styles.columnLabel}>{t('date', 'Date')}</span>
-          </Column>
-          <Column sm={3}>
-            <Controller
-              name="noteDate"
-              control={control}
-              render={({ field, fieldState }) => (
-                <ResponsiveWrapper>
-                  <OpenmrsDatePicker
-                    {...field}
-                    maxDate={new Date()}
-                    id="visitDateTimePicker"
-                    data-testid="visitDateTimePicker"
-                    labelText={t('visitDate', 'Visit date')}
-                    invalid={Boolean(fieldState?.error?.message)}
-                    invalidText={fieldState?.error?.message}
-                  />
-                </ResponsiveWrapper>
-              )}
-            />
-          </Column>
-        </Row>
-        <div className={styles.diagnosesText}>
-          {selectedPrimaryDiagnoses && selectedPrimaryDiagnoses.length ? (
-            <>
-              {selectedPrimaryDiagnoses.map((diagnosis, index) => (
-                <Tag
-                  className={styles.tag}
-                  filter
-                  key={index}
-                  onClose={() => handleRemoveDiagnosis(diagnosis, 'primaryInputSearch')}
-                  type="red"
-                >
-                  {diagnosis.display}
-                </Tag>
-              ))}
-            </>
-          ) : null}
-          {selectedSecondaryDiagnoses && selectedSecondaryDiagnoses.length ? (
-            <>
-              {selectedSecondaryDiagnoses.map((diagnosis, index) => (
-                <Tag
-                  classname={styles.tag}
-                  filter
-                  key={index}
-                  onClose={() => handleRemoveDiagnosis(diagnosis, 'secondaryInputSearch')}
-                  type="blue"
-                >
-                  {diagnosis.display}
-                </Tag>
-              ))}
-            </>
-          ) : null}
-          {selectedPrimaryDiagnoses &&
-            !selectedPrimaryDiagnoses.length &&
-            selectedSecondaryDiagnoses &&
-            !selectedSecondaryDiagnoses.length && (
-              <span>{t('emptyDiagnosisText', 'No diagnosis selected — Enter a diagnosis below')}</span>
-            )}
-        </div>
-        <Row className={styles.row}>
-          <Column sm={1}>
-            <span className={styles.columnLabel}>{t('primaryDiagnosis', 'Primary diagnosis')}</span>
-          </Column>
-          <Column sm={3}>
-            <FormGroup legendText={t('searchForPrimaryDiagnosis', 'Search for a primary diagnosis')}>
-              <DiagnosisSearch
-                name="primaryDiagnosisSearch"
+      <div className={styles.formContainer}>
+        <Stack gap={2}>
+          {isTablet ? <h2 className={styles.heading}>{t('addVisitNote', 'Add a visit note')}</h2> : null}
+          <Row className={styles.row}>
+            <Column sm={1}>
+              <span className={styles.columnLabel}>{t('date', 'Date')}</span>
+            </Column>
+            <Column sm={3}>
+              <Controller
+                name="noteDate"
                 control={control}
-                labelText={t('enterPrimaryDiagnoses', 'Enter Primary diagnoses')}
-                placeholder={t('primaryDiagnosisInputPlaceholder', 'Choose a primary diagnosis')}
-                handleSearch={handleSearch}
-                error={errors?.primaryDiagnosisSearch}
-                setIsSearching={setIsSearching}
+                render={({ field, fieldState }) => (
+                  <ResponsiveWrapper>
+                    <OpenmrsDatePicker
+                      {...field}
+                      maxDate={new Date()}
+                      id="visitDateTimePicker"
+                      data-testid="visitDateTimePicker"
+                      labelText={t('visitDate', 'Visit date')}
+                      invalid={Boolean(fieldState?.error?.message)}
+                      invalidText={fieldState?.error?.message}
+                    />
+                  </ResponsiveWrapper>
+                )}
               />
-              {error ? (
-                <InlineNotification
-                  className={styles.errorNotification}
-                  lowContrast
-                  title={t('error', 'Error')}
-                  subtitle={t('errorFetchingConcepts', 'There was a problem fetching concepts') + '.'}
-                  onClose={() => setError(null)}
-                />
-              ) : null}
-              <DiagnosesDisplay
-                fieldName={'primaryDiagnosisSearch'}
-                isDiagnosisNotSelected={isDiagnosisNotSelected}
-                isLoading={isLoadingPrimaryDiagnoses}
-                isSearching={isSearching}
-                onAddDiagnosis={handleAddDiagnosis}
-                searchResults={searchPrimaryResults}
-                t={t}
-                value={watch('primaryDiagnosisSearch')}
-              />
-            </FormGroup>
-          </Column>
-        </Row>
-        <Row className={styles.row}>
-          <Column sm={1}>
-            <span className={styles.columnLabel}>{t('secondaryDiagnosis', 'Secondary diagnosis')}</span>
-          </Column>
-          <Column sm={3}>
-            <FormGroup legendText={t('searchForSecondaryDiagnosis', 'Search for a secondary diagnosis')}>
-              <DiagnosisSearch
-                name="secondaryDiagnosisSearch"
-                control={control}
-                labelText={t('enterSecondaryDiagnoses', 'Enter Secondary diagnoses')}
-                placeholder={t('secondaryDiagnosisInputPlaceholder', 'Choose a secondary diagnosis')}
-                handleSearch={handleSearch}
-                setIsSearching={setIsSearching}
-              />
-              {error ? (
-                <InlineNotification
-                  className={styles.errorNotification}
-                  lowContrast
-                  title={t('error', 'Error')}
-                  subtitle={t('errorFetchingConcepts', 'There was a problem fetching concepts') + '.'}
-                  onClose={() => setError(null)}
-                />
-              ) : null}
-              <DiagnosesDisplay
-                fieldName={'secondaryDiagnosisSearch'}
-                isDiagnosisNotSelected={isDiagnosisNotSelected}
-                isLoading={isLoadingSecondaryDiagnoses}
-                isSearching={isSearching}
-                onAddDiagnosis={handleAddDiagnosis}
-                searchResults={searchSecondaryResults}
-                t={t}
-                value={watch('secondaryDiagnosisSearch')}
-              />
-            </FormGroup>
-          </Column>
-        </Row>
-        <Row className={styles.row}>
-          <Column sm={1}>
-            <span className={styles.columnLabel}>{t('note', 'Note')}</span>
-          </Column>
-          <Column sm={3}>
-            <Controller
-              name="clinicalNote"
-              control={control}
-              render={({ field: { onChange, onBlur, value } }) => (
-                <ResponsiveWrapper>
-                  <TextArea
-                    id="additionalNote"
-                    rows={rows}
-                    labelText={t('clinicalNoteLabel', 'Write your notes')}
-                    placeholder={t('clinicalNotePlaceholder', 'Write any notes here')}
-                    value={value}
-                    onBlur={onBlur}
-                    onChange={(event) => {
-                      onChange(event);
-                      const textareaLineHeight = 24; // This is the default line height for Carbon's TextArea component
-                      const newRows = Math.ceil(event.target.scrollHeight / textareaLineHeight);
-                      setRows(newRows);
-                    }}
-                  />
-                </ResponsiveWrapper>
-              )}
-            />
-          </Column>
-        </Row>
-        <Row className={styles.row}>
-          <Column sm={1}>
-            <span className={styles.columnLabel}>{t('image', 'Image')}</span>
-          </Column>
-          <Column sm={3}>
-            <FormGroup legendText="">
-              <p className={styles.imgUploadHelperText}>
-                {t('imageUploadHelperText', "Upload images or use this device's camera to capture images")}
-              </p>
-              <Button
-                className={styles.uploadButton}
-                kind={isTablet ? 'ghost' : 'tertiary'}
-                onClick={showImageCaptureModal}
-                renderIcon={(props) => <Add size={16} {...props} />}
-              >
-                {t('addImage', 'Add image')}
-              </Button>
-              <div className={styles.imgThumbnailGrid}>
-                {currentImages?.map((image, index) => (
-                  <div key={index} className={styles.imgThumbnailItem}>
-                    <div className={styles.imgThumbnailContainer}>
-                      <img
-                        className={styles.imgThumbnail}
-                        src={image.base64Content}
-                        alt={image.fileDescription ?? image.fileName}
-                      />
-                    </div>
-                    <Button kind="ghost" className={styles.removeButton} onClick={() => handleRemoveImage(index)}>
-                      <CloseFilled size={16} className={styles.closeIcon} />
-                    </Button>
-                  </div>
+            </Column>
+          </Row>
+          <div className={styles.diagnosesText}>
+            {selectedPrimaryDiagnoses && selectedPrimaryDiagnoses.length ? (
+              <>
+                {selectedPrimaryDiagnoses.map((diagnosis, index) => (
+                  <Tag
+                    className={styles.tag}
+                    filter
+                    key={index}
+                    onClose={() => handleRemoveDiagnosis(diagnosis, 'primaryInputSearch')}
+                    type="red"
+                  >
+                    {diagnosis.display}
+                  </Tag>
                 ))}
-              </div>
-            </FormGroup>
-          </Column>
-        </Row>
-      </Stack>
+              </>
+            ) : null}
+            {selectedSecondaryDiagnoses && selectedSecondaryDiagnoses.length ? (
+              <>
+                {selectedSecondaryDiagnoses.map((diagnosis, index) => (
+                  <Tag
+                    classname={styles.tag}
+                    filter
+                    key={index}
+                    onClose={() => handleRemoveDiagnosis(diagnosis, 'secondaryInputSearch')}
+                    type="blue"
+                  >
+                    {diagnosis.display}
+                  </Tag>
+                ))}
+              </>
+            ) : null}
+            {selectedPrimaryDiagnoses &&
+              !selectedPrimaryDiagnoses.length &&
+              selectedSecondaryDiagnoses &&
+              !selectedSecondaryDiagnoses.length && (
+                <span>{t('emptyDiagnosisText', 'No diagnosis selected — Enter a diagnosis below')}</span>
+              )}
+          </div>
+          <Row className={styles.row}>
+            <Column sm={1}>
+              <span className={styles.columnLabel}>{t('primaryDiagnosis', 'Primary diagnosis')}</span>
+            </Column>
+            <Column sm={3}>
+              <FormGroup legendText={t('searchForPrimaryDiagnosis', 'Search for a primary diagnosis')}>
+                <DiagnosisSearch
+                  name="primaryDiagnosisSearch"
+                  control={control}
+                  labelText={t('enterPrimaryDiagnoses', 'Enter Primary diagnoses')}
+                  placeholder={t('primaryDiagnosisInputPlaceholder', 'Choose a primary diagnosis')}
+                  handleSearch={handleSearch}
+                  error={errors?.primaryDiagnosisSearch}
+                  setIsSearching={setIsSearching}
+                />
+                {error ? (
+                  <InlineNotification
+                    className={styles.errorNotification}
+                    lowContrast
+                    title={t('error', 'Error')}
+                    subtitle={t('errorFetchingConcepts', 'There was a problem fetching concepts') + '.'}
+                    onClose={() => setError(null)}
+                  />
+                ) : null}
+                <DiagnosesDisplay
+                  fieldName={'primaryDiagnosisSearch'}
+                  isDiagnosisNotSelected={isDiagnosisNotSelected}
+                  isLoading={isLoadingPrimaryDiagnoses}
+                  isSearching={isSearching}
+                  onAddDiagnosis={handleAddDiagnosis}
+                  searchResults={searchPrimaryResults}
+                  t={t}
+                  value={watch('primaryDiagnosisSearch')}
+                />
+              </FormGroup>
+            </Column>
+          </Row>
+          <Row className={styles.row}>
+            <Column sm={1}>
+              <span className={styles.columnLabel}>{t('secondaryDiagnosis', 'Secondary diagnosis')}</span>
+            </Column>
+            <Column sm={3}>
+              <FormGroup legendText={t('searchForSecondaryDiagnosis', 'Search for a secondary diagnosis')}>
+                <DiagnosisSearch
+                  name="secondaryDiagnosisSearch"
+                  control={control}
+                  labelText={t('enterSecondaryDiagnoses', 'Enter Secondary diagnoses')}
+                  placeholder={t('secondaryDiagnosisInputPlaceholder', 'Choose a secondary diagnosis')}
+                  handleSearch={handleSearch}
+                  setIsSearching={setIsSearching}
+                />
+                {error ? (
+                  <InlineNotification
+                    className={styles.errorNotification}
+                    lowContrast
+                    title={t('error', 'Error')}
+                    subtitle={t('errorFetchingConcepts', 'There was a problem fetching concepts') + '.'}
+                    onClose={() => setError(null)}
+                  />
+                ) : null}
+                <DiagnosesDisplay
+                  fieldName={'secondaryDiagnosisSearch'}
+                  isDiagnosisNotSelected={isDiagnosisNotSelected}
+                  isLoading={isLoadingSecondaryDiagnoses}
+                  isSearching={isSearching}
+                  onAddDiagnosis={handleAddDiagnosis}
+                  searchResults={searchSecondaryResults}
+                  t={t}
+                  value={watch('secondaryDiagnosisSearch')}
+                />
+              </FormGroup>
+            </Column>
+          </Row>
+          <Row className={styles.row}>
+            <Column sm={1}>
+              <span className={styles.columnLabel}>{t('note', 'Note')}</span>
+            </Column>
+            <Column sm={3}>
+              <Controller
+                name="clinicalNote"
+                control={control}
+                render={({ field: { onChange, onBlur, value } }) => (
+                  <ResponsiveWrapper>
+                    <TextArea
+                      id="additionalNote"
+                      rows={rows}
+                      labelText={t('clinicalNoteLabel', 'Write your notes')}
+                      placeholder={t('clinicalNotePlaceholder', 'Write any notes here')}
+                      value={value}
+                      onBlur={onBlur}
+                      onChange={(event) => {
+                        onChange(event);
+                        const textareaLineHeight = 24; // This is the default line height for Carbon's TextArea component
+                        const newRows = Math.ceil(event.target.scrollHeight / textareaLineHeight);
+                        setRows(newRows);
+                      }}
+                    />
+                  </ResponsiveWrapper>
+                )}
+              />
+            </Column>
+          </Row>
+          <Row className={styles.row}>
+            <Column sm={1}>
+              <span className={styles.columnLabel}>{t('image', 'Image')}</span>
+            </Column>
+            <Column sm={3}>
+              <FormGroup legendText="">
+                <p className={styles.imgUploadHelperText}>
+                  {t('imageUploadHelperText', "Upload images or use this device's camera to capture images")}
+                </p>
+                <Button
+                  className={styles.uploadButton}
+                  kind={isTablet ? 'ghost' : 'tertiary'}
+                  onClick={showImageCaptureModal}
+                  renderIcon={(props) => <Add size={16} {...props} />}
+                >
+                  {t('addImage', 'Add image')}
+                </Button>
+                <div className={styles.imgThumbnailGrid}>
+                  {currentImages?.map((image, index) => (
+                    <div key={index} className={styles.imgThumbnailItem}>
+                      <div className={styles.imgThumbnailContainer}>
+                        <img
+                          className={styles.imgThumbnail}
+                          src={image.base64Content}
+                          alt={image.fileDescription ?? image.fileName}
+                        />
+                      </div>
+                      <Button kind="ghost" className={styles.removeButton} onClick={() => handleRemoveImage(index)}>
+                        <CloseFilled size={16} className={styles.closeIcon} />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </FormGroup>
+            </Column>
+          </Row>
+        </Stack>
+      </div>
       <ButtonSet className={classnames({ [styles.tablet]: isTablet, [styles.desktop]: !isTablet })}>
         <Button className={styles.button} kind="secondary" onClick={closeWorkspace}>
           {t('discard', 'Discard')}

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.scss
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.scss
@@ -50,6 +50,7 @@
 
 .grid {
   margin: layout.$spacing-05;
+  flex: 1;
 }
 
 .row {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR improves the styling of form container layouts in the Visit Notes and Vitals & Biometrics forms by ensuring they properly expand to fill available space within their parent containers. This fixes an issue where the styling of these form containers broke following the addition of the `visit-context-header` extension slot.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/0c367914-63ed-4f46-8d78-3497a61f8c0f)

After (with 'rde' on):
![image](https://github.com/user-attachments/assets/f3f8fd4e-2619-4b8b-a644-a5ba32fd5367)

After (with 'rde' off):
![image](https://github.com/user-attachments/assets/37993521-be9c-4d1d-98d0-0bf1b9abcbd7)

## Related Issue

https://issues.openmrs.org/browse/O3-4363

## Other
<!-- Anything not covered above -->
