### PR TITLE
(fix): Add missing translation wrappers

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -55,9 +55,9 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
         lastUpdated: allergy.lastUpdated ? formatDate(parseDate(allergy.lastUpdated), { time: false }) : '--',
         note: allergy?.note ?? '--',
         reaction: allergy.reactionManifestations?.sort((a, b) => a.localeCompare(b))?.join(', ') ?? '--',
-        reactionSeverity: allergy.reactionSeverity?.toUpperCase() ?? '--',
+        reactionSeverity: t(allergy.reactionSeverity) ?? '--',
       })),
-    [allergies],
+    [allergies, t],
   );
 
   if (isLoading) {

--- a/packages/esm-patient-tests-app/src/test-results/overview/common-overview.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/overview/common-overview.component.tsx
@@ -19,9 +19,9 @@ const CommonOverview: React.FC<CommonOverviewProps> = ({ patientUuid, overviewDa
   const { t } = useTranslation();
 
   const headers = [
-    { key: 'name', header: 'Test Name' },
-    { key: 'value', header: 'Value' },
-    { key: 'range', header: 'Reference Range' },
+    { key: 'name', header: t('testName', 'Test Name') },
+    { key: 'value', header: t('value', 'Value') },
+    { key: 'range', header: t('referenceRange', 'Reference range') },
   ];
 
   const handleSeeAvailableResults = useCallback(() => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR wraps some strings in the t function so that they can be translated.

## Screenshots
<!-- Required if you are making UI changes. -->
After in English:
<img width="1399" height="218" alt="Screenshot 2025-07-31 at 2 28 52 PM" src="https://github.com/user-attachments/assets/a35de01e-fa28-472d-96df-ffa54561c765" />

After in French:
<img width="1399" height="218" alt="Screenshot 2025-07-31 at 2 29 02 PM" src="https://github.com/user-attachments/assets/3878b75b-4c3d-4d2e-948d-1019b09620be" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
