### PR TITLE
(feat) O3-4641: Allow add drug order panel to be used in other worksPaces

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
@@ -16,6 +16,10 @@ import styles from './add-drug-order.scss';
 
 export interface AddDrugOrderWorkspaceAdditionalProps {
   order: DrugOrderBasketItem;
+  /**
+   * Whether this workspace was launched from a workspace other than order basket.
+   */
+  outsideOrderBasketWorkspace?: boolean;
 }
 
 export interface AddDrugOrderWorkspace extends DefaultPatientWorkspaceProps, AddDrugOrderWorkspaceAdditionalProps {}
@@ -25,6 +29,7 @@ export default function AddDrugOrderWorkspace({
   closeWorkspace,
   closeWorkspaceWithSavedChanges,
   promptBeforeClosing,
+  outsideOrderBasketWorkspace,
 }: AddDrugOrderWorkspace) {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
@@ -34,10 +39,10 @@ export default function AddDrugOrderWorkspace({
 
   const cancelDrugOrder = useCallback(() => {
     closeWorkspace({
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      ...(!!outsideOrderBasketWorkspace ? {} : { onWorkspaceClose: () => launchPatientWorkspace('order-basket') }),
       closeWorkspaceGroup: false,
     });
-  }, [closeWorkspace]);
+  }, [closeWorkspace, outsideOrderBasketWorkspace]);
 
   const openOrderForm = useCallback(
     (searchResult: DrugOrderBasketItem) => {
@@ -68,10 +73,10 @@ export default function AddDrugOrderWorkspace({
       }
       setOrders(newOrders);
       closeWorkspaceWithSavedChanges({
-        onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+        ...(!!outsideOrderBasketWorkspace ? {} : { onWorkspaceClose: () => launchPatientWorkspace('order-basket') }),
       });
     },
-    [orders, setOrders, closeWorkspaceWithSavedChanges, session.currentProvider.uuid],
+    [orders, setOrders, closeWorkspaceWithSavedChanges, session.currentProvider.uuid, outsideOrderBasketWorkspace],
   );
 
   if (!currentOrder) {
@@ -86,11 +91,13 @@ export default function AddDrugOrderWorkspace({
               renderIcon={(props: ComponentProps<typeof ArrowLeftIcon>) => <ArrowLeftIcon size={24} {...props} />}
               size="sm"
             >
-              <span>{t('backToOrderBasket', 'Back to order basket')}</span>
+              <span>
+                {!!outsideOrderBasketWorkspace ? t('back', 'Back') : t('backToOrderBasket', 'Back to order basket')}
+              </span>
             </Button>
           </div>
         )}
-        <DrugSearch openOrderForm={openOrderForm} />
+        <DrugSearch openOrderForm={openOrderForm} outsideOrderBasketWorkspace={outsideOrderBasketWorkspace} />
       </>
     );
   } else {
@@ -100,6 +107,7 @@ export default function AddDrugOrderWorkspace({
         onSave={saveDrugOrder}
         onCancel={cancelDrugOrder}
         promptBeforeClosing={promptBeforeClosing}
+        outsideOrderBasketWorkspace={outsideOrderBasketWorkspace}
       />
     );
   }

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -56,6 +56,7 @@ export interface DrugOrderFormProps {
   onSave: (finalizedOrder: DrugOrderBasketItem) => void;
   onCancel: () => void;
   promptBeforeClosing: (testFcn: () => boolean) => void;
+  outsideOrderBasketWorkspace?: boolean;
 }
 
 function useCreateMedicationOrderFormSchema() {
@@ -224,7 +225,13 @@ function InputWrapper({ children }) {
   );
 }
 
-export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, promptBeforeClosing }: DrugOrderFormProps) {
+export function DrugOrderForm({
+  initialOrderBasketItem,
+  onSave,
+  onCancel,
+  promptBeforeClosing,
+  outsideOrderBasketWorkspace,
+}: DrugOrderFormProps) {
   const { t } = useTranslation();
   const config = useConfig<ConfigObject>();
   const isTablet = useLayoutType() === 'tablet';
@@ -427,7 +434,9 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                 size="sm"
                 onClick={onCancel}
               >
-                <span>{t('backToOrderBasket', 'Back to order basket')}</span>
+                <span>
+                  {!!outsideOrderBasketWorkspace ? t('back', 'Back') : t('backToOrderBasket', 'Back to order basket')}
+                </span>
               </Button>
             </div>
           )}

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
@@ -10,9 +10,10 @@ import styles from './order-basket-search.scss';
 
 export interface DrugSearchProps {
   openOrderForm: (searchResult: DrugOrderBasketItem) => void;
+  outsideOrderBasketWorkspace?: boolean;
 }
 
-export default function DrugSearch({ openOrderForm }: DrugSearchProps) {
+export default function DrugSearch({ openOrderForm, outsideOrderBasketWorkspace }: DrugSearchProps) {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const [searchTerm, setSearchTerm] = useState('');
@@ -22,9 +23,9 @@ export default function DrugSearch({ openOrderForm }: DrugSearchProps) {
 
   const cancelDrugOrder = useCallback(() => {
     closeWorkspace('add-drug-order', {
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      ...(!!outsideOrderBasketWorkspace ? {} : { onWorkspaceClose: () => launchPatientWorkspace('order-basket') }),
     });
-  }, []);
+  }, [outsideOrderBasketWorkspace]);
 
   const focusAndClearSearchInput = () => {
     setSearchTerm('');
@@ -51,6 +52,7 @@ export default function DrugSearch({ openOrderForm }: DrugSearchProps) {
         searchTerm={debouncedSearchTerm}
         openOrderForm={openOrderForm}
         focusAndClearSearchInput={focusAndClearSearchInput}
+        outsideOrderBasketWorkspace={outsideOrderBasketWorkspace}
       />
       {isTablet && (
         <div className={styles.separatorContainer}>

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
@@ -28,17 +28,20 @@ export interface OrderBasketSearchResultsProps {
   searchTerm: string;
   openOrderForm: (searchResult: DrugOrderBasketItem) => void;
   focusAndClearSearchInput: () => void;
+  outsideOrderBasketWorkspace: boolean;
 }
 
 interface DrugSearchResultItemProps {
   drug: DrugSearchResult;
   openOrderForm: (searchResult: DrugOrderBasketItem) => void;
+  outsideOrderBasketWorkspace: boolean;
 }
 
 export default function OrderBasketSearchResults({
   searchTerm,
   openOrderForm,
   focusAndClearSearchInput,
+  outsideOrderBasketWorkspace,
 }: OrderBasketSearchResultsProps) {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
@@ -104,13 +107,24 @@ export default function OrderBasketSearchResults({
         </Button>
       </div>
       <div className={styles.resultsContainer}>
-        {drugs?.map((drug) => <DrugSearchResultItem key={drug.uuid} drug={drug} openOrderForm={openOrderForm} />)}
+        {drugs?.map((drug) => (
+          <DrugSearchResultItem
+            key={drug.uuid}
+            drug={drug}
+            openOrderForm={openOrderForm}
+            outsideOrderBasketWorkspace={outsideOrderBasketWorkspace}
+          />
+        ))}
       </div>
     </div>
   );
 }
 
-const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({ drug, openOrderForm }) => {
+const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({
+  drug,
+  openOrderForm,
+  outsideOrderBasketWorkspace,
+}) => {
   const isTablet = useLayoutType() === 'tablet';
   const { orders, setOrders } = useOrderBasket<DrugOrderBasketItem>('medications', prepMedicationOrderPostData);
   const { patientUuid } = usePatientChartStore();
@@ -146,10 +160,10 @@ const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({ drug, openO
       setOrders([...orders, searchResult]);
       closeWorkspace('add-drug-order', {
         ignoreChanges: true,
-        onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+        ...(!!outsideOrderBasketWorkspace ? {} : { onWorkspaceClose: () => launchPatientWorkspace('order-basket') }),
       });
     },
-    [orders, setOrders],
+    [orders, setOrders, outsideOrderBasketWorkspace],
   );
 
   const removeFromBasket = useCallback(

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.extension.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.extension.tsx
@@ -10,10 +10,15 @@ import OrderBasketItemTile from './order-basket-item-tile.component';
 import RxIcon from './rx-icon.component';
 import styles from './drug-order-basket-panel.scss';
 
+interface DrugOrderBasketPanelExtensionProps {
+  outsideOrderBasketWorkspace?: boolean;
+}
 /**
  * Designs: https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/62c6bb9500e7671a618efa56
  */
-export default function DrugOrderBasketPanelExtension() {
+export default function DrugOrderBasketPanelExtension({
+  outsideOrderBasketWorkspace,
+}: DrugOrderBasketPanelExtensionProps) {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const { orders, setOrders } = useOrderBasket<DrugOrderBasketItem>('medications', prepMedicationOrderPostData);
@@ -57,7 +62,8 @@ export default function DrugOrderBasketPanelExtension() {
   const openDrugSearch = () => {
     closeWorkspace('order-basket', {
       ignoreChanges: true,
-      onWorkspaceClose: () => launchPatientWorkspace('add-drug-order'),
+      onWorkspaceClose: () =>
+        launchPatientWorkspace('add-drug-order', { outsideOrderBasketWorkspace: outsideOrderBasketWorkspace }),
       closeWorkspaceGroup: false,
     });
   };
@@ -65,7 +71,7 @@ export default function DrugOrderBasketPanelExtension() {
   const openDrugForm = (order: DrugOrderBasketItem) => {
     closeWorkspace('order-basket', {
       ignoreChanges: true,
-      onWorkspaceClose: () => launchPatientWorkspace('add-drug-order', { order }),
+      onWorkspaceClose: () => launchPatientWorkspace('add-drug-order', { order, outsideOrderBasketWorkspace }),
       closeWorkspaceGroup: false,
     });
   };

--- a/packages/esm-patient-medications-app/translations/en.json
+++ b/packages/esm-patient-medications-app/translations/en.json
@@ -4,6 +4,7 @@
   "activeMedicationsTableTitle": "Active Medications",
   "add": "Add",
   "addDrugOrderWorkspaceTitle": "Add drug order",
+  "back": "Back",
   "backToOrderBasket": "Back to order basket",
   "clearSearchResults": "Clear Results",
   "decrement": "Decrement",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
Currently, the add drug order workspace will always go back to the order basket workspace once a drug order is saved.

When using the add drug order panel in a workspace that is not the order basket, after adding a drug the order basket will be opened rather than going back to the previous workspace.

This ticket aims to allow using the add order panel in other workspaces without opening the order basket workspace.

## Related Issue
https://openmrs.atlassian.net/browse/O3-4641
