### PR TITLE
(fix) O3-4615 fix loading state and pagination of encounters table

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/all-encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/all-encounters-table.component.tsx
@@ -21,7 +21,6 @@ const AllEncountersTable: React.FC<AllEncountersTableProps> = ({ patientUuid }) 
     totalCount,
     goTo,
     mutate: mutateEncounters,
-    paginated,
   } = usePaginatedEncounters(patientUuid, encounterTypeToFilter?.uuid, pageSize);
 
   const encountersTableProps: EncountersTableProps = {
@@ -31,7 +30,6 @@ const AllEncountersTable: React.FC<AllEncountersTableProps> = ({ patientUuid }) 
     isLoading,
     onEncountersUpdated: mutateEncounters,
     pageSize,
-    paginated,
     paginatedEncounters,
     patientUuid,
     setEncounterTypeToFilter,

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
@@ -60,7 +60,6 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
   isLoading,
   onEncountersUpdated,
   pageSize,
-  paginated,
   paginatedEncounters,
   patientUuid,
   setEncounterTypeToFilter,
@@ -145,7 +144,7 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
     [onEncountersUpdated, t],
   );
 
-  if (isLoadingEncounterTypes) {
+  if (isLoadingEncounterTypes || isLoading) {
     return <DataTableSkeleton role="progressbar" zebra />;
   }
 
@@ -318,7 +317,6 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
                   })}
                 </TableBody>
               </Table>
-              {isLoading && <InlineLoading />}
               {rows?.length === 0 && (
                 <div className={styles.tileContainer}>
                   <Tile className={styles.tile}>
@@ -333,7 +331,7 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
           </>
         )}
       </DataTable>
-      {paginated && (
+      {
         <Pagination
           forwardText={t('nextPage', 'Next page')}
           backwardText={t('previousPage', 'Previous page')}
@@ -350,7 +348,7 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
             }
           }}
         />
-      )}
+      }
     </div>
   );
 };

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.resource.ts
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.resource.ts
@@ -21,7 +21,6 @@ export interface EncountersTableProps {
   isLoading: boolean;
   onEncountersUpdated(): void;
   showVisitType: boolean;
-  paginated: boolean;
   paginatedEncounters: Array<Encounter>;
   showEncounterTypeFilter: boolean;
   encounterTypeToFilter?: EncounterType;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.test.tsx
@@ -9,7 +9,6 @@ import { type EncountersTableProps, useEncounterTypes } from './encounters-table
 
 const testProps: EncountersTableProps = {
   patientUuid: mockPatientAlice.uuid,
-  paginated: false,
   paginatedEncounters: mockEncountersAlice,
   totalCount: mockEncountersAlice.length,
   currentPage: 1,

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/visit-encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/visit-encounters-table.component.tsx
@@ -22,7 +22,7 @@ const VisitEncountersTable: React.FC<VisitEncountersTableProps> = ({ patientUuid
       }),
     [visit],
   );
-  const { results: paginatedEncounters, currentPage, goTo, paginated } = usePagination(mappedEncounters, pageSize);
+  const { results: paginatedEncounters, currentPage, goTo } = usePagination(mappedEncounters, pageSize);
 
   const encountersTableProps: EncountersTableProps = {
     patientUuid,
@@ -32,7 +32,6 @@ const VisitEncountersTable: React.FC<VisitEncountersTableProps> = ({ patientUuid
     isLoading: false,
     onEncountersUpdated: mutateVisits,
     showVisitType: false,
-    paginated,
     paginatedEncounters: paginatedEncounters,
     showEncounterTypeFilter: false,
     pageSize,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Per [new UX guidance](https://openmrs.slack.com/archives/CKS32D55G/p1746029230140069?thread_ts=1746025116.978079&cid=CKS32D55G), we change the encounters table to always show pagination component even when there is only one page of data
- There was a minor bug with the encounters table showing both a loading spinner and a "no encounters to display" message when data is loading. This is now fixed (it will show DataTableSkeleton when it's loading)

## Screenshots
<!-- Required if you are making UI changes. -->

![image](https://github.com/user-attachments/assets/91871545-b768-4286-a6ee-d86e42697f18)


https://github.com/user-attachments/assets/ac814dfa-750e-4933-b951-dcf8db9349d9



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
