### PR TITLE
(fix) O3-4655: Fix date formatting in test results components

### DIFF
--- a/packages/esm-patient-tests-app/src/test-results/overview/common-datatable.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/overview/common-datatable.component.tsx
@@ -10,10 +10,14 @@ import {
   TableCell,
   TableBody,
 } from '@carbon/react';
-import { useLayoutType } from '@openmrs/esm-framework';
+import { formatDate, parseDate, useLayoutType } from '@openmrs/esm-framework';
 import { type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
-import { type OverviewPanelData } from './useOverviewData';
+import { type OverviewPanelData as BaseOverviewPanelData } from './useOverviewData';
 import styles from './common-datatable.scss';
+
+interface OverviewPanelData extends BaseOverviewPanelData {
+  dateTime?: string;
+}
 
 interface CommonDataTableProps {
   data: Array<OverviewPanelData>;
@@ -38,6 +42,11 @@ const CommonDataTable: React.FC<CommonDataTableProps> = ({ title, data, descript
   };
 
   const isTablet = useLayoutType() === 'tablet';
+
+  data = data.map((item) => ({
+    ...item,
+    dateTime: formatDate(parseDate(item?.dateTime), { mode: 'standard', time: true }),
+  }));
 
   return (
     <DataTable rows={data} headers={tableHeaders} size="sm" useZebraStyles>

--- a/packages/esm-patient-tests-app/src/test-results/trendline/trendline.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/trendline/trendline.test.tsx
@@ -60,8 +60,8 @@ describe('Trendline', () => {
     mockUseObstreeData.mockReturnValue({
       trendlineData: {
         obs: [
-          { obsDatetime: '2023-01-01', value: '5', interpretation: 'NORMAL' },
-          { obsDatetime: '2023-01-02', value: '6', interpretation: 'HIGH' },
+          { obsDatetime: '05-Sept-2021, 04:07 AM', value: '5', interpretation: 'NORMAL' },
+          { obsDatetime: '11-May-2023, 11:02 AM', value: '6', interpretation: 'HIGH' },
         ],
         display: 'Test Chart Title',
         hiNormal: 10,
@@ -93,9 +93,9 @@ describe('Trendline', () => {
     expect(screen.getByRole('button', { name: /hide results table/i })).toBeInTheDocument();
     expect(screen.getByText('Date and time')).toBeInTheDocument();
     expect(screen.getByText('Value (mg/dL)')).toBeInTheDocument();
-    expect(screen.getByText('2023-01-01')).toBeInTheDocument();
+    expect(screen.getByText('05-Sept-2021, 04:07 AM')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();
-    expect(screen.getByText('2023-01-02')).toBeInTheDocument();
+    expect(screen.getByText('11-May-2023, 11:02 AM')).toBeInTheDocument();
     expect(screen.getByText('6')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Adds standardized date formatting with time display to test results components. Updates test data to use more realistic date formats and ensures consistent date display across the application.

## Screenshots

## Before
<img width="706" alt="Screenshot 2025-04-19 at 8 07 58 AM" src="https://github.com/user-attachments/assets/b4c8abd5-8261-4cf3-b449-be56fa3c117b" />

## After
<img width="1470" alt="Screenshot 2025-04-19 at 8 19 57 AM" src="https://github.com/user-attachments/assets/87de764f-6f84-4637-964d-c46559c6d6ec" />


## Related Issue
[O3-4655](https://openmrs.atlassian.net/browse/O3-4655)

## Other
<!-- Anything not covered above -->


[O3-4655]: https://openmrs.atlassian.net/browse/O3-4655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ