### PR TITLE
(fix): Typo in attachment privilege name

### DIFF
--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
@@ -222,7 +222,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({
         </div>
       </ModalBody>
       <ModalFooter>
-        <UserHasAccess privilege="Create Attachment">
+        <UserHasAccess privilege="Create Attachments">
           <Button kind="secondary" onClick={handleCancelUpload} size="lg">
             {getCoreTranslation('cancel')}
           </Button>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes a typo in the privilege name that prevented users from creating attachments. The correct privilege name as specified [here](https://github.com/openmrs/openmrs-module-attachments/blob/c2dd0c1d95984cd85fa8203748f003738906ff8a/omod/src/main/resources/config.xml#L160) is `Create Attachments` and not `Create Attachment`.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
