### PR TITLE
(test) O3-4827: Throw on patient deletion failure instead of failing silently in e2e

### DIFF
--- a/e2e/commands/patient-operations.ts
+++ b/e2e/commands/patient-operations.ts
@@ -101,5 +101,6 @@ export const getPatient = async (api: APIRequestContext, uuid: string): Promise<
 };
 
 export const deletePatient = async (api: APIRequestContext, uuid: string) => {
-  await api.delete(`patient/${uuid}`, { data: {} });
+  const response = await api.delete(`patient/${uuid}`, { data: {} });
+  await expect(response.ok()).toBeTruthy();
 };

--- a/e2e/core/test.ts
+++ b/e2e/core/test.ts
@@ -26,11 +26,7 @@ export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
     async ({ api }, use) => {
       const patient = await generateRandomPatient(api);
       await use(patient);
-      try {
-        if (patient) await deletePatient(api, patient.uuid);
-      } catch (e) {
-        console.warn('Failed to delete patient:', e);
-      }
+      await deletePatient(api, patient.uuid);
     },
     { scope: 'test', auto: true },
   ],
@@ -39,11 +35,7 @@ export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
     async ({ api, patient }, use) => {
       const visit = await startVisit(api, patient.uuid);
       await use(visit);
-      try {
-        if (visit) await endVisit(api, visit);
-      } catch (e) {
-        console.warn('Failed to end visit:', e);
-      }
+      await endVisit(api, visit);
     },
     { scope: 'test', auto: true },
   ],


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds a global afterEach to clean up dummy patients created during E2E testing from the patient chart repo 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-4827

## Other
<!-- Anything not covered above -->
