### PR TITLE
DRAFT (fix) O3-4709: Reduce calls to useVisit to improve performance

### DIFF
--- a/packages/esm-patient-chart-app/package.json
+++ b/packages/esm-patient-chart-app/package.json
@@ -43,7 +43,6 @@
   "peerDependencies": {
     "@carbon/react": "1.x",
     "@openmrs/esm-framework": "6.x",
-    "@openmrs/esm-patient-common-lib": "*",
     "dayjs": "1.x",
     "lodash-es": "4.x",
     "react": "18.x",

--- a/packages/esm-patient-chart-app/package.json
+++ b/packages/esm-patient-chart-app/package.json
@@ -43,6 +43,7 @@
   "peerDependencies": {
     "@carbon/react": "1.x",
     "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-patient-common-lib": "*",
     "dayjs": "1.x",
     "lodash-es": "4.x",
     "react": "18.x",

--- a/packages/esm-patient-chart-app/src/actions-buttons/delete-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/delete-visit.component.tsx
@@ -2,8 +2,8 @@ import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { OverflowMenuItem } from '@carbon/react';
 import { showModal } from '@openmrs/esm-framework';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 import styles from './action-button.scss';
-import { usePatientChartStore } from '@openmrs/esm-patient-common-lib/src';
 
 interface DeleteVisitOverflowMenuItemProps {
   patientUuid: string;

--- a/packages/esm-patient-chart-app/src/actions-buttons/delete-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/delete-visit.component.tsx
@@ -21,15 +21,17 @@ const DeleteVisitOverflowMenuItem: React.FC<DeleteVisitOverflowMenuItemProps> = 
     });
   }, [patientUuid, activeVisit]);
 
+  if (!activeVisit) {
+    return null;
+  }
+
   return (
-    activeVisit && (
-      <OverflowMenuItem
-        className={styles.menuitem}
-        itemText={t('deleteActiveVisit', 'Delete active visit')}
-        onClick={handleLaunchModal}
-        isDelete
-      />
-    )
+    <OverflowMenuItem
+      className={styles.menuitem}
+      isDelete
+      itemText={t('deleteActiveVisit', 'Delete active visit')}
+      onClick={handleLaunchModal}
+    />
   );
 };
 

--- a/packages/esm-patient-chart-app/src/actions-buttons/delete-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/delete-visit.component.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { OverflowMenuItem } from '@carbon/react';
-import { useVisit, showModal } from '@openmrs/esm-framework';
+import { showModal } from '@openmrs/esm-framework';
 import styles from './action-button.scss';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib/src';
 
 interface DeleteVisitOverflowMenuItemProps {
   patientUuid: string;
@@ -10,7 +11,7 @@ interface DeleteVisitOverflowMenuItemProps {
 
 const DeleteVisitOverflowMenuItem: React.FC<DeleteVisitOverflowMenuItemProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
-  const { activeVisit } = useVisit(patientUuid);
+  const { activeVisit } = usePatientChartStore().visits;
 
   const handleLaunchModal = useCallback(() => {
     const dispose = showModal('delete-visit-dialog', {

--- a/packages/esm-patient-chart-app/src/actions-buttons/delete-visit.test.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/delete-visit.test.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render } from '@testing-library/react';
-import { showModal, useVisit } from '@openmrs/esm-framework';
+import { showModal } from '@openmrs/esm-framework';
 import { mockCurrentVisit } from '__mocks__';
 import DeleteVisitOverflowMenuItem from './delete-visit.component';
 
-const mockUseVisit = jest.mocked(useVisit);
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  return {
+    usePatientChartStore: () => ({ visits: { activeVisit: mockCurrentVisit } }),
+  };
+});
+
 const mockShowModal = jest.mocked(showModal);
 
 describe('DeleteVisitOverflowMenuItem', () => {
   it('should launch delete visit dialog modal', async () => {
     const user = userEvent.setup();
-
-    mockUseVisit.mockReturnValueOnce({ activeVisit: mockCurrentVisit } as ReturnType<typeof useVisit>);
 
     render(<DeleteVisitOverflowMenuItem patientUuid="some-uuid" />);
 

--- a/packages/esm-patient-chart-app/src/actions-buttons/stop-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/stop-visit.component.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { showModal } from '@openmrs/esm-framework';
 import { OverflowMenuItem } from '@carbon/react';
+import { showModal } from '@openmrs/esm-framework';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 import styles from './action-button.scss';
-import { usePatientChartStore } from '@openmrs/esm-patient-common-lib/src';
 
 interface StopVisitOverflowMenuItemProps {
   patientUuid: string;

--- a/packages/esm-patient-chart-app/src/actions-buttons/stop-visit.component.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/stop-visit.component.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { showModal, useVisit } from '@openmrs/esm-framework';
+import { showModal } from '@openmrs/esm-framework';
 import { OverflowMenuItem } from '@carbon/react';
 import styles from './action-button.scss';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib/src';
 
 interface StopVisitOverflowMenuItemProps {
   patientUuid: string;
@@ -14,7 +15,7 @@ interface StopVisitOverflowMenuItemProps {
  */
 const StopVisitOverflowMenuItem: React.FC<StopVisitOverflowMenuItemProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
-  const { activeVisit } = useVisit(patientUuid);
+  const { activeVisit } = usePatientChartStore().visits;
 
   const handleLaunchModal = useCallback(() => {
     const dispose = showModal('end-visit-dialog', {

--- a/packages/esm-patient-chart-app/src/actions-buttons/stop-visit.test.tsx
+++ b/packages/esm-patient-chart-app/src/actions-buttons/stop-visit.test.tsx
@@ -2,18 +2,20 @@ import React from 'react';
 import StopVisitOverflowMenuItem from './stop-visit.component';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { showModal, useVisit } from '@openmrs/esm-framework';
+import { showModal } from '@openmrs/esm-framework';
 import { mockCurrentVisit } from '__mocks__';
 import { mockPatient } from 'tools';
 
-const mockUseVisit = jest.mocked(useVisit);
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  return {
+    usePatientChartStore: () => ({ visits: { activeVisit: mockCurrentVisit } }),
+  };
+});
 const mockShowModal = jest.mocked(showModal);
 
 describe('StopVisitOverflowMenuItem', () => {
   it('should be able to stop active visit', async () => {
     const user = userEvent.setup();
-
-    mockUseVisit.mockReturnValue({ activeVisit: mockCurrentVisit } as ReturnType<typeof useVisit>);
 
     render(<StopVisitOverflowMenuItem patientUuid={mockPatient.id} />);
 

--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list-tabs.component.tsx
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list-tabs.component.tsx
@@ -2,12 +2,12 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '@carbon/react';
 import { useConfig } from '@openmrs/esm-framework';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 import { EncounterList } from './encounter-list.component';
 import { getMenuItemTabsConfiguration } from '../utils/encounter-list-config-builder';
 import styles from './encounter-list-tabs.scss';
 import { filter } from '../utils/helpers';
 import { type Encounter } from '../types';
-import { usePatientChartStore } from '@openmrs/esm-patient-common-lib/src';
 
 interface EncounterListTabsComponentProps {
   patientUuid: string;

--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list-tabs.component.tsx
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list-tabs.component.tsx
@@ -1,12 +1,13 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '@carbon/react';
-import { useConfig, useVisit } from '@openmrs/esm-framework';
+import { useConfig } from '@openmrs/esm-framework';
 import { EncounterList } from './encounter-list.component';
 import { getMenuItemTabsConfiguration } from '../utils/encounter-list-config-builder';
 import styles from './encounter-list-tabs.scss';
 import { filter } from '../utils/helpers';
 import { type Encounter } from '../types';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib/src';
 
 interface EncounterListTabsComponentProps {
   patientUuid: string;
@@ -15,7 +16,7 @@ interface EncounterListTabsComponentProps {
 
 const EncounterListTabsComponent: React.FC<EncounterListTabsComponentProps> = ({ patientUuid, patient }) => {
   const { t } = useTranslation();
-  const { currentVisit } = useVisit(patientUuid);
+  const { currentVisit } = usePatientChartStore().visits;
 
   const config = useConfig();
   const { tabDefinitions = [] } = config;

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
@@ -3,6 +3,7 @@ import {
   WorkspaceContainer,
   setCurrentVisit,
   usePatient,
+  useVisit,
   useWorkspaces,
   useLeftNav,
 } from '@openmrs/esm-framework';
@@ -21,7 +22,8 @@ const PatientChart: React.FC = () => {
   const { patientUuid, view: encodedView } = useParams();
   const view = decodeURIComponent(encodedView);
   const { isLoading: isLoadingPatient, patient } = usePatient(patientUuid);
-  const state = useMemo(() => ({ patient, patientUuid }), [patient, patientUuid]);
+  const visits = useVisit(patientUuid);
+  const state = useMemo(() => ({ patient, patientUuid, visits }), [patient, patientUuid, visits]);
   const { workspaceWindowState, active } = useWorkspaces();
   const [layoutMode, setLayoutMode] = useState<LayoutMode>();
   // Keep state updated with the current patient. Anything used outside the patient

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
@@ -53,38 +53,34 @@ const PatientChart: React.FC = () => {
     <>
       <SideMenuPanel />
       <main className={classNames('omrs-main-content', styles.chartContainer)}>
-        <>
-          <div
-            className={classNames(
-              styles.innerChartContainer,
-              workspaceWindowState === 'normal' && active ? styles.closeWorkspace : styles.activeWorkspace,
-            )}
-          >
-            {isLoadingPatient ? (
-              <Loader />
-            ) : (
-              <>
-                <aside>
-                  <ExtensionSlot name="patient-header-slot" state={state} />
-                  <ExtensionSlot name="patient-highlights-bar-slot" state={state} />
-                  <ExtensionSlot name="patient-info-slot" state={state} />
-                </aside>
-                <div className={styles.grid}>
-                  <div
-                    className={classNames(styles.chartReview, { [styles.widthContained]: layoutMode == 'contained' })}
-                  >
-                    <ChartReview
-                      patient={state.patient}
-                      patientUuid={state.patientUuid}
-                      setDashboardLayoutMode={setLayoutMode}
-                      view={view}
-                    />
-                  </div>
+        <div
+          className={classNames(
+            styles.innerChartContainer,
+            workspaceWindowState === 'normal' && active ? styles.closeWorkspace : styles.activeWorkspace,
+          )}
+        >
+          {isLoadingPatient ? (
+            <Loader />
+          ) : (
+            <>
+              <aside>
+                <ExtensionSlot name="patient-header-slot" state={state} />
+                <ExtensionSlot name="patient-highlights-bar-slot" state={state} />
+                <ExtensionSlot name="patient-info-slot" state={state} />
+              </aside>
+              <div className={styles.grid}>
+                <div className={classNames(styles.chartReview, { [styles.widthContained]: layoutMode == 'contained' })}>
+                  <ChartReview
+                    patient={state.patient}
+                    patientUuid={state.patientUuid}
+                    setDashboardLayoutMode={setLayoutMode}
+                    view={view}
+                  />
                 </div>
-              </>
-            )}
-          </div>
-        </>
+              </div>
+            </>
+          )}
+        </div>
       </main>
       <WorkspaceContainer
         additionalWorkspaceProps={state}

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
@@ -1,3 +1,6 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import classNames from 'classnames';
+import { useParams } from 'react-router-dom';
 import {
   ExtensionSlot,
   WorkspaceContainer,
@@ -8,14 +11,11 @@ import {
   useLeftNav,
 } from '@openmrs/esm-framework';
 import { getPatientChartStore } from '@openmrs/esm-patient-common-lib';
-import classNames from 'classnames';
-import React, { useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { type LayoutMode } from './chart-review/dashboard-view.component';
 import { spaBasePath } from '../constants';
 import Loader from '../loader/loader.component';
 import ChartReview from '../patient-chart/chart-review/chart-review.component';
 import SideMenuPanel from '../side-nav/side-menu.component';
-import { type LayoutMode } from './chart-review/dashboard-view.component';
 import styles from './patient-chart.scss';
 
 const PatientChart: React.FC = () => {

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.component.tsx
@@ -19,13 +19,15 @@ import SideMenuPanel from '../side-nav/side-menu.component';
 import styles from './patient-chart.scss';
 
 const PatientChart: React.FC = () => {
+  const { workspaceWindowState, active } = useWorkspaces();
   const { patientUuid, view: encodedView } = useParams();
   const view = decodeURIComponent(encodedView);
-  const { isLoading: isLoadingPatient, patient } = usePatient(patientUuid);
   const visits = useVisit(patientUuid);
-  const state = useMemo(() => ({ patient, patientUuid, visits }), [patient, patientUuid, visits]);
-  const { workspaceWindowState, active } = useWorkspaces();
+  const { isLoading: isLoadingPatient, patient } = usePatient(patientUuid);
+
   const [layoutMode, setLayoutMode] = useState<LayoutMode>();
+  const state = useMemo(() => ({ patient, patientUuid, visits }), [patient, patientUuid, visits]);
+
   // Keep state updated with the current patient. Anything used outside the patient
   // chart (e.g., the current visit is used by the Active Visit Tag used in the
   // patient search) must be updated in the callback, which is called when the patient
@@ -74,8 +76,8 @@ const PatientChart: React.FC = () => {
                     <ChartReview
                       patient={state.patient}
                       patientUuid={state.patientUuid}
-                      view={view}
                       setDashboardLayoutMode={setLayoutMode}
+                      view={view}
                     />
                   </div>
                 </div>
@@ -85,9 +87,9 @@ const PatientChart: React.FC = () => {
         </>
       </main>
       <WorkspaceContainer
-        showSiderailAndBottomNav
-        contextKey={`patient/${patientUuid}`}
         additionalWorkspaceProps={state}
+        contextKey={`patient/${patientUuid}`}
+        showSiderailAndBottomNav
       />
     </>
   );

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import { showSnackbar, updateVisit, useVisitContextStore } from '@openmrs/esm-framework';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import styles from './end-visit-dialog.scss';
-import { usePatientChartStore } from '@openmrs/esm-patient-common-lib/src';
 
 interface EndVisitDialogProps {
   closeModal: () => void;

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
-import { showSnackbar, updateVisit, useVisit, useVisitContextStore } from '@openmrs/esm-framework';
+import { showSnackbar, updateVisit, useVisitContextStore } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import styles from './end-visit-dialog.scss';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib/src';
 
 interface EndVisitDialogProps {
-  patientUuid: string;
   closeModal: () => void;
 }
 
@@ -14,9 +14,9 @@ interface EndVisitDialogProps {
  * patient banner. It should only show when the patient has an active visit. See stop-visit.component.tsx
  * for the button.
  */
-const EndVisitDialog: React.FC<EndVisitDialogProps> = ({ patientUuid, closeModal }) => {
+const EndVisitDialog: React.FC<EndVisitDialogProps> = ({ closeModal }) => {
   const { t } = useTranslation();
-  const { activeVisit } = useVisit(patientUuid);
+  const { activeVisit } = usePatientChartStore().visits;
   const { mutateVisit } = useVisitContextStore();
 
   const handleEndVisit = () => {

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
@@ -50,6 +50,10 @@ const EndVisitDialog: React.FC<EndVisitDialogProps> = ({ closeModal }) => {
     }
   };
 
+  if (!activeVisit) {
+    return null;
+  }
+
   return (
     <div>
       <ModalHeader

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render } from '@testing-library/react';
-import { showSnackbar, updateVisit, useVisit, type Visit, type FetchResponse } from '@openmrs/esm-framework';
+import { showSnackbar, updateVisit, type Visit, type FetchResponse } from '@openmrs/esm-framework';
 import { mockCurrentVisit } from '__mocks__';
 import EndVisitDialog from './end-visit-dialog.component';
 
@@ -12,22 +12,25 @@ const endVisitPayload = {
 const mockCloseModal = jest.fn();
 const mockMutate = jest.fn();
 const mockShowSnackbar = jest.mocked(showSnackbar);
-const mockUseVisit = jest.mocked(useVisit);
 const mockUpdateVisit = jest.mocked(updateVisit);
 
-describe('End visit dialog', () => {
-  beforeEach(() => {
-    mockUseVisit.mockReturnValue({
-      activeVisit: mockCurrentVisit,
-      currentVisit: mockCurrentVisit,
-      currentVisitIsRetrospective: false,
-      error: null,
-      isLoading: false,
-      isValidating: false,
-      mutate: mockMutate,
-    });
-  });
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  return {
+    usePatientChartStore: () => ({
+      visits: {
+        activeVisit: mockCurrentVisit,
+        currentVisit: mockCurrentVisit,
+        currentVisitIsRetrospective: false,
+        error: null,
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      },
+    }),
+  };
+});
 
+describe('End visit dialog', () => {
   test('displays a success snackbar when the visit is ended successfully', async () => {
     const user = userEvent.setup();
 
@@ -40,7 +43,7 @@ describe('End visit dialog', () => {
       },
     } as unknown as FetchResponse<Visit>);
 
-    render(<EndVisitDialog patientUuid="some-patient-uuid" closeModal={mockCloseModal} />);
+    render(<EndVisitDialog closeModal={mockCloseModal} />);
 
     const closeModalButton = screen.getByRole('button', { name: /close/i });
     const cancelButton = screen.getByRole('button', { name: /cancel/i });
@@ -81,7 +84,7 @@ describe('End visit dialog', () => {
 
     mockUpdateVisit.mockRejectedValue(error);
 
-    render(<EndVisitDialog patientUuid="some-patient-uuid" closeModal={mockCloseModal} />);
+    render(<EndVisitDialog closeModal={mockCloseModal} />);
 
     expect(
       screen.getByText(/You can add additional encounters to this visit in the visit summary/i),

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { InlineLoading } from '@carbon/react';
-import { ErrorState, launchWorkspace, useVisit } from '@openmrs/esm-framework';
-import { CardHeader, EmptyState } from '@openmrs/esm-patient-common-lib';
+import { ErrorState, launchWorkspace } from '@openmrs/esm-framework';
+import { CardHeader, EmptyState, usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 import VisitSummary from './past-visits-components/visit-summary.component';
 import styles from './current-visit-summary.scss';
 
@@ -12,7 +12,7 @@ interface CurrentVisitSummaryProps {
 
 const CurrentVisitSummary: React.FC<CurrentVisitSummaryProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
-  const { isLoading, currentVisit, error, isValidating } = useVisit(patientUuid);
+  const { isLoading, currentVisit, error, isValidating } = usePatientChartStore().visits;
 
   if (isLoading) {
     return (

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
@@ -6,6 +6,7 @@ import CurrentVisitSummary from './current-visit-summary.component';
 
 const mockGetConfig = jest.mocked(getConfig);
 const mockUsePatientChartStore = jest.fn();
+
 jest.mock('@openmrs/esm-patient-common-lib', () => {
   return {
     ...jest.requireActual('@openmrs/esm-patient-common-lib'),

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/current-visit-summary.test.tsx
@@ -1,22 +1,30 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { useVisit, getConfig } from '@openmrs/esm-framework';
+import { getConfig } from '@openmrs/esm-framework';
 import { waitForLoadingToFinish } from 'tools';
 import CurrentVisitSummary from './current-visit-summary.component';
 
 const mockGetConfig = jest.mocked(getConfig);
-const mockUseVisits = jest.mocked(useVisit);
+const mockUsePatientChartStore = jest.fn();
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  return {
+    ...jest.requireActual('@openmrs/esm-patient-common-lib'),
+    usePatientChartStore: () => mockUsePatientChartStore(),
+  };
+});
 
 describe('CurrentVisitSummary', () => {
   test('renders an empty state when there is no active visit', () => {
-    mockUseVisits.mockReturnValueOnce({
-      activeVisit: null,
-      currentVisit: null,
-      currentVisitIsRetrospective: false,
-      error: null,
-      isLoading: false,
-      isValidating: false,
-      mutate: jest.fn(),
+    mockUsePatientChartStore.mockReturnValueOnce({
+      visits: {
+        activeVisit: null,
+        currentVisit: null,
+        currentVisitIsRetrospective: false,
+        error: null,
+        isLoading: false,
+        isValidating: false,
+        mutate: jest.fn(),
+      },
     });
 
     render(<CurrentVisitSummary patientUuid="some-uuid" />);
@@ -26,28 +34,30 @@ describe('CurrentVisitSummary', () => {
 
   test('renders a visit summary when for the active visit', async () => {
     mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
-    mockUseVisits.mockReturnValueOnce({
-      activeVisit: null,
-      currentVisit: {
-        uuid: 'some-uuid',
-        display: 'Visit 1',
-        startDatetime: '2021-03-23T10:00:00.000+0300',
-        stopDatetime: null,
-        location: {
+    mockUsePatientChartStore.mockReturnValueOnce({
+      visits: {
+        activeVisit: null,
+        currentVisit: {
           uuid: 'some-uuid',
-          display: 'Location 1',
+          display: 'Visit 1',
+          startDatetime: '2021-03-23T10:00:00.000+0300',
+          stopDatetime: null,
+          location: {
+            uuid: 'some-uuid',
+            display: 'Location 1',
+          },
+          visitType: {
+            uuid: 'some-uuid',
+            display: 'Visit Type 1',
+          },
+          encounters: [],
         },
-        visitType: {
-          uuid: 'some-uuid',
-          display: 'Visit Type 1',
-        },
-        encounters: [],
+        currentVisitIsRetrospective: false,
+        error: null,
+        isLoading: false,
+        isValidating: false,
+        mutate: jest.fn(),
       },
-      currentVisitIsRetrospective: false,
-      error: null,
-      isLoading: false,
-      isValidating: false,
-      mutate: jest.fn(),
     });
 
     render(<CurrentVisitSummary patientUuid="some-uuid" />);

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/retrospective-data-date-time-picker/retrospective-date-time-picker.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/retrospective-data-date-time-picker/retrospective-date-time-picker.component.tsx
@@ -1,10 +1,10 @@
-import { SelectItem, TimePickerSelect, TimePicker, Checkbox } from '@carbon/react';
-import { OpenmrsDatePicker, ResponsiveWrapper, useFeatureFlag, useVisit } from '@openmrs/esm-framework';
 import React, { useEffect, useState } from 'react';
+import { SelectItem, TimePickerSelect, TimePicker, Checkbox } from '@carbon/react';
 import { type Control, Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
+import { OpenmrsDatePicker, ResponsiveWrapper, useFeatureFlag } from '@openmrs/esm-framework';
 import styles from './restrospective-date-time-picker.scss';
-import { useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
 
 type FormValues = {
   retrospectiveDate: Date;
@@ -26,7 +26,7 @@ const RetrospectiveDateTimePicker = ({
   const { t } = useTranslation();
   const isRdeEnabled = useFeatureFlag('rde');
 
-  const { currentVisit } = useVisit(patientUuid);
+  const { currentVisit } = usePatientChartStore().visits;
   const isActiveVisit = !Boolean(currentVisit && currentVisit.stopDatetime);
   const maxDate = currentVisit?.stopDatetime;
   const minDate = currentVisit?.startDatetime;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/visit-context-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/visit-context-header.component.tsx
@@ -1,11 +1,11 @@
-import { Button, Loading } from '@carbon/react';
-import { showModal, useFeatureFlag } from '@openmrs/esm-framework';
-import classNames from 'classnames';
 import React from 'react';
+import classNames from 'classnames';
+import { Button, Loading } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import styles from './visit-context-header.scss';
-import VisitContextInfo from './visit-context-info.component';
+import { showModal, useFeatureFlag } from '@openmrs/esm-framework';
 import { usePatientChartStore, useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
+import VisitContextInfo from './visit-context-info.component';
+import styles from './visit-context-header.scss';
 
 interface VisitContextHeaderProps {
   patientUuid: string;
@@ -13,11 +13,11 @@ interface VisitContextHeaderProps {
 
 const VisitContextHeader: React.FC<VisitContextHeaderProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
+  const { currentVisit, isLoading } = usePatientChartStore().visits;
   const { systemVisitEnabled } = useSystemVisitSetting();
+
   const isRdeEnabled = useFeatureFlag('rde');
   const showVisitContextHeader = systemVisitEnabled && isRdeEnabled;
-
-  const { currentVisit, isLoading } = usePatientChartStore().visits;
   const isActiveVisit = !Boolean(currentVisit && currentVisit.stopDatetime);
 
   const openVisitSwitcherModal = () => {
@@ -31,6 +31,7 @@ const VisitContextHeader: React.FC<VisitContextHeaderProps> = ({ patientUuid }) 
   if (!showVisitContextHeader) {
     return null;
   }
+
   if (isLoading) {
     return (
       <div className={styles.visitContextHeader}>
@@ -38,6 +39,7 @@ const VisitContextHeader: React.FC<VisitContextHeaderProps> = ({ patientUuid }) 
       </div>
     );
   }
+
   return (
     <div
       className={classNames(styles.visitContextHeader, isActiveVisit ? styles.activeVisit : styles.retroactiveVisit)}

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/visit-context-header.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/visit-context-header.component.tsx
@@ -1,11 +1,11 @@
 import { Button, Loading } from '@carbon/react';
-import { showModal, useFeatureFlag, useVisit } from '@openmrs/esm-framework';
+import { showModal, useFeatureFlag } from '@openmrs/esm-framework';
 import classNames from 'classnames';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './visit-context-header.scss';
 import VisitContextInfo from './visit-context-info.component';
-import { useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
+import { usePatientChartStore, useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
 
 interface VisitContextHeaderProps {
   patientUuid: string;
@@ -17,7 +17,7 @@ const VisitContextHeader: React.FC<VisitContextHeaderProps> = ({ patientUuid }) 
   const isRdeEnabled = useFeatureFlag('rde');
   const showVisitContextHeader = systemVisitEnabled && isRdeEnabled;
 
-  const { currentVisit, isLoading } = useVisit(showVisitContextHeader ? patientUuid : null);
+  const { currentVisit, isLoading } = usePatientChartStore().visits;
   const isActiveVisit = !Boolean(currentVisit && currentVisit.stopDatetime);
 
   const openVisitSwitcherModal = () => {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/visit-context-header.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-context/visit-context-header.test.tsx
@@ -1,4 +1,4 @@
-import { useVisit, useVisitContextStore } from '@openmrs/esm-framework';
+import { useVisitContextStore } from '@openmrs/esm-framework';
 import { useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
 import { render, screen } from '@testing-library/react';
 import { mockCurrentVisit } from '__mocks__';
@@ -19,19 +19,22 @@ jest.mocked(useVisitContextStore).mockReturnValue({
   mutateVisit: jest.fn(),
 });
 
-jest.mocked(useVisit).mockReturnValue({
-  currentVisit: mockCurrentVisit,
-  error: null,
-  mutate: jest.fn(),
-  isValidating: false,
-  activeVisit: null,
-  currentVisitIsRetrospective: false,
-  isLoading: false,
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  return {
+    useSystemVisitSetting: () => mockUseSystemVisitSetting(),
+    usePatientChartStore: () => ({
+      visits: {
+        currentVisit: mockCurrentVisit,
+        error: null,
+        mutate: jest.fn(),
+        isValidating: false,
+        activeVisit: null,
+        currentVisitIsRetrospective: false,
+        isLoading: false,
+      },
+    }),
+  };
 });
-
-jest.mock('@openmrs/esm-patient-common-lib/src/useSystemVisitSetting', () => ({
-  useSystemVisitSetting: () => mockUseSystemVisitSetting(),
-}));
 
 describe('VisitContextHeader', () => {
   it('should not show header if system does not support visits', () => {

--- a/packages/esm-patient-common-lib/src/offline/visit.ts
+++ b/packages/esm-patient-common-lib/src/offline/visit.ts
@@ -1,15 +1,15 @@
+import { useEffect, useState } from 'react';
+import { v4 as uuid } from 'uuid';
 import {
   getSynchronizationItems,
-  type NewVisitPayload,
-  type QueueItemDescriptor,
   queueSynchronizationItem,
   useConnectivity,
   useSession,
+  type NewVisitPayload,
+  type QueueItemDescriptor,
   type useVisit,
   type Visit,
 } from '@openmrs/esm-framework';
-import { useEffect, useState } from 'react';
-import { v4 as uuid } from 'uuid';
 import { usePatientChartStore } from '../store/patient-chart-store';
 
 /**

--- a/packages/esm-patient-common-lib/src/offline/visit.ts
+++ b/packages/esm-patient-common-lib/src/offline/visit.ts
@@ -5,11 +5,12 @@ import {
   queueSynchronizationItem,
   useConnectivity,
   useSession,
-  useVisit,
+  type useVisit,
   type Visit,
 } from '@openmrs/esm-framework';
 import { useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';
+import { usePatientChartStore } from '../store/patient-chart-store';
 
 /**
  * The identifier of a visit in the sync queue.
@@ -31,7 +32,7 @@ export interface OfflineVisit extends NewVisitPayload {
 export function useVisitOrOfflineVisit(patientUuid: string) {
   const isOnline = useConnectivity();
 
-  const onlineVisit = useVisit(patientUuid);
+  const onlineVisit = usePatientChartStore().visits;
   const offlineVisit = useOfflineVisit(patientUuid);
 
   return isOnline ? onlineVisit : offlineVisit;

--- a/packages/esm-patient-common-lib/src/offline/visit.ts
+++ b/packages/esm-patient-common-lib/src/offline/visit.ts
@@ -5,12 +5,11 @@ import {
   queueSynchronizationItem,
   useConnectivity,
   useSession,
+  useVisit,
   type NewVisitPayload,
   type QueueItemDescriptor,
-  type useVisit,
   type Visit,
 } from '@openmrs/esm-framework';
-import { usePatientChartStore } from '../store/patient-chart-store';
 
 /**
  * The identifier of a visit in the sync queue.
@@ -32,7 +31,7 @@ export interface OfflineVisit extends NewVisitPayload {
 export function useVisitOrOfflineVisit(patientUuid: string) {
   const isOnline = useConnectivity();
 
-  const onlineVisit = usePatientChartStore().visits;
+  const onlineVisit = useVisit(patientUuid);
   const offlineVisit = useOfflineVisit(patientUuid);
 
   return isOnline ? onlineVisit : offlineVisit;

--- a/packages/esm-patient-common-lib/src/store/patient-chart-store.ts
+++ b/packages/esm-patient-common-lib/src/store/patient-chart-store.ts
@@ -1,8 +1,9 @@
-import { createGlobalStore, useStore } from '@openmrs/esm-framework';
+import { createGlobalStore, useStore, type VisitReturnType } from '@openmrs/esm-framework';
 
 export interface PatientChartStore {
   patientUuid?: string;
   patient?: fhir.Patient;
+  visits?: VisitReturnType;
 }
 
 const patientChartStoreName = 'patient-chart-global-store';

--- a/packages/esm-patient-forms-app/package.json
+++ b/packages/esm-patient-forms-app/package.json
@@ -44,7 +44,6 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "6.x",
-    "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-forms-app/package.json
+++ b/packages/esm-patient-forms-app/package.json
@@ -44,6 +44,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
+++ b/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
@@ -33,6 +33,7 @@ const ClinicalFormActionButton: React.FC = () => {
     else if (isHtmlFormOpen) {
       launchWorkspace(htmlFormEntryWorkspace, {
         workspaceTitle: recentlyOpenedHtmlForm?.additionalProps?.['workspaceTitle'],
+        formInfo: recentlyOpenedHtmlForm?.additionalProps?.['formInfo'],
       });
     } else {
       launchFormsWorkspace();

--- a/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
+++ b/packages/esm-patient-forms-app/src/clinical-form-action-button.component.tsx
@@ -26,6 +26,7 @@ const ClinicalFormActionButton: React.FC = () => {
     if (isFormOpen) {
       launchWorkspace(formEntryWorkspace, {
         workspaceTitle: recentlyOpenedForm?.additionalProps?.['workspaceTitle'],
+        formInfo: recentlyOpenedForm?.additionalProps?.['formInfo'],
       });
     }
     // we aren't currently supporting keeping HTML Form workspaces open, but just in case

--- a/packages/esm-patient-forms-app/src/clinical-form-action-button.test.tsx
+++ b/packages/esm-patient-forms-app/src/clinical-form-action-button.test.tsx
@@ -52,7 +52,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
 
   return {
     ...originalModule,
-    useVisitOrOfflineVisit: jest.fn().mockImplementation(() => mockCurrentVisit),
+    useLaunchWorkspaceRequiringVisit: jest.fn(),
   };
 });
 

--- a/packages/esm-patient-forms-app/src/forms/form-entry.workspace.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.workspace.tsx
@@ -91,15 +91,6 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({
 
   return (
     <div>
-      <pre style={{ padding: '1rem', backgroundColor: 'lightgray' }}>
-        formUuid: {formUuid}
-        <br />
-        showForm: {JSON.stringify(showForm)}
-        <br />
-        visitUuid: {visitUuid}
-        <br />
-        visitTypeUuid: {visitTypeUuid}
-      </pre>
       <ExtensionSlot name="visit-context-header-slot" state={{ patientUuid }} />
       {showForm && formInfo && patientUuid && patient && <ExtensionSlot name="form-widget-slot" state={state} />}
     </div>

--- a/packages/esm-patient-forms-app/src/forms/form-entry.workspace.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.workspace.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { ExtensionSlot, useConnectivity, useFeatureFlag, useVisitContextStore } from '@openmrs/esm-framework';
+import { ExtensionSlot, useConnectivity, useVisitContextStore } from '@openmrs/esm-framework';
 import {
   clinicalFormsWorkspace,
   type DefaultPatientWorkspaceProps,
@@ -91,6 +91,15 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({
 
   return (
     <div>
+      <pre style={{ padding: '1rem', backgroundColor: 'lightgray' }}>
+        formUuid: {formUuid}
+        <br />
+        showForm: {JSON.stringify(showForm)}
+        <br />
+        visitUuid: {visitUuid}
+        <br />
+        visitTypeUuid: {visitTypeUuid}
+      </pre>
       <ExtensionSlot name="visit-context-header-slot" state={{ patientUuid }} />
       {showForm && formInfo && patientUuid && patient && <ExtensionSlot name="form-widget-slot" state={state} />}
     </div>

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-detailed-summary.component.tsx
@@ -24,10 +24,15 @@ import {
   useConfig,
   useLayoutType,
   usePagination,
-  useVisit,
   launchWorkspace,
 } from '@openmrs/esm-framework';
-import { CardHeader, EmptyState, ErrorState, PatientChartPagination } from '@openmrs/esm-patient-common-lib';
+import {
+  CardHeader,
+  EmptyState,
+  ErrorState,
+  PatientChartPagination,
+  usePatientChartStore,
+} from '@openmrs/esm-patient-common-lib';
 import { immunizationFormSub, latestFirst, linkConfiguredSequences } from './utils';
 import { type ExistingDoses, type Sequence } from '../types';
 import { useImmunizations } from '../hooks/useImmunizations';
@@ -50,7 +55,7 @@ const ImmunizationsDetailedSummary: React.FC<ImmunizationsDetailedSummaryProps> 
   const headerTitle = t('immunizations', 'Immunizations');
   const pageUrl = window.getOpenmrsSpaBase() + `patient/${patientUuid}/chart`;
   const urlLabel = t('goToSummary', 'Go to Summary');
-  const { currentVisit } = useVisit(patientUuid);
+  const { currentVisit } = usePatientChartStore().visits;
   const isTablet = useLayoutType() === 'tablet';
   const sequenceDefinitions = immunizationsConfig?.sequenceDefinitions;
 

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import userEvent from '@testing-library/user-event';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import {
   getDefaultsFromConfigSchema,
   showSnackbar,
@@ -9,7 +9,6 @@ import {
   toOmrsIsoString,
   useConfig,
   useSession,
-  useVisit,
 } from '@openmrs/esm-framework';
 import { configSchema } from '../config-schema';
 import { type ImmunizationWidgetConfigObject } from '../types/fhir-immunization-domain';
@@ -26,7 +25,6 @@ const mockSavePatientImmunization = savePatientImmunization as jest.Mock;
 const mockSetTitle = jest.fn();
 const mockUseConfig = jest.mocked<() => { immunizationsConfig: ImmunizationWidgetConfigObject }>(useConfig);
 const mockUseSession = jest.mocked(useSession);
-const mockUseVisit = jest.mocked(useVisit);
 const mockMutate = jest.fn();
 const mockToOmrsIsoString = jest.mocked(toOmrsIsoString);
 const mockToDateObjectStrict = jest.mocked(toDateObjectStrict);
@@ -97,14 +95,22 @@ mockUseConfig.mockReturnValue({
 });
 
 mockUseSession.mockReturnValue(mockSessionDataResponse.data);
-mockUseVisit.mockReturnValue({
-  activeVisit: mockCurrentVisit,
-  currentVisit: mockCurrentVisit,
-  currentVisitIsRetrospective: false,
-  error: null,
-  isLoading: false,
-  isValidating: false,
-  mutate: mockMutate,
+
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  return {
+    ...jest.requireActual('@openmrs/esm-patient-common-lib'),
+    usePatientChartStore: () => ({
+      visits: {
+        activeVisit: mockCurrentVisit,
+        currentVisit: mockCurrentVisit,
+        currentVisitIsRetrospective: false,
+        error: null,
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      },
+    }),
+  };
 });
 
 describe('Immunizations Form', () => {

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -17,21 +17,25 @@ import {
   TimePickerSelect,
 } from '@carbon/react';
 import {
-  useSession,
-  useVisit,
-  useLayoutType,
-  useConfig,
-  toOmrsIsoString,
-  toDateObjectStrict,
-  showSnackbar,
-  ResponsiveWrapper,
-  OpenmrsDatePicker,
   getCoreTranslation,
+  OpenmrsDatePicker,
+  ResponsiveWrapper,
+  showSnackbar,
+  toDateObjectStrict,
+  toOmrsIsoString,
+  useConfig,
+  useLayoutType,
+  useSession,
 } from '@openmrs/esm-framework';
-import { type DefaultPatientWorkspaceProps, type amPm, convertTime12to24 } from '@openmrs/esm-patient-common-lib';
 import { immunizationFormSub } from './utils';
-import { mapToFHIRImmunizationResource } from './immunization-mapper';
+import {
+  type amPm,
+  type DefaultPatientWorkspaceProps,
+  convertTime12to24,
+  usePatientChartStore,
+} from '@openmrs/esm-patient-common-lib';
 import { savePatientImmunization } from './immunizations.resource';
+import { mapToFHIRImmunizationResource } from './immunization-mapper';
 import { type ConfigObject } from '../config-schema';
 import { type ImmunizationFormData } from '../types';
 import { useImmunizations } from '../hooks/useImmunizations';
@@ -49,7 +53,7 @@ const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({
   const currentUser = useSession();
   const isTablet = useLayoutType() === 'tablet';
   const { t } = useTranslation();
-  const { currentVisit } = useVisit(patientUuid);
+  const { currentVisit } = usePatientChartStore().visits;
   const { immunizationsConfig } = useConfig<ConfigObject>();
   const { immunizationsConceptSet } = useImmunizationsConceptSet(immunizationsConfig);
   const { mutate } = useImmunizations(patientUuid);

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -27,20 +27,20 @@ import {
   useLayoutType,
   useSession,
 } from '@openmrs/esm-framework';
-import { immunizationFormSub } from './utils';
 import {
   type amPm,
   type DefaultPatientWorkspaceProps,
   convertTime12to24,
   usePatientChartStore,
 } from '@openmrs/esm-patient-common-lib';
-import { savePatientImmunization } from './immunizations.resource';
+import { DoseInput } from './components/dose-input.component';
+import { immunizationFormSub } from './utils';
 import { mapToFHIRImmunizationResource } from './immunization-mapper';
+import { savePatientImmunization } from './immunizations.resource';
 import { type ConfigObject } from '../config-schema';
 import { type ImmunizationFormData } from '../types';
 import { useImmunizations } from '../hooks/useImmunizations';
 import { useImmunizationsConceptSet } from '../hooks/useImmunizationsConceptSet';
-import { DoseInput } from './components/dose-input.component';
 import styles from './immunizations-form.scss';
 
 const ImmunizationsForm: React.FC<DefaultPatientWorkspaceProps> = ({

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -40,9 +40,11 @@ const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, pageSize, urlLab
   if (isLoading) {
     return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;
   }
+
   if (error) {
     return <ErrorState error={error} headerTitle={headerTitle} />;
   }
+
   if (!visitNotes?.length) {
     return <EmptyState displayText={displayText} headerTitle={headerTitle} launchForm={launchVisitNoteForm} />;
   }

--- a/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.component.tsx
@@ -1,8 +1,14 @@
 import React, { type ComponentProps } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, DataTableSkeleton, InlineLoading } from '@carbon/react';
-import { AddIcon, launchWorkspace, useLayoutType, useVisit } from '@openmrs/esm-framework';
-import { CardHeader, EmptyState, ErrorState, launchStartVisitPrompt } from '@openmrs/esm-patient-common-lib';
+import { AddIcon, launchWorkspace, useLayoutType } from '@openmrs/esm-framework';
+import {
+  CardHeader,
+  EmptyState,
+  ErrorState,
+  launchStartVisitPrompt,
+  usePatientChartStore,
+} from '@openmrs/esm-patient-common-lib';
 import { useVisitNotes } from './visit-notes.resource';
 import PaginatedNotes from './paginated-notes.component';
 import styles from './notes-overview.scss';
@@ -16,7 +22,7 @@ interface NotesOverviewProps {
 
 const NotesMain: React.FC<NotesOverviewProps> = ({ patientUuid, pageSize, urlLabel, pageUrl }) => {
   const { t } = useTranslation();
-  const { currentVisit } = useVisit(patientUuid);
+  const { currentVisit } = usePatientChartStore().visits;
   const displayText = t('visitNotes', 'Visit notes');
   const headerTitle = t('visitNotes', 'Visit notes');
   const { visitNotes, error, isLoading, isValidating } = useVisitNotes(patientUuid);

--- a/packages/esm-patient-notes-app/src/notes/notes-main.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-main.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { screen, within } from '@testing-library/react';
-import { mockVisitNotes } from '__mocks__';
+import { mockCurrentVisit, mockVisitNotes } from '__mocks__';
 import { mockPatient, patientChartBasePath, renderWithSwr } from 'tools';
 import { useVisitNotes } from './visit-notes.resource';
 import NotesMain from './notes-main.component';
@@ -16,6 +16,24 @@ const mockUseVisitNotes = jest.mocked(useVisitNotes);
 
 jest.mock('./visit-notes.resource', () => {
   return { useVisitNotes: jest.fn().mockReturnValue([{}]) };
+});
+
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
+  return {
+    ...originalModule,
+    usePatientChartStore: () => ({
+      visits: {
+        activeVisit: mockCurrentVisit,
+        currentVisit: mockCurrentVisit,
+        currentVisitIsRetrospective: false,
+        error: null,
+        isLoading: false,
+        isValidating: false,
+        mutate: null,
+      },
+    }),
+  };
 });
 
 describe('NotesMain', () => {

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen, within } from '@testing-library/react';
 import { useConfig } from '@openmrs/esm-framework';
-import { mockVisitNotes, ConfigMock } from '__mocks__';
+import { mockVisitNotes, ConfigMock, mockCurrentVisit } from '__mocks__';
 import { mockPatient, patientChartBasePath, renderWithSwr } from 'tools';
 import { useVisitNotes } from './visit-notes.resource';
 import NotesOverview from './notes-overview.extension';
@@ -17,6 +17,24 @@ const mockUseConfig = jest.mocked(useConfig);
 
 jest.mock('./visit-notes.resource', () => {
   return { useVisitNotes: jest.fn().mockReturnValue([{}]) };
+});
+
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
+  return {
+    ...originalModule,
+    usePatientChartStore: () => ({
+      visits: {
+        activeVisit: mockCurrentVisit,
+        currentVisit: mockCurrentVisit,
+        currentVisitIsRetrospective: false,
+        error: null,
+        isLoading: false,
+        isValidating: false,
+        mutate: null,
+      },
+    }),
+  };
 });
 
 describe('NotesOverview', () => {

--- a/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
@@ -11,7 +11,7 @@ import {
 } from '@openmrs/esm-framework';
 import { type Order, useOrderTypes, usePatientOrders } from '@openmrs/esm-patient-common-lib';
 import { configSchema } from '../config-schema';
-import { mockOrders, mockSessionDataResponse } from '__mocks__';
+import { mockCurrentVisit, mockOrders, mockSessionDataResponse } from '__mocks__';
 import { mockPatient } from 'tools';
 import OrderDetailsTable from './order-details-table.component';
 
@@ -38,6 +38,7 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
     usePatientOrders: jest.fn(),
     useOrderTypes: jest.fn(),
     usePatient: jest.fn(),
+    useLaunchWorkspaceRequiringVisit: jest.fn(),
   };
 });
 

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/add-test-order.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/add-test-order.test.tsx
@@ -60,9 +60,6 @@ jest.mock('./useTestTypes', () => ({
 jest.mock('@openmrs/esm-patient-common-lib', () => ({
   ...jest.requireActual('@openmrs/esm-patient-common-lib'),
   useOrderType: jest.fn(),
-}));
-
-jest.mock('@openmrs/esm-patient-common-lib/src/store/patient-chart-store', () => ({
   getPatientUuidFromStore: jest.fn(() => mockPatient.id),
   usePatientChartStore: jest.fn(() => ({
     patientUuid: mockPatient.id,

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
 import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
-import { formattedBiometrics, mockBiometricsConfig, mockConceptUnits } from '__mocks__';
+import { formattedBiometrics, mockBiometricsConfig, mockConceptUnits, mockCurrentVisit } from '__mocks__';
 import { configSchema, type ConfigObject } from '../config-schema';
 import { mockPatient, patientChartBasePath, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { useVitalsAndBiometrics } from '../common';
@@ -35,6 +35,14 @@ mockUseConfig.mockReturnValue({
   ...getDefaultsFromConfigSchema(configSchema),
   ...mockBiometricsConfig,
 } as ConfigObject);
+
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
+  return {
+    ...originalModule,
+    useLaunchWorkspaceRequiringVisit: jest.fn(),
+  };
+});
 
 describe('Biometrics Overview', () => {
   it('renders an empty state view if biometrics data is unavailable', async () => {

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { type FetchResponse, showSnackbar, useConfig, getDefaultsFromConfigSchema } from '@openmrs/esm-framework';
 import { createOrUpdateVitalsAndBiometrics, useEncounterVitalsAndBiometrics } from '../common';
 import { type ConfigObject, configSchema } from '../config-schema';
-import { mockConceptUnits, mockVitalsConceptMetadata, mockVitalsConfig } from '__mocks__';
+import { mockConceptUnits, mockCurrentVisit, mockVitalsConceptMetadata, mockVitalsConfig } from '__mocks__';
 import { mockPatient } from 'tools';
 import VitalsAndBiometricsForm from './vitals-biometrics-form.workspace';
 
@@ -142,6 +142,24 @@ function setupMockUseEncounterVitalsAndBiometrics() {
     }),
   });
 }
+
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
+  return {
+    ...originalModule,
+    usePatientChartStore: () => ({
+      visits: {
+        activeVisit: mockCurrentVisit,
+        currentVisit: mockCurrentVisit,
+        currentVisitIsRetrospective: false,
+        error: null,
+        isLoading: false,
+        isValidating: false,
+        mutate: null,
+      },
+    }),
+  };
+});
 
 describe('VitalsBiometricsForm', () => {
   it('renders the vitals and biometrics form', async () => {

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
@@ -24,7 +24,7 @@ import {
   useVisit,
   useVisitContextStore,
 } from '@openmrs/esm-framework';
-import { type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
+import { usePatientChartStore, type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import { type ConfigObject } from '../config-schema';
 import {
   calculateBodyMassIndex,
@@ -68,7 +68,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
   const useMuacColorStatus = config.vitals.useMuacColors;
 
   const session = useSession();
-  const { currentVisit } = useVisit(patientUuid);
+  const { currentVisit } = usePatientChartStore().visits;
   const { conceptUnits, isLoading: isLoadingConceptUnits } = useConceptUnits();
   const { conceptRanges, conceptRangeMap } = useVitalsConceptMetadata(patientUuid);
   const {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -30,7 +30,6 @@ jest.mock('@openmrs/esm-patient-common-lib', () => {
 
   return {
     ...originalModule,
-    launchPatientWorkspace: jest.fn(),
     useLaunchWorkspaceRequiringVisit: jest.fn(),
     useVisitOrOfflineVisit: jest.fn().mockImplementation(() => ({ currentVisit: mockCurrentVisit })),
   };

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
 import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
 import { type ConfigObject, configSchema } from '../config-schema';
-import { formattedVitals, mockConceptUnits, mockVitalsConfig } from '__mocks__';
+import { formattedVitals, mockConceptUnits, mockCurrentVisit, mockVitalsConfig } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { useVitalsAndBiometrics } from '../common';
 import VitalsOverview from './vitals-overview.component';
@@ -24,6 +24,17 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   unobserve: jest.fn(),
   disconnect: jest.fn(),
 }));
+
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
+
+  return {
+    ...originalModule,
+    launchPatientWorkspace: jest.fn(),
+    useLaunchWorkspaceRequiringVisit: jest.fn(),
+    useVisitOrOfflineVisit: jest.fn().mockImplementation(() => ({ currentVisit: mockCurrentVisit })),
+  };
+});
 
 jest.mock('../common', () => {
   const originalModule = jest.requireActual('../common');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4664,7 +4664,6 @@ __metadata:
   peerDependencies:
     "@carbon/react": 1.x
     "@openmrs/esm-framework": 6.x
-    "@openmrs/esm-patient-common-lib": "*"
     dayjs: 1.x
     lodash-es: 4.x
     react: 18.x
@@ -4808,7 +4807,6 @@ __metadata:
     webpack: "npm:^5.99.9"
   peerDependencies:
     "@openmrs/esm-framework": 6.x
-    "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x

--- a/yarn.lock
+++ b/yarn.lock
@@ -4664,6 +4664,7 @@ __metadata:
   peerDependencies:
     "@carbon/react": 1.x
     "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-patient-common-lib": "*"
     dayjs: 1.x
     lodash-es: 4.x
     react: 18.x
@@ -4807,6 +4808,7 @@ __metadata:
     webpack: "npm:^5.99.9"
   peerDependencies:
     "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The patient chart calls `useVisit` in multiple places to determine the `activeVisit` and `currentVisit` of the patient. This results in similar performance issues with calling `usePatient` in multiple places (which we fixed a few months ago). Everytime we update the patient’s `activeVisit` or `currentVisit`, the browser makes ~10 requests. 

This PR stores the `useVisit` return values in the `PatientChartStore` to improve performance.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4709

## Other
<!-- Anything not covered above -->
