### PR TITLE
(feat) Patient Summary page layout adjustments

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.scss
@@ -36,8 +36,6 @@
 }
 
 .extensionWrapper {
-  height: 100%;
-
   > * {
     height: 100%;
     display: flex;

--- a/packages/esm-patient-vitals-app/src/routes.json
+++ b/packages/esm-patient-vitals-app/src/routes.json
@@ -35,7 +35,7 @@
       "component": "biometricsOverview",
       "slot": "patient-chart-summary-dashboard-slot",
       "meta": {
-        "fullWidth": false
+        "fullWidth": true
       },
       "order": 2
     },


### PR DESCRIPTION


## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Tweaks the dashboard layout of the Patient Summary page to improve utilization of the available space. Specifically, it:

- Removes the `height: 100%` property from the `.extensionWrapper` class, allowing the container to adjust its height based on its content rather than being forced to take up 100% of its parent's height.
- Sets the biometrics overview widget to `fullWidth` to ensure it spans the entire width of its parent container instead of being constrained to a narrower width.

These changes enable us to use the available space more effectively, ensuring that the widgets are displayed in a way that is both aesthetically pleasing and functional.

## Screenshots

### Before

https://github.com/user-attachments/assets/164823dd-3053-4256-8998-65ab61f53647

### After

https://github.com/user-attachments/assets/1818b353-db51-4360-b59f-8832b9fb5ee0

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
