### PR TITLE
(fix) O3-4855: Add ability to upload a patient avatar in the registration form from a URL

### DIFF
--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/camera-media-uploader.component.tsx
@@ -9,6 +9,7 @@ import FileReviewContainer from './file-review.component';
 import MediaUploaderComponent from './media-uploader.component';
 import UploadStatusComponent from './upload-status.component';
 import styles from './camera-media-uploader.scss';
+import PasteImageUrlComponent from './paste-image-url.component';
 
 interface CameraMediaUploaderModalProps {
   cameraOnly?: boolean;
@@ -128,6 +129,7 @@ const CameraMediaUploadTabs: React.FC<CameraMediaUploadTabsProps> = ({ title }) 
             <TabList aria-label="Attachments-upload-section" className={styles.tabList}>
               <Tab onClick={() => setView('camera')}>{t('webcam', 'Webcam')}</Tab>
               <Tab onClick={() => setView('upload')}>{t('uploadFiles', 'Upload files')}</Tab>
+              <Tab onClick={() => setView('pasteUrl')}>{t('pasteUrl', 'Paste URL')}</Tab>
             </TabList>
             <TabPanels>
               <TabPanel>
@@ -142,9 +144,12 @@ const CameraMediaUploadTabs: React.FC<CameraMediaUploadTabsProps> = ({ title }) 
                 ) : null}
                 {view === 'camera' && <CameraComponent mediaStream={mediaStream} stopCameraStream={stopCameraStream} />}
               </TabPanel>
+
               <TabPanel>
                 <MediaUploaderComponent />
               </TabPanel>
+
+              <TabPanel>{view === 'pasteUrl' && <PasteImageUrlComponent />}</TabPanel>
             </TabPanels>
           </Tabs>
         </div>

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/paste-image-url.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/paste-image-url.component.tsx
@@ -1,0 +1,86 @@
+import React, { useState, useContext } from 'react';
+import { TextInput, Button, InlineNotification } from '@carbon/react';
+import CameraMediaUploaderContext from './camera-media-uploader-context.resources';
+import styles from './paste-image-url.scss';
+
+const PasteImageUrlComponent: React.FC = () => {
+  const [url, setUrl] = useState('');
+  const [error, setError] = useState(false);
+  const { setFilesToUpload } = useContext(CameraMediaUploaderContext);
+
+  const handleLoadImage = async () => {
+    try {
+      setError(false);
+
+      const response = await fetch(url, { mode: 'cors' });
+
+      const contentType = response.headers.get('Content-Type');
+      if (!response.ok || !contentType?.startsWith('image/')) {
+        throw new Error('Invalid image type');
+      }
+
+      const blob = await response.blob();
+      const reader = new FileReader();
+
+      reader.onloadend = () => {
+        const base64 = reader.result as string;
+
+        if (!base64.startsWith('data:image/')) {
+          setError(true);
+          console.error('Invalid base64 format');
+          return;
+        }
+
+        setFilesToUpload([
+          {
+            base64Content: base64,
+            fileName: 'Image from URL',
+            fileType: 'image',
+            fileDescription: '',
+            status: 'uploading',
+            capturedFromWebcam: false,
+          },
+        ]);
+      };
+
+      reader.onerror = () => {
+        console.error('Base64 conversion failed');
+        setError(true);
+      };
+
+      reader.readAsDataURL(blob);
+    } catch (err) {
+      console.error('Failed to load or convert image:', err);
+      setError(true);
+    }
+  };
+
+  return (
+    <div className={styles.pasteUrlContainer}>
+      <TextInput
+        id="image-url"
+        labelText="Paste Image URL"
+        placeholder="https://example.com/photo.png"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        invalid={error}
+        invalidText="Image failed to load or convert. Please check the URL."
+        className={styles.urlInput}
+      />
+      <Button kind="primary" onClick={handleLoadImage} className={styles.loadButton}>
+        Load Image
+      </Button>
+
+      {error && (
+        <InlineNotification
+          kind="error"
+          title="Error"
+          subtitle="The image could not be loaded or converted. Make sure the URL is valid and publicly accessible."
+          lowContrast
+        />
+      )}
+    </div>
+  );
+};
+
+export default PasteImageUrlComponent;

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/paste-image-url.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/paste-image-url.component.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useContext } from 'react';
 import { TextInput, Button, InlineNotification } from '@carbon/react';
+import { useTranslation } from 'react-i18next';
 import CameraMediaUploaderContext from './camera-media-uploader-context.resources';
 import styles from './paste-image-url.scss';
 
 const PasteImageUrlComponent: React.FC = () => {
+  const { t } = useTranslation();
   const [url, setUrl] = useState('');
   const [error, setError] = useState(false);
   const { setFilesToUpload } = useContext(CameraMediaUploaderContext);
@@ -34,7 +36,7 @@ const PasteImageUrlComponent: React.FC = () => {
         setFilesToUpload([
           {
             base64Content: base64,
-            fileName: 'Image from URL',
+            fileName: t('imageFromUrl.fileName', 'Image from URL'),
             fileType: 'image',
             fileDescription: '',
             status: 'uploading',
@@ -59,23 +61,26 @@ const PasteImageUrlComponent: React.FC = () => {
     <div className={styles.pasteUrlContainer}>
       <TextInput
         id="image-url"
-        labelText="Paste Image URL"
-        placeholder="https://example.com/photo.png"
+        labelText={t('imageUrl.label', 'Paste Image URL')}
+        placeholder={t('imageUrl.placeholder', 'https://example.com/photo.png')}
         value={url}
         onChange={(e) => setUrl(e.target.value)}
         invalid={error}
-        invalidText="Image failed to load or convert. Please check the URL."
+        invalidText={t('imageUrl.invalidText', 'Image failed to load or convert. Please check the URL.')}
         className={styles.urlInput}
       />
       <Button kind="primary" onClick={handleLoadImage} className={styles.loadButton}>
-        Load Image
+        {t('imageUrl.loadButton', 'Load Image')}
       </Button>
 
       {error && (
         <InlineNotification
           kind="error"
-          title="Error"
-          subtitle="The image could not be loaded or converted. Make sure the URL is valid and publicly accessible."
+          title={t('error.title', 'Error')}
+          subtitle={t(
+            'imageUrlLoadErrorText',
+            'The image could not be loaded or converted. Make sure the URL is valid and publicly accessible.',
+          )}
           lowContrast
         />
       )}

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/paste-image-url.scss
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/paste-image-url.scss
@@ -1,8 +1,8 @@
 @use '@carbon/layout';
-@use '@openmrs/esm-styleguide/src/vars' as vars;
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .pasteUrlContainer {
-  color: vars.$ui-02;
+  color: $ui-02;
   width: 100%;
   height: 406px; // match esm-media-uploader
   padding: layout.$spacing-05;
@@ -22,7 +22,7 @@
     margin-top: layout.$spacing-05;
     max-width: 300px;
     max-height: 300px;
-    border: 1px solid vars.$ui-03;
+    border: 1px solid $ui-03;
     border-radius: 4px;
     display: block;
   }

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/paste-image-url.scss
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/paste-image-url.scss
@@ -1,0 +1,29 @@
+@use '@carbon/layout';
+@use '@openmrs/esm-styleguide/src/vars' as vars;
+
+.pasteUrlContainer {
+  color: vars.$ui-02;
+  width: 100%;
+  height: 406px; // match esm-media-uploader
+  padding: layout.$spacing-05;
+  box-sizing: border-box;
+
+  .urlInput {
+    width: 100%;
+    max-width: 500px;
+    margin-bottom: layout.$spacing-05;
+  }
+
+  .loadButton {
+    margin-top: layout.$spacing-03;
+  }
+
+  .previewImage {
+    margin-top: layout.$spacing-05;
+    max-width: 300px;
+    max-height: 300px;
+    border: 1px solid vars.$ui-03;
+    border-radius: 4px;
+    display: block;
+  }
+}

--- a/packages/esm-patient-attachments-app/translations/en.json
+++ b/packages/esm-patient-attachments-app/translations/en.json
@@ -43,6 +43,7 @@
   "noAttachmentsToDisplay": "There are no attachments to display for this patient",
   "noImageToDisplay": "No image to display",
   "options": "Options",
+  "pasteUrl": "Paste URL",
   "successfullyDeleted": "successfully deleted",
   "supportedFiletypes": "Supported files are {{supportedFiles}}",
   "tableView": "Table view",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR introduces a new feature that allows users to register a patient image using a direct image link during the registration process. Previously, the system supported uploading an image from the file system or capturing it via webcam. With this enhancement, users can now:

- Paste a direct image URL (e.g., from Cloudinary or another CDN).
- See a live preview of the image.
- Submit the form with the image being linked and displayed in the patient record.

This addition improves workflow efficiency, especially for users who manage external image sources.

The feature includes **graceful error handling** — if the URL is invalid or the image cannot be fetched, the UI shows a clear error message and prevents submission.

## Screenshots

![new](https://github.com/user-attachments/assets/9e8345ed-9523-4a8a-87ff-ade960436365)

https://github.com/user-attachments/assets/6dd95b21-c261-42f6-8d99-4d426522cba4



## Related Issue

https://openmrs.atlassian.net/browse/O3-4855

## Other

- Validated feature locally in development mode.
- Ensured compatibility with existing image upload and webcam features.
- Styling and interaction follow the OpenMRS 3.0 style guide.
