### PR TITLE
(fix): Encounter tile should be able to render lab results

### DIFF
--- a/packages/esm-patient-chart-app/src/clinical-views/utils/index.ts
+++ b/packages/esm-patient-chart-app/src/clinical-views/utils/index.ts
@@ -35,7 +35,7 @@ export const getEncounterTileColumns = (tileDefinition: MenuCardProps, config: C
           config: config,
         });
       }
-      return typeof obsValue === 'string' || typeof obsValue === 'number' ? obsValue : obsValue?.name?.name ?? '--';
+      return typeof obsValue === 'string' || (typeof obsValue === 'number' && !isNaN(obsValue)) ? obsValue : obsValue?.name?.name ?? '--';
     },
     getSummaryObsValue: column.hasSummary
       ? (encounter: Encounter) => {

--- a/packages/esm-patient-chart-app/src/clinical-views/utils/index.ts
+++ b/packages/esm-patient-chart-app/src/clinical-views/utils/index.ts
@@ -35,7 +35,7 @@ export const getEncounterTileColumns = (tileDefinition: MenuCardProps, config: C
           config: config,
         });
       }
-      return typeof obsValue === 'string' ? obsValue : obsValue?.name?.name ?? '--';
+      return typeof obsValue === 'string' || typeof obsValue === 'number' ? obsValue : obsValue?.name?.name ?? '--';
     },
     getSummaryObsValue: column.hasSummary
       ? (encounter: Encounter) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Previously, if the value of an observation wasn't a string, it was assumed that it would always be an object. This meant that lab test results would not be rendered. This PR fixes it by checking if the value is a string or a number.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
<img width="1253" height="148" alt="Screenshot 2025-07-25 at 6 34 45 PM" src="https://github.com/user-attachments/assets/e7ff426a-8bdd-48b0-89f8-8d161807c5b5" />

After:
<img width="1253" height="148" alt="Screenshot 2025-07-25 at 6 34 25 PM" src="https://github.com/user-attachments/assets/0fb7e910-20d4-4899-a2df-cbc5bf34a4f3" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
