### PR TITLE
(perf) O3-4656: Optimized Order Detail's Table with client-side filtering to reduce redundant API calls

### DIFF
--- a/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
@@ -129,11 +129,17 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({
   const [selectedToDate, setSelectedToDate] = useState(null);
   const selectedOrderName = orderTypes?.find((x) => x.uuid === selectedOrderTypeUuid)?.name;
   const {
-    data: allOrders,
+    data: fetchedOrders,
     error: error,
     isLoading,
     isValidating,
-  } = usePatientOrders(patientUuid, 'ACTIVE', selectedOrderTypeUuid, selectedFromDate, selectedToDate);
+  } = usePatientOrders(patientUuid, 'ACTIVE', null, selectedFromDate, selectedToDate);
+
+  const allOrders = useMemo(() => {
+    if (!fetchedOrders) return [];
+    if (!selectedOrderTypeUuid) return fetchedOrders;
+    return fetchedOrders.filter((order) => order.orderType.uuid === selectedOrderTypeUuid);
+  }, [fetchedOrders, selectedOrderTypeUuid]);
 
   // launch respective order basket based on order type
   const openOrderForm = useCallback(


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Optimized the `OrderDetailsTable` by avoiding repeated API calls when switching order types. Now, all orders are fetched once initially, and we use `useMemo` to filter them on the client side. This makes the UI faster and reduces unnecessary load on the backend, without changing any user-facing features.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
https://github.com/user-attachments/assets/f9b75561-3a58-428d-8e68-c6d25e113d19

After:
https://github.com/user-attachments/assets/43462d0f-709b-4f1b-a949-121951859382




## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4656

## Other
<!-- Anything not covered above -->
