### PR TITLE
(fix) Resolve failing workspace launcher in form-entry app

### DIFF
--- a/packages/esm-patient-chart-app/src/index.ts
+++ b/packages/esm-patient-chart-app/src/index.ts
@@ -4,7 +4,7 @@ import {
   getAsyncLifecycle,
   getSyncLifecycle,
 } from '@openmrs/esm-framework';
-import * as PatientCommonLib from '@openmrs/esm-patient-common-lib';
+import * as Framework from '@openmrs/esm-framework';
 import { createDashboardLink } from '@openmrs/esm-patient-common-lib';
 import { esmPatientChartSchema } from './config-schema';
 import { moduleName } from './constants';
@@ -22,9 +22,9 @@ import startVisitActionButtonOnPatientSearch from './visit/start-visit-button.co
 import stopVisitActionButtonComponent from './actions-buttons/stop-visit.component';
 import visitAttributeTagsComponent from './patient-banner-tags/visit-attribute-tags.component';
 
-// This allows @openmrs/esm-patient-common-lib to be accessed by modules that are not
+// This allows @openmrs/esm-framework to be accessed by modules that are not
 // using webpack. This is used for ngx-formentry.
-window['_openmrs_esm_patient_common_lib'] = PatientCommonLib;
+window['_openmrs_esm_framework'] = Framework;
 
 export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR makes **@openmrs/esm-framework** available for AFE to enable **workspace** launcher work since its migration to core.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
Related to this PR https://github.com/openmrs/openmrs-ngx-formentry/pull/160

@andrineM @RAJABIBRAZ this should resolve https://thepalladiumgroup.atlassian.net/browse/KHP3-8090
## Other
<!-- Anything not covered above -->
