### PR TITLE
(fix): Translation issues and form launch issues in clinical views

### DIFF
--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list.component.tsx
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list.component.tsx
@@ -7,7 +7,7 @@ import { EncounterListDataTable } from './table.component';
 import { launchEncounterForm } from '../utils/helpers';
 import { deleteEncounter } from '../utils/encounter-list.resource';
 import { useEncounterRows, useFormsJson } from '../hooks';
-import type { TableRow, Encounter, Mode, ColumnValue, FormattedColumn } from '../types';
+import type { TableRow, Encounter, Mode, FormattedColumn } from '../types';
 import styles from './encounter-list.scss';
 
 export interface EncounterListProps {
@@ -229,7 +229,7 @@ export const EncounterList: React.FC<EncounterListProps> = ({
   }, [columns, t]);
 
   const formLauncher = useMemo(() => {
-    if (formsJson && !formsJson['availableIntents']?.length) {
+    if (formsJson) {
       return (
         <Button
           kind="ghost"
@@ -275,7 +275,7 @@ export const EncounterList: React.FC<EncounterListProps> = ({
         </>
       ) : (
         <EmptyState
-          displayText={description}
+          displayText={t(description)}
           headerTitle={t(headerTitle)}
           launchForm={
             hideFormLauncher || deathStatus

--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-tile/encounter-tile.component.tsx
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-tile/encounter-tile.component.tsx
@@ -44,7 +44,7 @@ const EncounterData: React.FC<{
     return <CodeSnippetSkeleton type="multi" className="skeleton" />;
   }
 
-  if (error || lastEncounter == undefined) {
+  if (error || lastEncounter === undefined) {
     return (
       <div className={styles.tileBox}>
         {columns.map((column, ind) => (
@@ -62,7 +62,7 @@ const EncounterData: React.FC<{
       {columns.map((column, ind) => {
         return (
           <div key={ind}>
-            <span className={styles.tileTitle}>{column.header}</span>
+            <span className={styles.tileTitle}>{t(column.header)}</span>
             <span className={styles.tileValue}>
               <p>{column.getObsValue(lastEncounter)}</p>
             </span>

--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-tile/tile.scss
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-tile/tile.scss
@@ -23,6 +23,8 @@
 .columnContainer {
   display: flex;
   flex-direction: row;
+  gap: layout.$spacing-05;
+  justify-content: space-around;
 }
 
 .tileSubTitle {
@@ -36,7 +38,10 @@
 }
 
 .tileBox {
+  width: 25%;
   display: flex;
+  flex-direction: row;
+  flex: 1;
   gap: layout.$spacing-05;
 }
 

--- a/packages/esm-patient-chart-app/src/clinical-views/hooks/useFormsJson.ts
+++ b/packages/esm-patient-chart-app/src/clinical-views/hooks/useFormsJson.ts
@@ -4,7 +4,7 @@ import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type Form } from '../types';
 
 export function useFormsJson(formUuid: string) {
-  const url = `${restBaseUrl}/form/${formUuid}`;
+  const url = formUuid ? `${restBaseUrl}/form/${formUuid}` : null;
   const { data, isLoading, error } = useSWR<{ data: Form }, Error>(url, openmrsFetch);
 
   return {

--- a/packages/esm-patient-chart-app/src/clinical-views/hooks/useFormsJson.ts
+++ b/packages/esm-patient-chart-app/src/clinical-views/hooks/useFormsJson.ts
@@ -4,8 +4,8 @@ import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type Form } from '../types';
 
 export function useFormsJson(formUuid: string) {
-  const url = formUuid ? `${restBaseUrl}/form/${formUuid}` : null;
-  const { data, isLoading, error } = useSWR<{ data: Form }, Error>(url, openmrsFetch);
+  const url = `${restBaseUrl}/form/${formUuid}`;
+  const { data, isLoading, error } = useSWR<{ data: Form }, Error>(formUuid ? url : null, openmrsFetch);
 
   return {
     formsJson: data?.data ?? null,

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.component.tsx
@@ -33,7 +33,7 @@ interface DashboardViewProps {
 
 export function DashboardView({ dashboard, patientUuid, patient }: DashboardViewProps) {
   const widgetMetas = useExtensionSlotMeta(dashboard.slot);
-  const { t } = useTranslation(dashboard.moduleName);
+  const { t } = useTranslation();
   const {
     params: { view },
   } = useMatch(dashboardPath);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR does the following fixes:
- Fixed the form launcher logic to always display the form launch on the table header. Previously, this would only launch if there were *no* form intents. This option should always be available because otherwise there is no other way to launch a form from the encounter list when there are records in the encounter-list.
- Added the translation wrapper for the empty state description.
- Removed module-specific translation context from the `dashboard-view` component since it wasn't loading the translation overrides otherwise.
- Fixed encounter tiles logic that prevented the columns from being rendered
- Adjusted styling in encounter tiles

## Screenshots
<!-- Required if you are making UI changes. -->
1. Launch option for forms visible on encounter list:
<img width="1384" alt="Screenshot 2025-06-29 at 12 03 16 PM" src="https://github.com/user-attachments/assets/4d286a68-de8e-46c7-9cf6-ed34af11fb8c" />

2. Translations now loading for the dashboard title;
Before:
<img width="1384" alt="Screenshot 2025-06-29 at 12 07 04 PM" src="https://github.com/user-attachments/assets/796928c6-32a4-4859-8934-d32efab05cb4" />After:
<img width="1384" alt="Screenshot 2025-06-29 at 12 02 50 PM" src="https://github.com/user-attachments/assets/1e781aa8-ea62-4742-8483-073cef057b74" />

3. Empty state descriptor text loads text from translation overrides:
<img width="1384" alt="Screenshot 2025-06-29 at 12 05 15 PM" src="https://github.com/user-attachments/assets/f40888df-9ff6-4bc1-8ec5-dcd602cadc51" />

4. Encounter tiles render columns as intended:
Before:
<img width="1265" alt="Screenshot 2025-06-29 at 2 46 39 PM" src="https://github.com/user-attachments/assets/078a4ba4-0c09-47f9-9e40-36879800c899" />

After:
<img width="1267" alt="Screenshot 2025-06-29 at 2 43 45 PM" src="https://github.com/user-attachments/assets/8ae19847-49c1-4a33-95c0-45688d549b4f" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
