### PR TITLE
(fix) O3-4419: Fix order type filtering in order details table

### DIFF
--- a/__mocks__/mockOrders.mock.ts
+++ b/__mocks__/mockOrders.mock.ts
@@ -3,6 +3,7 @@ export const mockOrders = [
     uuid: '6709526b-878f-4d8c-8554-f51a8d1b218e',
     orderNumber: 'ORD-321',
     accessionNumber: null,
+    scheduleDate: '2024-11-22T05:40:29.000+0000',
     patient: {
       uuid: 'ae493d14-c793-4fce-8f1d-6f0cc6ad0010',
       display: '100014M - Daniel Scott',
@@ -25,7 +26,7 @@ export const mockOrders = [
         },
       ],
     },
-    action: 'NEW',
+    action: 'NEW' as const,
     careSetting: {
       uuid: '6f0c9a92-6f24-11e3-af88-005056821db0',
       name: 'Outpatient',
@@ -131,8 +132,20 @@ export const mockOrders = [
           resourceAlias: 'drug',
         },
       ],
+      name: 'Permethrin',
+      retired: false,
+      description: 'Permethrin',
+      strength: '10mg',
+      concept: {
+        uuid: '6315c226-01f6-4c59-9332-74f5347c3ef7',
+        display: 'Permethrin',
+      },
+      dosageForm: {
+        uuid: '162335AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        display: 'Ampule(s)',
+      },
     },
-    dosingType: 'org.openmrs.SimpleDosingInstructions',
+    dosingType: 'org.openmrs.SimpleDosingInstructions' as const,
     dose: 1,
     doseUnits: {
       uuid: '162335AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',

--- a/packages/esm-patient-common-lib/src/orders/useOrders.ts
+++ b/packages/esm-patient-common-lib/src/orders/useOrders.ts
@@ -27,7 +27,7 @@ export function usePatientOrders(
     startDate && endDate
       ? `${restBaseUrl}/order?patient=${patientUuid}&careSetting=${careSettingUuid}&v=full&activatedOnOrAfterDate=${startDate}&activatedOnOrBeforeDate=${endDate}`
       : `${restBaseUrl}/order?patient=${patientUuid}&careSetting=${careSettingUuid}&v=full&status=${status}`;
-  const ordersUrl = orderType ? `${baseOrdersUrl}&orderType=${orderType}` : baseOrdersUrl;
+  const ordersUrl = orderType ? `${baseOrdersUrl}&orderTypes=${orderType}` : baseOrdersUrl;
 
   const { data, error, isLoading, isValidating } = useSWR<FetchResponse<PatientOrderFetchResponse>, Error>(
     patientUuid ? ordersUrl : null,

--- a/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
@@ -9,15 +9,15 @@ import {
   useConfig,
   useSession,
 } from '@openmrs/esm-framework';
-import { useOrderTypes, usePatientOrders } from '@openmrs/esm-patient-common-lib';
+import { type Order, useOrderTypes, usePatientOrders } from '@openmrs/esm-patient-common-lib';
 import { configSchema } from '../config-schema';
 import { mockOrders, mockSessionDataResponse } from '__mocks__';
-import OrderDetailsTable from './orders-details-table.component';
 import { mockPatient } from 'tools';
+import OrderDetailsTable from './order-details-table.component';
 
-const mockUsePatientOrders = usePatientOrders as jest.Mock;
-const mockUseOrderTypes = useOrderTypes as jest.Mock;
-const mockOpenmrsFetch = openmrsFetch as jest.Mock;
+const mockUsePatientOrders = jest.mocked(usePatientOrders);
+const mockUseOrderTypes = jest.mocked(useOrderTypes);
+const mockOpenmrsFetch = jest.mocked(openmrsFetch);
 const mockSession = jest.mocked(useSession);
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
 const mockUseReactToPrint = jest.mocked(useReactToPrint);
@@ -58,6 +58,7 @@ describe('OrderDetailsTable', () => {
       error: undefined,
       isLoading: true,
       isValidating: false,
+      mutate: jest.fn(),
     });
 
     renderOrderDetailsTable();
@@ -70,6 +71,7 @@ describe('OrderDetailsTable', () => {
 
   it('renders an error state if there is a problem fetching orders', async () => {
     const error = {
+      name: 'Error',
       message: 'You are not logged in',
       response: {
         status: 401,
@@ -87,6 +89,7 @@ describe('OrderDetailsTable', () => {
       error: error,
       isLoading: false,
       isValidating: false,
+      mutate: jest.fn(),
     });
 
     renderOrderDetailsTable();
@@ -101,10 +104,16 @@ describe('OrderDetailsTable', () => {
         {
           uuid: 'Drug Order',
           display: 'Routine',
+          name: 'Drug Order',
+          retired: false,
+          description: 'Drug Order',
         },
         {
           uuid: 'Lab Order',
           display: 'Urgent',
+          name: 'Lab Order',
+          retired: false,
+          description: 'Lab Order',
         },
       ],
       error: null,
@@ -112,10 +121,11 @@ describe('OrderDetailsTable', () => {
       isValidating: false,
     });
     mockUsePatientOrders.mockReturnValue({
-      data: mockOrders,
+      data: mockOrders as unknown as Array<Order>,
       error: undefined,
       isLoading: false,
       isValidating: false,
+      mutate: jest.fn(),
     });
 
     renderOrderDetailsTable();
@@ -152,18 +162,31 @@ describe('OrderDetailsTable', () => {
   it('filters the orders list when the user types into the searchbox', async () => {
     mockUseOrderTypes.mockReturnValue({
       data: [
-        { uuid: drugOrderTypeUuid, display: 'Drug Order' },
-        { uuid: testOrderTypeUuid, display: 'Test Order' },
+        {
+          uuid: drugOrderTypeUuid,
+          display: 'Drug Order',
+          name: 'Drug Order',
+          retired: false,
+          description: 'Drug Order',
+        },
+        {
+          uuid: testOrderTypeUuid,
+          display: 'Test Order',
+          name: 'Test Order',
+          retired: false,
+          description: 'Test Order',
+        },
       ],
       isLoading: false,
       error: null,
       isValidating: false,
     });
     mockUsePatientOrders.mockReturnValue({
-      data: mockOrders,
+      data: mockOrders as unknown as Array<Order>,
       error: undefined,
       isLoading: false,
       isValidating: false,
+      mutate: jest.fn(),
     });
 
     renderOrderDetailsTable();
@@ -196,8 +219,20 @@ describe('OrderDetailsTable', () => {
 
     mockUseOrderTypes.mockReturnValue({
       data: [
-        { uuid: drugOrderTypeUuid, display: 'Drug Order' },
-        { uuid: testOrderTypeUuid, display: 'Test Order' },
+        {
+          uuid: drugOrderTypeUuid,
+          display: 'Drug Order',
+          name: 'Drug Order',
+          retired: false,
+          description: 'Drug Order',
+        },
+        {
+          uuid: testOrderTypeUuid,
+          display: 'Test Order',
+          name: 'Test Order',
+          retired: false,
+          description: 'Test Order',
+        },
       ],
       isLoading: false,
       error: null,
@@ -205,10 +240,11 @@ describe('OrderDetailsTable', () => {
     });
 
     mockUsePatientOrders.mockImplementation((_patientUuid, _status, orderType) => ({
-      data: orderType ? testOrders : allOrders,
+      data: orderType ? (testOrders as unknown as Array<Order>) : (allOrders as unknown as Array<Order>),
       error: undefined,
       isLoading: false,
       isValidating: false,
+      mutate: jest.fn(),
     }));
 
     renderOrderDetailsTable();
@@ -235,18 +271,31 @@ describe('OrderDetailsTable', () => {
     mockUseReactToPrint.mockReturnValue(mockHandlePrint);
     mockUseOrderTypes.mockReturnValue({
       data: [
-        { uuid: drugOrderTypeUuid, display: 'Drug Order' },
-        { uuid: testOrderTypeUuid, display: 'Test Order' },
+        {
+          uuid: drugOrderTypeUuid,
+          display: 'Drug Order',
+          name: 'Drug Order',
+          retired: false,
+          description: 'Drug Order',
+        },
+        {
+          uuid: testOrderTypeUuid,
+          display: 'Test Order',
+          name: 'Test Order',
+          retired: false,
+          description: 'Test Order',
+        },
       ],
       error: null,
       isLoading: false,
       isValidating: false,
     });
     mockUsePatientOrders.mockReturnValue({
-      data: mockOrders,
+      data: mockOrders as unknown as Array<Order>,
       error: undefined,
       isLoading: false,
       isValidating: false,
+      mutate: jest.fn(),
     });
     mockUseConfig.mockReturnValue({
       ...getDefaultsFromConfigSchema(configSchema),

--- a/packages/esm-patient-orders-app/src/orders-summary/orders-summary.component.tsx
+++ b/packages/esm-patient-orders-app/src/orders-summary/orders-summary.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import OrderDetailsTable from '../components/orders-details-table.component';
 import { type ConfigObject, useConfig } from '@openmrs/esm-framework';
+import OrderDetailsTable from '../components/order-details-table.component';
 
 export interface OrdersSummaryProps {
   patientUuid: string;
@@ -10,8 +10,8 @@ export interface OrdersSummaryProps {
 
 const OrdersSummary: React.FC<OrdersSummaryProps> = ({ patientUuid, patient }) => {
   const { t } = useTranslation();
-  const ordersDisplayText = t('orders', 'Orders');
   const { showPrintButton } = useConfig<ConfigObject>();
+  const ordersDisplayText = t('orders', 'Orders');
 
   return (
     <div style={{ marginBottom: '1.5rem' }}>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR attempts to fix an issue with the filtering of order types in the Order details table that is outlined [here](https://openmrs.atlassian.net/browse/O3-4419). Specifically, this PR:

- Changes the `orderType` parameter in the order types fetch request API URL  to `orderTypes`.
- Fixes the range date click handler logic to properly deal with timezone differences.
- Rename `orders-details-table` to `order-details-table` for consistency.
- Add type assertions and improve test data completeness.

## Screenshots
https://github.com/user-attachments/assets/ff90f28e-0283-4edc-ac1c-d336a3996a29

## Related Issue
[O3-4419](https://openmrs.atlassian.net/browse/O3-4419)

## Other
<!-- Anything not covered above -->


[O3-4419]: https://openmrs.atlassian.net/browse/O3-4419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ