### PR TITLE
(fix) Update compact delete visit button styling

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-action-items/delete-visit-action-item.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-action-items/delete-visit-action-item.component.tsx
@@ -40,12 +40,7 @@ const DeleteVisitActionItem: React.FC<DeleteVisitActionItemProps> = ({ patientUu
   return (
     <UserHasAccess privilege="Delete Visits">
       {compact ? (
-        <IconButton
-          onClick={deleteVisit}
-          label={getCoreTranslation('delete')}
-          kind="danger--ghost"
-          size={responsiveSize}
-        >
+        <IconButton onClick={deleteVisit} label={getCoreTranslation('delete')} kind="ghost" size={responsiveSize}>
           <TrashCanIcon size={16} />
         </IconButton>
       ) : (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Changes the `kind` of the delete visit icon button from `danger--ghost` to `ghost`. The previous `danger--ghost` kind had a transparent background that turned red on hover, which created insufficient contrast with the black SVG icon. Using the `ghost` kind instead provides a gray background on hover, ensuring better icon visibility. This approach also aligns with the Carbon Design System's recommendation for icon buttons when used as [inline actions in DataTables](https://carbondesignsystem.com/components/data-table/usage/#inline-actions).

## Screenshots

![CleanShot 2025-05-15 at 21 21 45@2x](https://github.com/user-attachments/assets/0fdc5322-8ee7-43ce-a0b4-031b33fa7e0e)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
