### PR TITLE
(fix) Fix vitals sign interpretation flagging

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -102,7 +102,7 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
       >
         {({ rows, headers, getTableProps, getHeaderProps }) => (
           <TableContainer className={styles.tableContainer}>
-            <Table className={styles.table} aria-label="vitals" {...getTableProps()}>
+            <Table aria-label="vitals" className={styles.table} {...getTableProps()}>
               <TableHead>
                 <TableRow>
                   {headers.map((header) => (
@@ -118,10 +118,11 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
                   <TableRow key={row.id}>
                     {row.cells.map((cell) => {
                       const vitalsObj = paginatedVitals.find((obj) => obj.id === row.id);
-                      const vitalSignInterpretation = vitalsObj && vitalsObj[cell.id.substring(2) + 'Interpretation'];
+                      const interpretationKey = cell.info.header + 'Interpretation';
+                      const interpretation = vitalsObj?.[interpretationKey];
 
                       return (
-                        <StyledTableCell key={`styled-cell-${cell.id}`} interpretation={vitalSignInterpretation}>
+                        <StyledTableCell key={`styled-cell-${cell.id}`} interpretation={interpretation}>
                           {cell.value?.content ?? cell.value}
                         </StyledTableCell>
                       );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This change improves the way vitals sign interpretations are retrieved in two ways:

- It uses a more direct and cleaner approach by accessing the interpretation through `cell.info.header` instead of manipulating the `cell.id`.
- It uses the optional chaining operator (`?.`) which is a safer way to access potentially undefined properties.

## Screenshots

### Before
![CleanShot 2025-04-18 at 12  02 29@2x](https://github.com/user-attachments/assets/44a6ea0a-5182-4a4d-ab02-eb2b3a31e8e6)

### After
![CleanShot 2025-04-18 at 12  02 11@2x](https://github.com/user-attachments/assets/acea88dd-7cc4-4239-9254-a9fc75d0aea5)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
