### PR TITLE
(fix) O3-4059: Fix date handling in results viewer page

### DIFF
--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
@@ -12,7 +12,7 @@ import {
   TableHeader,
   TableRow,
 } from '@carbon/react';
-import { showModal, useLayoutType, formatDate } from '@openmrs/esm-framework';
+import { showModal, useLayoutType, formatDate, parseDate } from '@openmrs/esm-framework';
 import { getPatientUuidFromStore, type OBSERVATION_INTERPRETATION } from '@openmrs/esm-patient-common-lib';
 import { type GroupedObservation } from '../../types';
 import styles from './individual-results-table.scss';
@@ -127,7 +127,9 @@ const IndividualResultsTable: React.FC<IndividualResultsTableProps> = ({ isLoadi
             <div className={styles.cardTitle}>
               <h4 className={styles.resultType}>{headerTitle}</h4>
               <div className={styles.displayFlex}>
-                <span className={styles.date}>{formatDate(new Date(subRows.date), { mode: 'standard' })}</span>
+                <span className={styles.date}>
+                  {formatDate(parseDate(subRows.date), { mode: 'standard', time: false })}
+                </span>
               </div>
             </div>
             <Table className={styles.table} {...getTableProps()} size={isDesktop ? 'md' : 'sm'}>

--- a/packages/esm-patient-tests-app/src/test-results/overview/common-overview.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/overview/common-overview.component.tsx
@@ -157,12 +157,12 @@ const InfoTooltip = ({ effectiveDateTime, issuedDateTime }) => {
         <div className={styles.tooltip}>
           <p>{t('dateCollected', 'Displaying date collected')}</p>
           <p>
-            <span className={styles.label}>{t('resulted', 'Resulted')}: </span>{' '}
-            {formatDatetime(issuedDateTime, { mode: 'wide' })}
-          </p>
-          <p>
             <span className={styles.label}>{t('ordered', 'Ordered')}: </span>{' '}
             {formatDatetime(effectiveDateTime, { mode: 'wide' })}
+          </p>
+          <p>
+            <span className={styles.label}>{t('resulted', 'Resulted')}: </span>{' '}
+            {formatDatetime(issuedDateTime, { mode: 'wide' })}
           </p>
         </div>
       </ToggletipContent>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes inaccurate dates in the test results viewer `IndividualResultsTable` component by leveraging the `parseDate` function instead of `new Date` for proper date parsing and explicitly disabling time display. It also reorders date information in the `CommonOverview` component tooltip for better chronological sequence.

## Screenshots
<img width="1470" alt="Screenshot 2025-04-19 at 7 57 15 PM" src="https://github.com/user-attachments/assets/e58dfdcb-14b6-4edf-a57d-a7089390c634" />

<img width="1470" alt="Screenshot 2025-04-19 at 7 57 41 PM" src="https://github.com/user-attachments/assets/91a92059-88cd-4daa-a2f9-2a7549e394d0" />

## Before formating date

With `new Date()`

<img width="1470" alt="Screenshot 2025-04-19 at 8 11 52 PM" src="https://github.com/user-attachments/assets/5ee3672b-1d6a-438d-8d0b-3ac345fc9fab" />

## After

With `parseDate`

<img width="1470" alt="Screenshot 2025-04-19 at 7 57 29 PM" src="https://github.com/user-attachments/assets/41c8605f-4735-4c4b-bb55-b941fabbb76b" />







## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[jira ticket](https://openmrs.atlassian.net/browse/O3-4059)

## Other
<!-- Anything not covered above -->

