### PR TITLE
(feat) O3-4882: Remove defaultInitialServiceQueue config element from the patient chart

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -85,11 +85,6 @@ export const esmPatientChartSchema = {
     _description: 'Whether start visit form should display service queue fields`',
     _default: false,
   },
-  defaultInitialServiceQueue: {
-    _type: Type.String,
-    _description: 'The name of the default service queue to be selected when the start visit form is opened',
-    _default: 'Outpatient Triage',
-  },
   showUpcomingAppointments: {
     _type: Type.Boolean,
     _description: 'Whether start visit form should display upcoming appointments',


### PR DESCRIPTION
…

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
 Remove `defaultInitialServiceQueue` config element from the patient chart to live in Service Queues app

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-4882

## Other
<!-- Anything not covered above -->
