### PR TITLE
(fix) Support multiple units in BMI calculation

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
@@ -1,7 +1,19 @@
 import isNumber from 'lodash/isNumber';
 import { type ConceptMetadata } from '../common';
 
-export function calculateBodyMassIndex(weight: number, height: number): number {
+export function calculateBodyMassIndex(weight: number, height: number, weightUnit: string, heightUnit: string): number {
+  if (weightUnit == 'lb') {
+    weight = weight * 0.45359237;
+  }
+  if (weightUnit == 'gm') {
+    weight = weight / 1000;
+  }
+  if (heightUnit == 'm') {
+    height = height * 100;
+  }
+  if (heightUnit == 'in') {
+    height = height * 0.0254;
+  }
   if (!weight || !height) return;
 
   if (weight > 0 && height > 0) {

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
@@ -2,7 +2,7 @@ import isNumber from 'lodash/isNumber';
 import { type ConceptMetadata } from '../common';
 
 export function calculateBodyMassIndex(weight: number, height: number, weightUnit: string, heightUnit: string): number {
-  if (weightUnit == 'lb') {
+  if (weightUnit == 'lb' || weightUnit == 'lbs') {
     weight = weight * 0.45359237;
   }
   if (weightUnit == 'g') {

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
@@ -5,7 +5,7 @@ export function calculateBodyMassIndex(weight: number, height: number, weightUni
   if (weightUnit == 'lb') {
     weight = weight * 0.45359237;
   }
-  if (weightUnit == 'gm') {
+  if (weightUnit == 'g') {
     weight = weight / 1000;
   }
   if (heightUnit == 'm') {

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
@@ -1,23 +1,28 @@
 import isNumber from 'lodash/isNumber';
 import { type ConceptMetadata } from '../common';
 
-export function calculateBodyMassIndex(weight: number, height: number, weightUnit: string, heightUnit: string): number {
-  if (weightUnit == 'lb' || weightUnit == 'lbs') {
-    weight = weight * 0.45359237;
-  }
-  if (weightUnit == 'g') {
-    weight = weight / 1000;
-  }
-  if (heightUnit == 'm') {
-    height = height * 100;
-  }
-  if (heightUnit == 'in') {
-    height = height * 0.0254;
-  }
+export function calculateBodyMassIndex(
+  weight: number,
+  height: number,
+  weightUnit: 'lb' | 'lbs' | 'g',
+  heightUnit: 'm' | 'cm' | 'in',
+): number {
   if (!weight || !height) return;
 
   if (weight > 0 && height > 0) {
-    return Number((weight / (height / 100) ** 2).toFixed(1));
+    if (weightUnit === 'lb' || weightUnit === 'lbs') {
+      weight = weight * 0.45359237;
+    }
+    if (weightUnit === 'g') {
+      weight = weight / 1000;
+    }
+    if (heightUnit === 'cm') {
+      height = height / 100;
+    }
+    if (heightUnit === 'in') {
+      height = height * 0.0254;
+    }
+    return Number((weight / height ** 2).toFixed(1));
   }
 }
 

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
@@ -138,8 +138,8 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
       const computedBodyMassIndex = calculateBodyMassIndex(
         weight,
         height,
-        conceptUnits.get(config.concepts.weightUuid),
-        conceptUnits.get(config.concepts.heightUuid),
+        conceptUnits.get(config.concepts.weightUuid) as 'lb' | 'lbs' | 'g',
+        conceptUnits.get(config.concepts.heightUuid) as 'm' | 'cm' | 'in',
       );
       setValue('computedBodyMassIndex', computedBodyMassIndex);
     }

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
@@ -135,10 +135,15 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
 
   useEffect(() => {
     if (height && weight) {
-      const computedBodyMassIndex = calculateBodyMassIndex(weight, height);
+      const computedBodyMassIndex = calculateBodyMassIndex(
+        weight,
+        height,
+        conceptUnits.get(config.concepts.weightUuid),
+        conceptUnits.get(config.concepts.heightUuid),
+      );
       setValue('computedBodyMassIndex', computedBodyMassIndex);
     }
-  }, [weight, height, setValue]);
+  }, [weight, height, setValue, conceptUnits, config.concepts.weightUuid, config.concepts.heightUuid]);
 
   function onError(err) {
     if (err?.oneFieldRequired) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Right now if weight and height are not in `kg` and `m` respectively the BMI is wrongly calculated.
With this PR multiple units `weight 'lb', 'lbs', 'g'`, `height: 'm', 'cm', 'in'` will be supported.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
[O3-1781](https://openmrs.atlassian.net/browse/O3-1781)

## Other

Slack conversation: https://openmrs.slack.com/archives/C02UNMKFH8V/p1744360774246389


[O3-1781]: https://openmrs.atlassian.net/browse/O3-1781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ