### PR TITLE
(fix) Use correct x-axis scale for biometrics and vitals charts

### DIFF
--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
@@ -8,6 +8,8 @@ import { type ConfigObject } from '../config-schema';
 import { type PatientVitalsAndBiometrics } from '../common';
 import styles from './biometrics-chart.scss';
 
+type BiometricType = 'weight' | 'height' | 'bmi';
+
 interface BiometricsChartProps {
   conceptUnits: Map<string, string>;
   config: ConfigObject;
@@ -15,12 +17,10 @@ interface BiometricsChartProps {
 }
 
 interface BiometricChartData {
-  groupName: 'Weight' | 'Height' | 'Body mass index' | string;
+  groupName: BiometricType;
   title: string;
   value: number | string;
 }
-
-const chartColors = { weight: '#6929c4', height: '#6929c4', bmi: '#6929c4' };
 
 const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, conceptUnits, config }) => {
   const { t } = useTranslation();
@@ -31,7 +31,7 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
     groupName: 'weight',
   });
 
-  const biometrics = [
+  const biometrics: { id: BiometricType; title: string; value: BiometricType }[] = [
     {
       id: 'weight',
       title: `${t('weight', 'Weight')} (${conceptUnits.get(config.concepts.weightUuid) ?? ''})`,
@@ -42,11 +42,7 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
       title: `${t('height', 'Height')} (${conceptUnits.get(config.concepts.heightUuid) ?? ''})`,
       value: 'height',
     },
-    {
-      id: 'bmi',
-      title: `${t('bmi', 'BMI')} (${bmiUnit})`,
-      value: 'bmi',
-    },
+    { id: 'bmi', title: `${t('bmi', 'BMI')} (${bmiUnit})`, value: 'bmi' },
   ];
 
   const chartData = useMemo(
@@ -59,7 +55,7 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
           (biometrics) =>
             biometrics[selectedBiometrics.value] && {
               group: selectedBiometrics.title,
-              key: formatDate(new Date(biometrics.date), { mode: 'wide', year: false, time: false }),
+              key: biometrics.date,
               value: biometrics[selectedBiometrics.value],
               date: biometrics.date,
             },
@@ -74,7 +70,7 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
         bottom: {
           title: t('date', 'Date'),
           mapsTo: 'key',
-          scaleType: ScaleTypes.LABELS,
+          scaleType: ScaleTypes.TIME,
         },
         left: {
           mapsTo: 'value',

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
@@ -55,7 +55,7 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
           (biometrics) =>
             biometrics[selectedBiometrics.value] && {
               group: selectedBiometrics.title,
-              key: biometrics.date,
+              key: formatDate(parseDate(biometrics.date), { year: true }),
               value: biometrics[selectedBiometrics.value],
               date: biometrics.date,
             },
@@ -69,7 +69,7 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
       axes: {
         bottom: {
           title: t('date', 'Date'),
-          mapsTo: 'key',
+          mapsTo: 'date',
           scaleType: ScaleTypes.TIME,
         },
         left: {

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
@@ -95,6 +95,11 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
           )} -
           <span style="color: #c6c6c6; font-size: 1rem; font-weight:400">${value}</span></div>`,
       },
+      zoomBar: {
+        top: {
+          enabled: true,
+        },
+      },
       height: '400px',
     };
   }, [selectedBiometrics, t]);

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Tab, TabListVertical, TabPanel, TabPanels, TabsVertical } from '@carbon/react';
 import { LineChart, ScaleTypes } from '@carbon/charts-react';
-import { formatDate, parseDate } from '@openmrs/esm-framework';
 import { type ConfigObject } from '../config-schema';
 import { withUnit, type PatientVitalsAndBiometrics } from '../common';
 import styles from './vitals-chart.scss';
@@ -14,9 +13,11 @@ interface VitalsChartProps {
   patientVitals: Array<PatientVitalsAndBiometrics>;
 }
 
+type VitalSignKey = 'systolic' | 'spo2' | 'temperature' | 'respiratoryRate' | 'pulse';
+
 interface VitalsChartData {
   title: string;
-  value: string;
+  value: VitalSignKey;
 }
 
 const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, config }) => {
@@ -27,7 +28,7 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
     value: 'systolic',
   });
 
-  const vitalSigns = [
+  const vitalSigns: { id: string; title: string; value: VitalSignKey }[] = [
     {
       id: 'bloodPressure',
       title: withUnit(t('bp', 'BP'), conceptUnits.get(config.concepts.systolicBloodPressureUuid) ?? '-'),
@@ -61,19 +62,17 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
       .slice(0, 10)
       .sort((vitalA, vitalB) => new Date(vitalA.date).getTime() - new Date(vitalB.date).getTime())
       .map((vitals) => {
-        const formattedDate = formatDate(parseDate(vitals.date.toString()), { year: false });
-
         if (['systolic', 'diastolic'].includes(selectedVitalsSign.value)) {
           return [
             {
               group: 'Systolic blood pressure',
-              key: formattedDate,
+              key: vitals.date,
               value: vitals.systolic,
               date: vitals.date,
             },
             {
               group: 'Diastolic blood pressure',
-              key: formattedDate,
+              key: vitals.date,
               value: vitals.diastolic,
               date: vitals.date,
             },
@@ -81,7 +80,7 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
         }
         return {
           group: selectedVitalsSign.value,
-          key: formattedDate,
+          key: vitals.date,
           value: vitals[selectedVitalsSign.value],
           date: vitals.date,
         };
@@ -94,7 +93,7 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
       bottom: {
         title: t('date', 'Date'),
         mapsTo: 'key',
-        scaleType: ScaleTypes.LABELS,
+        scaleType: ScaleTypes.TIME,
       },
       left: {
         mapsTo: 'value',

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
@@ -118,6 +118,11 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
         ).toUpperCase()}
         <span style="color: #c6c6c6; font-size: 1rem; font-weight:600">${key}</span></div>`,
     },
+    zoomBar: {
+      top: {
+        enabled: true,
+      },
+    },
     height: '400px',
   };
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Tab, TabListVertical, TabPanel, TabPanels, TabsVertical } from '@carbon/react';
 import { LineChart, ScaleTypes } from '@carbon/charts-react';
+import { formatDate, parseDate } from '@openmrs/esm-framework';
 import { type ConfigObject } from '../config-schema';
 import { withUnit, type PatientVitalsAndBiometrics } from '../common';
 import styles from './vitals-chart.scss';
@@ -66,13 +67,13 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
           return [
             {
               group: 'Systolic blood pressure',
-              key: vitals.date,
+              key: formatDate(parseDate(vitals.date), { year: true }),
               value: vitals.systolic,
               date: vitals.date,
             },
             {
               group: 'Diastolic blood pressure',
-              key: vitals.date,
+              key: formatDate(parseDate(vitals.date), { year: true }),
               value: vitals.diastolic,
               date: vitals.date,
             },
@@ -80,7 +81,7 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
         }
         return {
           group: selectedVitalsSign.value,
-          key: vitals.date,
+          key: formatDate(parseDate(vitals.date)),
           value: vitals[selectedVitalsSign.value],
           date: vitals.date,
         };
@@ -92,7 +93,7 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
     axes: {
       bottom: {
         title: t('date', 'Date'),
-        mapsTo: 'key',
+        mapsTo: 'date',
         scaleType: ScaleTypes.TIME,
       },
       left: {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue where the x-axis scale was not being used correctly for the biometrics and vitals charts. Currently, the x-axis scale is set to `ScaleTypes.LABELS`, which spaces each data point evenly regardless of the actual time difference between measurements. This scale type is best for named groups, categories, or arbitrary labels.

For date/time data, `ScaleTypes.TIME` should be used. This scale spaces points according to the actual time difference between measurements—so if two measurements are a day apart, they appear close together; if they're months apart, they appear far apart. This diff switches the x-axis scale to `ScaleTypes.TIME` for the biometrics and vitals charts.

## Screenshots

Source pulse values:

![CleanShot 2025-05-20 at 14 22 08@2x](https://github.com/user-attachments/assets/75d1ec87-d318-4b57-8cc2-59860001059f)

![CleanShot 2025-05-20 at 14 23 10@2x](https://github.com/user-attachments/assets/f1c36aab-a570-48ba-bd93-88027224ca7c)

### Before
![CleanShot 2025-05-20 at 14 19 55@2x](https://github.com/user-attachments/assets/31ecfa94-57ed-43c3-9c8c-8f7aae725361)

### After
![CleanShot 2025-05-20 at 14 19 05@2x](https://github.com/user-attachments/assets/6dc7e0b6-d998-4b8e-beed-a2efc8b9917e)

## Related Issue
https://openmrs.atlassian.net/browse/O3-4714

## Other
<!-- Anything not covered above -->
