### PR TITLE
(feat) Use age-based reference ranges in vitals widget

### DIFF
--- a/__mocks__/vitals-and-biometrics.mock.ts
+++ b/__mocks__/vitals-and-biometrics.mock.ts
@@ -635,144 +635,6 @@ export const mockBiometricsResponse = {
       },
     },
     {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/6448739f-59dd-4af8-94d4-d524a99f1297',
-      resource: {
-        resourceType: 'Observation',
-        id: '6448739f-59dd-4af8-94d4-d524a99f1297',
-        text: {
-          status: 'generated',
-          div: '<div xmlns="http://www.w3.org/1999/xhtml"><table class="hapiPropertyTable"><tbody><tr><td>Id:</td><td>6448739f-59dd-4af8-94d4-d524a99f1297</td></tr><tr><td>Status:</td><td>FINAL</td></tr><tr><td>Category:</td><td> Exam </td></tr><tr><td>Code:</td><td> Weight (kg) </td></tr><tr><td>Subject:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Patient/8673ee4f-e2ab-4077-ba55-4980f408773e">John Wilson (Old Identification Number: 100GEJ)</a></td></tr><tr><td>Encounter:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Encounter/db1c2b8b-de5a-44fb-987b-68e5ba9bf8dd">Encounter/db1c2b8b-de5a-44fb-987b-68e5ba9bf8dd</a></td></tr><tr><td>Effective:</td><td> 11 February 2021 07:10:15 </td></tr><tr><td>Issued:</td><td>11/02/2021 06:41:16 PM</td></tr><tr><td>Value:</td><td>75.0 kg </td></tr><tr><td>Reference Ranges:</td><td><table class="subPropertyTable"><tbody><tr><th>-</th><th>Low</th><th>High</th><th>Type</th><th>Applies To</th><th>Age</th></tr><tr><td>1</td><td>0.0 </td><td>250.0 </td><td> absolute </td><td/><td> - </td></tr></tbody></table></td></tr></tbody></table></div>',
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Weight (kg)',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '3141-9',
-              display: 'Weight (kg)',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/db1c2b8b-de5a-44fb-987b-68e5ba9bf8dd',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2021-02-11T07:10:15+00:00',
-        issued: '2021-02-11T18:41:16.000+00:00',
-        valueQuantity: {
-          value: 75,
-          unit: 'kg',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 0,
-            },
-            high: {
-              value: 250,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/c71ad411-9c41-40fc-a4dc-ecbee9200a72',
-      resource: {
-        resourceType: 'Observation',
-        id: 'c71ad411-9c41-40fc-a4dc-ecbee9200a72',
-        text: {
-          status: 'generated',
-          div: '<div xmlns="http://www.w3.org/1999/xhtml"><table class="hapiPropertyTable"><tbody><tr><td>Id:</td><td>c71ad411-9c41-40fc-a4dc-ecbee9200a72</td></tr><tr><td>Status:</td><td>FINAL</td></tr><tr><td>Category:</td><td> Exam </td></tr><tr><td>Code:</td><td> Weight (kg) </td></tr><tr><td>Subject:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Patient/8673ee4f-e2ab-4077-ba55-4980f408773e">John Wilson (Old Identification Number: 100GEJ)</a></td></tr><tr><td>Encounter:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Encounter/b4399c30-73c1-48a6-abed-520912ffbd96">Encounter/b4399c30-73c1-48a6-abed-520912ffbd96</a></td></tr><tr><td>Effective:</td><td> 17 February 2021 21:10:04 </td></tr><tr><td>Issued:</td><td>17/02/2021 09:10:04 PM</td></tr><tr><td>Value:</td><td>10.0 kg </td></tr><tr><td>Reference Ranges:</td><td><table class="subPropertyTable"><tbody><tr><th>-</th><th>Low</th><th>High</th><th>Type</th><th>Applies To</th><th>Age</th></tr><tr><td>1</td><td>0.0 </td><td>250.0 </td><td> absolute </td><td/><td> - </td></tr></tbody></table></td></tr></tbody></table></div>',
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Weight (kg)',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '3141-9',
-              display: 'Weight (kg)',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/b4399c30-73c1-48a6-abed-520912ffbd96',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2021-02-17T21:10:04+00:00',
-        issued: '2021-02-17T21:10:04.000+00:00',
-        valueQuantity: {
-          value: 10,
-          unit: 'kg',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 0,
-            },
-            high: {
-              value: 250,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
       fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/6fafa681-632c-4151-8f0f-0abc59a75afa',
       resource: {
         resourceType: 'Observation',
@@ -1256,75 +1118,6 @@ export const mockBiometricsResponse = {
       },
     },
     {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/e55de98d-b689-4e44-86bb-6f5e1e53476e',
-      resource: {
-        resourceType: 'Observation',
-        id: 'e55de98d-b689-4e44-86bb-6f5e1e53476e',
-        text: {
-          status: 'generated',
-          div: '<div xmlns="http://www.w3.org/1999/xhtml"><table class="hapiPropertyTable"><tbody><tr><td>Id:</td><td>e55de98d-b689-4e44-86bb-6f5e1e53476e</td></tr><tr><td>Status:</td><td>FINAL</td></tr><tr><td>Category:</td><td> Exam </td></tr><tr><td>Code:</td><td> Weight (kg) </td></tr><tr><td>Subject:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Patient/8673ee4f-e2ab-4077-ba55-4980f408773e">John Wilson (Old Identification Number: 100GEJ)</a></td></tr><tr><td>Encounter:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Encounter/838c9b30-9671-4af9-bf3e-b3a6ed6ab5ef">Encounter/838c9b30-9671-4af9-bf3e-b3a6ed6ab5ef</a></td></tr><tr><td>Effective:</td><td> 23 March 2021 06:39:19 </td></tr><tr><td>Issued:</td><td>23/03/2021 06:39:19 AM</td></tr><tr><td>Value:</td><td>99.0 kg </td></tr><tr><td>Reference Ranges:</td><td><table class="subPropertyTable"><tbody><tr><th>-</th><th>Low</th><th>High</th><th>Type</th><th>Applies To</th><th>Age</th></tr><tr><td>1</td><td>0.0 </td><td>250.0 </td><td> absolute </td><td/><td> - </td></tr></tbody></table></td></tr></tbody></table></div>',
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Weight (kg)',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '3141-9',
-              display: 'Weight (kg)',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/838c9b30-9671-4af9-bf3e-b3a6ed6ab5ef',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2021-03-23T06:39:19+00:00',
-        issued: '2021-03-23T06:39:19.000+00:00',
-        valueQuantity: {
-          value: 99,
-          unit: 'kg',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 0,
-            },
-            high: {
-              value: 250,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
       fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/5a3c78a7-6e20-429c-8621-59fe20884004',
       resource: {
         resourceType: 'Observation',
@@ -1371,75 +1164,6 @@ export const mockBiometricsResponse = {
         issued: '2021-03-30T10:49:59.000+00:00',
         valueQuantity: {
           value: 87,
-          unit: 'kg',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 0,
-            },
-            high: {
-              value: 250,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/46f73822-f7a7-4bea-9241-5354598128e2',
-      resource: {
-        resourceType: 'Observation',
-        id: '46f73822-f7a7-4bea-9241-5354598128e2',
-        text: {
-          status: 'generated',
-          div: '<div xmlns="http://www.w3.org/1999/xhtml"><table class="hapiPropertyTable"><tbody><tr><td>Id:</td><td>46f73822-f7a7-4bea-9241-5354598128e2</td></tr><tr><td>Status:</td><td>FINAL</td></tr><tr><td>Category:</td><td> Exam </td></tr><tr><td>Code:</td><td> Weight (kg) </td></tr><tr><td>Subject:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Patient/8673ee4f-e2ab-4077-ba55-4980f408773e">John Wilson (Old Identification Number: 100GEJ)</a></td></tr><tr><td>Encounter:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Encounter/b5e913b6-a6cb-4be1-ac5c-173580558d20">Encounter/b5e913b6-a6cb-4be1-ac5c-173580558d20</a></td></tr><tr><td>Effective:</td><td> 08 April 2021 14:44:24 </td></tr><tr><td>Issued:</td><td>08/04/2021 02:44:24 PM</td></tr><tr><td>Value:</td><td>67.0 kg </td></tr><tr><td>Reference Ranges:</td><td><table class="subPropertyTable"><tbody><tr><th>-</th><th>Low</th><th>High</th><th>Type</th><th>Applies To</th><th>Age</th></tr><tr><td>1</td><td>0.0 </td><td>250.0 </td><td> absolute </td><td/><td> - </td></tr></tbody></table></td></tr></tbody></table></div>',
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Weight (kg)',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '3141-9',
-              display: 'Weight (kg)',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/b5e913b6-a6cb-4be1-ac5c-173580558d20',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2021-04-08T14:44:24+00:00',
-        issued: '2021-04-08T14:44:24.000+00:00',
-        valueQuantity: {
-          value: 67,
           unit: 'kg',
         },
         referenceRange: [
@@ -2015,75 +1739,6 @@ export const mockBiometricsResponse = {
       },
     },
     {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/fd9448a7-9c6c-486c-80db-be2cfc9a75bc',
-      resource: {
-        resourceType: 'Observation',
-        id: 'fd9448a7-9c6c-486c-80db-be2cfc9a75bc',
-        text: {
-          status: 'generated',
-          div: '<div xmlns="http://www.w3.org/1999/xhtml"><table class="hapiPropertyTable"><tbody><tr><td>Id:</td><td>fd9448a7-9c6c-486c-80db-be2cfc9a75bc</td></tr><tr><td>Status:</td><td>FINAL</td></tr><tr><td>Category:</td><td> Exam </td></tr><tr><td>Code:</td><td> Height (cm) </td></tr><tr><td>Subject:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Patient/8673ee4f-e2ab-4077-ba55-4980f408773e">John Wilson (Old Identification Number: 100GEJ)</a></td></tr><tr><td>Encounter:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Encounter/6f25a7db-63b0-46bc-9b97-0fd1b6204a06">Encounter/6f25a7db-63b0-46bc-9b97-0fd1b6204a06</a></td></tr><tr><td>Effective:</td><td> 09 December 2020 13:25:28 </td></tr><tr><td>Issued:</td><td>09/12/2020 01:25:29 PM</td></tr><tr><td>Value:</td><td>199.0 cm </td></tr><tr><td>Reference Ranges:</td><td><table class="subPropertyTable"><tbody><tr><th>-</th><th>Low</th><th>High</th><th>Type</th><th>Applies To</th><th>Age</th></tr><tr><td>1</td><td>10.0 </td><td>272.0 </td><td> absolute </td><td/><td> - </td></tr></tbody></table></td></tr></tbody></table></div>',
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Height (cm)',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '8302-2',
-              display: 'Height (cm)',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/6f25a7db-63b0-46bc-9b97-0fd1b6204a06',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2020-12-09T13:25:28+00:00',
-        issued: '2020-12-09T13:25:29.000+00:00',
-        valueQuantity: {
-          value: 199,
-          unit: 'cm',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 10,
-            },
-            high: {
-              value: 272,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
       fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/6480ade6-ea10-4e57-af15-113a40cf7df7',
       resource: {
         resourceType: 'Observation',
@@ -2498,75 +2153,6 @@ export const mockBiometricsResponse = {
       },
     },
     {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/655e71e0-f569-4157-95e8-961017eed1f6',
-      resource: {
-        resourceType: 'Observation',
-        id: '655e71e0-f569-4157-95e8-961017eed1f6',
-        text: {
-          status: 'generated',
-          div: '<div xmlns="http://www.w3.org/1999/xhtml"><table class="hapiPropertyTable"><tbody><tr><td>Id:</td><td>655e71e0-f569-4157-95e8-961017eed1f6</td></tr><tr><td>Status:</td><td>FINAL</td></tr><tr><td>Category:</td><td> Exam </td></tr><tr><td>Code:</td><td> Height (cm) </td></tr><tr><td>Subject:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Patient/8673ee4f-e2ab-4077-ba55-4980f408773e">John Wilson (Old Identification Number: 100GEJ)</a></td></tr><tr><td>Encounter:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Encounter/000df441-1367-4e3d-ae67-b0c852cc2654">Encounter/000df441-1367-4e3d-ae67-b0c852cc2654</a></td></tr><tr><td>Effective:</td><td> 21 February 2021 11:00:44 </td></tr><tr><td>Issued:</td><td>21/02/2021 11:00:44 AM</td></tr><tr><td>Value:</td><td>185.0 cm </td></tr><tr><td>Reference Ranges:</td><td><table class="subPropertyTable"><tbody><tr><th>-</th><th>Low</th><th>High</th><th>Type</th><th>Applies To</th><th>Age</th></tr><tr><td>1</td><td>10.0 </td><td>272.0 </td><td> absolute </td><td/><td> - </td></tr></tbody></table></td></tr></tbody></table></div>',
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Height (cm)',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '8302-2',
-              display: 'Height (cm)',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/000df441-1367-4e3d-ae67-b0c852cc2654',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2021-02-21T11:00:44+00:00',
-        issued: '2021-02-21T11:00:44.000+00:00',
-        valueQuantity: {
-          value: 185,
-          unit: 'cm',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 10,
-            },
-            high: {
-              value: 272,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
       fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/d732275c-876a-4750-b525-b1521735971c',
       resource: {
         resourceType: 'Observation',
@@ -2682,75 +2268,6 @@ export const mockBiometricsResponse = {
         issued: '2021-03-10T13:44:04.000+00:00',
         valueQuantity: {
           value: 10,
-          unit: 'cm',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 10,
-            },
-            high: {
-              value: 272,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/f8556923-f044-44a5-bb66-b20b7dff824e',
-      resource: {
-        resourceType: 'Observation',
-        id: 'f8556923-f044-44a5-bb66-b20b7dff824e',
-        text: {
-          status: 'generated',
-          div: '<div xmlns="http://www.w3.org/1999/xhtml"><table class="hapiPropertyTable"><tbody><tr><td>Id:</td><td>f8556923-f044-44a5-bb66-b20b7dff824e</td></tr><tr><td>Status:</td><td>FINAL</td></tr><tr><td>Category:</td><td> Exam </td></tr><tr><td>Code:</td><td> Height (cm) </td></tr><tr><td>Subject:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Patient/8673ee4f-e2ab-4077-ba55-4980f408773e">John Wilson (Old Identification Number: 100GEJ)</a></td></tr><tr><td>Encounter:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Encounter/e00cbc9f-9bc8-4710-b824-b10f030bc344">Encounter/e00cbc9f-9bc8-4710-b824-b10f030bc344</a></td></tr><tr><td>Effective:</td><td> 13 March 2021 21:37:54 </td></tr><tr><td>Issued:</td><td>13/03/2021 09:37:54 PM</td></tr><tr><td>Value:</td><td>88.0 cm </td></tr><tr><td>Reference Ranges:</td><td><table class="subPropertyTable"><tbody><tr><th>-</th><th>Low</th><th>High</th><th>Type</th><th>Applies To</th><th>Age</th></tr><tr><td>1</td><td>10.0 </td><td>272.0 </td><td> absolute </td><td/><td> - </td></tr></tbody></table></td></tr></tbody></table></div>',
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Height (cm)',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '8302-2',
-              display: 'Height (cm)',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/e00cbc9f-9bc8-4710-b824-b10f030bc344',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2021-03-13T21:37:54+00:00',
-        issued: '2021-03-13T21:37:54.000+00:00',
-        valueQuantity: {
-          value: 88,
           unit: 'cm',
         },
         referenceRange: [
@@ -3096,75 +2613,6 @@ export const mockBiometricsResponse = {
         issued: '2021-03-30T10:49:59.000+00:00',
         valueQuantity: {
           value: 185,
-          unit: 'cm',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 10,
-            },
-            high: {
-              value: 272,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/9e396c1d-4396-47aa-85ab-fa1ea989a7fe',
-      resource: {
-        resourceType: 'Observation',
-        id: '9e396c1d-4396-47aa-85ab-fa1ea989a7fe',
-        text: {
-          status: 'generated',
-          div: '<div xmlns="http://www.w3.org/1999/xhtml"><table class="hapiPropertyTable"><tbody><tr><td>Id:</td><td>9e396c1d-4396-47aa-85ab-fa1ea989a7fe</td></tr><tr><td>Status:</td><td>FINAL</td></tr><tr><td>Category:</td><td> Exam </td></tr><tr><td>Code:</td><td> Height (cm) </td></tr><tr><td>Subject:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Patient/8673ee4f-e2ab-4077-ba55-4980f408773e">John Wilson (Old Identification Number: 100GEJ)</a></td></tr><tr><td>Encounter:</td><td><a href="http://localhost:8080/openmrs/ws/fhir2/R4/Encounter/b5e913b6-a6cb-4be1-ac5c-173580558d20">Encounter/b5e913b6-a6cb-4be1-ac5c-173580558d20</a></td></tr><tr><td>Effective:</td><td> 08 April 2021 14:44:24 </td></tr><tr><td>Issued:</td><td>08/04/2021 02:44:24 PM</td></tr><tr><td>Value:</td><td>172.0 cm </td></tr><tr><td>Reference Ranges:</td><td><table class="subPropertyTable"><tbody><tr><th>-</th><th>Low</th><th>High</th><th>Type</th><th>Applies To</th><th>Age</th></tr><tr><td>1</td><td>10.0 </td><td>272.0 </td><td> absolute </td><td/><td> - </td></tr></tbody></table></td></tr></tbody></table></div>',
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Height (cm)',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '8302-2',
-              display: 'Height (cm)',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/b5e913b6-a6cb-4be1-ac5c-173580558d20',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2021-04-08T14:44:24+00:00',
-        issued: '2021-04-08T14:44:24.000+00:00',
-        valueQuantity: {
-          value: 172,
           unit: 'cm',
         },
         referenceRange: [
@@ -3599,20 +3047,6 @@ export const formattedBiometrics = [
   },
 ];
 
-export const mockConceptMetadata = [
-  {
-    uuid: '5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-    display: 'Systolic',
-    hiNormal: 140,
-    hiAbsolute: 250,
-    hiCritical: 180,
-    lowNormal: 100,
-    lowAbsolute: 0,
-    lowCritical: 85,
-    units: 'mmHg',
-  },
-];
-
 export const mockVitalsData = [
   {
     id: 'e8a96dcc-5bb6-4975-be3b-214440e34fa4',
@@ -3904,7 +3338,7 @@ export const mockVitalsData = [
   },
 ];
 
-export const mockVitalSigns = mockVitalsData[0];
+export const mockVitalsSigns = mockVitalsData[0];
 
 export const mockVitalsSignsConcepts = {
   data: {
@@ -3913,102 +3347,102 @@ export const mockVitalsSignsConcepts = {
         setMembers: [
           {
             uuid: '5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-            display: 'Systolic blood pressure',
-            hiNormal: 140,
-            hiAbsolute: 250.0,
-            hiCritical: 180,
-            lowNormal: 100,
+            display: 'Systolic Blood Pressure',
+            hiNormal: 120,
+            hiAbsolute: 250,
+            hiCritical: 250,
+            lowNormal: 90,
             lowAbsolute: 0,
-            lowCritical: 85,
+            lowCritical: 0,
             units: 'mmHg',
           },
           {
             uuid: '5086AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-            display: 'Diastolic blood pressure',
-            hiNormal: 90,
+            display: 'Diastolic Blood Pressure',
+            hiNormal: 80,
             hiAbsolute: 150,
-            hiCritical: 120,
-            lowNormal: 55,
+            hiCritical: 150,
+            lowNormal: 60,
             lowAbsolute: 0,
-            lowCritical: 40,
+            lowCritical: 0,
             units: 'mmHg',
-          },
-          {
-            uuid: '5088AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-            display: 'Temperature (C)',
-            hiNormal: 37.5,
-            hiAbsolute: 43.0,
-            hiCritical: null,
-            lowNormal: 36.5,
-            lowAbsolute: 25.0,
-            lowCritical: null,
-            units: 'DEG C',
-          },
-          {
-            uuid: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-            display: 'Height (cm)',
-            hiNormal: null,
-            hiAbsolute: 272.0,
-            hiCritical: null,
-            lowNormal: null,
-            lowAbsolute: 10.0,
-            lowCritical: null,
-            units: 'cm',
-          },
-          {
-            uuid: '5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-            display: 'Weight (kg)',
-            hiNormal: null,
-            hiAbsolute: 250.0,
-            hiCritical: null,
-            lowNormal: null,
-            lowAbsolute: 0.0,
-            lowCritical: null,
-            units: 'kg',
           },
           {
             uuid: '5087AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
             display: 'Pulse',
             hiNormal: 100,
             hiAbsolute: 230,
-            hiCritical: 130,
-            lowNormal: 55,
+            hiCritical: 230,
+            lowNormal: 60,
             lowAbsolute: 0,
-            lowCritical: 49,
+            lowCritical: 0,
             units: 'beats/min',
           },
           {
-            uuid: '5092AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-            display: 'Blood oxygen saturation',
-            hiNormal: 100,
-            hiAbsolute: 100.0,
-            hiCritical: null,
-            lowNormal: 95,
-            lowAbsolute: 0.0,
-            lowCritical: null,
-            units: '%',
+            uuid: '5088AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            display: 'Temperature',
+            hiNormal: 37.5,
+            hiAbsolute: 43,
+            hiCritical: 43,
+            lowNormal: 35,
+            lowAbsolute: 25,
+            lowCritical: 25,
+            units: 'DEG C',
           },
           {
-            uuid: '1343AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-            display: 'MID-UPPER ARM CIRCUMFERENCE',
-            hiNormal: 25,
-            hiAbsolute: null,
-            hiCritical: null,
-            lowNormal: 23,
-            lowAbsolute: null,
-            lowCritical: null,
+            uuid: '5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            display: 'Weight',
+            hiNormal: 250,
+            hiAbsolute: 250,
+            hiCritical: 250,
+            lowNormal: 0,
+            lowAbsolute: 0,
+            lowCritical: 0,
+            units: 'kg',
+          },
+          {
+            uuid: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            display: 'Height',
+            hiNormal: 272,
+            hiAbsolute: 272,
+            hiCritical: 272,
+            lowNormal: 10,
+            lowAbsolute: 10,
+            lowCritical: 10,
             units: 'cm',
           },
           {
+            uuid: '5092AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            display: 'Oxygen Saturation',
+            hiNormal: 100,
+            hiAbsolute: 100,
+            hiCritical: 100,
+            lowNormal: 95,
+            lowAbsolute: 0,
+            lowCritical: 0,
+            units: '%',
+          },
+          {
             uuid: '5242AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-            display: 'Respiratory rate',
-            hiNormal: 70.0,
-            hiAbsolute: 999.0,
-            hiCritical: 120.0,
-            lowNormal: null,
-            lowAbsolute: 0.0,
-            lowCritical: null,
+            display: 'Respiratory Rate',
+            hiNormal: 30,
+            hiAbsolute: 100,
+            hiCritical: 100,
+            lowNormal: 12,
+            lowAbsolute: 0,
+            lowCritical: 0,
             units: 'breaths/min',
+          },
+          {
+            uuid: '1343AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            display: 'Mid-Upper Arm Circumference',
+            hiNormal: 50,
+            hiAbsolute: 50,
+            hiCritical: 50,
+            lowNormal: 0,
+            lowAbsolute: 0,
+            lowCritical: 0,
+            units: 'cm',
           },
         ],
       },
@@ -4686,186 +4120,6 @@ export const mockFhirVitalsResponse = {
       },
     },
     {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/0a1f6a92-30a4-47b9-8add-5237d807f8a9',
-      resource: {
-        resourceType: 'Observation',
-        id: '0a1f6a92-30a4-47b9-8add-5237d807f8a9',
-        meta: {
-          tag: [
-            {
-              system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue',
-              code: 'SUBSETTED',
-              display: 'Resource encoded in summary mode',
-            },
-          ],
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Systolic',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '8480-6',
-              display: 'Systolic',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/71a9faed-1102-4ab6-b412-06b7de69eceb',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2021-05-10T06:41:46+00:00',
-        issued: '2021-05-10T06:41:46.000+00:00',
-        valueQuantity: {
-          value: 120,
-          unit: 'mmHg',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 100,
-            },
-            high: {
-              value: 140,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://terminology.hl7.org/CodeSystem/referencerange-meaning',
-                  code: 'normal',
-                },
-              ],
-            },
-          },
-          {
-            low: {
-              value: 85,
-            },
-            high: {
-              value: 180,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://terminology.hl7.org/CodeSystem/referencerange-meaning',
-                  code: 'treatment',
-                },
-              ],
-            },
-          },
-          {
-            low: {
-              value: 0,
-            },
-            high: {
-              value: 250,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/801e6cbb-29d2-4581-9d6b-f75c1967351c',
-      resource: {
-        resourceType: 'Observation',
-        id: '801e6cbb-29d2-4581-9d6b-f75c1967351c',
-        meta: {
-          tag: [
-            {
-              system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue',
-              code: 'SUBSETTED',
-              display: 'Resource encoded in summary mode',
-            },
-          ],
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Height (cm)',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '8302-2',
-              display: 'Height (cm)',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/71a9faed-1102-4ab6-b412-06b7de69eceb',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2021-05-10T06:41:46+00:00',
-        issued: '2021-05-10T06:41:46.000+00:00',
-        valueQuantity: {
-          value: 198,
-          unit: 'cm',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 10,
-            },
-            high: {
-              value: 272,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
       fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/5cd10d94-6322-45f1-ac2c-f595d2a81941',
       resource: {
         resourceType: 'Observation',
@@ -5331,117 +4585,6 @@ export const mockFhirVitalsResponse = {
       },
     },
     {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/9469ec9c-ade7-4424-b940-2238717c104c',
-      resource: {
-        resourceType: 'Observation',
-        id: '9469ec9c-ade7-4424-b940-2238717c104c',
-        meta: {
-          tag: [
-            {
-              system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue',
-              code: 'SUBSETTED',
-              display: 'Resource encoded in summary mode',
-            },
-          ],
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5086AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Diastolic',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '35094-2',
-              display: 'Diastolic',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '8462-4',
-              display: 'Diastolic',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/b524d4c6-2426-4af1-a8e5-e03379286968',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2021-05-07T09:04:51+00:00',
-        issued: '2021-05-07T09:04:51.000+00:00',
-        valueQuantity: {
-          value: 80,
-          unit: 'mmHg',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 55,
-            },
-            high: {
-              value: 90,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://terminology.hl7.org/CodeSystem/referencerange-meaning',
-                  code: 'normal',
-                },
-              ],
-            },
-          },
-          {
-            low: {
-              value: 40,
-            },
-            high: {
-              value: 120,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://terminology.hl7.org/CodeSystem/referencerange-meaning',
-                  code: 'treatment',
-                },
-              ],
-            },
-          },
-          {
-            low: {
-              value: 0,
-            },
-            high: {
-              value: 150,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
       fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/d58614c6-a824-4a36-97ff-8e2969f1d776',
       resource: {
         resourceType: 'Observation',
@@ -5534,80 +4677,6 @@ export const mockFhirVitalsResponse = {
             },
             high: {
               value: 250,
-            },
-            type: {
-              coding: [
-                {
-                  system: 'http://fhir.openmrs.org/ext/obs/reference-range',
-                  code: 'absolute',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-    {
-      fullUrl: 'https://openmrs-spa.org/openmrs/ws/fhir2//R4/Observation/9e396c1d-4396-47aa-85ab-fa1ea989a7fe',
-      resource: {
-        resourceType: 'Observation',
-        id: '9e396c1d-4396-47aa-85ab-fa1ea989a7fe',
-        meta: {
-          tag: [
-            {
-              system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue',
-              code: 'SUBSETTED',
-              display: 'Resource encoded in summary mode',
-            },
-          ],
-        },
-        status: 'final',
-        category: [
-          {
-            coding: [
-              {
-                system: 'http://terminology.hl7.org/CodeSystem/observation-category',
-                code: 'exam',
-                display: 'Exam',
-              },
-            ],
-          },
-        ],
-        code: {
-          coding: [
-            {
-              code: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-              display: 'Height (cm)',
-            },
-            {
-              system: 'http://loinc.org',
-              code: '8302-2',
-              display: 'Height (cm)',
-            },
-          ],
-        },
-        subject: {
-          reference: 'Patient/8673ee4f-e2ab-4077-ba55-4980f408773e',
-          type: 'Patient',
-          display: 'John Wilson (Old Identification Number: 100GEJ)',
-        },
-        encounter: {
-          reference: 'Encounter/b5e913b6-a6cb-4be1-ac5c-173580558d20',
-          type: 'Encounter',
-        },
-        effectiveDateTime: '2021-04-08T14:44:24+00:00',
-        issued: '2021-04-08T14:44:24.000+00:00',
-        valueQuantity: {
-          value: 172,
-          unit: 'cm',
-        },
-        referenceRange: [
-          {
-            low: {
-              value: 10,
-            },
-            high: {
-              value: 272,
             },
             type: {
               coding: [
@@ -6063,15 +5132,49 @@ export const formattedVitals = [
   },
 ];
 
-export const mockVitalsConceptMetadata = mockVitalsSignsConcepts.data.results[0].setMembers;
-
-export const mockConceptUnits = new Map<string, string>(
-  mockVitalsConceptMetadata.map((concept) => [concept.uuid, concept.units]),
-);
+export const mockVitalsConceptMetadata = {
+  data: null,
+  error: null,
+  isLoading: false,
+  conceptMetadata: mockVitalsSignsConcepts.data.results[0].setMembers,
+  conceptRanges: mockVitalsSignsConcepts.data.results[0].setMembers.map((concept) => ({
+    uuid: concept.uuid,
+    display: concept.display,
+    hiNormal: concept.hiNormal ?? null,
+    hiAbsolute: concept.hiAbsolute ?? null,
+    hiCritical: concept.hiCritical ?? null,
+    lowNormal: concept.lowNormal ?? null,
+    lowAbsolute: concept.lowAbsolute ?? null,
+    lowCritical: concept.lowCritical ?? null,
+    units: concept.units ?? null,
+  })),
+  conceptRangeMap: new Map(
+    mockVitalsSignsConcepts.data.results[0].setMembers.map((concept) => [
+      concept.uuid,
+      {
+        hiNormal: concept.hiNormal ?? null,
+        hiAbsolute: concept.hiAbsolute ?? null,
+        hiCritical: concept.hiCritical ?? null,
+        lowNormal: concept.lowNormal ?? null,
+        lowAbsolute: concept.lowAbsolute ?? null,
+        lowCritical: concept.lowCritical ?? null,
+      },
+    ]),
+  ),
+};
 
 export const mockConceptRanges = new Map<string, { lowAbsolute: number | null; highAbsolute: number | null }>(
-  mockVitalsConceptMetadata.map((concept) => [
+  mockVitalsConceptMetadata.conceptMetadata.map((concept) => [
     concept.uuid,
-    { lowAbsolute: concept.lowAbsolute ?? null, highAbsolute: concept.hiAbsolute ?? null },
+    {
+      lowAbsolute: concept.lowAbsolute ?? null,
+      highAbsolute: concept.hiAbsolute ?? null,
+    },
   ]),
 );
+
+export const mockConceptUnits = new Map<string, string>(
+  mockVitalsConceptMetadata.conceptMetadata.map((concept) => [concept.uuid, concept.units]),
+);
+
+mockVitalsConceptMetadata.data = mockConceptUnits;

--- a/__mocks__/vitals-concept-metadata.mock.ts
+++ b/__mocks__/vitals-concept-metadata.mock.ts
@@ -1,0 +1,48 @@
+import { mockVitalsSignsConcepts } from './vitals-and-biometrics.mock';
+
+const mockConceptData = mockVitalsSignsConcepts.data.results[0].setMembers;
+
+export const mockConceptUnits = new Map<string, string>(
+  mockConceptData.map((concept) => [concept.uuid, concept.units]),
+);
+
+export const mockVitalsConceptMetadata = {
+  data: mockConceptUnits,
+  error: null,
+  isLoading: false,
+  conceptMetadata: mockConceptData,
+  conceptRanges: mockConceptData.map((concept) => ({
+    uuid: concept.uuid,
+    display: concept.display,
+    hiNormal: concept.hiNormal ?? null,
+    hiAbsolute: concept.hiAbsolute ?? null,
+    hiCritical: concept.hiCritical ?? null,
+    lowNormal: concept.lowNormal ?? null,
+    lowAbsolute: concept.lowAbsolute ?? null,
+    lowCritical: concept.lowCritical ?? null,
+    units: concept.units ?? null,
+  })),
+  conceptRangeMap: new Map(
+    mockConceptData.map((concept) => [
+      concept.uuid,
+      {
+        uuid: concept.uuid,
+        display: concept.display,
+        hiNormal: concept.hiNormal ?? null,
+        hiAbsolute: concept.hiAbsolute ?? null,
+        hiCritical: concept.hiCritical ?? null,
+        lowNormal: concept.lowNormal ?? null,
+        lowAbsolute: concept.lowAbsolute ?? null,
+        lowCritical: concept.lowCritical ?? null,
+        units: concept.units ?? null,
+      },
+    ]),
+  ),
+};
+
+export const mockConceptRanges = new Map<string, { lowAbsolute: number | null; highAbsolute: number | null }>(
+  mockConceptData.map((concept) => [
+    concept.uuid,
+    { lowAbsolute: concept.lowAbsolute ?? null, highAbsolute: concept.hiAbsolute ?? null },
+  ]),
+);

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-base.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-base.component.tsx
@@ -5,7 +5,7 @@ import { Add, Analytics, Table } from '@carbon/react/icons';
 import { formatDatetime, parseDate, useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { CardHeader, EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { useLaunchVitalsAndBiometricsForm } from '../utils';
-import { useVitalsConceptMetadata, useVitalsAndBiometrics, withUnit } from '../common';
+import { useConceptUnits, useVitalsAndBiometrics, withUnit } from '../common';
 import { type ConfigObject } from '../config-schema';
 import type { BiometricsTableHeader, BiometricsTableRow } from './types';
 import BiometricsChart from './biometrics-chart.component';
@@ -29,7 +29,7 @@ const BiometricsBase: React.FC<BiometricsBaseProps> = ({ patientUuid, pageSize, 
   const config = useConfig<ConfigObject>();
   const { bmiUnit } = config.biometrics;
   const { data: biometrics, isLoading, error, isValidating } = useVitalsAndBiometrics(patientUuid, 'biometrics');
-  const { data: conceptUnits } = useVitalsConceptMetadata();
+  const { conceptUnits } = useConceptUnits();
   const launchBiometricsForm = useLaunchVitalsAndBiometricsForm();
 
   const tableHeaders: Array<BiometricsTableHeader> = [

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
-import { formattedBiometrics, mockBiometricsConfig, mockConceptMetadata, mockConceptUnits } from '__mocks__';
+import { formattedBiometrics, mockBiometricsConfig, mockConceptUnits } from '__mocks__';
 import { configSchema, type ConfigObject } from '../config-schema';
 import { mockPatient, patientChartBasePath, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { useVitalsAndBiometrics } from '../common';
@@ -22,9 +22,9 @@ jest.mock('../common', () => {
 
   return {
     ...originalModule,
-    useVitalsConceptMetadata: jest.fn().mockImplementation(() => ({
-      data: mockConceptUnits,
-      conceptMetadata: mockConceptMetadata,
+    useConceptUnits: jest.fn().mockImplementation(() => ({
+      conceptUnits: mockConceptUnits,
+      error: null,
       isLoading: false,
     })),
     useVitalsAndBiometrics: jest.fn(),
@@ -36,7 +36,7 @@ mockUseConfig.mockReturnValue({
   ...mockBiometricsConfig,
 } as ConfigObject);
 
-describe('BiometricsOverview', () => {
+describe('Biometrics Overview', () => {
   it('renders an empty state view if biometrics data is unavailable', async () => {
     mockUseVitalsAndBiometrics.mockReturnValue({
       data: [],

--- a/packages/esm-patient-vitals-app/src/common/helpers.ts
+++ b/packages/esm-patient-vitals-app/src/common/helpers.ts
@@ -1,8 +1,8 @@
 import { type OpenmrsResource } from '@openmrs/esm-framework';
 import { type ConceptMetadata } from '../common';
+import type { ObsReferenceRanges, ObservationInterpretation } from './types';
 import { type VitalsBiometricsFormData } from '../vitals-biometrics-form/schema';
 import { type VitalsAndBiometricsFieldValuesMap } from './data.resource';
-import type { ObsReferenceRanges, ObservationInterpretation } from './types';
 
 export function calculateBodyMassIndex(weight: number, height: number) {
   if (weight > 0 && height > 0) {

--- a/packages/esm-patient-vitals-app/src/common/index.ts
+++ b/packages/esm-patient-vitals-app/src/common/index.ts
@@ -1,18 +1,19 @@
 export {
+  createOrUpdateVitalsAndBiometrics,
   deleteEncounter,
   invalidateCachedVitalsAndBiometrics,
+  useConceptUnits,
+  useEncounterVitalsAndBiometrics,
   useVitalsAndBiometrics,
   useVitalsConceptMetadata,
-  createOrUpdateVitalsAndBiometrics,
-  useEncounterVitalsAndBiometrics,
   withUnit,
   type ConceptMetadata,
 } from './data.resource';
 export {
   assessValue,
   calculateBodyMassIndex,
-  getReferenceRangesForConcept,
   generatePlaceholder,
+  getReferenceRangesForConcept,
   interpretBloodPressure,
 } from './helpers';
 export type { ObservationInterpretation, PatientVitalsAndBiometrics } from './types';

--- a/packages/esm-patient-vitals-app/src/common/types.ts
+++ b/packages/esm-patient-vitals-app/src/common/types.ts
@@ -26,6 +26,64 @@ export type MappedVitals = {
   encounterId: string;
 };
 
+export interface FHIRObservationResource {
+  resourceType: string;
+  id: string;
+  category: Array<{
+    coding: Array<{
+      system: string;
+      code: string;
+      display: string;
+    }>;
+  }>;
+  code: {
+    coding: Array<{
+      code: string;
+      display: string;
+    }>;
+    text: string;
+  };
+  encounter?: {
+    reference: string;
+    type: string;
+  };
+  effectiveDateTime: string;
+  issued: string;
+  valueString?: string;
+  valueQuantity?: {
+    value: number;
+    unit: string;
+    system: string;
+    code: string;
+  };
+  valueCodeableConcept?: {
+    coding: [
+      {
+        code: string;
+        display: string;
+      },
+    ];
+    text: string;
+  };
+  referenceRange: Array<{
+    low?: {
+      value: number;
+    };
+    high?: {
+      value: number;
+    };
+    type: {
+      coding: Array<{
+        system: string;
+        code: string;
+      }>;
+    };
+  }>;
+  hasMember?: Array<{
+    reference: string;
+  }>;
+}
+
 export interface PatientVitalsAndBiometrics {
   id: string;
   date: string;
@@ -33,18 +91,22 @@ export interface PatientVitalsAndBiometrics {
   diastolic?: number;
   bloodPressureRenderInterpretation?: ObservationInterpretation;
   pulse?: number;
+  pulseRenderInterpretation?: ObservationInterpretation;
   temperature?: number;
+  temperatureRenderInterpretation?: ObservationInterpretation;
   spo2?: number;
+  spo2RenderInterpretation?: ObservationInterpretation;
   height?: number;
   weight?: number;
   bmi?: number | null;
   respiratoryRate?: number;
+  respiratoryRateRenderInterpretation?: ObservationInterpretation;
   muac?: number;
 }
 
 export interface VitalsResponse {
   entry: Array<{
-    resource: FHIRResource['resource'];
+    resource: FHIRObservationResource;
   }>;
   id: string;
   meta: {

--- a/packages/esm-patient-vitals-app/src/components/weight-tile/weight-tile.component.tsx
+++ b/packages/esm-patient-vitals-app/src/components/weight-tile/weight-tile.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { InlineLoading } from '@carbon/react';
 import { useConfig } from '@openmrs/esm-framework';
-import { useVitalsAndBiometrics, useVitalsConceptMetadata } from '../../common';
+import { useVitalsAndBiometrics, useConceptUnits } from '../../common';
 import { type ConfigObject } from '../../config-schema';
 import styles from './weight-tile.scss';
 
@@ -11,15 +11,16 @@ interface WeightTileInterface {
 }
 
 const WeightTile: React.FC<WeightTileInterface> = ({ patientUuid }) => {
-  const { t } = useTranslation();
   const config = useConfig<ConfigObject>();
-  const { data: conceptUnits } = useVitalsConceptMetadata();
+  const { t } = useTranslation();
+  const { conceptUnits } = useConceptUnits();
   const { data: biometrics, isLoading } = useVitalsAndBiometrics(patientUuid, 'biometrics');
   const weightData = biometrics?.filter((result) => result.weight);
 
   if (isLoading) {
     return <InlineLoading role="progressbar" description={`${t('loading', 'Loading')} ...`} />;
   }
+
   if (weightData?.length) {
     return (
       <div>
@@ -31,6 +32,7 @@ const WeightTile: React.FC<WeightTileInterface> = ({ patientUuid }) => {
       </div>
     );
   }
+
   return (
     <div>
       <p className={styles.label}>{t('weight', 'Weight')}</p>

--- a/packages/esm-patient-vitals-app/src/components/weight-tile/weight-tile.test.tsx
+++ b/packages/esm-patient-vitals-app/src/components/weight-tile/weight-tile.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
 import { configSchema, type ConfigObject } from '../../config-schema';
 import { getByTextWithMarkup, mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
-import { formattedBiometrics, mockBiometricsConfig, mockConceptMetadata, mockVitalsSignsConcepts } from '__mocks__';
+import { formattedBiometrics, mockBiometricsConfig, mockVitalsSignsConcepts } from '__mocks__';
 import { useVitalsAndBiometrics } from '../../common';
 import WeightTile from './weight-tile.component';
 
@@ -18,9 +18,10 @@ jest.mock('../../common', () => {
 
   return {
     ...originalModule,
-    useVitalsConceptMetadata: jest.fn().mockImplementation(() => ({
-      data: mockConceptUnits,
-      conceptMetadata: mockConceptMetadata,
+    useConceptUnits: jest.fn().mockImplementation(() => ({
+      conceptUnits: mockConceptUnits,
+      error: null,
+      isLoading: false,
     })),
     useVitalsAndBiometrics: jest.fn(),
   };

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.component.tsx
@@ -14,6 +14,7 @@ import {
   assessValue,
   getReferenceRangesForConcept,
   interpretBloodPressure,
+  useConceptUnits,
   useVitalsAndBiometrics,
   useVitalsConceptMetadata,
 } from '../common';
@@ -34,8 +35,9 @@ interface VitalsHeaderProps {
 const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, hideLinks = false }) => {
   const { t } = useTranslation();
   const config = useConfig<ConfigObject>();
-  const { data: conceptUnits, conceptMetadata } = useVitalsConceptMetadata();
+  const { conceptUnits } = useConceptUnits();
   const { data: vitals, isLoading, isValidating } = useVitalsAndBiometrics(patientUuid, 'both');
+  const { conceptRanges } = useVitalsConceptMetadata(patientUuid);
   const latestVitals = vitals?.[0];
   const [showDetailsPanel, setShowDetailsPanel] = useState(false);
   const toggleDetailsPanel = () => setShowDetailsPanel(!showDetailsPanel);
@@ -59,7 +61,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, hideLinks = fa
     );
   }
 
-  if (latestVitals && Object.keys(latestVitals)?.length && conceptMetadata?.length) {
+  if (latestVitals && Object.keys(latestVitals)?.length && conceptRanges?.length) {
     const hasActiveVisit = Boolean(currentVisit?.uuid);
     const vitalsTakenToday = Boolean(dayjs(latestVitals?.date).isToday());
     const vitalsOverdue = hasActiveVisit && !vitalsTakenToday;
@@ -148,7 +150,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, hideLinks = fa
                 latestVitals?.systolic,
                 latestVitals?.diastolic,
                 config?.concepts,
-                conceptMetadata,
+                conceptRanges,
               )}
               unitName={t('bp', 'BP')}
               unitSymbol={(latestVitals?.systolic && conceptUnits.get(config.concepts.systolicBloodPressureUuid)) ?? ''}
@@ -157,7 +159,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, hideLinks = fa
             <VitalsHeaderItem
               interpretation={assessValue(
                 latestVitals?.pulse,
-                getReferenceRangesForConcept(config.concepts.pulseUuid, conceptMetadata),
+                getReferenceRangesForConcept(config.concepts.pulseUuid, conceptRanges),
               )}
               unitName={t('heartRate', 'Heart rate')}
               unitSymbol={(latestVitals?.pulse && conceptUnits.get(config.concepts.pulseUuid)) ?? ''}
@@ -166,7 +168,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, hideLinks = fa
             <VitalsHeaderItem
               interpretation={assessValue(
                 latestVitals?.respiratoryRate,
-                getReferenceRangesForConcept(config.concepts.respiratoryRateUuid, conceptMetadata),
+                getReferenceRangesForConcept(config.concepts.respiratoryRateUuid, conceptRanges),
               )}
               unitName={t('respiratoryRate', 'R. rate')}
               unitSymbol={
@@ -177,7 +179,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, hideLinks = fa
             <VitalsHeaderItem
               interpretation={assessValue(
                 latestVitals?.spo2,
-                getReferenceRangesForConcept(config.concepts.oxygenSaturationUuid, conceptMetadata),
+                getReferenceRangesForConcept(config.concepts.oxygenSaturationUuid, conceptRanges),
               )}
               unitName={t('spo2', 'SpO2')}
               unitSymbol={(latestVitals?.spo2 && conceptUnits.get(config.concepts.oxygenSaturationUuid)) ?? ''}
@@ -186,7 +188,7 @@ const VitalsHeader: React.FC<VitalsHeaderProps> = ({ patientUuid, hideLinks = fa
             <VitalsHeaderItem
               interpretation={assessValue(
                 latestVitals?.temperature,
-                getReferenceRangesForConcept(config.concepts.temperatureUuid, conceptMetadata),
+                getReferenceRangesForConcept(config.concepts.temperatureUuid, conceptRanges),
               )}
               unitName={t('temperatureAbbreviated', 'Temp')}
               unitSymbol={(latestVitals?.temperature && conceptUnits.get(config.concepts.temperatureUuid)) ?? ''}

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
@@ -5,10 +5,15 @@ import userEvent from '@testing-library/user-event';
 import { type WorkspacesInfo, getDefaultsFromConfigSchema, useConfig, useWorkspaces } from '@openmrs/esm-framework';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { mockPatient, getByTextWithMarkup, renderWithSwr, waitForLoadingToFinish } from 'tools';
-import { mockVitalsConfig, mockCurrentVisit, mockConceptUnits, mockConceptMetadata, formattedVitals } from '__mocks__';
+import {
+  formattedVitals,
+  mockConceptUnits,
+  mockCurrentVisit,
+  mockVitalsConceptMetadata,
+  mockVitalsConfig,
+} from '__mocks__';
 import { configSchema, type ConfigObject } from '../config-schema';
-import { patientVitalsBiometricsFormWorkspace } from '../constants';
-import { invalidateCachedVitalsAndBiometrics, useVitalsAndBiometrics } from '../common';
+import { useVitalsAndBiometrics } from '../common';
 import VitalsHeader from './vitals-header.component';
 
 const testProps = {
@@ -38,16 +43,17 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
   };
 });
 
-jest.mock('../common', () => {
-  const originalModule = jest.requireActual('../common');
+jest.mock('../common/data.resource', () => {
+  const originalModule = jest.requireActual('../common/data.resource');
 
   return {
     ...originalModule,
-    useVitalsConceptMetadata: jest.fn().mockImplementation(() => ({
-      data: mockConceptUnits,
-      conceptMetadata: mockConceptMetadata,
+    useConceptUnits: jest.fn().mockImplementation(() => ({
+      conceptUnits: mockConceptUnits,
+      error: null,
       isLoading: false,
     })),
+    useVitalsConceptMetadata: jest.fn().mockImplementation(() => mockVitalsConceptMetadata),
     useVitalsAndBiometrics: jest.fn(),
   };
 });
@@ -74,7 +80,20 @@ describe('VitalsHeader', () => {
 
   it('renders the most recently recorded values in the vitals header', async () => {
     mockUseVitalsAndBiometrics.mockReturnValue({
-      data: formattedVitals,
+      data: [
+        {
+          id: '0',
+          date: '2021-05-19T04:26:51.000Z',
+          pulse: 76,
+          temperature: 37,
+          respiratoryRate: 12,
+          diastolic: 89,
+          systolic: 121,
+          bmi: null,
+          muac: 23,
+          bloodPressureRenderInterpretation: 'normal',
+        },
+      ],
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
     renderWithSwr(<VitalsHeader {...testProps} />);
@@ -134,8 +153,23 @@ describe('VitalsHeader', () => {
   });
 
   it('does not flag normal values that lie within the provided reference ranges', async () => {
+    const normalVitals = [
+      {
+        id: '0',
+        date: '2021-05-19T04:26:51.000Z',
+        pulse: 76,
+        temperature: 37,
+        respiratoryRate: 12,
+        diastolic: 75, // Within normal range (60-80)
+        systolic: 115, // Within normal range (90-120)
+        bmi: null,
+        muac: 23,
+        bloodPressureRenderInterpretation: 'normal',
+      },
+    ];
+
     mockUseVitalsAndBiometrics.mockReturnValue({
-      data: formattedVitals,
+      data: normalVitals,
     } as ReturnType<typeof useVitalsAndBiometrics>);
 
     renderWithSwr(<VitalsHeader {...testProps} />);

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
@@ -15,14 +15,13 @@ import {
 } from '@carbon/react';
 import {
   age,
-  createErrorHandler,
+  ExtensionSlot,
   showSnackbar,
+  useAbortController,
   useConfig,
   useLayoutType,
   useSession,
-  ExtensionSlot,
   useVisit,
-  useAbortController,
 } from '@openmrs/esm-framework';
 import { type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import { type ConfigObject } from '../config-schema';
@@ -34,14 +33,15 @@ import {
 } from './vitals-biometrics-form.utils';
 import {
   assessValue,
+  createOrUpdateVitalsAndBiometrics,
   getReferenceRangesForConcept,
   interpretBloodPressure,
   invalidateCachedVitalsAndBiometrics,
-  useVitalsConceptMetadata,
-  createOrUpdateVitalsAndBiometrics,
+  useConceptUnits,
   useEncounterVitalsAndBiometrics,
 } from '../common';
 import { prepareObsForSubmission } from '../common/helpers';
+import { useVitalsConceptMetadata } from '../common/data.resource';
 import { VitalsAndBiometricsFormSchema, type VitalsBiometricsFormData } from './schema';
 import VitalsAndBiometricsInput from './vitals-biometrics-input.component';
 import styles from './vitals-biometrics-form.scss';
@@ -68,12 +68,8 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
 
   const session = useSession();
   const { currentVisit } = useVisit(patientUuid);
-  const {
-    data: conceptUnits,
-    conceptMetadata,
-    conceptRanges,
-    isLoading: isLoadingConceptMetadata,
-  } = useVitalsConceptMetadata();
+  const { conceptUnits, isLoading: isLoadingConceptUnits } = useConceptUnits();
+  const { conceptRanges, conceptRangeMap } = useVitalsConceptMetadata(patientUuid);
   const {
     getRefinedInitialValues,
     isLoading: isLoadingEncounter,
@@ -153,28 +149,17 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
 
   const concepts = useMemo(
     () => ({
-      midUpperArmCircumferenceRange: conceptRanges.get(config.concepts.midUpperArmCircumferenceUuid),
-      diastolicBloodPressureRange: conceptRanges.get(config.concepts.diastolicBloodPressureUuid),
-      systolicBloodPressureRange: conceptRanges.get(config.concepts.systolicBloodPressureUuid),
-      oxygenSaturationRange: conceptRanges.get(config.concepts.oxygenSaturationUuid),
-      respiratoryRateRange: conceptRanges.get(config.concepts.respiratoryRateUuid),
-      temperatureRange: conceptRanges.get(config.concepts.temperatureUuid),
-      weightRange: conceptRanges.get(config.concepts.weightUuid),
-      heightRange: conceptRanges.get(config.concepts.heightUuid),
-      pulseRange: conceptRanges.get(config.concepts.pulseUuid),
+      midUpperArmCircumferenceRange: conceptRangeMap.get(config.concepts.midUpperArmCircumferenceUuid),
+      diastolicBloodPressureRange: conceptRangeMap.get(config.concepts.diastolicBloodPressureUuid),
+      systolicBloodPressureRange: conceptRangeMap.get(config.concepts.systolicBloodPressureUuid),
+      oxygenSaturationRange: conceptRangeMap.get(config.concepts.oxygenSaturationUuid),
+      respiratoryRateRange: conceptRangeMap.get(config.concepts.respiratoryRateUuid),
+      temperatureRange: conceptRangeMap.get(config.concepts.temperatureUuid),
+      weightRange: conceptRangeMap.get(config.concepts.weightUuid),
+      heightRange: conceptRangeMap.get(config.concepts.heightUuid),
+      pulseRange: conceptRangeMap.get(config.concepts.pulseUuid),
     }),
-    [
-      conceptRanges,
-      config.concepts.diastolicBloodPressureUuid,
-      config.concepts.heightUuid,
-      config.concepts.midUpperArmCircumferenceUuid,
-      config.concepts.oxygenSaturationUuid,
-      config.concepts.pulseUuid,
-      config.concepts.respiratoryRateUuid,
-      config.concepts.systolicBloodPressureUuid,
-      config.concepts.temperatureUuid,
-      config.concepts.weightUuid,
-    ],
+    [conceptRangeMap, config.concepts],
   );
 
   const savePatientVitalsAndBiometrics = useCallback(
@@ -187,7 +172,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
 
       const allFieldsAreValid = Object.entries(formData)
         .filter(([, value]) => Boolean(value))
-        .every(([key, value]) => isValueWithinReferenceRange(conceptMetadata, config.concepts[`${key}Uuid`], value));
+        .every(([key, value]) => isValueWithinReferenceRange(conceptRanges, config.concepts[`${key}Uuid`], value));
 
       if (allFieldsAreValid) {
         setShowErrorMessage(false);
@@ -224,7 +209,6 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
             });
           })
           .catch(() => {
-            createErrorHandler();
             showSnackbar({
               title:
                 formContext === 'creating'
@@ -241,17 +225,17 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
     },
     [
       abortController,
-      conceptMetadata,
+      closeWorkspaceWithSavedChanges,
       config.concepts,
       config.vitals.encounterTypeUuid,
       dirtyFields,
       editEncounterUuid,
+      conceptRanges,
       formContext,
       initialFieldValuesMap,
+      mutateEncounter,
       patientUuid,
       session?.sessionLocation?.uuid,
-      closeWorkspaceWithSavedChanges,
-      mutateEncounter,
       t,
     ],
   );
@@ -274,7 +258,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
     );
   }
 
-  if (isLoadingConceptMetadata || isLoadingInitialValues) {
+  if (isLoadingConceptUnits || isLoadingInitialValues) {
     return (
       <Form className={styles.form}>
         <ExtensionSlot name="visit-context-header-slot" state={{ patientUuid }} />
@@ -322,7 +306,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                 fieldProperties={[
                   {
                     id: 'temperature',
-                    max: concepts.temperatureRange?.highAbsolute,
+                    max: concepts.temperatureRange?.hiAbsolute,
                     min: concepts.temperatureRange?.lowAbsolute,
                     name: t('temperature', 'Temperature'),
                     type: 'number',
@@ -330,14 +314,11 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                 ]}
                 interpretation={
                   temperature &&
-                  assessValue(
-                    temperature,
-                    getReferenceRangesForConcept(config.concepts.temperatureUuid, conceptMetadata),
-                  )
+                  assessValue(temperature, getReferenceRangesForConcept(config.concepts.temperatureUuid, conceptRanges))
                 }
                 isValueWithinReferenceRange={
                   temperature
-                    ? isValueWithinReferenceRange(conceptMetadata, config.concepts['temperatureUuid'], temperature)
+                    ? isValueWithinReferenceRange(conceptRanges, config.concepts['temperatureUuid'], temperature)
                     : true
                 }
                 showErrorMessage={showErrorMessage}
@@ -354,37 +335,32 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                     separator: '/',
                     type: 'number',
                     min: concepts.systolicBloodPressureRange?.lowAbsolute,
-                    max: concepts.systolicBloodPressureRange?.highAbsolute,
+                    max: concepts.systolicBloodPressureRange?.hiAbsolute,
                     id: 'systolicBloodPressure',
                   },
                   {
                     name: t('diastolic', 'diastolic'),
                     type: 'number',
                     min: concepts.diastolicBloodPressureRange?.lowAbsolute,
-                    max: concepts.diastolicBloodPressureRange?.highAbsolute,
+                    max: concepts.diastolicBloodPressureRange?.hiAbsolute,
                     id: 'diastolicBloodPressure',
                   },
                 ]}
                 interpretation={
                   systolicBloodPressure &&
                   diastolicBloodPressure &&
-                  interpretBloodPressure(
-                    systolicBloodPressure,
-                    diastolicBloodPressure,
-                    config.concepts,
-                    conceptMetadata,
-                  )
+                  interpretBloodPressure(systolicBloodPressure, diastolicBloodPressure, config.concepts, conceptRanges)
                 }
                 isValueWithinReferenceRange={
                   systolicBloodPressure &&
                   diastolicBloodPressure &&
                   isValueWithinReferenceRange(
-                    conceptMetadata,
+                    conceptRanges,
                     config.concepts.systolicBloodPressureUuid,
                     systolicBloodPressure,
                   ) &&
                   isValueWithinReferenceRange(
-                    conceptMetadata,
+                    conceptRanges,
                     config.concepts.diastolicBloodPressureUuid,
                     diastolicBloodPressure,
                   )
@@ -402,15 +378,15 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                     name: t('pulse', 'Pulse'),
                     type: 'number',
                     min: concepts.pulseRange?.lowAbsolute,
-                    max: concepts.pulseRange?.highAbsolute,
+                    max: concepts.pulseRange?.hiAbsolute,
                     id: 'pulse',
                   },
                 ]}
                 interpretation={
-                  pulse && assessValue(pulse, getReferenceRangesForConcept(config.concepts.pulseUuid, conceptMetadata))
+                  pulse && assessValue(pulse, getReferenceRangesForConcept(config.concepts.pulseUuid, conceptRanges))
                 }
                 isValueWithinReferenceRange={
-                  pulse && isValueWithinReferenceRange(conceptMetadata, config.concepts['pulseUuid'], pulse)
+                  pulse && isValueWithinReferenceRange(conceptRanges, config.concepts['pulseUuid'], pulse)
                 }
                 label={t('heartRate', 'Heart rate')}
                 showErrorMessage={showErrorMessage}
@@ -425,7 +401,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                     name: t('respirationRate', 'Respiration rate'),
                     type: 'number',
                     min: concepts.respiratoryRateRange?.lowAbsolute,
-                    max: concepts.respiratoryRateRange?.highAbsolute,
+                    max: concepts.respiratoryRateRange?.hiAbsolute,
                     id: 'respiratoryRate',
                   },
                 ]}
@@ -433,12 +409,12 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                   respiratoryRate &&
                   assessValue(
                     respiratoryRate,
-                    getReferenceRangesForConcept(config.concepts.respiratoryRateUuid, conceptMetadata),
+                    getReferenceRangesForConcept(config.concepts.respiratoryRateUuid, conceptRanges),
                   )
                 }
                 isValueWithinReferenceRange={
                   respiratoryRate &&
-                  isValueWithinReferenceRange(conceptMetadata, config.concepts['respiratoryRateUuid'], respiratoryRate)
+                  isValueWithinReferenceRange(conceptRanges, config.concepts['respiratoryRateUuid'], respiratoryRate)
                 }
                 showErrorMessage={showErrorMessage}
                 label={t('respirationRate', 'Respiration rate')}
@@ -453,7 +429,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                     name: t('oxygenSaturation', 'Oxygen saturation'),
                     type: 'number',
                     min: concepts.oxygenSaturationRange?.lowAbsolute,
-                    max: concepts.oxygenSaturationRange?.highAbsolute,
+                    max: concepts.oxygenSaturationRange?.hiAbsolute,
                     id: 'oxygenSaturation',
                   },
                 ]}
@@ -461,16 +437,12 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                   oxygenSaturation &&
                   assessValue(
                     oxygenSaturation,
-                    getReferenceRangesForConcept(config.concepts.oxygenSaturationUuid, conceptMetadata),
+                    getReferenceRangesForConcept(config.concepts.oxygenSaturationUuid, conceptRanges),
                   )
                 }
                 isValueWithinReferenceRange={
                   oxygenSaturation &&
-                  isValueWithinReferenceRange(
-                    conceptMetadata,
-                    config.concepts['oxygenSaturationUuid'],
-                    oxygenSaturation,
-                  )
+                  isValueWithinReferenceRange(conceptRanges, config.concepts['oxygenSaturationUuid'], oxygenSaturation)
                 }
                 showErrorMessage={showErrorMessage}
                 label={t('spo2', 'SpO2')}
@@ -510,16 +482,15 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                     name: t('weight', 'Weight'),
                     type: 'number',
                     min: concepts.weightRange?.lowAbsolute,
-                    max: concepts.weightRange?.highAbsolute,
+                    max: concepts.weightRange?.hiAbsolute,
                     id: 'weight',
                   },
                 ]}
                 interpretation={
-                  weight &&
-                  assessValue(weight, getReferenceRangesForConcept(config.concepts.weightUuid, conceptMetadata))
+                  weight && assessValue(weight, getReferenceRangesForConcept(config.concepts.weightUuid, conceptRanges))
                 }
                 isValueWithinReferenceRange={
-                  height && isValueWithinReferenceRange(conceptMetadata, config.concepts['weightUuid'], weight)
+                  height && isValueWithinReferenceRange(conceptRanges, config.concepts['weightUuid'], weight)
                 }
                 showErrorMessage={showErrorMessage}
                 label={t('weight', 'Weight')}
@@ -534,16 +505,15 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                     name: t('height', 'Height'),
                     type: 'number',
                     min: concepts.heightRange?.lowAbsolute,
-                    max: concepts.heightRange?.highAbsolute,
+                    max: concepts.heightRange?.hiAbsolute,
                     id: 'height',
                   },
                 ]}
                 interpretation={
-                  height &&
-                  assessValue(height, getReferenceRangesForConcept(config.concepts.heightUuid, conceptMetadata))
+                  height && assessValue(height, getReferenceRangesForConcept(config.concepts.heightUuid, conceptRanges))
                 }
                 isValueWithinReferenceRange={
-                  weight && isValueWithinReferenceRange(conceptMetadata, config.concepts['heightUuid'], height)
+                  weight && isValueWithinReferenceRange(conceptRanges, config.concepts['heightUuid'], height)
                 }
                 showErrorMessage={showErrorMessage}
                 label={t('height', 'Height')}
@@ -573,7 +543,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                     name: t('muac', 'MUAC'),
                     type: 'number',
                     min: concepts.midUpperArmCircumferenceRange?.lowAbsolute,
-                    max: concepts.midUpperArmCircumferenceRange?.highAbsolute,
+                    max: concepts.midUpperArmCircumferenceRange?.hiAbsolute,
                     id: 'midUpperArmCircumference',
                   },
                 ]}
@@ -582,7 +552,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
                   height &&
                   weight &&
                   isValueWithinReferenceRange(
-                    conceptMetadata,
+                    conceptRanges,
                     config.concepts['midUpperArmCircumferenceUuid'],
                     midUpperArmCircumference,
                   )

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.test.tsx
@@ -91,7 +91,7 @@ jest.mock('../common', () => {
   return {
     ...originalModule,
     launchPatientWorkspace: jest.fn(),
-    useVitalsConceptMetadata: jest.fn().mockImplementation(() => ({
+    useConceptUnits: jest.fn().mockImplementation(() => ({
       data: mockConceptUnits,
       conceptMetadata: { ...overridenMetadata },
       isLoading: false,

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -34,7 +34,7 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
 }) => {
   const isTablet = useLayoutType() === 'tablet';
 
-  const StyledTableCell = ({ interpretation, children }: { interpretation: string; children: React.ReactNode }) => {
+  const StyledTableCell = ({ children, interpretation }: { children: React.ReactNode; interpretation: string }) => {
     switch (interpretation) {
       case 'critically_high':
         return <TableCell className={styles.criticallyHigh}>{children}</TableCell>;

--- a/packages/esm-patient-vitals-app/src/vitals/types.ts
+++ b/packages/esm-patient-vitals-app/src/vitals/types.ts
@@ -1,13 +1,18 @@
-import { type PatientVitalsAndBiometrics } from '../common';
+import { type PatientVitalsAndBiometrics, type ObservationInterpretation } from '../common';
 
 export interface VitalsTableRow extends PatientVitalsAndBiometrics {
   id: string;
   dateRender: string;
   bloodPressureRender: string;
+  bloodPressureRenderInterpretation?: ObservationInterpretation;
   pulseRender: string | number;
+  pulseRenderInterpretation?: ObservationInterpretation;
   spo2Render: string | number;
+  spo2RenderInterpretation?: ObservationInterpretation;
   temperatureRender: string | number;
+  temperatureRenderInterpretation?: ObservationInterpretation;
   respiratoryRateRender: string | number;
+  respiratoryRateRenderInterpretation?: ObservationInterpretation;
 }
 
 export interface VitalsTableHeader {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
 import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
 import { type ConfigObject, configSchema } from '../config-schema';
-import { formattedVitals, mockConceptMetadata, mockConceptUnits, mockVitalsConfig } from '__mocks__';
+import { formattedVitals, mockConceptUnits, mockVitalsConfig } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { useVitalsAndBiometrics } from '../common';
 import VitalsOverview from './vitals-overview.component';
@@ -40,9 +40,9 @@ jest.mock('../common', () => {
   return {
     ...originalModule,
     launchPatientWorkspace: jest.fn(),
-    useVitalsConceptMetadata: jest.fn().mockImplementation(() => ({
-      data: mockConceptUnits,
-      conceptMetadata: mockConceptMetadata,
+    useConceptUnits: jest.fn().mockImplementation(() => ({
+      conceptUnits: mockConceptUnits,
+      error: null,
       isLoading: false,
     })),
     useVitalsAndBiometrics: jest.fn(),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR implements age-based reference ranges for vitals on the frontend. Specifically, it makes the following changes:

- Adds patient age-based reference range fetching via the `conceptreferencerange` endpoint via the useVitalsConceptMetadata hook
- Updates the vitals sign interpretation flagging to leverage the new age-based reference ranges
- Modifies the FHIR observation handling to use the new age-based reference ranges

## Screenshots

### Before

![CleanShot 2025-04-28 at 12  40 24@2x](https://github.com/user-attachments/assets/0a055f0c-062b-49fa-aab7-b02a81b646ce)

### After

![CleanShot 2025-04-28 at 12  40 41@2x](https://github.com/user-attachments/assets/b6b37b75-eabe-49f4-b0f2-67fe8e89443b)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
