### PR TITLE
(feat) Optimize visit data revalidation to avoid SWR cache cascades

### DIFF
--- a/packages/esm-patient-chart-app/package.json
+++ b/packages/esm-patient-chart-app/package.json
@@ -17,7 +17,7 @@
     "test:watch": "cross-env TZ=UTC jest --watch --config jest.config.js --color",
     "coverage": "yarn test --coverage",
     "typescript": "tsc",
-    "extract-translations": "i18next 'src/**/*.component.tsx' 'src/**/*.modal.tsx' 'src/**/*.extension.tsx' 'src/**/*.workspace.tsx' 'src/**/*.hook.tsx' 'src/index.ts' --config ../../tools/i18next-parser.config.js"
+    "extract-translations": "i18next 'src/**/*.component.tsx' 'src/**/*.modal.tsx' 'src/**/*.extension.tsx' 'src/**/*.workspace.tsx' 'src/**/hooks/*.tsx' 'src/index.ts' --config ../../tools/i18next-parser.config.js"
   },
   "browserslist": [
     "extends browserslist-config-openmrs"

--- a/packages/esm-patient-chart-app/src/visit/hooks/useDeleteVisit.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useDeleteVisit.test.tsx
@@ -1,0 +1,269 @@
+import { useSWRConfig } from 'swr';
+import { renderHook, act } from '@testing-library/react';
+import { showSnackbar, useVisit, type Visit, type VisitType } from '@openmrs/esm-framework';
+import { invalidateVisitAndEncounterData } from '@openmrs/esm-patient-common-lib';
+import { useDeleteVisit } from './useDeleteVisit';
+import { deleteVisit, restoreVisit } from '../visits-widget/visit.resource';
+
+jest.mock('swr', () => ({
+  useSWRConfig: jest.fn(),
+}));
+
+jest.mock('../visits-widget/visit.resource', () => {
+  const original = jest.requireActual('../visits-widget/visit.resource');
+  return {
+    ...original,
+    deleteVisit: jest.fn(),
+    restoreVisit: jest.fn(),
+  };
+});
+
+jest.mock('@openmrs/esm-patient-common-lib', () => ({
+  invalidateVisitAndEncounterData: jest.fn(),
+}));
+
+const mockDeleteVisit = jest.mocked(deleteVisit);
+const mockRestoreVisit = jest.mocked(restoreVisit);
+const mockShowSnackbar = jest.mocked(showSnackbar);
+const mockUseSWRConfig = jest.mocked(useSWRConfig);
+const mockUseVisit = jest.mocked(useVisit);
+const mockInvalidateVisitAndEncounterData = jest.mocked(invalidateVisitAndEncounterData);
+
+const mockMutateCurrentVisit = jest.fn();
+const mockGlobalMutate = jest.fn();
+
+const mockVisitType = {
+  uuid: 'visit-type-123',
+  display: 'Outpatient Visit',
+  name: 'Outpatient Visit',
+};
+
+const mockVisit = {
+  uuid: 'visit-123',
+  patient: { uuid: 'patient-123' },
+  visitType: mockVisitType,
+  startDatetime: '2023-01-01T10:00:00Z',
+  stopDatetime: null,
+  location: { uuid: 'location-123', display: 'Test Location' },
+  encounters: [],
+  attributes: [],
+  voided: false,
+  links: [],
+  resourceVersion: '1.8',
+} as Visit;
+
+describe('useDeleteVisit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseVisit.mockReturnValue({
+      mutate: mockMutateCurrentVisit,
+      currentVisit: null,
+      activeVisit: null,
+      currentVisitIsRetrospective: false,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+    });
+
+    mockUseSWRConfig.mockReturnValue({
+      mutate: mockGlobalMutate,
+      cache: new Map(),
+    } as any);
+  });
+
+  it('should delete visit successfully and trigger revalidation', async () => {
+    mockDeleteVisit.mockResolvedValue({ data: {} } as any);
+    const onVisitDelete = jest.fn();
+
+    const { result } = renderHook(() => useDeleteVisit(mockVisit, onVisitDelete));
+
+    await act(async () => {
+      result.current.initiateDeletingVisit();
+    });
+
+    expect(mockDeleteVisit).toHaveBeenCalledWith('visit-123');
+    expect(mockMutateCurrentVisit).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateVisitAndEncounterData).toHaveBeenCalledWith(mockGlobalMutate, 'patient-123');
+
+    expect(mockShowSnackbar).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Outpatient Visit deleted',
+        subtitle: 'Outpatient Visit deleted successfully',
+        kind: 'success',
+        actionButtonLabel: 'Undo',
+        onActionButtonClick: expect.any(Function),
+      }),
+    );
+
+    expect(onVisitDelete).toHaveBeenCalled();
+  });
+
+  it('should handle delete error and trigger revalidation', async () => {
+    mockDeleteVisit.mockRejectedValue(new Error('Delete failed'));
+    const onVisitDelete = jest.fn();
+
+    const { result } = renderHook(() => useDeleteVisit(mockVisit, onVisitDelete));
+
+    await act(async () => {
+      result.current.initiateDeletingVisit();
+    });
+
+    expect(mockMutateCurrentVisit).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateVisitAndEncounterData).toHaveBeenCalledWith(mockGlobalMutate, 'patient-123');
+
+    expect(mockShowSnackbar).toHaveBeenCalledWith({
+      title: 'Error deleting visit',
+      kind: 'error',
+      subtitle: 'An error occurred when deleting visit',
+    });
+
+    expect(onVisitDelete).not.toHaveBeenCalled();
+  });
+
+  it('should restore visit successfully when undo is clicked', async () => {
+    mockRestoreVisit.mockResolvedValue({ data: {} } as any);
+    const onVisitRestore = jest.fn();
+
+    const { result } = renderHook(() => useDeleteVisit(mockVisit, undefined, onVisitRestore));
+
+    // First delete to get the restore function
+    mockDeleteVisit.mockResolvedValue({ data: {} } as any);
+    await act(async () => {
+      result.current.initiateDeletingVisit();
+    });
+
+    // Get the restore function from the snackbar
+    const restoreFunction = mockShowSnackbar.mock.calls[0][0].onActionButtonClick;
+
+    // Clear mocks to test restore independently
+    jest.clearAllMocks();
+    mockUseVisit.mockReturnValue({
+      mutate: mockMutateCurrentVisit,
+      currentVisit: null,
+      activeVisit: null,
+      currentVisitIsRetrospective: false,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+    });
+    mockUseSWRConfig.mockReturnValue({
+      mutate: mockGlobalMutate,
+      cache: new Map(),
+    } as any);
+
+    // Test restore functionality
+    await act(async () => {
+      restoreFunction();
+    });
+
+    expect(mockRestoreVisit).toHaveBeenCalledWith('visit-123');
+    expect(mockMutateCurrentVisit).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateVisitAndEncounterData).toHaveBeenCalledWith(mockGlobalMutate, 'patient-123');
+
+    expect(mockShowSnackbar).toHaveBeenCalledWith({
+      title: 'Visit restored',
+      subtitle: 'Outpatient Visit restored successfully',
+      kind: 'success',
+    });
+
+    expect(onVisitRestore).toHaveBeenCalled();
+  });
+
+  it('should handle restore error and trigger revalidation', async () => {
+    mockRestoreVisit.mockRejectedValue(new Error('Restore failed'));
+    const onVisitRestore = jest.fn();
+
+    const { result } = renderHook(() => useDeleteVisit(mockVisit, undefined, onVisitRestore));
+
+    // First delete to get the restore function
+    mockDeleteVisit.mockResolvedValue({ data: {} } as any);
+    await act(async () => {
+      result.current.initiateDeletingVisit();
+    });
+
+    const restoreFunction = mockShowSnackbar.mock.calls[0][0].onActionButtonClick;
+
+    // Clear mocks to test restore independently
+    jest.clearAllMocks();
+    mockUseVisit.mockReturnValue({
+      mutate: mockMutateCurrentVisit,
+      currentVisit: null,
+      activeVisit: null,
+      currentVisitIsRetrospective: false,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+    });
+    mockUseSWRConfig.mockReturnValue({
+      mutate: mockGlobalMutate,
+      cache: new Map(),
+    } as any);
+
+    // Test restore error
+    await act(async () => {
+      restoreFunction();
+    });
+
+    expect(mockMutateCurrentVisit).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateVisitAndEncounterData).toHaveBeenCalledWith(mockGlobalMutate, 'patient-123');
+
+    expect(mockShowSnackbar).toHaveBeenCalledWith({
+      title: "Visit couldn't be restored",
+      subtitle: 'Error occurred when restoring Outpatient Visit',
+      kind: 'error',
+    });
+
+    expect(onVisitRestore).not.toHaveBeenCalled();
+  });
+
+  it('should manage loading state correctly', async () => {
+    mockDeleteVisit.mockResolvedValue({ data: {} } as any);
+
+    const { result } = renderHook(() => useDeleteVisit(mockVisit));
+
+    // Initially not deleting
+    expect(result.current.isDeletingVisit).toBe(false);
+
+    // Start deletion and wait for completion
+    await act(async () => {
+      result.current.initiateDeletingVisit();
+    });
+
+    // Should no longer be loading after completion
+    expect(result.current.isDeletingVisit).toBe(false);
+  });
+
+  it('should handle visit with missing patient UUID', () => {
+    const visitWithoutPatient = { ...mockVisit, patient: null };
+
+    expect(() => {
+      renderHook(() => useDeleteVisit(visitWithoutPatient));
+    }).not.toThrow();
+  });
+
+  it('should handle visit with empty patient UUID', () => {
+    const visitWithEmptyPatient = { ...mockVisit, patient: { uuid: '' } };
+
+    expect(() => {
+      renderHook(() => useDeleteVisit(visitWithEmptyPatient));
+    }).not.toThrow();
+  });
+
+  it('should handle visit with missing visit type display', async () => {
+    const visitWithoutDisplay = {
+      ...mockVisit,
+      visitType: { ...mockVisitType, display: undefined },
+    };
+
+    mockDeleteVisit.mockResolvedValue({ data: {} } as any);
+    const { result } = renderHook(() => useDeleteVisit(visitWithoutDisplay));
+
+    await act(async () => {
+      result.current.initiateDeletingVisit();
+    });
+
+    // Should complete without throwing
+    expect(mockDeleteVisit).toHaveBeenCalled();
+  });
+});

--- a/packages/esm-patient-chart-app/src/visit/hooks/useDeleteVisit.tsx
+++ b/packages/esm-patient-chart-app/src/visit/hooks/useDeleteVisit.tsx
@@ -7,7 +7,7 @@ import { deleteVisit, restoreVisit } from '../visits-widget/visit.resource';
 
 export function useDeleteVisit(visit: Visit, onVisitDelete = () => {}, onVisitRestore = () => {}) {
   const { t } = useTranslation();
-  const { mutate } = useSWRConfig();
+  const { mutate: globalMutate } = useSWRConfig();
   const { mutate: mutateCurrentVisit } = useVisit(visit?.patient?.uuid || '');
   const [isDeletingVisit, setIsDeletingVisit] = useState(false);
   const patientUuid = visit?.patient?.uuid || '';
@@ -19,7 +19,7 @@ export function useDeleteVisit(visit: Visit, onVisitDelete = () => {}, onVisitRe
         mutateCurrentVisit();
 
         // Use targeted SWR invalidation instead of global mutateVisit
-        invalidateVisitAndEncounterData(mutate, patientUuid);
+        invalidateVisitAndEncounterData(globalMutate, patientUuid);
 
         showSnackbar({
           title: t('visitRestored', 'Visit restored'),
@@ -33,7 +33,7 @@ export function useDeleteVisit(visit: Visit, onVisitDelete = () => {}, onVisitRe
       .catch(() => {
         // On error, revalidate to get correct state
         mutateCurrentVisit();
-        invalidateVisitAndEncounterData(mutate, patientUuid);
+        invalidateVisitAndEncounterData(globalMutate, patientUuid);
         showSnackbar({
           title: t('visitNotRestored', "Visit couldn't be restored"),
           subtitle: t('errorWhenRestoringVisit', 'Error occurred when restoring {{visit}}', {
@@ -53,7 +53,7 @@ export function useDeleteVisit(visit: Visit, onVisitDelete = () => {}, onVisitRe
         mutateCurrentVisit();
 
         // Use targeted SWR invalidation instead of global mutateVisit
-        invalidateVisitAndEncounterData(mutate, patientUuid);
+        invalidateVisitAndEncounterData(globalMutate, patientUuid);
 
         showSnackbar({
           title: t('visitDeleted', '{{visit}} deleted', {
@@ -71,7 +71,7 @@ export function useDeleteVisit(visit: Visit, onVisitDelete = () => {}, onVisitRe
       .catch(() => {
         // On error, revalidate to get correct state
         mutateCurrentVisit();
-        invalidateVisitAndEncounterData(mutate, patientUuid);
+        invalidateVisitAndEncounterData(globalMutate, patientUuid);
 
         showSnackbar({
           title: t('errorDeletingVisit', 'Error deleting visit'),

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
@@ -103,7 +103,7 @@ const VisitForm: React.FC<VisitFormProps> = ({
   const visitHeaderSlotState = useMemo(() => ({ patientUuid }), [patientUuid]);
   const { activePatientEnrollment, isLoading } = useActivePatientEnrollment(patientUuid);
   const { mutate: mutateCurrentVisit } = useVisit(patientUuid);
-  const { mutate } = useSWRConfig();
+  const { mutate: globalMutate } = useSWRConfig();
   const allVisitTypes = useConditionalVisitTypes();
 
   const [errorFetchingResources, setErrorFetchingResources] = useState<{
@@ -309,7 +309,7 @@ const VisitForm: React.FC<VisitFormProps> = ({
             // Use targeted SWR invalidation instead of global mutateVisit
             // This will invalidate visit history and encounter tables for this patient
             // (current visit is already updated with mutateCurrentVisit)
-            invalidateVisitAndEncounterData(mutate, patientUuid);
+            invalidateVisitAndEncounterData(globalMutate, patientUuid);
 
             // handleVisitAttributes already has code to show error snackbar when attribute fails to update
             // no need for catch block here
@@ -347,12 +347,12 @@ const VisitForm: React.FC<VisitFormProps> = ({
           config.offlineVisitTypeUuid,
           payload.startDatetime,
         ).then(
-          (offlineVisit) => {
+          () => {
             // Use same targeted approach for offline visits for consistency
             mutateCurrentVisit();
 
             // Also invalidate visit history and encounter tables
-            invalidateVisitAndEncounterData(mutate, patientUuid);
+            invalidateVisitAndEncounterData(globalMutate, patientUuid);
             closeWorkspace({ ignoreChanges: true });
             showSnackbar({
               isLowContrast: true,
@@ -381,9 +381,9 @@ const VisitForm: React.FC<VisitFormProps> = ({
       config.offlineVisitTypeUuid,
       config.showExtraVisitAttributesSlot,
       extraVisitInfo,
+      globalMutate,
       handleVisitAttributes,
       isOnline,
-      mutate,
       mutateCurrentVisit,
       patientUuid,
       t,

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
@@ -1,4 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import classNames from 'classnames';
+import dayjs from 'dayjs';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import { Controller, FormProvider, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { useSWRConfig } from 'swr';
 import {
   Button,
   ButtonSet,
@@ -25,28 +31,20 @@ import {
   useConnectivity,
   useEmrConfiguration,
   useLayoutType,
-  useVisitContextStore,
+  useVisit,
   type AssignedExtension,
   type NewVisitPayload,
   type Visit,
 } from '@openmrs/esm-framework';
 import {
   createOfflineVisitForPatient,
+  invalidateVisitAndEncounterData,
   useActivePatientEnrollment,
   type DefaultPatientWorkspaceProps,
 } from '@openmrs/esm-patient-common-lib';
-import classNames from 'classnames';
-import dayjs from 'dayjs';
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
-import { Controller, FormProvider, useForm } from 'react-hook-form';
-import { useTranslation } from 'react-i18next';
 import { type ChartConfig } from '../../config-schema';
 import { useVisitAttributeTypes } from '../hooks/useVisitAttributeType';
-import BaseVisitType from './base-visit-type.component';
-import LocationSelector from './location-selector.component';
 import { MemoizedRecommendedVisitType } from './recommended-visit-type.component';
-import VisitAttributeTypeFields from './visit-attribute-type.component';
-import VisitDateTimeSection from './visit-date-time.component';
 import {
   convertToDate,
   createVisitAttribute,
@@ -61,7 +59,12 @@ import {
   type VisitFormCallbacks,
   type VisitFormData,
 } from './visit-form.resource';
+import BaseVisitType from './base-visit-type.component';
+import LocationSelector from './location-selector.component';
+import VisitAttributeTypeFields from './visit-attribute-type.component';
+import VisitDateTimeSection from './visit-date-time.component';
 import styles from './visit-form.scss';
+
 dayjs.extend(isSameOrBefore);
 
 interface VisitFormProps extends DefaultPatientWorkspaceProps {
@@ -99,7 +102,8 @@ const VisitForm: React.FC<VisitFormProps> = ({
   );
   const visitHeaderSlotState = useMemo(() => ({ patientUuid }), [patientUuid]);
   const { activePatientEnrollment, isLoading } = useActivePatientEnrollment(patientUuid);
-  const { mutateVisit } = useVisitContextStore();
+  const { mutate: mutateCurrentVisit } = useVisit(patientUuid);
+  const { mutate } = useSWRConfig();
   const allVisitTypes = useConditionalVisitTypes();
 
   const [errorFetchingResources, setErrorFetchingResources] = useState<{
@@ -295,6 +299,18 @@ const VisitForm: React.FC<VisitFormProps> = ({
             // to update visit attributes or any other OnVisitCreatedOrUpdated actions
             const visit = response.data;
 
+            // For visit creation, we need to update:
+            // 1. Current visit data (for critical components like visit summary, action buttons)
+            // 2. Visit history table (for the paginated visit list)
+
+            // Update current visit data for critical components (useVisit hook)
+            mutateCurrentVisit();
+
+            // Use targeted SWR invalidation instead of global mutateVisit
+            // This will invalidate visit history and encounter tables for this patient
+            // (current visit is already updated with mutateCurrentVisit)
+            invalidateVisitAndEncounterData(mutate, patientUuid);
+
             // handleVisitAttributes already has code to show error snackbar when attribute fails to update
             // no need for catch block here
             const visitAttributesRequest = handleVisitAttributes(visitAttributes, response.data.uuid).then(
@@ -323,9 +339,6 @@ const VisitForm: React.FC<VisitFormProps> = ({
           })
           .catch(() => {
             // do nothing, this catches any reject promises used for short-circuiting
-          })
-          .finally(() => {
-            mutateVisit();
           });
       } else {
         createOfflineVisitForPatient(
@@ -334,8 +347,12 @@ const VisitForm: React.FC<VisitFormProps> = ({
           config.offlineVisitTypeUuid,
           payload.startDatetime,
         ).then(
-          () => {
-            mutateVisit();
+          (offlineVisit) => {
+            // Use same targeted approach for offline visits for consistency
+            mutateCurrentVisit();
+
+            // Also invalidate visit history and encounter tables
+            invalidateVisitAndEncounterData(mutate, patientUuid);
             closeWorkspace({ ignoreChanges: true });
             showSnackbar({
               isLowContrast: true,
@@ -366,10 +383,11 @@ const VisitForm: React.FC<VisitFormProps> = ({
       extraVisitInfo,
       handleVisitAttributes,
       isOnline,
-      mutateVisit,
-      visitFormCallbacks,
+      mutate,
+      mutateCurrentVisit,
       patientUuid,
       t,
+      visitFormCallbacks,
       visitToEdit,
     ],
   );

--- a/packages/esm-patient-chart-app/src/visit/visit-history-table/visit-history-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-history-table/visit-history-table.component.tsx
@@ -18,11 +18,11 @@ import {
 import { ErrorState, isDesktop, useLayoutType } from '@openmrs/esm-framework';
 import { EmptyState } from '@openmrs/esm-patient-common-lib';
 import { usePaginatedVisits } from '../visits-widget/visit.resource';
+import VisitActionsCell from './visit-actions-cell.component';
 import VisitDateCell from './visit-date-cell.component';
 import VisitDiagnosisCell from './visit-diagnoses-cell.component';
 import VisitSummary from '../visits-widget/past-visits-components/visit-summary.component';
 import VisitTypeCell from './visit-type-cell.component';
-import VisitActionsCell from './visit-actions-cell.component';
 import styles from './visit-history-table.scss';
 
 interface VisitHistoryTableProps {

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/delete-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/delete-visit-dialog.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ModalHeader, ModalBody, ModalFooter, InlineLoading } from '@carbon/react';
 import { type Visit } from '@openmrs/esm-framework';
-import { useDeleteVisit } from '../hooks/useDeleteVisit.hook';
+import { useDeleteVisit } from '../hooks/useDeleteVisit';
 import styles from './start-visit-dialog.scss';
 
 interface DeleteVisitDialogProps {

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
-import { showSnackbar, updateVisit, useVisit, useVisitContextStore } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
+import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
+import { showSnackbar, updateVisit, useVisit } from '@openmrs/esm-framework';
 import styles from './end-visit-dialog.scss';
 
 interface EndVisitDialogProps {
@@ -16,8 +16,7 @@ interface EndVisitDialogProps {
  */
 const EndVisitDialog: React.FC<EndVisitDialogProps> = ({ patientUuid, closeModal }) => {
   const { t } = useTranslation();
-  const { activeVisit } = useVisit(patientUuid);
-  const { mutateVisit } = useVisitContextStore();
+  const { activeVisit, mutate: mutateCurrentVisit } = useVisit(patientUuid);
 
   const handleEndVisit = () => {
     if (activeVisit) {
@@ -29,7 +28,8 @@ const EndVisitDialog: React.FC<EndVisitDialogProps> = ({ patientUuid, closeModal
 
       updateVisit(activeVisit.uuid, endVisitPayload, abortController)
         .then((response) => {
-          mutateVisit();
+          // Single targeted revalidation to update visit end time
+          mutateCurrentVisit();
           closeModal();
 
           showSnackbar({

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.component.tsx
@@ -16,7 +16,7 @@ interface EndVisitDialogProps {
  */
 const EndVisitDialog: React.FC<EndVisitDialogProps> = ({ patientUuid, closeModal }) => {
   const { t } = useTranslation();
-  const { activeVisit, mutate: mutateCurrentVisit } = useVisit(patientUuid);
+  const { activeVisit, mutate } = useVisit(patientUuid);
 
   const handleEndVisit = () => {
     if (activeVisit) {
@@ -28,8 +28,7 @@ const EndVisitDialog: React.FC<EndVisitDialogProps> = ({ patientUuid, closeModal
 
       updateVisit(activeVisit.uuid, endVisitPayload, abortController)
         .then((response) => {
-          // Single targeted revalidation to update visit end time
-          mutateCurrentVisit();
+          mutate();
           closeModal();
 
           showSnackbar({

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/all-encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/all-encounters-table.component.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useState } from 'react';
-import { useVisitContextStore, type EncounterType } from '@openmrs/esm-framework';
+import React, { useState } from 'react';
+import { type EncounterType } from '@openmrs/esm-framework';
 import { type EncountersTableProps, usePaginatedEncounters } from './encounters-table.resource';
 import EncountersTable from './encounters-table.component';
 
@@ -22,9 +22,6 @@ const AllEncountersTable: React.FC<AllEncountersTableProps> = ({ patientUuid }) 
     goTo,
     mutate,
   } = usePaginatedEncounters(patientUuid, encounterTypeToFilter?.uuid, pageSize);
-
-  const mutateEncounters = useCallback(() => mutate(), [mutate]);
-  useVisitContextStore(mutateEncounters);
 
   const encountersTableProps: EncountersTableProps = {
     currentPage,

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
@@ -1,5 +1,6 @@
 import React, { type ComponentProps, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSWRConfig } from 'swr';
 import {
   Button,
   ComboBox,
@@ -26,18 +27,22 @@ import {
 import {
   EditIcon,
   isDesktop,
+  launchWorkspace,
   showModal,
   showSnackbar,
   TrashCanIcon,
-  useLayoutType,
-  useSession,
-  userHasAccess,
   useConfig,
+  useLayoutType,
+  userHasAccess,
+  useSession,
+  useVisit,
   type EncounterType,
-  launchWorkspace,
-  useVisitContextStore,
 } from '@openmrs/esm-framework';
-import { type HtmlFormEntryForm, launchFormEntryOrHtmlForms } from '@openmrs/esm-patient-common-lib';
+import {
+  type HtmlFormEntryForm,
+  launchFormEntryOrHtmlForms,
+  invalidateVisitAndEncounterData,
+} from '@openmrs/esm-patient-common-lib';
 import {
   deleteEncounter,
   mapEncounter,
@@ -71,7 +76,8 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
   const pageSizes = [10, 20, 30, 40, 50];
   const desktopLayout = isDesktop(useLayoutType());
   const session = useSession();
-  const { mutateVisit } = useVisitContextStore();
+  const { mutate: mutateCurrentVisit } = useVisit(patientUuid);
+  const { mutate } = useSWRConfig();
   const responsiveSize = desktopLayout ? 'sm' : 'lg';
 
   const { data: encounterTypes, isLoading: isLoadingEncounterTypes } = useEncounterTypes();
@@ -118,7 +124,11 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
           const abortController = new AbortController();
           deleteEncounter(encounterUuid, abortController)
             .then(() => {
-              mutateVisit();
+              // Update current visit data for critical components
+              mutateCurrentVisit();
+
+              // Also invalidate visit history and encounter tables since the encounter was deleted
+              invalidateVisitAndEncounterData(mutate, patientUuid);
 
               showSnackbar({
                 isLowContrast: true,
@@ -142,7 +152,7 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
         },
       });
     },
-    [mutateVisit, t],
+    [mutate, mutateCurrentVisit, patientUuid, t],
   );
 
   if (isLoadingEncounterTypes || isLoading) {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/visit-encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/visit-encounters-table.component.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
+import { usePagination, type Visit } from '@openmrs/esm-framework';
 import EncountersTable from './encounters-table.component';
 import { type EncountersTableProps } from './encounters-table.resource';
-import { usePagination, useVisitContextStore, type Visit } from '@openmrs/esm-framework';
 
 interface VisitEncountersTableProps {
   patientUuid: string;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -1,12 +1,10 @@
-import { useCallback } from 'react';
 import {
   openmrsFetch,
   restBaseUrl,
-  useOpenmrsInfinite,
   type OpenmrsResource,
   type Visit,
+  useOpenmrsInfinite,
   useOpenmrsPagination,
-  useVisitContextStore,
 } from '@openmrs/esm-framework';
 
 const customRepresentation =
@@ -26,8 +24,6 @@ export function useInfiniteVisits(
   }
 
   const { data, mutate, ...rest } = useOpenmrsInfinite<Visit>(patientUuid ? url : null);
-  const mutateVisit = useCallback(() => mutate(), [mutate]);
-  useVisitContextStore(mutateVisit);
 
   return { visits: data, mutate, ...rest };
 }
@@ -46,9 +42,6 @@ export function usePaginatedVisits(
   }
 
   const ret = useOpenmrsPagination<Visit>(url, pageSize);
-  const { mutate } = ret;
-  const mutateVisit = useCallback(() => mutate(), [mutate]);
-  useVisitContextStore(mutateVisit);
 
   return ret;
 }

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -101,6 +101,7 @@
   "notes__lower": "notes",
   "noVisitsToDisplay": "No visits to display",
   "noVisitTypesToDisplay": "No visit types to display",
+  "offlineVisit": "Offline Visit",
   "On scheduled date": "On scheduled date",
   "ongoing": "Ongoing",
   "optional": "optional",

--- a/packages/esm-patient-common-lib/src/index.ts
+++ b/packages/esm-patient-common-lib/src/index.ts
@@ -16,4 +16,5 @@ export * from './time-helper';
 export * from './types';
 export * from './useAllowedFileExtensions';
 export * from './useSystemVisitSetting';
+export * from './visit';
 export * from './workspaces';

--- a/packages/esm-patient-common-lib/src/visit/index.ts
+++ b/packages/esm-patient-common-lib/src/visit/index.ts
@@ -1,0 +1,2 @@
+export * from './revalidation-utils';
+export * from './visit-mutations';

--- a/packages/esm-patient-common-lib/src/visit/revalidation-utils.test.ts
+++ b/packages/esm-patient-common-lib/src/visit/revalidation-utils.test.ts
@@ -1,0 +1,98 @@
+import {
+  invalidateVisitHistory,
+  invalidatePatientEncounters,
+  invalidateVisitAndEncounterData,
+} from './revalidation-utils';
+
+const mockMutate = jest.fn();
+
+describe('revalidation-utils', () => {
+  describe('invalidateVisitHistory', () => {
+    it('should invalidate visit history keys but not current visit keys', () => {
+      const patientUuid = 'test-patient-123';
+
+      invalidateVisitHistory(mockMutate, patientUuid);
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      expect(mockMutate).toHaveBeenCalledWith(expect.any(Function));
+
+      // Test the cache key matcher function
+      const matcherFn = mockMutate.mock.calls[0][0];
+
+      // Should invalidate visit history keys (with pagination params)
+      expect(
+        matcherFn(
+          '/ws/rest/v1/visit?patient=test-patient-123&v=custom:(uuid,location)&limit=10&startIndex=0&totalCount=true',
+        ),
+      ).toBe(true);
+
+      // Should invalidate visit history keys (without includeInactive)
+      expect(matcherFn('/ws/rest/v1/visit?patient=test-patient-123&v=custom:(uuid,location)')).toBe(true);
+
+      // Should NOT invalidate current visit keys (with includeInactive=false)
+      expect(matcherFn('/ws/rest/v1/visit?patient=test-patient-123&v=custom&includeInactive=false')).toBe(false);
+
+      // Should not match other patient's keys
+      expect(matcherFn('/ws/rest/v1/visit?patient=other-patient&v=custom')).toBe(false);
+
+      // Should not match non-visit endpoints
+      expect(matcherFn('/ws/rest/v1/encounter?patient=test-patient-123')).toBe(false);
+
+      // Should not match non-string keys
+      expect(matcherFn({ url: '/ws/rest/v1/visit?patient=test-patient-123' })).toBe(false);
+    });
+  });
+
+  describe('invalidatePatientEncounters', () => {
+    it('should invalidate encounter keys for the specified patient', () => {
+      const patientUuid = 'test-patient-123';
+
+      invalidatePatientEncounters(mockMutate, patientUuid);
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      expect(mockMutate).toHaveBeenCalledWith(expect.any(Function));
+
+      // Test the cache key matcher function
+      const matcherFn = mockMutate.mock.calls[0][0];
+
+      // Should match encounter endpoints with patient parameter
+      expect(matcherFn('/ws/rest/v1/encounter?patient=test-patient-123&v=custom')).toBe(true);
+      expect(matcherFn('/ws/rest/v1/encounter?limit=20&patient=test-patient-123&v=custom')).toBe(true);
+      expect(matcherFn('/ws/rest/v1/encounter?limit=20&startIndex=0&patient=test-patient-123&totalCount=true')).toBe(
+        true,
+      );
+
+      // Should not match other patient's encounters
+      expect(matcherFn('/ws/rest/v1/encounter?patient=other-patient&v=custom')).toBe(false);
+
+      // Should not match non-encounter endpoints
+      expect(matcherFn('/ws/rest/v1/visit?patient=test-patient-123')).toBe(false);
+
+      // Should not match non-string keys
+      expect(matcherFn({ url: '/ws/rest/v1/encounter?patient=test-patient-123' })).toBe(false);
+    });
+  });
+
+  describe('invalidateVisitAndEncounterData', () => {
+    it('should call both visit history and encounter invalidation functions', () => {
+      const patientUuid = 'test-patient-123';
+
+      invalidateVisitAndEncounterData(mockMutate, patientUuid);
+
+      // Should be called twice - once for visits, once for encounters
+      expect(mockMutate).toHaveBeenCalledTimes(2);
+      expect(mockMutate).toHaveBeenNthCalledWith(1, expect.any(Function));
+      expect(mockMutate).toHaveBeenNthCalledWith(2, expect.any(Function));
+
+      // Test that both matcher functions work correctly
+      const visitMatcherFn = mockMutate.mock.calls[0][0];
+      const encounterMatcherFn = mockMutate.mock.calls[1][0];
+
+      // Visit matcher should work
+      expect(visitMatcherFn('/ws/rest/v1/visit?patient=test-patient-123&v=custom&limit=10')).toBe(true);
+
+      // Encounter matcher should work
+      expect(encounterMatcherFn('/ws/rest/v1/encounter?patient=test-patient-123&v=custom')).toBe(true);
+    });
+  });
+});

--- a/packages/esm-patient-common-lib/src/visit/revalidation-utils.ts
+++ b/packages/esm-patient-common-lib/src/visit/revalidation-utils.ts
@@ -1,0 +1,102 @@
+import type { KeyedMutator } from 'swr';
+import { restBaseUrl } from '@openmrs/esm-framework';
+
+/**
+ * Invalidates visit history table data without triggering global visit revalidation cascade.
+ *
+ * This function provides surgical SWR cache invalidation for visit operations. It targets only
+ * the paginated visit data used by the visit history table, avoiding unnecessary revalidation
+ * of the 28+ components that use current visit data via the useVisit hook.
+ *
+ * The implementation uses URL pattern matching to discriminate between:
+ * - Current visit keys (includeInactive=false) - these are NOT invalidated
+ * - Visit history keys (no includeInactive param, or pagination params) - these ARE invalidated
+ *
+ * Cache key patterns:
+ * - Current visit: /visit?patient=123&v=custom&includeInactive=false
+ * - Visit history: /visit?patient=123&v=custom:(uuid,location...)&limit=10&startIndex=0&totalCount=true
+ *
+ * This approach eliminates the 13+ cascade revalidation requests that were previously triggered
+ * by global mutateVisit() calls, reducing network traffic and improving performance.
+ *
+ * @param mutate - SWR mutate function from useSWRConfig()
+ * @param patientUuid - Patient UUID to target visit data for
+ *
+ * @example
+ * ```typescript
+ * import { useSWRConfig } from 'swr';
+ * import { invalidateVisitHistory } from '@openmrs/esm-patient-common-lib';
+ *
+ * function MyComponent({ patientUuid }) {
+ *   const { mutate } = useSWRConfig();
+ *
+ *   const handleVisitUpdate = async () => {
+ *     // Perform visit operation...
+ *     await updateVisit(visitData);
+ *
+ *     // Invalidate only visit history table, not current visit components
+ *     invalidateVisitHistory(mutate, patientUuid);
+ *   };
+ * }
+ * ```
+ */
+export function invalidateVisitHistory(mutate: KeyedMutator<unknown>, patientUuid: string): void {
+  mutate((key) => {
+    if (typeof key === 'string' && key.includes(`${restBaseUrl}/visit?patient=${patientUuid}`)) {
+      // Current visit keys have includeInactive=false
+      const isCurrentVisitKey = key.includes('includeInactive=false');
+
+      // Visit history keys typically have pagination parameters or no includeInactive parameter
+      const hasHistoryParams = key.includes('limit=') || key.includes('startIndex=') || key.includes('totalCount=');
+      const hasNoIncludeInactive = !key.includes('includeInactive');
+
+      // Invalidate if it's clearly a history key OR if it doesn't have includeInactive=false
+      // This ensures we target visit history while preserving current visit cache
+      return !isCurrentVisitKey && (hasHistoryParams || hasNoIncludeInactive);
+    }
+    return false;
+  });
+}
+
+/**
+ * Invalidates visit-related encounter data for a specific patient.
+ *
+ * This function is useful when operations create or modify encounters within visits,
+ * requiring the encounter lists and related data to be refreshed.
+ *
+ * @param mutate - SWR mutate function from useSWRConfig()
+ * @param patientUuid - Patient UUID to target encounter data for
+ *
+ * @example
+ * ```typescript
+ * // After creating a visit note (which creates an encounter)
+ * invalidatePatientEncounters(mutate, patientUuid);
+ * ```
+ */
+export function invalidatePatientEncounters(mutate: KeyedMutator<unknown>, patientUuid: string): void {
+  mutate((key) => {
+    return (
+      typeof key === 'string' && key.includes(`${restBaseUrl}/encounter`) && key.includes(`patient=${patientUuid}`)
+    );
+  });
+}
+
+/**
+ * Combination utility that invalidates both visit history and encounter data.
+ *
+ * This is commonly needed when operations affect both visit structure and encounter content,
+ * such as form submissions, visit note creation, or encounter deletion.
+ *
+ * @param mutate - SWR mutate function from useSWRConfig()
+ * @param patientUuid - Patient UUID to target data for
+ *
+ * @example
+ * ```typescript
+ * // After form submission that creates encounters within a visit
+ * invalidateVisitAndEncounterData(mutate, patientUuid);
+ * ```
+ */
+export function invalidateVisitAndEncounterData(mutate: KeyedMutator<unknown>, patientUuid: string): void {
+  invalidateVisitHistory(mutate, patientUuid);
+  invalidatePatientEncounters(mutate, patientUuid);
+}

--- a/packages/esm-patient-common-lib/src/visit/visit-mutations.ts
+++ b/packages/esm-patient-common-lib/src/visit/visit-mutations.ts
@@ -1,0 +1,199 @@
+import { useCallback } from 'react';
+import { useSWRConfig } from 'swr';
+import { useVisit, type Visit, restBaseUrl } from '@openmrs/esm-framework';
+
+export interface VisitMutationOptions {
+  encounters?: boolean;
+  notes?: boolean;
+  orders?: boolean;
+  observations?: boolean;
+}
+
+/**
+ * Hook providing optimistic update utilities for visit-related data.
+ * This hook helps reduce the number of network requests by updating SWR caches directly
+ * instead of triggering full revalidations across all visit-related hooks.
+ *
+ * @param patientUuid The UUID of the patient
+ * @returns Object containing optimistic update functions
+ */
+export function useOptimisticVisitMutations(patientUuid: string) {
+  const { mutate } = useSWRConfig();
+  const { currentVisit } = useVisit(patientUuid);
+
+  /**
+   * Optimistically updates visit data in SWR caches without triggering network requests.
+   * Updates both the current visit cache and visit list caches.
+   */
+  const updateVisitOptimistically = useCallback(
+    (visitUuid: string, updates: Partial<Visit>) => {
+      // Update current visit SWR cache if it matches
+      if (currentVisit?.uuid === visitUuid) {
+        mutate(
+          `${restBaseUrl}/visit?patient=${patientUuid}&v=custom`,
+          (current: any) => ({
+            ...current,
+            data: { ...current?.data, ...updates },
+          }),
+          false, // Don't revalidate
+        );
+      }
+
+      // Update visit lists across all hooks using regex pattern matching
+      const visitListPattern = new RegExp(`${restBaseUrl}/visit\\?patient=${patientUuid}`);
+
+      mutate(
+        visitListPattern,
+        (current: any) => {
+          if (!current?.data?.results) return current;
+          return {
+            ...current,
+            data: {
+              ...current.data,
+              results: current.data.results.map((visit: Visit) =>
+                visit.uuid === visitUuid ? { ...visit, ...updates } : visit,
+              ),
+            },
+          };
+        },
+        false, // Don't revalidate
+      );
+    },
+    [currentVisit, mutate, patientUuid],
+  );
+
+  /**
+   * Optimistically removes a visit from SWR caches without triggering network requests.
+   * Removes from visit lists and revalidates current visit if the deleted visit was current.
+   */
+  const removeVisitOptimistically = useCallback(
+    (visitUuid: string) => {
+      // Remove from all visit list caches
+      const visitListPattern = new RegExp(`${restBaseUrl}/visit\\?patient=${patientUuid}`);
+
+      mutate(
+        visitListPattern,
+        (current: any) => {
+          if (!current?.data?.results) return current;
+          return {
+            ...current,
+            data: {
+              ...current.data,
+              results: current.data.results.filter((visit: Visit) => visit.uuid !== visitUuid),
+            },
+          };
+        },
+        false, // Don't revalidate
+      );
+
+      // If deleted visit was current, revalidate current visit to get new state
+      if (currentVisit?.uuid === visitUuid) {
+        mutate(`${restBaseUrl}/visit?patient=${patientUuid}&v=custom`);
+      }
+    },
+    [currentVisit, mutate, patientUuid],
+  );
+
+  /**
+   * Optimistically adds a new visit to SWR caches without triggering network requests.
+   * Adds to visit lists and updates current visit cache if appropriate.
+   */
+  const addVisitOptimistically = useCallback(
+    (newVisit: Visit) => {
+      // Add to visit list caches
+      const visitListPattern = new RegExp(`${restBaseUrl}/visit\\?patient=${patientUuid}`);
+
+      mutate(
+        visitListPattern,
+        (current: any) => {
+          if (!current?.data?.results) return current;
+          return {
+            ...current,
+            data: {
+              ...current.data,
+              results: [newVisit, ...current.data.results],
+            },
+          };
+        },
+        false, // Don't revalidate
+      );
+
+      // If this is an active visit (no stopDatetime), update current visit cache
+      if (!newVisit.stopDatetime) {
+        mutate(
+          `${restBaseUrl}/visit?patient=${patientUuid}&v=custom`,
+          (current: any) => ({
+            ...current,
+            data: newVisit,
+          }),
+          false, // Don't revalidate
+        );
+      }
+    },
+    [mutate, patientUuid],
+  );
+
+  /**
+   * Selectively invalidates only specific visit-related data that cannot be optimistically updated.
+   * This replaces the global mutateVisit() pattern with targeted revalidation.
+   */
+  const invalidateVisitRelatedData = useCallback(
+    (options: VisitMutationOptions = {}) => {
+      const promises = [];
+
+      if (options.encounters) {
+        promises.push(mutate(new RegExp(`${restBaseUrl}/encounter\\?patient=${patientUuid}`)));
+      }
+      if (options.notes) {
+        promises.push(mutate(new RegExp(`${restBaseUrl}/encounter\\?patient=${patientUuid}.*obs=`)));
+      }
+      if (options.orders) {
+        promises.push(mutate(new RegExp(`${restBaseUrl}/order\\?patient=${patientUuid}`)));
+      }
+      if (options.observations) {
+        promises.push(mutate(new RegExp(`${restBaseUrl}/obs\\?patient=${patientUuid}`)));
+      }
+
+      return Promise.all(promises);
+    },
+    [mutate, patientUuid],
+  );
+
+  /**
+   * Revalidates only the current visit data with a single targeted request.
+   * This confirms the optimistic update with fresh server data.
+   */
+  const revalidateCurrentVisit = useCallback(() => {
+    // Single revalidation request for current visit only
+    return mutate(`${restBaseUrl}/visit?patient=${patientUuid}&v=custom`);
+  }, [mutate, patientUuid]);
+
+  /**
+   * Fallback function that triggers full revalidation when optimistic updates fail.
+   * This ensures data consistency when errors occur.
+   */
+  const revalidateAllVisitData = useCallback(() => {
+    // Revalidate current visit
+    mutate(`${restBaseUrl}/visit?patient=${patientUuid}&v=custom`);
+
+    // Revalidate visit lists
+    mutate(new RegExp(`${restBaseUrl}/visit\\?patient=${patientUuid}`));
+
+    // Revalidate related data
+    return invalidateVisitRelatedData({
+      encounters: true,
+      notes: true,
+      orders: true,
+      observations: true,
+    });
+  }, [mutate, patientUuid, invalidateVisitRelatedData]);
+
+  return {
+    addVisitOptimistically,
+    invalidateVisitRelatedData,
+    removeVisitOptimistically,
+    revalidateAllVisitData,
+    revalidateCurrentVisit,
+    updateVisitOptimistically,
+  };
+}

--- a/packages/esm-patient-forms-app/src/forms/form-entry.workspace.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.workspace.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { ExtensionSlot, useConnectivity, useFeatureFlag, useVisitContextStore } from '@openmrs/esm-framework';
+import { useSWRConfig } from 'swr';
+import { ExtensionSlot, useConnectivity, useVisit } from '@openmrs/esm-framework';
 import {
   clinicalFormsWorkspace,
+  invalidateVisitAndEncounterData,
+  useVisitOrOfflineVisit,
   type DefaultPatientWorkspaceProps,
   type FormEntryProps,
-  useVisitOrOfflineVisit,
 } from '@openmrs/esm-patient-common-lib';
 
 interface FormEntryComponentProps extends DefaultPatientWorkspaceProps {
@@ -28,7 +30,8 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({
   const { currentVisit } = useVisitOrOfflineVisit(patientUuid);
   const [showForm, setShowForm] = useState(true);
   const isOnline = useConnectivity();
-  const { mutateVisit } = useVisitContextStore();
+  const { mutate: mutateCurrentVisit } = useVisit(patientUuid);
+  const { mutate } = useSWRConfig();
 
   const state = useMemo(
     () => ({
@@ -48,7 +51,12 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({
       },
       closeWorkspaceWithSavedChanges: () => {
         typeof mutateForm === 'function' && mutateForm();
-        mutateVisit();
+        // Update current visit data for critical components
+        mutateCurrentVisit();
+
+        // Also invalidate visit history and encounter tables since form submission may create/update encounters
+        invalidateVisitAndEncounterData(mutate, patientUuid);
+
         closeWorkspaceWithSavedChanges();
       },
       promptBeforeClosing,
@@ -69,8 +77,9 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({
       patientUuid,
       patient,
       isOnline,
+      mutate,
       mutateForm,
-      mutateVisit,
+      mutateCurrentVisit,
       closeWorkspace,
       closeWorkspaceWithSavedChanges,
       promptBeforeClosing,

--- a/packages/esm-patient-forms-app/src/forms/form-entry.workspace.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.workspace.tsx
@@ -31,7 +31,7 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({
   const [showForm, setShowForm] = useState(true);
   const isOnline = useConnectivity();
   const { mutate: mutateCurrentVisit } = useVisit(patientUuid);
-  const { mutate } = useSWRConfig();
+  const { mutate: globalMutate } = useSWRConfig();
 
   const state = useMemo(
     () => ({
@@ -55,7 +55,7 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({
         mutateCurrentVisit();
 
         // Also invalidate visit history and encounter tables since form submission may create/update encounters
-        invalidateVisitAndEncounterData(mutate, patientUuid);
+        invalidateVisitAndEncounterData(globalMutate, patientUuid);
 
         closeWorkspaceWithSavedChanges();
       },
@@ -64,27 +64,27 @@ const FormEntry: React.FC<FormEntryComponentProps> = ({
       clinicalFormsWorkspaceName,
     }),
     [
-      formUuid,
-      visitUuid,
-      visitTypeUuid,
-      encounterUuid,
-      visitStartDatetime,
-      visitStopDatetime,
-      currentVisit?.uuid,
-      currentVisit?.visitType?.uuid,
-      currentVisit?.startDatetime,
-      currentVisit?.stopDatetime,
-      patientUuid,
-      patient,
-      isOnline,
-      mutate,
-      mutateForm,
-      mutateCurrentVisit,
-      closeWorkspace,
-      closeWorkspaceWithSavedChanges,
-      promptBeforeClosing,
       additionalProps,
       clinicalFormsWorkspaceName,
+      closeWorkspace,
+      closeWorkspaceWithSavedChanges,
+      currentVisit?.startDatetime,
+      currentVisit?.stopDatetime,
+      currentVisit?.uuid,
+      currentVisit?.visitType?.uuid,
+      encounterUuid,
+      formUuid,
+      globalMutate,
+      isOnline,
+      mutateCurrentVisit,
+      mutateForm,
+      patient,
+      patientUuid,
+      promptBeforeClosing,
+      visitStartDatetime,
+      visitStopDatetime,
+      visitTypeUuid,
+      visitUuid,
     ],
   );
 

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.workspace.tsx
@@ -200,11 +200,11 @@ const VisitNotesForm: React.FC<VisitNotesFormProps> = ({
   const currentImages = watch('images');
 
   const { mutateVisitNotes } = useVisitNotes(patientUuid);
-  const { mutate } = useSWRConfig();
+  const { mutate: globalMutate } = useSWRConfig();
 
   const mutateAttachments = useCallback(
-    () => mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/attachment`)),
-    [mutate],
+    () => globalMutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/attachment`)),
+    [globalMutate],
   );
 
   const locationUuid = session?.sessionLocation?.uuid;
@@ -449,7 +449,7 @@ const VisitNotesForm: React.FC<VisitNotesFormProps> = ({
         .then(() => {
           // Invalidate encounter and notes data since we created a new encounter with notes
           // Also invalidate visit history table since the visit now has new encounters
-          invalidateVisitAndEncounterData(mutate, patientUuid);
+          invalidateVisitAndEncounterData(globalMutate, patientUuid);
           mutateVisitNotes();
 
           if (images?.length) {
@@ -486,9 +486,9 @@ const VisitNotesForm: React.FC<VisitNotesFormProps> = ({
       encounterNoteTextConceptUuid,
       encounterTypeUuid,
       formConceptUuid,
+      globalMutate,
       isEditing,
       locationUuid,
-      mutate,
       mutateAttachments,
       mutateVisitNotes,
       patientUuid,

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.workspace.tsx
@@ -22,9 +22,8 @@ import {
   useLayoutType,
   useSession,
   useVisit,
-  useVisitContextStore,
 } from '@openmrs/esm-framework';
-import { type DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
+import { type DefaultPatientWorkspaceProps, useOptimisticVisitMutations } from '@openmrs/esm-patient-common-lib';
 import { type ConfigObject } from '../config-schema';
 import {
   calculateBodyMassIndex,
@@ -82,7 +81,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
   const [showErrorNotification, setShowErrorNotification] = useState(false);
   const [showErrorMessage, setShowErrorMessage] = useState(false);
   const abortController = useAbortController();
-  const { mutateVisit } = useVisitContextStore();
+  const { invalidateVisitRelatedData } = useOptimisticVisitMutations(patientUuid);
 
   const isLoadingInitialValues = useMemo(
     () => (formContext === 'creating' ? false : isLoadingEncounter),
@@ -198,7 +197,8 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
             if (mutateEncounter) {
               mutateEncounter();
             }
-            mutateVisit();
+            // Only invalidate observations data since we created new vitals/biometrics observations
+            invalidateVisitRelatedData({ observations: true, encounters: true });
             invalidateCachedVitalsAndBiometrics();
             closeWorkspaceWithSavedChanges();
             showSnackbar({
@@ -237,7 +237,7 @@ const VitalsAndBiometricsForm: React.FC<VitalsAndBiometricsFormProps> = ({
       formContext,
       initialFieldValuesMap,
       mutateEncounter,
-      mutateVisit,
+      invalidateVisitRelatedData,
       patientUuid,
       session?.sessionLocation?.uuid,
       t,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR addresses performance bottlenecks in visit and encounter data management by replacing global revalidation with more targeted cache invalidation.

Presently, the global `mutateVisit()` revalidation function triggers 13+ unnecessary network requests per operation, and all visit-related components are revalidated even when only specific data changed.

This approach:

- Replaces the global `mutateVisit()` with targeted SWR cache invalidation to reduce 13+ revalidation requests to 1 per operation.
- Moves revalidation utilities from the chart app to `@openmrs/esm-patient-common-lib` for better reusability.
- Creates multiple utility functions for surgical cache invalidation:
  - `invalidateVisitHistory()` - Only invalidates visit history table data
  - `invalidatePatientEncounters()` - Only invalidates encounter data
  - `invalidateVisitAndEncounterData()` - Combines both for operations affecting both
  - `useOptimisticVisitMutations()` - Hook for optimistic updates without network requests
- Fixes the encounter table cache invalidation regex to handle flexible URL parameter order.
- Updates all visit/encounter operations to use surgical cache targeting:
  - Visit creation/editing (`visit-form.workspace.tsx`)
  - Visit deletion/restoration (`useDeleteVisit.hook.tsx`)
  - Encounter deletion (`encounters-table.component.tsx`)
  - Form submissions (`form-entry.workspace.tsx`)
  - Visit note creation (`visit-notes-form.workspace.tsx`)
  - Order basket operations (`order-basket.workspace.tsx`)
  - Vitals/biometrics forms (`vitals-biometrics-form.workspace.tsx`)
  - End visit dialog (`end-visit-dialog.component.tsx`)
- Preserves current visit component performance by avoiding unnecessary revalidation.
- Ensures the `AllEncountersTable` updates correctly after form submissions and other encounter operations.

This eliminates the performance issue where visit CRUD operations triggered excessive network requests returning 304 responses, while maintaining proper data synchronization across all visit and encounter tables.

## Screenshots

### Before

https://github.com/user-attachments/assets/f66b3805-aaa2-4b87-b17d-474614f60d3d

### After

https://github.com/user-attachments/assets/908ec1dc-6122-4145-89b4-25f81c9e36f9

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
