### PR TITLE
(fix) O3-4762: Fix visibility of frequency and route fields in drug order form 

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -510,7 +510,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                   </Column>
                 </Grid>
                 <Grid className={styles.gridRow}>
-                  <Column lg={8} md={4} sm={4}>
+                  <Column lg={16} md={4} sm={4}>
                     <InputWrapper>
                       <ControlledFieldInput
                         control={control}
@@ -525,7 +525,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                       />
                     </InputWrapper>
                   </Column>
-                  <Column lg={8} md={4} sm={4}>
+                  <Column lg={16} md={4} sm={4}>
                     <InputWrapper>
                       <ControlledFieldInput
                         control={control}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

In the drug order form, options with long content in both the `Frequency` and `Route` dropdown fields were being truncated on screens larger than tablets. This made it difficult for users to read and select the complete options. This PR increases the column width for both fields from `lg={8}` to `lg={16}` to provide more space for displaying the full content of each option. This ensures that long option text is fully visible without truncation.

## Screenshots
### Before

![route-and-frequency-dropdown-options-truncated](https://github.com/user-attachments/assets/55107b71-d804-431d-a40f-e4a871a9a766)

### After
https://github.com/user-attachments/assets/58b555b0-4b91-45da-91a9-6e7df3a77cdd

## Related Issue
https://openmrs.atlassian.net/browse/O3-4762

## Other
<!-- Anything not covered above -->
