### PR TITLE
(feat) O3-4749: FormRenderer to support both workspaces and FDE props

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -29,7 +29,7 @@ interface FormRendererProps
   closeWorkspaceWithSavedChanges?: DefaultPatientWorkspaceProps['closeWorkspaceWithSavedChanges'];
   setTitle?: DefaultPatientWorkspaceProps['setTitle'];
   hideControls?: boolean;
-  handlePostResponse?: (encounter: any) => void;
+  handlePostResponse?: (encounter: Encounter) => void;
   preFilledQuestions?: Record<string, string>;
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR addresses a compatibility issue between the `esm-form-engine-app`'s `FormRenderer` component and the `form-widget-slot` used in the `esm-fast-data-entry-app`.

The `FormRenderer` is an extension component that currently expects several workspace-related props such as `closeWorkspace`, `promptBeforeClosing`, and `closeWorkspaceWithSavedChanges`:

```tsx
const FormRenderer: React.FC<FormRendererProps> = ({
  additionalProps,
  closeWorkspace,
  closeWorkspaceWithSavedChanges,
  encounterUuid,
  formUuid,
  patientUuid,
  promptBeforeClosing,
  visit,
  clinicalFormsWorkspaceName = clinicalFormsWorkspace,
}) => {
```

However, when used within the `form-widget-slot` in the `esm-fast-data-entry-app`, these workspace props are either not provided or only partially stubbed:

```tsx
<ExtensionSlot
  name="form-widget-slot"
  state={{
    view: 'form',
    formUuid,
    visitUuid: visitUuid ?? '',
    visitTypeUuid: visitTypeUuid ?? '',
    patientUuid,
    patient,
    encounterUuid: encounterUuid ?? '',
    closeWorkspace: () => undefined,
    handlePostResponse: (encounter) => {
      handlePostResponse(encounter);
      updateFormComponent();
    },
    handleEncounterCreate,
    handleOnValidate,
    showDiscardSubmitButtons: false,
    preFilledQuestions: {
      ...activeSessionMeta,
      encDate: activeSessionMeta.sessionDate,
    },
  }}
/>
```

As a result, forms fail to render correctly in the Fast Data Entry (FDE) app.

---

## Fix

This PR updates the `FormRendererProps` type definition to treat workspace-related props as optional, enabling the component to function properly in both workspace and non-workspace contexts like the FDE.

## Screenshots
<!-- Required if you are making UI changes. -->
**Before fix**

![RFE-FDE](https://github.com/user-attachments/assets/984ce90d-1fa1-4a8f-8372-a4aae6f088a3)

**After fix**

![fde-forms-rendering](https://github.com/user-attachments/assets/50a8ac43-2410-4bd4-9783-31b444e3d2cd)

## Screencast
[fde-fde.webm](https://github.com/user-attachments/assets/587b6c36-5840-4f3c-823f-d9c4ba83f6c1)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[https://openmrs.atlassian.net/browse/O3-4749](https://openmrs.atlassian.net/browse/O3-4749)

## Other
<!-- Anything not covered above -->

Fast Data Entry: [https://github.com/openmrs/openmrs-esm-fast-data-entry-app/pull/115](https://github.com/openmrs/openmrs-esm-fast-data-entry-app/pull/115)

React Form Engine: [https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/550](https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/550)
