### PR TITLE
(fix): Order basket should record orders under configured encounter type

### DIFF
--- a/packages/esm-patient-orders-app/src/api/api.ts
+++ b/packages/esm-patient-orders-app/src/api/api.ts
@@ -41,7 +41,10 @@ export function getMedicationByUuid(abortController: AbortController, orderUuid:
   );
 }
 
-export function useOrderEncounter(patientUuid: string): {
+export function useOrderEncounter(
+  patientUuid: string,
+  encounterTypeUuid: string,
+): {
   visitRequired: boolean;
   isLoading: boolean;
   error: Error;
@@ -74,17 +77,28 @@ export function useOrderEncounter(patientUuid: string): {
       ? {
           visitRequired: true,
           isLoading: visit?.isLoading,
-          encounterUuid: visit?.currentVisit?.encounters?.[0]?.uuid,
+          encounterUuid: visit?.currentVisit?.encounters?.find(
+            (encounter) => encounter.encounterType?.uuid === encounterTypeUuid,
+          )?.uuid,
           error: visit?.error,
           mutate: visit?.mutate,
         }
       : {
           visitRequired: false,
           isLoading: todayEncounter?.isLoading,
-          encounterUuid: todayEncounter?.data?.data?.results?.[0]?.uuid,
+          encounterUuid: todayEncounter?.data?.data?.results?.find(
+            (encounter) => encounter.encounterType.uuid === encounterTypeUuid,
+          )?.uuid,
           error: todayEncounter?.error,
           mutate: todayEncounter?.mutate,
         };
-  }, [isLoadingSystemVisitSetting, errorFetchingSystemVisitSetting, visit, todayEncounter, systemVisitEnabled]);
+  }, [
+    isLoadingSystemVisitSetting,
+    errorFetchingSystemVisitSetting,
+    visit,
+    todayEncounter,
+    systemVisitEnabled,
+    encounterTypeUuid,
+  ]);
   return results;
 }

--- a/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/order-basket.workspace.tsx
@@ -43,7 +43,7 @@ const OrderBasket: React.FC<DefaultPatientWorkspaceProps> = ({
     encounterUuid,
     error: errorFetchingEncounterUuid,
     mutate: mutateEncounterUuid,
-  } = useOrderEncounter(patientUuid);
+  } = useOrderEncounter(patientUuid, config.orderEncounterType);
   const [isSavingOrders, setIsSavingOrders] = useState(false);
   const [creatingEncounterError, setCreatingEncounterError] = useState('');
   const { mutate: mutateOrders } = useMutatePatientOrders(patientUuid);


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Up until now, the behavior of the order basket has been to always record orders under the first encounter of the list of encounters of the current visit, or in the case of visits is disabled, the first encounter from the list of encounters made on that day. This means that orders got assigned to random encounters. If there was no encounter found, then an encounter of the encounter type that is configured [here](https://github.com/openmrs/openmrs-esm-patient-chart/blob/e3f23625bf3f52259e95243010805bfde1d5f1a5/packages/esm-patient-orders-app/src/config-schema.ts#L4) would be created.
This PR updates the functionality to instead find an encounter of the configured type, instead of returning just the first encounter.


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
