### PR TITLE
(feat) O3-4702 : Add visit uuid to custom form Url

### DIFF
--- a/packages/esm-patient-forms-app/src/hooks/use-forms.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-forms.ts
@@ -23,13 +23,7 @@ function useCustomFormsUrl(patientUuid: string, visitUuid: string) {
   const { customFormsUrl, showHtmlFormEntryForms } = useConfig<ConfigObject>();
   const hasCustomFormsUrl = Boolean(customFormsUrl);
 
-  let baseUrl = hasCustomFormsUrl
-    ? customFormsUrl.indexOf('?') === -1
-      ? `${customFormsUrl}?patientUuid=\${patientUuid}&visitUuid=\${visitUuid}`
-      : customFormsUrl
-    : showHtmlFormEntryForms
-      ? formEncounterUrl
-      : formEncounterUrlPoc;
+  const baseUrl = hasCustomFormsUrl ? customFormsUrl : showHtmlFormEntryForms ? formEncounterUrl : formEncounterUrlPoc;
 
   const url = interpolateUrl(baseUrl, {
     patientUuid: patientUuid,

--- a/packages/esm-patient-forms-app/src/hooks/use-forms.ts
+++ b/packages/esm-patient-forms-app/src/hooks/use-forms.ts
@@ -34,7 +34,6 @@ function useCustomFormsUrl(patientUuid: string, visitUuid: string) {
   return {
     url,
     hasCustomFormsUrl,
-    showHtmlFormEntryForms,
   };
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR allows us to pass `visitUuid` to the forms custom endpoint.  This does not break form endpoints

## Screenshots
[Kapture 2025-05-15 at 14.02.13.webm](https://github.com/user-attachments/assets/c13c9b6c-20b3-4951-8213-2c54a27af613)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
