### PR TITLE
(fix) O3-4623: Make completion date field optional in programs from

### DIFF
--- a/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
@@ -19,23 +19,23 @@ import { z } from 'zod';
 import { useForm, Controller, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
+  getCoreTranslation,
+  LocationPicker,
   OpenmrsDatePicker,
   parseDate,
   showSnackbar,
   useConfig,
   useLayoutType,
-  useLocations,
   useSession,
-  LocationPicker,
 } from '@openmrs/esm-framework';
 import { type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 import { type ConfigObject } from '../config-schema';
 import {
   createProgramEnrollment,
+  findLastState,
+  updateProgramEnrollment,
   useAvailablePrograms,
   useEnrollments,
-  updateProgramEnrollment,
-  findLastState,
 } from './programs.resource';
 import styles from './programs-form.scss';
 
@@ -64,7 +64,6 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const session = useSession();
-  const availableLocations = useLocations();
   const { data: availablePrograms } = useAvailablePrograms();
   const { data: enrollments, mutateEnrollments } = useEnrollments(patientUuid);
   const { showProgramStatusField } = useConfig<ConfigObject>();
@@ -346,7 +345,7 @@ const ProgramsForm: React.FC<ProgramsFormProps> = ({
       </Stack>
       <ButtonSet className={classNames(isTablet ? styles.tablet : styles.desktop)}>
         <Button className={styles.button} kind="secondary" onClick={closeWorkspace}>
-          {t('cancel', 'Cancel')}
+          {getCoreTranslation('cancel')}
         </Button>
         <Button className={styles.button} disabled={isSubmitting} kind="primary" type="submit">
           {isSubmitting ? (

--- a/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.workspace.tsx
@@ -47,7 +47,7 @@ const createProgramsFormSchema = (t: TFunction) =>
   z.object({
     selectedProgram: z.string().refine((value) => !!value, t('programRequired', 'Program is required')),
     enrollmentDate: z.date(),
-    completionDate: z.date().nullable(),
+    completionDate: z.date().optional().nullable(),
     enrollmentLocation: z.string(),
     selectedProgramStatus: z.string(),
   });

--- a/packages/esm-patient-programs-app/translations/en.json
+++ b/packages/esm-patient-programs-app/translations/en.json
@@ -4,7 +4,6 @@
   "activePrograms": "Active programs",
   "add": "Add",
   "addPrograms": "Add programs",
-  "cancel": "Cancel",
   "carePrograms": "Care Programs",
   "chooseProgram": "Choose a program",
   "chooseStatus": "Choose a program status",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I made the completionDate field optional in the Zod schema to fix a validation error that occurred when the user cleared the date input.

## Screenshots


https://github.com/user-attachments/assets/e637eb8f-9d65-4260-8bb6-eaf2e74df6e4


## Related Issue
https://openmrs.atlassian.net/browse/O3-4623

## Other
<!-- Anything not covered above -->
