### PR TITLE
(BREAKING) Remove deprecated launchPatientWorkspace function

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-error.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-error.component.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Button } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { clinicalFormsWorkspace, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { clinicalFormsWorkspace } from '@openmrs/esm-patient-common-lib';
+import { launchWorkspace } from '@openmrs/esm-framework';
 import styles from './form-error.scss';
 
 interface FormErrorProps {
@@ -17,7 +18,7 @@ const FormError: React.FC<FormErrorProps> = ({
 
   const handleOpenFormList = () => {
     closeWorkspace();
-    launchPatientWorkspace(clinicalFormsWorkspaceName);
+    launchWorkspace(clinicalFormsWorkspaceName);
   };
 
   return (

--- a/packages/esm-form-engine-app/src/form-renderer/form-error.test.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-error.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { clinicalFormsWorkspace, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { launchWorkspace } from '@openmrs/esm-framework';
+import { clinicalFormsWorkspace } from '@openmrs/esm-patient-common-lib';
 import FormError from './form-error.component';
 
-const mocklaunchPatientWorkspace = jest.mocked(launchPatientWorkspace);
+const mocklaunchWorkspace = jest.mocked(launchWorkspace);
 
 jest.mock('@openmrs/esm-patient-common-lib', () => ({
-  launchPatientWorkspace: jest.fn(),
+  launchWorkspace: jest.fn(),
 }));
 
 describe('FormError', () => {
@@ -46,6 +47,6 @@ describe('FormError', () => {
     await user.click(link);
 
     expect(closeWorkspace).toHaveBeenCalled();
-    expect(mocklaunchPatientWorkspace).toHaveBeenCalledWith(clinicalFormsWorkspace);
+    expect(mocklaunchWorkspace).toHaveBeenCalledWith(clinicalFormsWorkspace);
   });
 });

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -2,12 +2,8 @@ import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { InlineLoading } from '@carbon/react';
 import { FormEngine } from '@openmrs/esm-form-engine-lib';
-import { showModal, type Visit } from '@openmrs/esm-framework';
-import {
-  clinicalFormsWorkspace,
-  type DefaultPatientWorkspaceProps,
-  launchPatientWorkspace,
-} from '@openmrs/esm-patient-common-lib';
+import { launchWorkspace, showModal, type Visit } from '@openmrs/esm-framework';
+import { clinicalFormsWorkspace, type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import FormError from './form-error.component';
 import useFormSchema from '../hooks/useFormSchema';
 import styles from './form-renderer.scss';
@@ -39,7 +35,7 @@ const FormRenderer: React.FC<FormRendererProps> = ({
 
   const handleCloseForm = useCallback(() => {
     closeWorkspace();
-    !encounterUuid && openClinicalFormsWorkspaceOnFormClose && launchPatientWorkspace(clinicalFormsWorkspaceName);
+    !encounterUuid && openClinicalFormsWorkspaceOnFormClose && launchWorkspace(clinicalFormsWorkspaceName);
   }, [closeWorkspace, encounterUuid, openClinicalFormsWorkspaceOnFormClose, clinicalFormsWorkspaceName]);
 
   const handleConfirmQuestionDeletion = useCallback(() => {

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-action-menu.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-action-menu.component.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Layer, OverflowMenu, OverflowMenuItem } from '@carbon/react';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { showModal, useLayoutType } from '@openmrs/esm-framework';
+import { launchWorkspace, showModal, useLayoutType } from '@openmrs/esm-framework';
 import { type Allergy } from '../types';
 import styles from './allergies-action-menu.scss';
 import { patientAllergiesFormWorkspace } from '../constants';
@@ -17,8 +16,8 @@ export const AllergiesActionMenu = ({ allergy, patientUuid }: allergiesActionMen
   const isTablet = useLayoutType() === 'tablet';
 
   const launchEditAllergiesForm = useCallback(() => {
-    launchPatientWorkspace(patientAllergiesFormWorkspace, {
-      workspaceTitle: t('editAllergy', 'Edit an Allergy'),
+    launchWorkspace(patientAllergiesFormWorkspace, {
+      workspaceTitle: t('editAllergy', 'Edit an allergy'),
       allergy,
       formContext: 'editing',
     });

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -13,8 +13,8 @@ import {
   TableHeader,
   TableRow,
 } from '@carbon/react';
-import { AddIcon, formatDate, parseDate, useLayoutType } from '@openmrs/esm-framework';
-import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { AddIcon, formatDate, launchWorkspace, parseDate, useLayoutType } from '@openmrs/esm-framework';
+import { CardHeader, EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { patientAllergiesFormWorkspace } from '../constants';
 import { useAllergies } from './allergy-intolerance.resource';
 import { AllergiesActionMenu } from './allergies-action-menu.component';
@@ -26,14 +26,14 @@ interface AllergiesDetailedSummaryProps {
 
 const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ patient }) => {
   const { t } = useTranslation();
-  const displayText = t('allergyIntolerances', 'allergy intolerances');
-  const headerTitle = t('allergies', 'Allergies');
-  const { allergies, error, isLoading, isValidating } = useAllergies(patient.id);
   const layout = useLayoutType();
+  const { allergies, error, isLoading, isValidating } = useAllergies(patient.id);
   const isTablet = layout === 'tablet';
   const isDesktop = layout === 'small-desktop' || layout === 'large-desktop';
+  const displayText = t('allergyIntolerances', 'allergy intolerances');
+  const headerTitle = t('allergies', 'Allergies');
 
-  const launchAllergiesForm = useCallback(() => launchPatientWorkspace(patientAllergiesFormWorkspace), []);
+  const launchAllergiesForm = useCallback(() => launchWorkspace(patientAllergiesFormWorkspace), []);
 
   const tableHeaders = [
     { key: 'display', header: t('allergen', 'Allergen') },

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-overview.component.tsx
@@ -13,14 +13,8 @@ import {
   TableRow,
 } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { AddIcon, useLayoutType, usePagination } from '@openmrs/esm-framework';
-import {
-  CardHeader,
-  EmptyState,
-  ErrorState,
-  launchPatientWorkspace,
-  PatientChartPagination,
-} from '@openmrs/esm-patient-common-lib';
+import { AddIcon, launchWorkspace, useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { CardHeader, EmptyState, ErrorState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import { allergiesCount, patientAllergiesFormWorkspace } from '../constants';
 import { useAllergies } from './allergy-intolerance.resource';
 import styles from './allergies-overview.scss';
@@ -63,7 +57,7 @@ const AllergiesOverview: React.FC<AllergiesOverviewProps> = ({ patient }) => {
     }));
   }, [paginatedAllergies]);
 
-  const launchAllergiesForm = useCallback(() => launchPatientWorkspace(patientAllergiesFormWorkspace), []);
+  const launchAllergiesForm = useCallback(() => launchWorkspace(patientAllergiesFormWorkspace), []);
 
   if (isLoading) {
     return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;

--- a/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/start-visit.component.tsx
@@ -1,7 +1,7 @@
-import { OverflowMenuItem } from '@carbon/react';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { OverflowMenuItem } from '@carbon/react';
+import { launchWorkspace } from '@openmrs/esm-framework';
 import styles from './action-button.scss';
 
 interface StartVisitOverflowMenuItemProps {
@@ -14,7 +14,7 @@ const StartVisitOverflowMenuItem: React.FC<StartVisitOverflowMenuItemProps> = ({
 
   const handleLaunchModal = useCallback(
     () =>
-      launchPatientWorkspace('start-visit-workspace-form', {
+      launchWorkspace('start-visit-workspace-form', {
         openedFrom: 'patient-chart-start-visit',
       }),
     [],

--- a/packages/esm-patient-chart-app/src/actions-buttons/start-visit.test.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/start-visit.test.tsx
@@ -1,18 +1,11 @@
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { launchWorkspace } from '@openmrs/esm-framework';
 import { mockPatient } from 'tools';
 import StartVisitOverflowMenuItem from './start-visit.component';
 
-jest.mock('@openmrs/esm-patient-common-lib', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
-
-  return {
-    ...originalModule,
-    launchPatientWorkspace: jest.fn(),
-  };
-});
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 
 describe('StartVisitOverflowMenuItem', () => {
   it('should launch the start visit form', async () => {
@@ -24,8 +17,8 @@ describe('StartVisitOverflowMenuItem', () => {
     expect(startVisitButton).toBeInTheDocument();
 
     await user.click(startVisitButton);
-    expect(launchPatientWorkspace).toHaveBeenCalledTimes(1);
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('start-visit-workspace-form', {
+    expect(mockLaunchWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('start-visit-workspace-form', {
       openedFrom: 'patient-chart-start-visit',
     });
   });

--- a/packages/esm-patient-chart-app/src/clinical-views/utils/helpers.ts
+++ b/packages/esm-patient-chart-app/src/clinical-views/utils/helpers.ts
@@ -1,5 +1,4 @@
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { age, formatDate, parseDate, type Visit } from '@openmrs/esm-framework';
+import { age, formatDate, launchWorkspace, parseDate, type Visit } from '@openmrs/esm-framework';
 import type {
   ConfigConcepts,
   Encounter,
@@ -21,7 +20,7 @@ export function launchEncounterForm(
   intent: string = '*',
   patientUuid?: string,
 ) {
-  launchPatientWorkspace('patient-form-entry-workspace', {
+  launchWorkspace('patient-form-entry-workspace', {
     workspaceTitle: form?.name,
     mutateForm: onFormSave,
     formInfo: {

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { useMatch } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Extension, ExtensionSlot, useExtensionSlotMeta } from '@openmrs/esm-framework';
-import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
+import { launchWorkspace, Extension, ExtensionSlot, useExtensionSlotMeta } from '@openmrs/esm-framework';
+import { launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
 import { dashboardPath } from '../../constants';
 import styles from './dashboard-view.scss';
 
@@ -43,7 +43,7 @@ export function DashboardView({ dashboard, patientUuid, patient }: DashboardView
       basePath: view,
       patient,
       patientUuid,
-      launchPatientWorkspace,
+      launchWorkspace,
       launchStartVisitPrompt,
     }),
     [patient, patientUuid, view],

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.component.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from 'react';
-import { Button } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { showSnackbar } from '@openmrs/esm-framework';
+import { Button } from '@carbon/react';
+import { launchWorkspace, showSnackbar } from '@openmrs/esm-framework';
 
 interface StartVisitButtonProps {
   patientUuid: string;
@@ -21,7 +20,7 @@ const StartVisitButton = ({ patientUuid, handleReturnToSearchList, hidePatientSe
     hidePatientSearch?.();
 
     try {
-      launchPatientWorkspace(startVisitWorkspaceForm, {
+      launchWorkspace(startVisitWorkspaceForm, {
         patientUuid,
         openedFrom: 'patient-chart-start-visit',
         handleReturnToSearchList,

--- a/packages/esm-patient-chart-app/src/visit/start-visit-button.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/start-visit-button.test.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
+import { launchWorkspace } from '@openmrs/esm-framework';
 import { mockPatient } from 'tools';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import StartVisitButton from './start-visit-button.component';
 
-const mockLaunchPatientWorkspace = jest.mocked(launchPatientWorkspace);
-
-jest.mock('@openmrs/esm-patient-common-lib', () => ({
-  launchPatientWorkspace: jest.fn(),
-}));
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 
 describe('StartVisitButton', () => {
   it('renders the start visit button', () => {
@@ -26,8 +22,8 @@ describe('StartVisitButton', () => {
     const startVisitButton = screen.getByRole('button', { name: /start visit/i });
     await user.click(startVisitButton);
 
-    expect(mockLaunchPatientWorkspace).toHaveBeenCalledTimes(1);
-    expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('start-visit-workspace-form', {
+    expect(mockLaunchWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('start-visit-workspace-form', {
       patientUuid: mockPatient.id,
       openedFrom: 'patient-chart-start-visit',
     });

--- a/packages/esm-patient-chart-app/src/visit/visit-action-items/edit-visit-details.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-action-items/edit-visit-details.component.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import { Button, IconButton } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { EditIcon, UserHasAccess, type Visit, getCoreTranslation, useLayoutType } from '@openmrs/esm-framework';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import {
+  EditIcon,
+  UserHasAccess,
+  type Visit,
+  getCoreTranslation,
+  launchWorkspace,
+  useLayoutType,
+} from '@openmrs/esm-framework';
 
 interface EditVisitDetailsActionItemProps {
   patientUuid: string;
@@ -21,7 +27,7 @@ const EditVisitDetailsActionItem: React.FC<EditVisitDetailsActionItemProps> = ({
   const responsiveSize = isTablet ? 'lg' : 'sm';
 
   const editVisitDetails = () => {
-    launchPatientWorkspace('start-visit-workspace-form', {
+    launchWorkspace('start-visit-workspace-form', {
       workspaceTitle: t('editVisitDetails', 'Edit visit details'),
       visitToEdit: visit,
       openedFrom: 'patient-chart-edit-visit',

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.component.tsx
@@ -1,7 +1,8 @@
-import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
-import { launchPatientChartWithWorkspaceOpen, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
+import { launchWorkspace } from '@openmrs/esm-framework';
+import { launchPatientChartWithWorkspaceOpen } from '@openmrs/esm-patient-common-lib';
 import styles from './start-visit-dialog.scss';
 
 interface StartVisitDialogProps {
@@ -21,7 +22,7 @@ const StartVisitDialog: React.FC<StartVisitDialogProps> = ({ patientUuid, closeM
         additionalProps: { openedFrom: 'patient-chart-start-visit' },
       });
     } else {
-      launchPatientWorkspace('start-visit-workspace-form', { openedFrom: 'patient-chart-start-visit' });
+      launchWorkspace('start-visit-workspace-form', { openedFrom: 'patient-chart-start-visit' });
     }
 
     closeModal();

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/start-visit-dialog.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { launchWorkspace } from '@openmrs/esm-framework';
 import StartVisitDialog from './start-visit-dialog.component';
 
 const defaultProps = {
@@ -10,14 +10,7 @@ const defaultProps = {
   visitType: null,
 };
 
-jest.mock('@openmrs/esm-patient-common-lib', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
-
-  return {
-    ...originalModule,
-    launchPatientWorkspace: jest.fn(),
-  };
-});
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 
 describe('StartVisit', () => {
   test('should launch start visit form', async () => {
@@ -35,7 +28,7 @@ describe('StartVisit', () => {
 
     await user.click(startNewVisitButton);
 
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('start-visit-workspace-form', {
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('start-visit-workspace-form', {
       openedFrom: 'patient-chart-start-visit',
     });
   });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.component.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { ErrorState, useVisit } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { InlineLoading } from '@carbon/react';
-import { launchPatientWorkspace, CardHeader, EmptyState } from '@openmrs/esm-patient-common-lib';
-
+import { ErrorState, launchWorkspace, useVisit } from '@openmrs/esm-framework';
+import { CardHeader, EmptyState } from '@openmrs/esm-patient-common-lib';
 import VisitSummary from './past-visits-components/visit-summary.component';
 import styles from './current-visit-summary.scss';
+
 interface CurrentVisitSummaryProps {
   patientUuid: string;
 }
@@ -34,7 +34,7 @@ const CurrentVisitSummary: React.FC<CurrentVisitSummaryProps> = ({ patientUuid }
         headerTitle={t('currentVisit', 'Current visit')}
         displayText={t('noActiveVisitMessage', 'active visit')}
         launchForm={() =>
-          launchPatientWorkspace('start-visit-workspace-form', { openedFrom: 'patient-chart-current-visit-summary' })
+          launchWorkspace('start-visit-workspace-form', { openedFrom: 'patient-chart-current-visit-summary' })
         }
       />
     );

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/visit-context-switcher.modal.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/visit-context-switcher.modal.tsx
@@ -1,20 +1,20 @@
 import React, { useCallback, useState } from 'react';
+import classNames from 'classnames';
+import dayjs from 'dayjs';
 import { Button, ModalBody, ModalFooter, ModalHeader, RadioButton, InlineLoading, Tile } from '@carbon/react';
+import { useTranslation } from 'react-i18next';
 import {
   ErrorState,
+  launchWorkspace,
   OpenmrsDatePicker,
   useDebounce,
   useOnVisible,
   useVisitContextStore,
   type Visit,
 } from '@openmrs/esm-framework';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import classNames from 'classnames';
-import { useTranslation } from 'react-i18next';
 import { useInfiniteVisits } from '../visit.resource';
 import VisitContextInfo from './visit-context-info.component';
 import styles from './visit-context-switcher.scss';
-import dayjs from 'dayjs';
 
 interface VisitContextSwitcherProps {
   patientUuid: string;
@@ -51,7 +51,7 @@ const VisitContextSwitcherModal: React.FC<VisitContextSwitcherProps> = ({
 
   const openStartVisitWorkspace = () => {
     closeModal();
-    launchPatientWorkspace('start-visit-workspace-form', {
+    launchWorkspace('start-visit-workspace-form', {
       openedFrom: 'visit-context-switcher',
     });
   };

--- a/packages/esm-patient-common-lib/src/empty-state/empty-state.test.tsx
+++ b/packages/esm-patient-common-lib/src/empty-state/empty-state.test.tsx
@@ -1,17 +1,10 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { launchPatientWorkspace } from '..';
+import { render, screen } from '@testing-library/react';
+import { launchWorkspace } from '@openmrs/esm-framework';
 import { EmptyState } from '.';
 
-jest.mock('@openmrs/esm-patient-common-lib', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
-
-  return {
-    ...originalModule,
-    launchPatientWorkspace: jest.fn(),
-  };
-});
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 
 describe('EmptyState', () => {
   it('renders an empty state widget card', () => {
@@ -19,7 +12,7 @@ describe('EmptyState', () => {
       <EmptyState
         headerTitle="appointments"
         displayText="appointments"
-        launchForm={() => launchPatientWorkspace('sample-form-workspace')}
+        launchForm={() => launchWorkspace('sample-form-workspace')}
       />,
     );
 
@@ -35,7 +28,7 @@ describe('EmptyState', () => {
       <EmptyState
         headerTitle="appointments"
         displayText="appointments"
-        launchForm={() => launchPatientWorkspace('sample-form-workspace')}
+        launchForm={() => launchWorkspace('sample-form-workspace')}
       />,
     );
 
@@ -44,7 +37,7 @@ describe('EmptyState', () => {
 
     await user.click(recordAppointmentsLink);
 
-    expect(launchPatientWorkspace).toHaveBeenCalledTimes(1);
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('sample-form-workspace');
+    expect(mockLaunchWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('sample-form-workspace');
   });
 });

--- a/packages/esm-patient-common-lib/src/form-entry-interop.ts
+++ b/packages/esm-patient-common-lib/src/form-entry-interop.ts
@@ -1,4 +1,5 @@
-import { launchPatientWorkspace, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
+import { launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
+import { launchWorkspace } from '@openmrs/esm-framework';
 
 export const clinicalFormsWorkspace = 'clinical-forms-workspace';
 export const formEntryWorkspace = 'patient-form-entry-workspace';
@@ -67,7 +68,7 @@ export function launchFormEntry(
   clinicalFormsWorkspaceName = clinicalFormsWorkspace,
   formEntryWorkspaceName = formEntryWorkspace,
 ) {
-  launchPatientWorkspace(formEntryWorkspaceName, {
+  launchWorkspace(formEntryWorkspaceName, {
     workspaceTitle: formName,
     clinicalFormsWorkspaceName,
     formEntryWorkspaceName,
@@ -94,7 +95,7 @@ export function launchHtmlFormEntry(
   htmlForm: HtmlFormEntryForm,
   workspaceName = htmlFormEntryWorkspace,
 ) {
-  launchPatientWorkspace(workspaceName, {
+  launchWorkspace(workspaceName, {
     workspaceTitle: formName,
     patientUuid,
     formInfo: {

--- a/packages/esm-patient-common-lib/src/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces.ts
@@ -5,21 +5,16 @@ import {
   showModal,
   useFeatureFlag,
 } from '@openmrs/esm-framework';
-import { useCallback } from 'react';
 import { launchStartVisitPrompt } from './launchStartVisitPrompt';
-import { useVisitOrOfflineVisit } from './offline/visit';
+import { useCallback } from 'react';
 import { usePatientChartStore } from './store/patient-chart-store';
 import { useSystemVisitSetting } from './useSystemVisitSetting';
+import { useVisitOrOfflineVisit } from './offline/visit';
 
 export interface DefaultPatientWorkspaceProps extends DefaultWorkspaceProps {
   patient: fhir.Patient;
   patientUuid: string;
 }
-
-/**
- * @deprecated Use `launchWorkspace()` instead
- */
-export const launchPatientWorkspace = launchWorkspace;
 
 export function launchPatientChartWithWorkspaceOpen({
   patientUuid,
@@ -55,7 +50,7 @@ export function useLaunchWorkspaceRequiringVisit<T extends object>(workspaceName
           const dispose = showModal('visit-context-switcher', {
             patientUuid,
             closeModal: () => dispose(),
-            onAfterVisitSelected: () => launchPatientWorkspace(workspaceName, additionalProps),
+            onAfterVisitSelected: () => launchWorkspace(workspaceName, additionalProps),
             size: 'sm',
           });
         } else {

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-action-menu.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-action-menu.component.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Layer, OverflowMenu, OverflowMenuItem } from '@carbon/react';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { showModal, useLayoutType } from '@openmrs/esm-framework';
+import { launchWorkspace, showModal, useLayoutType } from '@openmrs/esm-framework';
 import { type Condition } from './conditions.resource';
 import styles from './conditions-action-menu.scss';
 
@@ -17,7 +16,7 @@ export const ConditionsActionMenu = ({ condition, patientUuid }: conditionsActio
 
   const launchEditConditionsForm = useCallback(
     () =>
-      launchPatientWorkspace('conditions-form-workspace', {
+      launchWorkspace('conditions-form-workspace', {
         workspaceTitle: t('editCondition', 'Edit a Condition'),
         condition,
         formContext: 'editing',

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.component.tsx
@@ -16,8 +16,8 @@ import {
   TableRow,
   Tile,
 } from '@carbon/react';
-import { AddIcon, formatDate, parseDate, useLayoutType } from '@openmrs/esm-framework';
-import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { AddIcon, formatDate, launchWorkspace, parseDate, useLayoutType } from '@openmrs/esm-framework';
+import { CardHeader, EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { ConditionsActionMenu } from './conditions-action-menu.component';
 import { useConditions, type ConditionTableHeader, useConditionsSorting } from './conditions.resource';
 import styles from './conditions-detailed-summary.scss';
@@ -91,7 +91,7 @@ function ConditionsDetailedSummary({ patient }) {
 
   const launchConditionsForm = useCallback(
     () =>
-      launchPatientWorkspace('conditions-form-workspace', {
+      launchWorkspace('conditions-form-workspace', {
         formContext: 'creating',
       }),
     [],

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-detailed-summary.test.tsx
@@ -1,22 +1,13 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { openmrsFetch } from '@openmrs/esm-framework';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { screen } from '@testing-library/react';
+import { launchWorkspace, openmrsFetch } from '@openmrs/esm-framework';
 import { mockFhirConditionsResponse } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import ConditionsDetailedSummary from './conditions-detailed-summary.component';
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
-
-jest.mock('@openmrs/esm-patient-common-lib', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
-
-  return {
-    ...originalModule,
-    launchPatientWorkspace: jest.fn(),
-  };
-});
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 
 it('renders an empty state view if conditions data is unavailable', async () => {
   mockOpenmrsFetch.mockReturnValueOnce({ data: [] });
@@ -91,6 +82,6 @@ it('clicking the Add button or Record Conditions link launches the conditions fo
 
   await user.click(recordConditionsLink);
 
-  expect(launchPatientWorkspace).toHaveBeenCalledTimes(1);
-  expect(launchPatientWorkspace).toHaveBeenCalledWith('conditions-form-workspace', { formContext: 'creating' });
+  expect(mockLaunchWorkspace).toHaveBeenCalledTimes(1);
+  expect(mockLaunchWorkspace).toHaveBeenCalledWith('conditions-form-workspace', { formContext: 'creating' });
 });

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.component.tsx
@@ -21,20 +21,15 @@ import {
   formatDate,
   parseDate,
   isDesktop as isDesktopLayout,
+  launchWorkspace,
   useLayoutType,
   usePagination,
   useConfig,
 } from '@openmrs/esm-framework';
-import {
-  EmptyState,
-  ErrorState,
-  PatientChartPagination,
-  launchPatientWorkspace,
-  CardHeader,
-} from '@openmrs/esm-patient-common-lib';
-import type { ConfigObject } from '../config-schema';
+import { EmptyState, ErrorState, PatientChartPagination, CardHeader } from '@openmrs/esm-patient-common-lib';
 import { ConditionsActionMenu } from './conditions-action-menu.component';
 import { type Condition, useConditions, useConditionsSorting } from './conditions.resource';
+import { type ConfigObject } from '../config-schema';
 import styles from './conditions-overview.scss';
 
 interface ConditionTableRow extends Condition {
@@ -70,7 +65,7 @@ const ConditionsOverview: React.FC<ConditionsOverviewProps> = ({ patientUuid }) 
   const [filter, setFilter] = useState<'All' | 'Active' | 'Inactive'>('Active');
   const launchConditionsForm = useCallback(
     () =>
-      launchPatientWorkspace('conditions-form-workspace', {
+      launchWorkspace('conditions-form-workspace', {
         formContext: 'creating',
       }),
     [],

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-overview.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { type FetchResponse, getDefaultsFromConfigSchema, openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import {
+  type FetchResponse,
+  getDefaultsFromConfigSchema,
+  launchWorkspace,
+  openmrsFetch,
+  useConfig,
+} from '@openmrs/esm-framework';
 import { type ConfigObject, configSchema } from '../config-schema';
 import { mockFhirConditionsResponse } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
@@ -10,11 +15,7 @@ import ConditionsOverview from './conditions-overview.component';
 
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
 const mockOpenmrsFetch = jest.mocked(openmrsFetch);
-
-jest.mock('@openmrs/esm-patient-common-lib', () => ({
-  ...jest.requireActual('@openmrs/esm-patient-common-lib'),
-  launchPatientWorkspace: jest.fn(),
-}));
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 
 mockUseConfig.mockReturnValue({
   ...getDefaultsFromConfigSchema(configSchema),
@@ -102,7 +103,7 @@ describe('ConditionsOverview', () => {
 
     await user.click(recordConditionsLink);
 
-    expect(launchPatientWorkspace).toHaveBeenCalledTimes(1);
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('conditions-form-workspace', { formContext: 'creating' });
+    expect(mockLaunchWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('conditions-form-workspace', { formContext: 'creating' });
   });
 });

--- a/packages/esm-patient-flags-app/src/flags/flags-highlight-bar.test.tsx
+++ b/packages/esm-patient-flags-app/src/flags/flags-highlight-bar.test.tsx
@@ -1,22 +1,14 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { launchWorkspace } from '@openmrs/esm-framework';
 import { mockPatient } from 'tools';
 import { mockPatientFlags } from '__mocks__';
 import { usePatientFlags } from './hooks/usePatientFlags';
 import FlagsHighlightBar from './flags-highlight-bar.component';
 
 const mockUsePatientFlags = jest.mocked(usePatientFlags);
-
-jest.mock('@openmrs/esm-patient-common-lib', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
-
-  return {
-    ...originalModule,
-    launchPatientWorkspace: jest.fn(),
-  };
-});
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 
 jest.mock('./hooks/usePatientFlags', () => {
   const originalModule = jest.requireActual('./hooks/usePatientFlags');
@@ -58,7 +50,7 @@ it('renders a highlights bar showing a summary of the available flags', async ()
 
   await user.click(editButton);
 
-  expect(launchPatientWorkspace).toHaveBeenCalledWith('edit-flags-side-panel-form');
+  expect(mockLaunchWorkspace).toHaveBeenCalledWith('edit-flags-side-panel-form');
 
   const closeButton = screen.getByRole('button', { name: /close flags bar/i });
 

--- a/packages/esm-patient-flags-app/src/flags/flags.component.tsx
+++ b/packages/esm-patient-flags-app/src/flags/flags.component.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Tag, Toggletip, ToggletipButton, ToggletipContent } from '@carbon/react';
-import { CloseIcon, EditIcon } from '@openmrs/esm-framework';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { CloseIcon, EditIcon, launchWorkspace } from '@openmrs/esm-framework';
 import { usePatientFlags } from './hooks/usePatientFlags';
 import styles from './flags.scss';
 
@@ -17,7 +16,7 @@ const Flags: React.FC<FlagsProps> = ({ patientUuid, onHandleCloseHighlightBar, s
   const { flags, isLoading, error } = usePatientFlags(patientUuid);
   const filteredFlags = flags.filter((f) => !f.voided);
 
-  const handleClickEditFlags = useCallback(() => launchPatientWorkspace('edit-flags-side-panel-form'), []);
+  const handleClickEditFlags = useCallback(() => launchWorkspace('edit-flags-side-panel-form'), []);
 
   const InfoFlags = () => {
     const hasInfoFlag = (tags) => tags?.filter((t) => t.display.includes('info')).length;

--- a/packages/esm-patient-flags-app/src/flags/flags.test.tsx
+++ b/packages/esm-patient-flags-app/src/flags/flags.test.tsx
@@ -1,22 +1,14 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { screen, render } from '@testing-library/react';
+import { launchWorkspace } from '@openmrs/esm-framework';
 import { mockPatient } from 'tools';
 import { mockPatientFlags } from '__mocks__';
 import { usePatientFlags } from './hooks/usePatientFlags';
 import Flags from './flags.component';
 
 const mockUsePatientFlags = jest.mocked(usePatientFlags);
-
-jest.mock('@openmrs/esm-patient-common-lib', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
-
-  return {
-    ...originalModule,
-    launchPatientWorkspace: jest.fn(),
-  };
-});
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 
 jest.mock('./hooks/usePatientFlags', () => {
   const originalModule = jest.requireActual('./hooks/usePatientFlags');
@@ -51,5 +43,5 @@ it('renders flags in the patient flags slot', async () => {
 
   await user.click(editButton);
 
-  expect(launchPatientWorkspace).toHaveBeenCalledWith('edit-flags-side-panel-form');
+  expect(mockLaunchWorkspace).toHaveBeenCalledWith('edit-flags-side-panel-form');
 });

--- a/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
+++ b/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
@@ -1,11 +1,10 @@
 import React, { type ComponentProps } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ActionMenuButton, DocumentIcon, useWorkspaces } from '@openmrs/esm-framework';
+import { ActionMenuButton, DocumentIcon, launchWorkspace, useWorkspaces } from '@openmrs/esm-framework';
 import {
   clinicalFormsWorkspace,
   formEntryWorkspace,
   htmlFormEntryWorkspace,
-  launchPatientWorkspace,
   useLaunchWorkspaceRequiringVisit,
 } from '@openmrs/esm-patient-common-lib';
 
@@ -25,13 +24,13 @@ const ClinicalFormActionButton: React.FC = () => {
 
   const launchPatientWorkspaceCb = () => {
     if (isFormOpen) {
-      launchPatientWorkspace(formEntryWorkspace, {
+      launchWorkspace(formEntryWorkspace, {
         workspaceTitle: recentlyOpenedForm?.additionalProps?.['workspaceTitle'],
       });
     }
     // we aren't currently supporting keeping HTML Form workspaces open, but just in case
     else if (isHtmlFormOpen) {
-      launchPatientWorkspace(htmlFormEntryWorkspace, {
+      launchWorkspace(htmlFormEntryWorkspace, {
         workspaceTitle: recentlyOpenedHtmlForm?.additionalProps?.['workspaceTitle'],
       });
     } else {

--- a/packages/esm-patient-forms-app/src/form-entry-interop.ts
+++ b/packages/esm-patient-forms-app/src/form-entry-interop.ts
@@ -1,10 +1,6 @@
-import { navigate, type Visit } from '@openmrs/esm-framework';
-import {
-  type HtmlFormEntryForm,
-  launchPatientWorkspace,
-  launchStartVisitPrompt,
-} from '@openmrs/esm-patient-common-lib';
 import { isEmpty } from 'lodash-es';
+import { launchWorkspace, navigate, type Visit } from '@openmrs/esm-framework';
+import { type HtmlFormEntryForm, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
 import { formEngineResourceName, htmlformentryFormEngine, uiStyleResourceName, uiStyleSimple } from './constants';
 import type { Form } from './types';
 
@@ -39,7 +35,7 @@ export function launchFormEntry(
   mutateForm?: () => void,
   currentVisit?: Visit,
 ) {
-  launchPatientWorkspace('patient-form-entry-workspace', {
+  launchWorkspace('patient-form-entry-workspace', {
     workspaceTitle: formName,
     mutateForm,
     formInfo: { encounterUuid, formUuid, visit: currentVisit },

--- a/packages/esm-patient-forms-app/src/forms/forms-dashboard.test.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-dashboard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, launchWorkspace, useConfig } from '@openmrs/esm-framework';
 import { useVisitOrOfflineVisit } from '@openmrs/esm-patient-common-lib';
 import { configSchema, type ConfigObject } from '../config-schema';
 import { mockCurrentVisit } from '__mocks__';
@@ -8,6 +8,7 @@ import FormsDashboard from './forms-dashboard.component';
 import { mockPatient } from 'tools';
 
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 const mockUseVisitOrOfflineVisit = useVisitOrOfflineVisit as jest.Mock;
 
 jest.mock('../hooks/use-forms', () => ({
@@ -24,7 +25,6 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
 
   return {
     ...originalModule,
-    launchPatientWorkspace: jest.fn(),
     useVisitOrOfflineVisit: jest.fn(),
   };
 });

--- a/packages/esm-patient-forms-app/src/offline.ts
+++ b/packages/esm-patient-forms-app/src/offline.ts
@@ -1,3 +1,4 @@
+import { escapeRegExp } from 'lodash-es';
 import {
   makeUrl,
   messageOmrsServiceWorker,
@@ -10,10 +11,8 @@ import {
   type Visit,
 } from '@openmrs/esm-framework';
 import { launchFormEntry } from '@openmrs/esm-patient-common-lib';
-import { type Form } from './types';
-import { isFormJsonSchema } from './offline-forms/offline-form-helpers';
 import { formEncounterUrl, formEncounterUrlPoc } from './constants';
-import escapeRegExp from 'lodash-es/escapeRegExp';
+import { type Form } from './types';
 
 // General note on the following imports and this file in general:
 // Yes, the imports below are super super dirty.
@@ -24,7 +23,7 @@ import escapeRegExp from 'lodash-es/escapeRegExp';
 // work. Trust me, I tried. But by now, I don't want to waste any more time on this issue when this
 // workaround here exists.
 // If anyone reading this comment wants to take on the challenge, please feel
-// free to do so and, if successful, notify me when `launchPatientWorkspace` can be called
+// free to do so and, if successful, notify me when `launchWorkspace` can be called
 // from `esm-form-entry-app` and/or directly migrate this file's content to the appropriate location.
 import type { PatientFormSyncItemContent } from '../../esm-form-entry-app/src/app/offline/sync';
 import type { EncounterCreate } from '../../esm-form-entry-app/src/app/types';

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
@@ -25,14 +25,9 @@ import {
   useLayoutType,
   usePagination,
   useVisit,
+  launchWorkspace,
 } from '@openmrs/esm-framework';
-import {
-  CardHeader,
-  EmptyState,
-  ErrorState,
-  launchPatientWorkspace,
-  PatientChartPagination,
-} from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyState, ErrorState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import { immunizationFormSub, latestFirst, linkConfiguredSequences } from './utils';
 import { type ExistingDoses, type Sequence } from '../types';
 import { useImmunizations } from '../hooks/useImmunizations';
@@ -67,7 +62,7 @@ const ImmunizationsDetailedSummary: React.FC<ImmunizationsDetailedSummaryProps> 
       launchStartVisitPrompt();
       return;
     }
-    launchPatientWorkspace('immunization-form-workspace');
+    launchWorkspace('immunization-form-workspace');
   }, [currentVisit, launchStartVisitPrompt]);
 
   const sortedImmunizations = orderBy(

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-overview.component.tsx
@@ -14,14 +14,8 @@ import {
   TableHeader,
   TableRow,
 } from '@carbon/react';
-import { AddIcon, formatDate, parseDate, usePagination } from '@openmrs/esm-framework';
-import {
-  launchPatientWorkspace,
-  CardHeader,
-  EmptyState,
-  ErrorState,
-  PatientChartPagination,
-} from '@openmrs/esm-patient-common-lib';
+import { AddIcon, formatDate, launchWorkspace, parseDate, usePagination } from '@openmrs/esm-framework';
+import { CardHeader, EmptyState, ErrorState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import { useImmunizations } from '../hooks/useImmunizations';
 import styles from './immunizations-overview.scss';
 
@@ -42,7 +36,7 @@ const ImmunizationsOverview: React.FC<ImmunizationsOverviewProps> = ({ patient, 
   const { data: immunizations, error, isLoading, isValidating } = useImmunizations(patientUuid);
   const { results: paginatedImmunizations, goTo, currentPage } = usePagination(immunizations ?? [], immunizationsCount);
 
-  const launchImmunizationsForm = React.useCallback(() => launchPatientWorkspace('immunization-form-workspace'), []);
+  const launchImmunizationsForm = React.useCallback(() => launchWorkspace('immunization-form-workspace'), []);
 
   const tableHeaders = [
     {

--- a/packages/esm-patient-lists-app/src/action-button/patient-lists-action-button.extension.tsx
+++ b/packages/esm-patient-lists-app/src/action-button/patient-lists-action-button.extension.tsx
@@ -1,9 +1,8 @@
 import React, { type ComponentProps } from 'react';
 import { useTranslation } from 'react-i18next';
-import { EventsIcon, ActionMenuButton } from '@openmrs/esm-framework';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { EventsIcon, ActionMenuButton, launchWorkspace } from '@openmrs/esm-framework';
 
-const handleLaunchPatientListsWorkspace = () => launchPatientWorkspace('patient-lists');
+const handleLaunchPatientListsWorkspace = () => launchWorkspace('patient-lists');
 
 function PatientListsActionButton() {
   const { t } = useTranslation();

--- a/packages/esm-patient-lists-app/src/workspaces/patient-list-details.workspace.tsx
+++ b/packages/esm-patient-lists-app/src/workspaces/patient-list-details.workspace.tsx
@@ -1,8 +1,8 @@
 import React, { type ComponentProps, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
-import { ArrowLeftIcon, formatDate, parseDate } from '@openmrs/esm-framework';
-import { type DefaultPatientWorkspaceProps, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { ArrowLeftIcon, formatDate, launchWorkspace, parseDate } from '@openmrs/esm-framework';
+import { type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import { type MappedList, usePatientListMembers } from '../patient-lists.resource';
 import PatientListDetailsTable from './patient-list-details-table.component';
 import styles from './patient-list-details.scss';
@@ -16,7 +16,7 @@ function PatientListDetailsWorkspace({ list }: PatientListDetailsWorkspaceProps)
   const { listMembers, isLoading } = usePatientListMembers(list.id);
 
   const closeListDetailsWorkspace = useCallback(() => {
-    launchPatientWorkspace('patient-lists');
+    launchWorkspace('patient-lists');
   }, []);
 
   return (

--- a/packages/esm-patient-lists-app/src/workspaces/patient-lists.workspace.tsx
+++ b/packages/esm-patient-lists-app/src/workspaces/patient-lists.workspace.tsx
@@ -20,8 +20,8 @@ import {
   TableToolbarSearch,
   Tile,
 } from '@carbon/react';
-import { EmptyDataIllustration, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { useDebounce, useLayoutType } from '@openmrs/esm-framework';
+import { EmptyDataIllustration } from '@openmrs/esm-patient-common-lib';
+import { launchWorkspace, useDebounce, useLayoutType } from '@openmrs/esm-framework';
 import { usePatientLists } from '../patient-lists.resource';
 import styles from './patient-lists.scss';
 
@@ -34,7 +34,7 @@ function PatientListsWorkspace() {
   const { patientLists, isLoading } = usePatientLists();
 
   const launchListDetailsWorkspace = useCallback((list) => {
-    launchPatientWorkspace('patient-list-details', { list, workspaceTitle: list.name });
+    launchWorkspace('patient-list-details', { list, workspaceTitle: list.name });
   }, []);
 
   const tableHeaders: Array<typeof DataTableHeader> = [

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
@@ -3,20 +3,20 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render, within, renderHook, waitFor } from '@testing-library/react';
 import { getByTextWithMarkup, mockPatient } from 'tools';
-import { getTemplateOrderBasketItem, useDrugSearch, useDrugTemplate } from './drug-search/drug-search.resource';
 import {
   mockDrugSearchResultApiData,
   mockDrugOrderTemplateApiData,
   mockPatientDrugOrdersApiData,
   mockSessionDataResponse,
 } from '__mocks__';
-import { closeWorkspace, useSession } from '@openmrs/esm-framework';
+import { getTemplateOrderBasketItem, useDrugSearch, useDrugTemplate } from './drug-search/drug-search.resource';
+import { closeWorkspace, launchWorkspace, useSession } from '@openmrs/esm-framework';
 import { type PostDataPrepFunction, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { _resetOrderBasketStore } from '@openmrs/esm-patient-common-lib/src/orders/store';
 import AddDrugOrderWorkspace from './add-drug-order.workspace';
 
 const mockCloseWorkspace = closeWorkspace as jest.Mock;
-const mockLaunchPatientWorkspace = jest.fn();
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 const mockUseSession = jest.mocked(useSession);
 const mockUseDrugSearch = jest.mocked(useDrugSearch);
 const mockUseDrugTemplate = jest.mocked(useDrugTemplate);
@@ -24,11 +24,6 @@ const usePatientOrdersMock = jest.fn();
 
 mockCloseWorkspace.mockImplementation((name, { onWorkspaceClose }) => onWorkspaceClose());
 mockUseSession.mockReturnValue(mockSessionDataResponse.data);
-
-jest.mock('@openmrs/esm-patient-common-lib', () => ({
-  ...jest.requireActual('@openmrs/esm-patient-common-lib'),
-  launchPatientWorkspace: (...args: any[]) => mockLaunchPatientWorkspace(...args),
-}));
 
 /** This is needed to render the order form */
 global.IntersectionObserver = jest.fn(function (callback, options) {
@@ -133,7 +128,7 @@ describe('AddDrugOrderWorkspace drug search', () => {
         startDate: expect.any(Date),
       }),
     ]);
-    expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('order-basket');
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('order-basket');
   });
 
   test('can open the drug form ', async () => {

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
@@ -1,12 +1,8 @@
 import React, { type ComponentProps, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
-import { ArrowLeftIcon, useLayoutType, useSession } from '@openmrs/esm-framework';
-import {
-  type DefaultPatientWorkspaceProps,
-  launchPatientWorkspace,
-  useOrderBasket,
-} from '@openmrs/esm-patient-common-lib';
+import { ArrowLeftIcon, launchWorkspace, useLayoutType, useSession } from '@openmrs/esm-framework';
+import { type DefaultPatientWorkspaceProps, useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { careSettingUuid, prepMedicationOrderPostData } from '../api/api';
 import { ordersEqual } from './drug-search/helpers';
 import type { DrugOrderBasketItem } from '../types';
@@ -34,7 +30,7 @@ export default function AddDrugOrderWorkspace({
 
   const cancelDrugOrder = useCallback(() => {
     closeWorkspace({
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      onWorkspaceClose: () => launchWorkspace('order-basket'),
       closeWorkspaceGroup: false,
     });
   }, [closeWorkspace]);
@@ -68,7 +64,7 @@ export default function AddDrugOrderWorkspace({
       }
       setOrders(newOrders);
       closeWorkspaceWithSavedChanges({
-        onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+        onWorkspaceClose: () => launchWorkspace('order-basket'),
       });
     },
     [orders, setOrders, closeWorkspaceWithSavedChanges, session.currentProvider.uuid],

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.component.tsx
@@ -1,8 +1,14 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Search } from '@carbon/react';
-import { useConfig, useDebounce, ResponsiveWrapper, closeWorkspace, useLayoutType } from '@openmrs/esm-framework';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import {
+  useConfig,
+  useDebounce,
+  ResponsiveWrapper,
+  closeWorkspace,
+  useLayoutType,
+  launchWorkspace,
+} from '@openmrs/esm-framework';
 import { type ConfigObject } from '../../config-schema';
 import { type DrugOrderBasketItem } from '../../types';
 import OrderBasketSearchResults from './order-basket-search-results.component';
@@ -22,7 +28,7 @@ export default function DrugSearch({ openOrderForm }: DrugSearchProps) {
 
   const cancelDrugOrder = useCallback(() => {
     closeWorkspace('add-drug-order', {
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      onWorkspaceClose: () => launchWorkspace('order-basket'),
     });
   }, []);
 

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/order-basket-search-results.component.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Button, ButtonSkeleton, SkeletonText, Tile } from '@carbon/react';
 import { ShoppingCartArrowUp } from '@carbon/react/icons';
-import { launchPatientWorkspace, useOrderBasket, usePatientChartStore } from '@openmrs/esm-patient-common-lib';
+import { useOrderBasket, usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 import {
   ArrowRightIcon,
   closeWorkspace,
@@ -11,6 +11,7 @@ import {
   useConfig,
   useLayoutType,
   UserHasAccess,
+  launchWorkspace,
 } from '@openmrs/esm-framework';
 import { type ConfigObject } from '../../config-schema';
 import { prepMedicationOrderPostData, useActivePatientOrders } from '../../api/api';
@@ -146,7 +147,7 @@ const DrugSearchResultItem: React.FC<DrugSearchResultItemProps> = ({ drug, openO
       setOrders([...orders, searchResult]);
       closeWorkspace('add-drug-order', {
         ignoreChanges: true,
-        onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+        onWorkspaceClose: () => launchWorkspace('order-basket'),
       });
     },
     [orders, setOrders],

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.extension.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.extension.tsx
@@ -2,8 +2,15 @@ import React, { type ComponentProps, useCallback, useEffect, useMemo, useState }
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import { Button, Tile } from '@carbon/react';
-import { AddIcon, ChevronDownIcon, ChevronUpIcon, closeWorkspace, useLayoutType } from '@openmrs/esm-framework';
-import { launchPatientWorkspace, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import {
+  AddIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  closeWorkspace,
+  launchWorkspace,
+  useLayoutType,
+} from '@openmrs/esm-framework';
+import { useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import { prepMedicationOrderPostData } from '../api/api';
 import type { DrugOrderBasketItem } from '../types';
 import OrderBasketItemTile from './order-basket-item-tile.component';
@@ -57,7 +64,7 @@ export default function DrugOrderBasketPanelExtension() {
   const openDrugSearch = () => {
     closeWorkspace('order-basket', {
       ignoreChanges: true,
-      onWorkspaceClose: () => launchPatientWorkspace('add-drug-order'),
+      onWorkspaceClose: () => launchWorkspace('add-drug-order'),
       closeWorkspaceGroup: false,
     });
   };
@@ -65,7 +72,7 @@ export default function DrugOrderBasketPanelExtension() {
   const openDrugForm = (order: DrugOrderBasketItem) => {
     closeWorkspace('order-basket', {
       ignoreChanges: true,
-      onWorkspaceClose: () => launchPatientWorkspace('add-drug-order', { order }),
+      onWorkspaceClose: () => launchWorkspace('add-drug-order', { order }),
       closeWorkspaceGroup: false,
     });
   };

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -1,14 +1,8 @@
 import React, { type ComponentProps } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, DataTableSkeleton, InlineLoading } from '@carbon/react';
-import { AddIcon, useLayoutType, useVisit } from '@openmrs/esm-framework';
-import {
-  CardHeader,
-  EmptyState,
-  ErrorState,
-  launchPatientWorkspace,
-  launchStartVisitPrompt,
-} from '@openmrs/esm-patient-common-lib';
+import { AddIcon, launchWorkspace, useLayoutType, useVisit } from '@openmrs/esm-framework';
+import { CardHeader, EmptyState, ErrorState, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
 import { useVisitNotes } from './visit-notes.resource';
 import PaginatedNotes from './paginated-notes.component';
 import styles from './notes-overview.scss';
@@ -31,7 +25,7 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, pageSize, urlLab
 
   const launchVisitNoteForm = React.useCallback(() => {
     if (currentVisit) {
-      launchPatientWorkspace('visit-notes-form-workspace');
+      launchWorkspace('visit-notes-form-workspace');
     } else {
       launchStartVisitPrompt();
     }

--- a/packages/esm-patient-notes-app/src/visit-note-action-button.test.tsx
+++ b/packages/esm-patient-notes-app/src/visit-note-action-button.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { screen, render } from '@testing-library/react';
 import { type LayoutType, useLayoutType, useWorkspaces, ActionMenuButton } from '@openmrs/esm-framework';
 import { useLaunchWorkspaceRequiringVisit } from '@openmrs/esm-patient-common-lib';
 import VisitNoteActionButton from './visit-note-action-button.extension';
@@ -26,7 +26,6 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
 
   return {
     ...originalModule,
-    launchPatientWorkspace: jest.fn(),
     useVisitOrOfflineVisit: jest.fn().mockReturnValue({ currentVisit: null }),
     useLaunchWorkspaceRequiringVisit: jest.fn(),
   };

--- a/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
@@ -36,7 +36,6 @@ import {
   EmptyState,
   ErrorState,
   getDrugOrderByUuid,
-  launchPatientWorkspace,
   PatientChartPagination,
   type Order,
   type OrderBasketItem,
@@ -53,6 +52,7 @@ import {
   formatDate,
   getCoreTranslation,
   getPatientName,
+  launchWorkspace,
   parseDate,
   PrinterIcon,
   useConfig,
@@ -647,7 +647,7 @@ function OrderBasketItemActions({
   }, [orderItem, openOrderForm, orders, setOrders]);
 
   const handleAddResultsClick = useCallback(() => {
-    launchPatientWorkspace('test-results-form-workspace', { order: orderItem });
+    launchWorkspace('test-results-form-workspace', { order: orderItem });
   }, [orderItem]);
 
   const handleCancelClick = useCallback(() => {

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-form/general-order-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-form/general-order-form.component.tsx
@@ -1,16 +1,6 @@
 import React, { type ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import {
-  type OrderBasketItem,
-  type DefaultPatientWorkspaceProps,
-  launchPatientWorkspace,
-  useOrderBasket,
-  useOrderType,
-  priorityOptions,
-  type OrderUrgency,
-} from '@openmrs/esm-patient-common-lib';
-import { useLayoutType, useSession, useConfig, ExtensionSlot, OpenmrsDatePicker } from '@openmrs/esm-framework';
-import {
   Button,
   ButtonSet,
   Column,
@@ -27,9 +17,25 @@ import { useTranslation } from 'react-i18next';
 import { Controller, type ControllerRenderProps, type FieldErrors, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import {
+  priorityOptions,
+  type DefaultPatientWorkspaceProps,
+  type OrderBasketItem,
+  type OrderUrgency,
+  useOrderBasket,
+  useOrderType,
+} from '@openmrs/esm-patient-common-lib';
+import {
+  useLayoutType,
+  useSession,
+  useConfig,
+  ExtensionSlot,
+  OpenmrsDatePicker,
+  launchWorkspace,
+} from '@openmrs/esm-framework';
 import { ordersEqual, prepOrderPostData } from '../resources';
-import styles from './general-order-form.scss';
 import { type ConfigObject } from '../../../config-schema';
+import styles from './general-order-form.scss';
 
 export interface OrderFormProps extends DefaultPatientWorkspaceProps {
   initialOrder: OrderBasketItem;
@@ -125,7 +131,7 @@ export function OrderForm({
       setOrders(newOrders);
 
       closeWorkspaceWithSavedChanges({
-        onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+        onWorkspaceClose: () => launchWorkspace('order-basket'),
         closeWorkspaceGroup: false,
       });
     },
@@ -135,7 +141,7 @@ export function OrderForm({
   const cancelOrder = useCallback(() => {
     setOrders(orders.filter((order) => order.concept.uuid !== defaultValues.concept.conceptUuid));
     closeWorkspace({
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      onWorkspaceClose: () => launchWorkspace('order-basket'),
       closeWorkspaceGroup: false,
     });
   }, [closeWorkspace, orders, setOrders, defaultValues]);

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-type.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-type.component.tsx
@@ -9,14 +9,10 @@ import {
   type DefaultWorkspaceProps,
   MaybeIcon,
   useLayoutType,
+  launchWorkspace,
 } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
-import {
-  type OrderBasketItem,
-  launchPatientWorkspace,
-  useOrderBasket,
-  useOrderType,
-} from '@openmrs/esm-patient-common-lib';
+import { type OrderBasketItem, useOrderBasket, useOrderType } from '@openmrs/esm-patient-common-lib';
 import OrderBasketItemTile from './order-basket-item-tile.component';
 import { prepOrderPostData } from './resources';
 import { type OrderTypeDefinition } from '../../config-schema';
@@ -72,7 +68,7 @@ const GeneralOrderType: React.FC<GeneralOrderTypeProps> = ({ orderTypeUuid, clos
     closeWorkspace({
       ignoreChanges: true,
       onWorkspaceClose: () =>
-        launchPatientWorkspace('orderable-concept-workspace', {
+        launchWorkspace('orderable-concept-workspace', {
           orderTypeUuid,
         }),
       closeWorkspaceGroup: false,
@@ -83,7 +79,7 @@ const GeneralOrderType: React.FC<GeneralOrderTypeProps> = ({ orderTypeUuid, clos
     closeWorkspace({
       ignoreChanges: true,
       onWorkspaceClose: () =>
-        launchPatientWorkspace('orderable-concept-workspace', {
+        launchWorkspace('orderable-concept-workspace', {
           order,
           orderTypeUuid,
         }),

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/orderable-concept-search/orderable-concept-search.workspace.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/orderable-concept-search/orderable-concept-search.workspace.tsx
@@ -3,6 +3,7 @@ import { Button, Search } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import {
   ArrowLeftIcon,
+  launchWorkspace,
   ResponsiveWrapper,
   useConfig,
   useDebounce,
@@ -10,7 +11,6 @@ import {
   type DefaultWorkspaceProps,
 } from '@openmrs/esm-framework';
 import {
-  launchPatientWorkspace,
   type OrderBasketItem,
   useOrderBasket,
   useOrderType,
@@ -70,7 +70,7 @@ const OrderableConceptSearchWorkspace: React.FC<OrderableConceptSearchWorkspaceP
 
   const cancelDrugOrder = useCallback(() => {
     closeWorkspace({
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      onWorkspaceClose: () => launchWorkspace('order-basket'),
       closeWorkspaceGroup: false,
     });
   }, [closeWorkspace]);
@@ -143,7 +143,7 @@ function ConceptSearch({ closeWorkspace, orderTypeUuid, openOrderForm, orderable
 
   const cancelDrugOrder = useCallback(() => {
     closeWorkspace({
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      onWorkspaceClose: () => launchWorkspace('order-basket'),
     });
   }, [closeWorkspace]);
 

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/orderable-concept-search/search-results.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/orderable-concept-search/search-results.component.tsx
@@ -1,11 +1,7 @@
-import React, { type ComponentProps, useCallback } from 'react';
-import {
-  launchPatientWorkspace,
-  useOrderBasket,
-  type OrderBasketItem,
-  useOrderableConceptSets,
-  type OrderableConcept,
-} from '@openmrs/esm-patient-common-lib';
+import React, { type ComponentProps, useCallback, useMemo } from 'react';
+import classNames from 'classnames';
+import { ShoppingCartArrowUp } from '@carbon/react/icons';
+import { Tile, Button, SkeletonText, ButtonSkeleton } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import {
   ArrowRightIcon,
@@ -13,13 +9,16 @@ import {
   ShoppingCartArrowDownIcon,
   useLayoutType,
   useSession,
+  launchWorkspace,
 } from '@openmrs/esm-framework';
-import { ShoppingCartArrowUp } from '@carbon/react/icons';
-import { useMemo } from 'react';
-import classNames from 'classnames';
-import { Tile, Button, SkeletonText, ButtonSkeleton } from '@carbon/react';
-import styles from './search-results.scss';
+import {
+  useOrderBasket,
+  type OrderBasketItem,
+  useOrderableConceptSets,
+  type OrderableConcept,
+} from '@openmrs/esm-patient-common-lib';
 import { createEmptyOrder, prepOrderPostData } from '../resources';
+import styles from './search-results.scss';
 
 interface OrderableConceptSearchResultsProps {
   searchTerm: string;
@@ -186,7 +185,7 @@ const TestTypeSearchResultItem: React.FC<TestTypeSearchResultItemProps> = ({
     setOrders([...orders, orderBasketItem]);
     closeWorkspace({
       ignoreChanges: true,
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      onWorkspaceClose: () => launchWorkspace('order-basket'),
       closeWorkspaceGroup: false,
     });
   }, [orders, setOrders, createOrderBasketItem, concept, closeWorkspace]);

--- a/packages/esm-patient-programs-app/src/programs/programs-action-menu.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-action-menu.component.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Layer, OverflowMenu, OverflowMenuItem } from '@carbon/react';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { showModal, useLayoutType } from '@openmrs/esm-framework';
+import { launchWorkspace, showModal, useLayoutType } from '@openmrs/esm-framework';
 import styles from './programs-action-menu.scss';
 
 interface ProgramActionsProps {
@@ -16,7 +15,7 @@ export const ProgramsActionMenu = ({ patientUuid, programEnrollmentId }: Program
 
   const launchEditProgramsForm = useCallback(
     () =>
-      launchPatientWorkspace('programs-form-workspace', {
+      launchWorkspace('programs-form-workspace', {
         workspaceTitle: t('editProgramEnrollment', 'Edit program enrollment'),
         programEnrollmentId,
       }),

--- a/packages/esm-patient-programs-app/src/programs/programs-action-menu.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-action-menu.test.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@testing-library/react';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { showModal, useLayoutType } from '@openmrs/esm-framework';
+import { launchWorkspace, showModal, useLayoutType } from '@openmrs/esm-framework';
 import { mockPatient } from 'tools';
 import { ProgramsActionMenu } from './programs-action-menu.component';
 
 const mockShowModal = jest.mocked(showModal);
 const mockUseLayoutType = jest.mocked(useLayoutType);
-
-jest.mock('@openmrs/esm-patient-common-lib', () => ({
-  launchPatientWorkspace: jest.fn(),
-}));
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 
 const testProps = {
   programEnrollmentId: '123',
@@ -51,7 +47,7 @@ describe('ProgramActionsMenu', () => {
     await user.click(screen.getByRole('button'));
     await user.click(screen.getByText('Edit'));
 
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
       programEnrollmentId: testProps.programEnrollmentId,
       workspaceTitle: 'Edit program enrollment',
     });

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.component.tsx
@@ -24,8 +24,9 @@ import {
   useConfig,
   useLayoutType,
   isDesktop as desktopLayout,
+  launchWorkspace,
 } from '@openmrs/esm-framework';
-import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { findLastState, usePrograms } from './programs.resource';
 import { ProgramsActionMenu } from './programs-action-menu.component';
 import styles from './programs-detailed-summary.scss';
@@ -91,7 +92,7 @@ const ProgramsDetailedSummary: React.FC<ProgramsDetailedSummaryProps> = ({ patie
     [enrollments, t],
   );
 
-  const launchProgramsForm = useCallback(() => launchPatientWorkspace('programs-form-workspace'), []);
+  const launchProgramsForm = useCallback(() => launchWorkspace('programs-form-workspace'), []);
 
   const isEnrolledInAllPrograms = useMemo(() => {
     if (!availablePrograms?.length || !enrollments?.length) {

--- a/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-detailed-summary.test.tsx
@@ -1,24 +1,15 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, within } from '@testing-library/react';
-import { getDefaultsFromConfigSchema, openmrsFetch, useConfig } from '@openmrs/esm-framework';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { getDefaultsFromConfigSchema, launchWorkspace, openmrsFetch, useConfig } from '@openmrs/esm-framework';
 import { mockCareProgramsResponse, mockEnrolledInAllProgramsResponse, mockEnrolledProgramsResponse } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { type ConfigObject, configSchema } from '../config-schema';
 import ProgramsDetailedSummary from './programs-detailed-summary.component';
 
-const mockOpenmrsFetch = openmrsFetch as jest.Mock;
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
-
-jest.mock('@openmrs/esm-patient-common-lib', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
-
-  return {
-    ...originalModule,
-    launchPatientWorkspace: jest.fn(),
-  };
-});
+const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
 describe('ProgramsDetailedSummary', () => {
   it('renders an empty state view when the patient is not enrolled into any programs', async () => {
@@ -86,12 +77,12 @@ describe('ProgramsDetailedSummary', () => {
     expect(addButton).toBeEnabled();
     await user.click(addButton);
 
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace');
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('programs-form-workspace');
 
     await user.click(actionMenuButton);
     await user.click(screen.getByText('Edit'));
 
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
       programEnrollmentId: mockEnrolledProgramsResponse[0].uuid,
       workspaceTitle: 'Edit program enrollment',
     });

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.component.tsx
@@ -15,18 +15,13 @@ import {
   TableHeader,
   TableRow,
 } from '@carbon/react';
-import {
-  launchPatientWorkspace,
-  CardHeader,
-  EmptyState,
-  ErrorState,
-  PatientChartPagination,
-} from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyState, ErrorState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
 import {
   AddIcon,
   type ConfigObject,
   formatDate,
   formatDatetime,
+  launchWorkspace,
   useConfig,
   useLayoutType,
   usePagination,
@@ -59,7 +54,7 @@ const ProgramsOverview: React.FC<ProgramsOverviewProps> = ({ basePath, patientUu
 
   const { results: paginatedEnrollments, goTo, currentPage } = usePagination(enrollments ?? [], programsCount);
 
-  const launchProgramsForm = useCallback(() => launchPatientWorkspace('programs-form-workspace'), []);
+  const launchProgramsForm = useCallback(() => launchWorkspace('programs-form-workspace'), []);
 
   const tableHeaders = [
     {

--- a/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-overview.test.tsx
@@ -1,22 +1,13 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, within } from '@testing-library/react';
-import { openmrsFetch } from '@openmrs/esm-framework';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { launchWorkspace, openmrsFetch } from '@openmrs/esm-framework';
 import { mockCareProgramsResponse, mockEnrolledInAllProgramsResponse, mockEnrolledProgramsResponse } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import ProgramsOverview from './programs-overview.component';
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
-
-jest.mock('@openmrs/esm-patient-common-lib', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
-
-  return {
-    ...originalModule,
-    launchPatientWorkspace: jest.fn(),
-  };
-});
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 
 const testProps = {
   basePath: `/patient/${mockPatient.id}/chart`,
@@ -82,16 +73,15 @@ describe('ProgramsOverview', () => {
     const actionMenuButton = within(row).getByRole('button', { name: /options$/i });
     expect(actionMenuButton).toBeInTheDocument();
 
-    // Clicking "Add" launches the programs form in a workspace
     expect(addButton).toBeEnabled();
     await user.click(addButton);
 
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace');
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('programs-form-workspace');
 
     await user.click(actionMenuButton);
     await user.click(screen.getByText('Edit'));
 
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('programs-form-workspace', {
       programEnrollmentId: mockEnrolledProgramsResponse[0].uuid,
       workspaceTitle: 'Edit program enrollment',
     });

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/add-test-order.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/add-test-order.test.tsx
@@ -7,6 +7,7 @@ import {
   age,
   closeWorkspace,
   getDefaultsFromConfigSchema,
+  launchWorkspace,
   useConfig,
   useLayoutType,
   useSession,
@@ -23,6 +24,7 @@ const mockUseLayoutType = jest.mocked(useLayoutType);
 const mockUseSession = jest.mocked(useSession);
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
 const mockUseOrderType = jest.mocked(useOrderType);
+const mockLaunchWorkspace = jest.mocked(launchWorkspace);
 
 mockCloseWorkspace.mockImplementation(({ onWorkspaceClose }) => {
   onWorkspaceClose?.();
@@ -55,11 +57,8 @@ jest.mock('./useTestTypes', () => ({
   useTestTypes: () => mockUseTestTypes(),
 }));
 
-const mockLaunchPatientWorkspace = jest.fn();
-
 jest.mock('@openmrs/esm-patient-common-lib', () => ({
   ...jest.requireActual('@openmrs/esm-patient-common-lib'),
-  launchPatientWorkspace: (...args) => mockLaunchPatientWorkspace(...args),
   useOrderType: jest.fn(),
 }));
 
@@ -173,7 +172,7 @@ describe('AddLabOrder', () => {
     });
 
     expect(mockCloseWorkspaceWithSavedChanges).toHaveBeenCalled();
-    expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('order-basket');
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('order-basket');
   });
 
   test('from lab search, click add directly to order basket', async () => {
@@ -211,7 +210,7 @@ describe('AddLabOrder', () => {
     expect(back).toBeInTheDocument();
     await user.click(back);
     expect(mockCloseWorkspace).toHaveBeenCalled();
-    expect(mockLaunchPatientWorkspace).toHaveBeenCalledWith('order-basket');
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('order-basket');
   });
 
   test('should display a patient header on tablet', () => {

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/add-test-order.workspace.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/add-test-order.workspace.tsx
@@ -8,6 +8,7 @@ import {
   ArrowLeftIcon,
   getPatientName,
   formatDate,
+  launchWorkspace,
   parseDate,
   useLayoutType,
   useConfig,
@@ -15,15 +16,14 @@ import {
 import {
   type DefaultPatientWorkspaceProps,
   type OrderBasketItem,
-  launchPatientWorkspace,
   useOrderType,
   usePatientChartStore,
 } from '@openmrs/esm-patient-common-lib';
+import { type ConfigObject } from '../../config-schema';
+import type { TestOrderBasketItem } from '../../types';
 import { LabOrderForm } from './test-order-form.component';
 import { TestTypeSearch } from './test-type-search.component';
 import styles from './add-test-order.scss';
-import { type ConfigObject } from '../../config-schema';
-import type { TestOrderBasketItem } from '../../types';
 
 export interface AddLabOrderWorkspaceAdditionalProps {
   order?: OrderBasketItem;
@@ -75,7 +75,7 @@ export default function AddLabOrderWorkspace({
   const cancelOrder = useCallback(() => {
     closeWorkspace({
       ignoreChanges: true,
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      onWorkspaceClose: () => launchWorkspace('order-basket'),
       closeWorkspaceGroup: false,
     });
   }, [closeWorkspace]);

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
@@ -1,14 +1,6 @@
 import React, { type ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
-import {
-  type DefaultPatientWorkspaceProps,
-  launchPatientWorkspace,
-  type OrderUrgency,
-  priorityOptions,
-  useOrderBasket,
-  useOrderType,
-} from '@openmrs/esm-patient-common-lib';
-import { ExtensionSlot, OpenmrsDatePicker, useConfig, useLayoutType, useSession } from '@openmrs/esm-framework';
+
 import {
   Button,
   ButtonSet,
@@ -25,10 +17,25 @@ import {
 } from '@carbon/react';
 import { Controller, type ControllerRenderProps, type FieldErrors, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 import { useTranslation } from 'react-i18next';
+import {
+  type DefaultPatientWorkspaceProps,
+  type OrderUrgency,
+  priorityOptions,
+  useOrderBasket,
+  useOrderType,
+} from '@openmrs/esm-patient-common-lib';
+import {
+  ExtensionSlot,
+  launchWorkspace,
+  OpenmrsDatePicker,
+  useConfig,
+  useLayoutType,
+  useSession,
+} from '@openmrs/esm-framework';
 import { prepTestOrderPostData, useOrderReasons } from '../api';
 import { ordersEqual } from './test-order';
-import { z } from 'zod';
 import { type ConfigObject } from '../../config-schema';
 import { type TestOrderBasketItem } from '../../types';
 import styles from './test-order-form.scss';
@@ -150,7 +157,7 @@ export function LabOrderForm({
       setOrders(newOrders);
 
       closeWorkspaceWithSavedChanges({
-        onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+        onWorkspaceClose: () => launchWorkspace('order-basket'),
         closeWorkspaceGroup: false,
       });
     },
@@ -160,7 +167,7 @@ export function LabOrderForm({
   const cancelOrder = useCallback(() => {
     setOrders(orders.filter((order) => order.testType.conceptUuid !== defaultValues.testType.conceptUuid));
     closeWorkspace({
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      onWorkspaceClose: () => launchWorkspace('order-basket'),
       closeWorkspaceGroup: false,
     });
   }, [closeWorkspace, orders, setOrders, defaultValues]);

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-type-search.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-type-search.component.tsx
@@ -1,23 +1,24 @@
 import React, { type ComponentProps, useCallback, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
-import { type TFunction, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { Button, ButtonSkeleton, Search, SkeletonText, Tile } from '@carbon/react';
 import { ShoppingCartArrowUp } from '@carbon/react/icons';
 import {
   ArrowRightIcon,
   closeWorkspace,
+  launchWorkspace,
   ResponsiveWrapper,
   ShoppingCartArrowDownIcon,
   useDebounce,
   useLayoutType,
   useSession,
 } from '@openmrs/esm-framework';
-import { launchPatientWorkspace, useOrderBasket, useOrderType } from '@openmrs/esm-patient-common-lib';
+import { useOrderBasket } from '@openmrs/esm-patient-common-lib';
 import type { TestOrderBasketItem } from '../../types';
 import { prepTestOrderPostData } from '../api';
 import { createEmptyLabOrder } from './test-order';
-import styles from './test-type-search.scss';
 import { useTestTypes, type TestType } from './useTestTypes';
+import styles from './test-type-search.scss';
 
 export interface TestTypeSearchProps {
   openLabForm: (searchResult: TestOrderBasketItem) => void;
@@ -51,7 +52,7 @@ export function TestTypeSearch({ openLabForm, orderTypeUuid, orderableConceptSet
   const cancelOrder = useCallback(() => {
     closeWorkspace('add-lab-order', {
       ignoreChanges: true,
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      onWorkspaceClose: () => launchWorkspace('order-basket'),
     });
   }, []);
 
@@ -205,7 +206,7 @@ const TestTypeSearchResultItem: React.FC<TestTypeSearchResultItemProps> = ({
     setOrders([...orders, labOrder]);
     closeWorkspace('add-lab-order', {
       ignoreChanges: true,
-      onWorkspaceClose: () => launchPatientWorkspace('order-basket'),
+      onWorkspaceClose: () => launchWorkspace('order-basket'),
     });
   }, [orders, setOrders, createLabOrder, testType]);
 

--- a/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-panel.extension.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-panel.extension.tsx
@@ -10,18 +10,14 @@ import {
   useLayoutType,
   useConfig,
   MaybeIcon,
+  launchWorkspace,
 } from '@openmrs/esm-framework';
-import {
-  launchPatientWorkspace,
-  type OrderBasketItem,
-  useOrderBasket,
-  useOrderType,
-} from '@openmrs/esm-patient-common-lib';
+import { type OrderBasketItem, useOrderBasket, useOrderType } from '@openmrs/esm-patient-common-lib';
+import type { ConfigObject } from '../../config-schema';
 import type { TestOrderBasketItem } from '../../types';
 import { LabOrderBasketItemTile } from './lab-order-basket-item-tile.component';
 import { prepTestOrderPostData } from '../api';
 import styles from './lab-order-basket-panel.scss';
-import type { ConfigObject } from '../../config-schema';
 
 /**
  * Designs: https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/648c44d9d4052c613e7f23da
@@ -99,7 +95,7 @@ function LabOrderBasketPanel({ orderTypeUuid, label, icon }: LabOrderBasketPanel
     closeWorkspace('order-basket', {
       ignoreChanges: true,
       onWorkspaceClose: () =>
-        launchPatientWorkspace('add-lab-order', {
+        launchWorkspace('add-lab-order', {
           orderTypeUuid: orderTypeUuid,
         }),
       closeWorkspaceGroup: false,
@@ -111,7 +107,7 @@ function LabOrderBasketPanel({ orderTypeUuid, label, icon }: LabOrderBasketPanel
       closeWorkspace('order-basket', {
         ignoreChanges: true,
         onWorkspaceClose: () =>
-          launchPatientWorkspace('add-lab-order', {
+          launchWorkspace('add-lab-order', {
             order,
             orderTypeUuid: orderTypeUuid,
           }),

--- a/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-panel.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-panel.test.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render } from '@testing-library/react';
 import { useOrderType } from '@openmrs/esm-patient-common-lib';
-import LabOrderBasketPanel from './lab-order-basket-panel.extension';
 import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
 import { type ConfigObject, configSchema } from '../../config-schema';
 import type { TestOrderBasketItem } from '../../types';
+import LabOrderBasketPanel from './lab-order-basket-panel.extension';
 
 const mockUseOrderBasket = jest.fn();
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);

--- a/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-and-biometrics-header/vitals-header.test.tsx
@@ -3,7 +3,6 @@ import dayjs from 'dayjs';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type WorkspacesInfo, getDefaultsFromConfigSchema, useConfig, useWorkspaces } from '@openmrs/esm-framework';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { mockPatient, getByTextWithMarkup, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import {
   formattedVitals,
@@ -22,7 +21,6 @@ const testProps = {
 };
 
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
-const mockLaunchPatientWorkspace = jest.mocked(launchPatientWorkspace);
 const mockUseVitalsAndBiometrics = jest.mocked(useVitalsAndBiometrics);
 const mockUseWorkspaces = jest.mocked(useWorkspaces);
 
@@ -37,7 +35,6 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
 
   return {
     ...originalModule,
-    launchPatientWorkspace: jest.fn(),
     useVisitOrOfflineVisit: jest.fn().mockImplementation(() => ({ currentVisit: mockCurrentVisit })),
     useLaunchWorkspaceRequiringVisit: jest.fn().mockImplementation(() => mockUseLaunchWorkspaceRequiringVisit),
   };

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-input.test.tsx
@@ -90,7 +90,6 @@ jest.mock('../common', () => {
 
   return {
     ...originalModule,
-    launchPatientWorkspace: jest.fn(),
     useConceptUnits: jest.fn().mockImplementation(() => ({
       data: mockConceptUnits,
       conceptMetadata: { ...overridenMetadata },

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -25,21 +25,11 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   disconnect: jest.fn(),
 }));
 
-jest.mock('@openmrs/esm-patient-common-lib', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
-
-  return {
-    ...originalModule,
-    launchPatientWorkspace: jest.fn(),
-  };
-});
-
 jest.mock('../common', () => {
   const originalModule = jest.requireActual('../common');
 
   return {
     ...originalModule,
-    launchPatientWorkspace: jest.fn(),
     useConceptUnits: jest.fn().mockImplementation(() => ({
       conceptUnits: mockConceptUnits,
       error: null,


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes the deprecated `launchPatientWorkspace` function from the `@openmrs/esm-patient-common-lib` package and replaces all occurrences of it with the `launchWorkspace` function from the `@openmrs/esm-framework` package.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
