### PR TITLE
(feat): Add support to render visit details in encounter list

### DIFF
--- a/packages/esm-patient-chart-app/src/clinical-views/hooks/useEncounterRows.ts
+++ b/packages/esm-patient-chart-app/src/clinical-views/hooks/useEncounterRows.ts
@@ -7,7 +7,7 @@ export const encounterRepresentation =
   'custom:(uuid,encounterDatetime,encounterType,location:(uuid,name),' +
   'patient:(uuid,display,age,identifiers,person),encounterProviders:(uuid,provider:(uuid,name)),' +
   'obs:(uuid,obsDatetime,voided,groupMembers,concept:(uuid,name:(uuid,name)),value:(uuid,name:(uuid,name),' +
-  'names:(uuid,conceptNameType,name))),form:(uuid,name))';
+  'names:(uuid,conceptNameType,name))),form:(uuid,name),visit:(uuid,startDatetime,stopDatetime,visitType:(uuid,display)))';
 
 interface EncounterResponse {
   results: Encounter[];

--- a/packages/esm-patient-chart-app/src/clinical-views/types.ts
+++ b/packages/esm-patient-chart-app/src/clinical-views/types.ts
@@ -25,7 +25,15 @@ export interface Encounter extends OpenmrsResource {
   form?: {
     uuid: string;
   };
-  visit?: string;
+  visit?: {
+    uuid: string;
+    startDatetime: string;
+    stopDatetime?: string;
+    visitType?: {
+      uuid: string;
+      display: string;
+    };
+  };
 }
 
 export interface Observation {
@@ -273,33 +281,13 @@ export interface ConfigConcepts {
   otherConceptUuid: string;
 }
 
-export interface Encounter extends OpenmrsResource {
-  encounterDatetime: Date;
-  encounterType: { uuid: string; name: string };
-  patient: {
-    uuid: string;
-    display: string;
-    age: number;
-    birthDate: string;
-  };
-  location: {
-    uuid: string;
-    display: string;
-    name: string;
-  };
-  encounterProviders?: Array<{ encounterRole: string; provider: { uuid: string; name: string } }>;
-  obs: Array<Observation>;
-  form?: {
-    uuid: string;
-  };
-  visit?: string;
-}
-
 export enum EncounterPropertyType {
   location = 'location',
   provider = 'provider',
+  encounterType = 'encounterType',
   visitType = 'visitType',
   ageAtEncounter = 'ageAtEncounter',
+  visitDate = 'visitDate',
 }
 
 export interface GetObsFromEncounterParams {

--- a/packages/esm-patient-chart-app/src/clinical-views/utils/helpers.ts
+++ b/packages/esm-patient-chart-app/src/clinical-views/utils/helpers.ts
@@ -137,7 +137,8 @@ export function getObsFromEncounter({
   config,
 }: GetObsFromEncounterParams) {
   let obs = findObs(encounter, obsConcept);
-  if (!encounter || !obsConcept) {
+
+  if (!encounter && !obsConcept) {
     return '--';
   }
 
@@ -149,7 +150,7 @@ export function getObsFromEncounter({
 
   // handles things like location, provider, visit type, etc. that are not in the encounter
   if (type) {
-    getEncounterProperty(encounter, type);
+    return getEncounterProperty(encounter, type);
   }
 
   if (secondaryConcept && typeof obs.value === 'object' && obs.value.names) {
@@ -203,12 +204,23 @@ export const getEncounterProperty = (encounter: Encounter, type: EncounterProper
     return encounter.encounterProviders.map((p) => p.provider.name).join(' | ');
   }
 
-  if (type === 'visitType') {
+  if (type === 'encounterType') {
     return encounter.encounterType.name;
   }
 
   if (type === 'ageAtEncounter') {
     return age(encounter.patient.birthDate, encounter.encounterDatetime);
+  }
+
+  if (type === 'visitDate') {
+    if (encounter.visit?.startDatetime) {
+      return formatDate(parseDate(encounter.visit.startDatetime), { mode: 'wide' });
+    }
+    return '--';
+  }
+
+  if (type === 'visitType') {
+    return encounter.visit?.visitType?.display ?? '--';
   }
 };
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR does the following:
1. Adds support to configure encounter lists to display visit details like the visit date, if there is a visit date attached to the encounter, if not it will render the default of `--`. 
2. Fixes a bug in an if condition where previously, the helper function would return a `--` if there was no `obsConcept` which shouldn't be the case as there would be no `obsConcept` configured for columns that intend to display encounter/visit details.
3. Previously the type `visitType` actually displayed the `encounterType`. This was adjusted so that the type `visitType` actually renders the `visitType` by adding support for it.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
<img width="1407" height="352" alt="Screenshot 2025-07-17 at 2 42 07 PM" src="https://github.com/user-attachments/assets/9215c862-99cc-4c69-9594-6163847d3c2a" />

After (support for visit date):

<img width="1407" height="352" alt="Screenshot 2025-07-17 at 2 27 12 PM" src="https://github.com/user-attachments/assets/2df9c2bc-ac77-4fd8-a6ba-015bb3f45cd1" />

Support for visit type:
<img width="1407" height="352" alt="Screenshot 2025-07-17 at 2 30 04 PM" src="https://github.com/user-attachments/assets/35444ee4-c994-428a-80da-a6ec60907e91" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
