### PR TITLE
(feat) O3-4859 : RDE support for the lab order results workspace

### DIFF
--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.component.tsx
@@ -97,6 +97,22 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
                 message: t('timeIsRequired', 'time is required'),
               });
             }
+
+            if (data.retrospectiveTime) {
+              const timeValue = data.retrospectiveTime;
+              const pattern = /^(0[1-9]|1[0-2]):([0-5][0-9])$/;
+              if (!pattern.test(timeValue)) {
+                ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  path: ['retrospectiveTime'],
+                  message: t(
+                    'invalidTimeFormatMessage',
+                    'Please enter a valid time in 12 HR format HH:MM (e.g., 02:30).',
+                  ),
+                });
+              }
+            }
+
             if (!data.retrospectiveTimeFormat) {
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,
@@ -365,29 +381,13 @@ const LabResultsForm: React.FC<LabResultsFormProps> = ({
               <Controller
                 name={'retrospectiveTime'}
                 control={control}
-                render={({ field: { onChange, value } }) => (
+                render={({ field: { onChange, value, onBlur } }) => (
                   <div className={styles.timePickerWrapper}>
                     <TimePicker
                       id={'retrospective-time-picker-input'}
                       labelText={t('time', 'Time')}
-                      onBlur={(event) => {
-                        const timeValue = event.target.value;
-                        if (timeValue) {
-                          const pattern = /^(0[1-9]|1[0-2]):([0-5][0-9])$/;
-                          if (!pattern.test(timeValue)) {
-                            setError('retrospectiveTime', {
-                              type: 'manual',
-                              message: t(
-                                'invalidTimeFormatMessage',
-                                'Please enter a valid time in 12 HR format HH:MM (e.g., 02:30).',
-                              ),
-                            });
-                            setValue('retrospectiveTime', '');
-                          }
-                        }
-                      }}
+                      onBlur={onBlur}
                       onChange={(event) => onChange(event.target.value)}
-                      pattern="^(0[1-9]|1[0-2]):([0-5][0-9])$"
                       value={value}
                       className={styles.timePicker}
                       invalid={Boolean(errors.retrospectiveTime)}

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.scss
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.scss
@@ -93,3 +93,26 @@
 .emptyFormError {
   margin: 0.625rem 0;
 }
+
+.pickerWrapper {
+  display: flex;
+  align-items: center;
+  margin: layout.$spacing-05;
+  flex: 1;
+}
+
+.datePicker {
+  :global(.cds--date-picker-input__wrapper) {
+    inline-size: layout.$spacing-13;
+  }
+}
+
+.timePicker {
+  display: flex;
+  align-items: baseline;
+
+  :global(.cds--form-requirement) {
+    max-width: layout.$spacing-12;
+    max-height: 0 !important;
+  }
+}

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results.resource.ts
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results.resource.ts
@@ -10,7 +10,7 @@ const labEncounterRepresentation =
 const labConceptRepresentation =
   'custom:(uuid,display,name,datatype,set,answers,hiNormal,hiAbsolute,hiCritical,lowNormal,lowAbsolute,lowCritical,units,allowDecimal,' +
   'setMembers:(uuid,display,answers,datatype,hiNormal,hiAbsolute,hiCritical,lowNormal,lowAbsolute,lowCritical,units,allowDecimal,set,setMembers:(uuid)))';
-const conceptObsRepresentation = 'custom:(uuid,display,concept:(uuid,display),groupMembers,value)';
+const conceptObsRepresentation = 'custom:(uuid,obsDatetime,display,concept:(uuid,display),groupMembers,value)';
 
 type NullableNumber = number | null | undefined;
 export interface LabOrderConcept {
@@ -149,6 +149,7 @@ export function useLabEncounter(encounterUuid: string) {
 
 export function useObservation(obsUuid: string) {
   const url = `${restBaseUrl}/obs/${obsUuid}?v=${conceptObsRepresentation}`;
+  // const url = `${restBaseUrl}/obs/${obsUuid}?v=full`;
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: Observation }, Error>(
     obsUuid ? url : null,
@@ -261,7 +262,6 @@ export function createObservationPayload(
 }
 
 export function updateObservation(observationUuid: string, payload: Record<string, any>) {
-  console.log('DEBUG: Updating observation with payload', payload);
   return openmrsFetch(`${restBaseUrl}/obs/${observationUuid}`, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds retrospective data entry capability to the lab results workspace. With this new change, the user can select an optional date, which will be recorded as the `obsDatetime` value in the encounter's observation.

## Screenshots
<img width="496" height="1080" alt="image" src="https://github.com/user-attachments/assets/88164bd0-38f9-405a-9414-3a61c7f175ed" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4859

## Other
<!-- Anything not covered above -->
