### PR TITLE
(test) O3-4944: Add delete scenario to immunizations e2e test

### DIFF
--- a/e2e/specs/immunizations.spec.ts
+++ b/e2e/specs/immunizations.spec.ts
@@ -15,11 +15,11 @@ test('Record, edit and delete an immunization', async ({ page, patient }) => {
     await immunizationsPage.goTo(patient.uuid);
   });
 
-  await test.step('And I click the Record immunizations button', async () => {
+  await test.step('And I start recording an immunization', async () => {
     await page.getByRole('button', { name: /record immunizations/i }).click();
   });
 
-  await test.step('Then I should see the Immunization form in the workspace', async () => {
+  await test.step('Then I should see the immunizations form launch in the workspace', async () => {
     await expect(page.getByText(/immunization form/i)).toBeVisible();
   });
 
@@ -30,60 +30,60 @@ test('Record, edit and delete an immunization', async ({ page, patient }) => {
     await vaccinationDateInput.getByRole('spinbutton', { name: /year/i }).fill('2024');
   });
 
-  await test.step('And I choose "Hepatitis B vaccination" from the immunization dropdown', async () => {
+  await test.step('And I choose "Hepatitis B vaccination"', async () => {
     await page.getByRole('combobox', { name: /immunization/i }).click();
     await page.getByText(/hepatitis b vaccination/i).click();
   });
 
-  await test.step('And I click the Save button', async () => {
+  await test.step('And I save the immunization', async () => {
     await page.getByRole('button', { name: /save/i }).click();
   });
 
-  await test.step('Then I should see a success notification for the saved vaccination', async () => {
+  await test.step('Then I should see a success notification', async () => {
     await expect(page.getByText(/vaccination saved successfully/i)).toBeVisible();
   });
 
-  await test.step('Then I should see the immunizations History card with correct headers', async () => {
+  await test.step('Then the immunizations history card should have the expected headers', async () => {
     await expect(historyHeaderRow).toContainText(/vaccine/i);
     await expect(historyHeaderRow).toContainText(/doses/i);
   });
 
-  await test.step('And I should see a row with the correct immunization name and dose', async () => {
+  await test.step('And the immunizations history card should have the expected immunization name and dose', async () => {
     await expect(immunizationHistoryTable).toContainText(/hepatitis b vaccination/i);
     await expect(immunizationHistoryTable).toContainText(/dose 1/i);
   });
 
-  await test.step('And I should see the immunizations summary table with correct headers', async () => {
+  await test.step('And the immunizations summary table should have the expected headers', async () => {
     await expect(headerRow).toContainText(/vaccine/i);
     await expect(headerRow).toContainText(/recent vaccination/i);
   });
 
-  await test.step('And I should see the a table row with the correct immunization details', async () => {
+  await test.step('And the immunizations summary table should show the vaccine name and the last dose date', async () => {
     await expect(immunizationType).toContainText(/hepatitis b vaccination/i);
     await expect(vaccinationDate).toContainText(/last dose on 08-Mar-2024, dose 1/i);
   });
 
-  await test.step('When I click the Expand all rows button', async () => {
+  await test.step('When I expand all rows', async () => {
     await immunizationsSummaryTable.getByRole('button', { name: /expand all rows/i }).click();
   });
 
-  await test.step('Then I should see the expanded immunization details section', async () => {
+  await test.step('Then I should see the expanded immunization details section showing the dose number and vaccination date', async () => {
     await expect(immunizationsSummaryTable.getByText(/dose number within series/i)).toBeVisible();
     await expect(immunizationsSummaryTable.getByText(/vaccination date/i)).toBeVisible();
   });
 
-  await test.step('And I click the Edit button for the immunization', async () => {
+  await test.step('And I edit the immunization', async () => {
     await immunizationsSummaryTable.getByRole('button', { name: /edit/i }).click();
   });
 
-  await test.step('Then I should see the immunization form in edit mode with the current values', async () => {
+  await test.step('Then the immunization form should launch in edit mode with the current values pre-filled', async () => {
     await expect(page.getByText(/immunization form/i)).toBeVisible();
   });
 
-  await test.step('Then the vaccine dropdown should show Hepatitis B vaccination and be disabled', async () => {
-    const dropdown = page.getByRole('combobox', { name: /immunization/i });
-    await expect(dropdown).toBeDisabled();
-    await expect(dropdown).toHaveText(/hepatitis b vaccination/i);
+  await test.step('Then the vaccine field should show "Hepatitis B vaccination" and be disabled', async () => {
+    const vaccineField = page.getByRole('combobox', { name: /immunization/i });
+    await expect(vaccineField).toBeDisabled();
+    await expect(vaccineField).toHaveText(/hepatitis b vaccination/i);
   });
 
   await test.step('And I set the vaccination date to 02/01/2025', async () => {
@@ -99,44 +99,44 @@ test('Record, edit and delete an immunization', async ({ page, patient }) => {
     await doseNumberInput.fill('2');
   });
 
-  await test.step('And I click the Save button', async () => {
+  await test.step('And I save the changes', async () => {
     await page.getByRole('button', { name: /save/i }).click();
   });
 
-  await test.step('Then I should see a success notification for the updated vaccination', async () => {
+  await test.step('Then I should see a success notification', async () => {
     await expect(page.getByText(/vaccination saved successfully/i)).toBeVisible();
   });
 
-  await test.step('And I should see the updated immunization in the History card', async () => {
+  await test.step('And the immunizations history card should show the updated immunization', async () => {
     await expect(immunizationHistoryTable).toContainText(/02-Jan-2025/i);
     await expect(immunizationHistoryTable).toContainText(/dose 2/i);
   });
 
-  await test.step('And I should see the updated immunization details in the table', async () => {
+  await test.step('And the immunizations summary table should show the updated immunization details', async () => {
     await expect(
       immunizationsSummaryTable.getByRole('cell', { name: /last dose on 02-Jan-2025, dose 2/i }),
     ).toBeVisible();
   });
 
-  await test.step('And expanding the details section should show the correct updated information', async () => {
+  await test.step('And the expanded section should show the updated values', async () => {
     await expect(immunizationsSummaryTable.getByText(/dose number within series/i)).toBeVisible();
     await expect(immunizationsSummaryTable.getByRole('cell', { name: '2', exact: true })).toBeVisible();
     await expect(immunizationsSummaryTable.getByRole('cell', { name: '02-Jan-2025', exact: true })).toBeVisible();
   });
 
-  await test.step('And I delete the immunization dose', async () => {
+  await test.step('And when I delete the immunization dose', async () => {
     await immunizationsSummaryTable.getByRole('button', { name: /delete/i }).click();
   });
 
-  await test.step('Then a confirmation modal should open', async () => {
+  await test.step('Then a confirmation modal should appear', async () => {
     await expect(page.getByRole('dialog')).toContainText(/are you sure you want to delete/i);
   });
 
-  await test.step('And when I confirm deletion', async () => {
+  await test.step('And when I confirm the deletion', async () => {
     await page.getByRole('button', { name: 'danger Delete' }).click();
   });
 
-  await test.step('Then I should see a success notification confirming deletion', async () => {
+  await test.step('Then I should see a success notification', async () => {
     await expect(page.getByText(/Immunization dose deleted/i)).toBeVisible();
   });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR enhances the immunizations.spec.ts Playwright test to cover the full lifecycle of an immunization record:

- Add step coverage for Immunization History card

- Verifies correct headers and row data after adding a new immunization.

- Improve summary table checks

- Confirms correct headers and updated dose/date details after editing.

- Add delete flow verification

- Clicks delete action, validates confirmation modal, confirms deletion.

- Verifies success notification and empty state message.

- Refactor date input filling


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[jira ticket ](https://openmrs.atlassian.net/browse/O3-4944?focusedCommentId=158244)

## Other
<!-- Anything not covered above -->
