### PR TITLE
(feat) 03-4664 :retrospective data date time picker

### DIFF
--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -211,3 +211,11 @@ export const visitContextHeader = getAsyncLifecycle(
   () => import('./visit/visits-widget/visit-context/visit-context-header.component'),
   { featureName: 'visit-context-header', moduleName },
 );
+
+export const retrospectiveDateTimePicker = getAsyncLifecycle(
+  () =>
+    import(
+      './visit/visits-widget/visit-context/retrospective-data-date-time-picker/retrospective-date-time-picker.component'
+    ),
+  { featureName: 'retrospective-date-time-picker', moduleName },
+);

--- a/packages/esm-patient-chart-app/src/routes.json
+++ b/packages/esm-patient-chart-app/src/routes.json
@@ -180,6 +180,11 @@
       "name": "visit-context-header",
       "slot": "visit-context-header-slot",
       "component": "visitContextHeader"
+    },
+    {
+      "name": "retrospective-date-time-picker",
+      "slot": "restrospective-date-time-picker-slot",
+      "component": "retrospectiveDateTimePicker"
     }
   ],
   "featureFlags": [

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/retrospective-data-date-time-picker/restrospective-date-time-picker.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/retrospective-data-date-time-picker/restrospective-date-time-picker.scss
@@ -1,0 +1,15 @@
+@use '@carbon/layout';
+
+.wrapper {
+  padding: 0 layout.$spacing-05;
+}
+
+.heading {
+  font-weight: 600;
+  margin-bottom: layout.$spacing-03;
+}
+
+.pickerWrapper {
+  display: flex;
+  gap: layout.$spacing-05;
+}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/retrospective-data-date-time-picker/retrospective-date-time-picker.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/retrospective-data-date-time-picker/retrospective-date-time-picker.component.tsx
@@ -12,7 +12,7 @@ type TFormValues = {
   'retrospective-time-format': string;
 };
 
-export const RetrospectiveDateTimePicker = ({
+const RetrospectiveDateTimePicker = ({
   patientUuid,
   onChange,
 }: {
@@ -115,3 +115,5 @@ export const RetrospectiveDateTimePicker = ({
     </section>
   );
 };
+
+export default RetrospectiveDateTimePicker;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/retrospective-data-date-time-picker/retrospective-date-time-picker.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/retrospective-data-date-time-picker/retrospective-date-time-picker.component.tsx
@@ -1,0 +1,117 @@
+import { SelectItem, TimePickerSelect, TimePicker, Checkbox } from '@carbon/react';
+import { OpenmrsDatePicker, ResponsiveWrapper, useFeatureFlag, useVisit } from '@openmrs/esm-framework';
+import React, { useEffect, useState } from 'react';
+import { Controller, useForm, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import styles from './restrospective-date-time-picker.scss';
+import { useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
+
+type TFormValues = {
+  'retrospective-date': string;
+  'retrospective-time': string;
+  'retrospective-time-format': string;
+};
+
+export const RetrospectiveDateTimePicker = ({
+  patientUuid,
+  onChange,
+}: {
+  patientUuid: string;
+  onChange?: (data: TFormValues) => void;
+}) => {
+  const { t } = useTranslation();
+  const formContext = useFormContext<TFormValues>();
+  const { systemVisitEnabled } = useSystemVisitSetting();
+  const isRdeEnabled = useFeatureFlag('rde');
+
+  const showDatePicker = systemVisitEnabled && isRdeEnabled;
+
+  const { currentVisit, isLoading } = useVisit(patientUuid);
+  const isActiveVisit = !Boolean(currentVisit && currentVisit.stopDatetime);
+
+  const [manuallyEnableDateTimePicker, setManuallyEnableDateTimePicker] = useState<boolean | false>(false);
+
+  // this form is for when the component is not rendered inside a form context
+  // when this happens we assume the caller passed an onChange function which we
+  // call to supply the data
+  const form = useForm<TFormValues>();
+  const unManagedFormValues = form.getValues();
+
+  const control = formContext ? formContext.control : form.control;
+
+  // disable inputs if isActiveVisit and user has not manually enabled the picker.
+  const disableInputs = isActiveVisit && !manuallyEnableDateTimePicker;
+
+  useEffect(() => {
+    onChange?.(unManagedFormValues);
+  }, [onChange, unManagedFormValues]);
+
+  if (showDatePicker === false) {
+    return null;
+  }
+
+  return (
+    <section className={styles.wrapper}>
+      <h4 className={styles.heading}>Encounter time</h4>
+      <div className={styles.pickerWrapper}>
+        <Controller
+          name={'retrospective-date'}
+          control={control}
+          render={({ field, fieldState }) => (
+            <OpenmrsDatePicker
+              {...field}
+              id={'retrospective-date-picker-input'}
+              labelText={t('date', 'Date')}
+              invalid={Boolean(fieldState?.error?.message)}
+              invalidText={fieldState?.error?.message}
+              isDisabled={disableInputs}
+            />
+          )}
+        />
+        <Controller
+          name={'retrospective-time'}
+          control={control}
+          render={({ field: { onBlur, onChange, value } }) => (
+            <div>
+              <TimePicker
+                id={'retrospective-time-picker-input'}
+                labelText={t('time', 'Time')}
+                onBlur={onBlur}
+                onChange={(event) => onChange(event.target.value)}
+                pattern="^(0[1-9]|1[0-2]):([0-5][0-9])$"
+                value={value}
+                isDisabled={disableInputs}
+              >
+                <Controller
+                  name={'retrospective-time-format'}
+                  control={formContext.control}
+                  render={({ field: { onChange, value } }) => (
+                    <TimePickerSelect
+                      aria-label={t('timeFormat ', 'Time Format')}
+                      id={`am-pm-input`}
+                      onChange={(event) => onChange(event.target.value)}
+                      value={value}
+                    >
+                      <SelectItem value="AM" text="AM" />
+                      <SelectItem value="PM" text="PM" />
+                    </TimePickerSelect>
+                  )}
+                />
+              </TimePicker>
+            </div>
+          )}
+        />
+        {!isActiveVisit && (
+          <Checkbox
+            checked={manuallyEnableDateTimePicker}
+            className={styles.checkbox}
+            labelText={'Enable'}
+            onChange={(_, { checked, id }) => {
+              setManuallyEnableDateTimePicker(checked);
+            }}
+          />
+        )}
+      </div>
+    </section>
+  );
+};

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/retrospective-data-date-time-picker/retrospective-date-time-picker.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/retrospective-data-date-time-picker/retrospective-date-time-picker.component.tsx
@@ -65,6 +65,7 @@ const RetrospectiveDateTimePicker = ({
               invalid={Boolean(fieldState?.error?.message)}
               invalidText={fieldState?.error?.message}
               isDisabled={disableInputs}
+              maxDate={new Date()}
             />
           )}
         />
@@ -80,18 +81,20 @@ const RetrospectiveDateTimePicker = ({
                 onChange={(event) => onChange(event.target.value)}
                 pattern="^(0[1-9]|1[0-2]):([0-5][0-9])$"
                 value={value}
-                isDisabled={disableInputs}
+                disabled={disableInputs}
               >
                 <Controller
                   name={'retrospective-time-format'}
-                  control={formContext.control}
+                  control={control}
                   render={({ field: { onChange, value } }) => (
                     <TimePickerSelect
                       aria-label={t('timeFormat ', 'Time Format')}
                       id={`am-pm-input`}
                       onChange={(event) => onChange(event.target.value)}
                       value={value}
+                      disabled={disableInputs}
                     >
+                      <SelectItem value="" text="" />
                       <SelectItem value="AM" text="AM" />
                       <SelectItem value="PM" text="PM" />
                     </TimePickerSelect>
@@ -101,10 +104,11 @@ const RetrospectiveDateTimePicker = ({
             </div>
           )}
         />
-        {!isActiveVisit && (
+        {isActiveVisit && (
           <Checkbox
             checked={manuallyEnableDateTimePicker}
             className={styles.checkbox}
+            id={'enable-date-time-picker'}
             labelText={'Enable'}
             onChange={(_, { checked, id }) => {
               setManuallyEnableDateTimePicker(checked);


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [X] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds a new reusable retrospective data date time picker, which will be used for RDE data entry anywhere RDE is supported.

If used within a form context, the component will use the form's "context" and act as a normal form field. This allows it to be slotted anywhere. For use cases outside form contexts, a `onChange` prop can be passed, which will be supplied with the data as the user inputs it from the UI.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4664

## Other
<!-- Anything not covered above -->
