### PR TITLE
(fix) : Add optional chaining to prevent `undefined` errors on drug and order uuid

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
@@ -120,7 +120,7 @@ const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({ drug, openO
     [orders, drug],
   );
   const drugAlreadyPrescribed = useMemo(
-    () => activeOrders?.some((order) => order.drug.uuid == drug.uuid),
+    () => activeOrders?.some((order) => order?.drug?.uuid === drug?.uuid),
     [activeOrders, drug],
   );
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR ensures safe access to **drug.uuid** and **order.drug.uuid** by adding optional chaining in the DrugSearchResultItem component.
## Screenshots
![Peek 2025-05-13 09-14](https://github.com/user-attachments/assets/f93ed7db-683b-4cb9-9eb0-9534dd9dcb11)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
