### PR TITLE
(fix) Filter out undefined encounters in EncountersTable

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
@@ -86,7 +86,10 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
     externalModuleName: '@openmrs/esm-patient-forms-app',
   });
   const { htmlFormEntryForms } = formsConfig;
-  const paginatedMappedEncounters = useMemo(() => paginatedEncounters?.map(mapEncounter), [paginatedEncounters]);
+  const paginatedMappedEncounters = useMemo(
+    () => (paginatedEncounters ?? []).map(mapEncounter).filter(Boolean),
+    [paginatedEncounters],
+  );
 
   const tableHeaders = [
     {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
@@ -221,6 +221,8 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
                   {rows?.map((row, i) => {
                     const encounter = paginatedMappedEncounters[i];
 
+                    if (!encounter) return null;
+
                     const isVisitNoteEncounter = (encounter: MappedEncounter) =>
                       encounter.encounterType === 'Visit Note' && !encounter.form;
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This fix ensures `paginatedMappedEncounters` only contains valid encounter objects by filtering out any undefined or null values after mapping. This prevents 'Cannot read properties of undefined (reading "id")' errors in the UI and E2E tests when the encounters array is empty or contains invalid data. This is a defensive and canonical fix that improves robustness without affecting valid data rendering.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
