### PR TITLE
(test) 03-4751 E2E auto translation of form labels to system language

### DIFF
--- a/e2e/commands/index.ts
+++ b/e2e/commands/index.ts
@@ -4,3 +4,4 @@ export * from './encounter-operations';
 export * from './patient-operations';
 export * from './provider-operations';
 export * from './visit-operations';
+export * from './user-operations';

--- a/e2e/commands/user-operations.ts
+++ b/e2e/commands/user-operations.ts
@@ -1,0 +1,15 @@
+import { type APIRequestContext } from '@playwright/test';
+
+export const restoreLanguage = async (api: APIRequestContext, userUuid: string) => {
+  await api.post(`user/${userUuid}`, {
+    data: {
+      defaultLocale: 'en',
+    },
+  });
+};
+
+export async function getCurrentUserUuid(api: APIRequestContext): Promise<string> {
+  const response = await api.get('/ws/rest/v1/session');
+  const session = await response.json();
+  return session.user.uuid;
+}

--- a/e2e/pages/home-page.ts
+++ b/e2e/pages/home-page.ts
@@ -1,0 +1,14 @@
+import { type Page } from '@playwright/test';
+
+export class HomePage {
+  constructor(readonly page: Page) {}
+
+  readonly myAccountButton = () => this.page.getByRole('button', { name: /my account/i });
+
+  readonly changeLanguageButton = () =>
+    this.page.getByLabel(/change language/i).getByRole('button', { name: /change/i });
+
+  async goTo() {
+    await this.page.goto('/openmrs/spa/home');
+  }
+}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Adds an e2e test to assert that clinical form labels get translated when the user changes the system language. This helps guard against regressions in how i18n is implemented in the form engine.

Other unrelated changes include:

Replacing expect().not.toBeVisible() with expect().toBeHidden() in assertions as suggested by the Playwright ESLint plugin.
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-4751

## Other
<!-- Anything not covered above -->
