### PR TITLE
(feat) O3-3664: enhance visit form to handle deceased patients

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.resource.ts
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.resource.ts
@@ -115,7 +115,7 @@ export function deleteVisitAttribute(visitUuid: string, visitAttributeUuid: stri
   });
 }
 
-export function useVisitFormSchemaAndDefaultValues(visitToEdit: Visit) {
+export function useVisitFormSchemaAndDefaultValues(visitToEdit: Visit, config: { isDeceased: boolean }) {
   const { t } = useTranslation();
   const { visitAttributeTypes, restrictByVisitLocationTag } = useConfig<ChartConfig>();
   const isEmrApiModuleInstalled = useFeatureFlag('emrapi-module');
@@ -140,8 +140,13 @@ export function useVisitFormSchemaAndDefaultValues(visitToEdit: Visit) {
     const startDateTime = convertToDateTimeFields(visitToEdit?.startDatetime ?? now);
     const stopDateTime = convertToDateTimeFields(visitToEdit?.stopDatetime ?? now);
 
-    const visitStatus: VisitStatus =
-      visitToEdit == null ? 'new' : visitToEdit.stopDatetime === null ? 'ongoing' : 'past';
+    const visitStatus: VisitStatus = config.isDeceased
+      ? 'past'
+      : visitToEdit == null
+        ? 'new'
+        : visitToEdit.stopDatetime === null
+          ? 'ongoing'
+          : 'past';
 
     const defaultValues: Partial<VisitFormData> = {
       visitStatus,
@@ -275,7 +280,7 @@ export function useVisitFormSchemaAndDefaultValues(visitToEdit: Visit) {
       });
 
     return { visitFormSchema, defaultValues, firstEncounterDateTime, lastEncounterDateTime };
-  }, [t, visitAttributeTypes, visitToEdit, defaultVisitLocation, emrConfiguration]);
+  }, [t, visitAttributeTypes, visitToEdit, defaultVisitLocation, emrConfiguration, config.isDeceased]);
 }
 
 // Returns a Date object based on date, time and am/pm inputs from user.

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -775,7 +775,11 @@ describe('useVisitFormSchemaAndDefaultValues', () => {
       result: {
         current: { visitFormSchema, defaultValues },
       },
-    } = renderHook(() => useVisitFormSchemaAndDefaultValues(mockPastVisitWithEncounters));
+    } = renderHook(() =>
+      useVisitFormSchemaAndDefaultValues(mockPastVisitWithEncounters, {
+        isDeceased: false,
+      }),
+    );
 
     // verify start time set to past end time
     const stopDateTime = dayjs(mockPastVisitWithEncounters.stopDatetime);

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
@@ -113,8 +113,9 @@ const VisitForm: React.FC<VisitFormProps> = ({
   const [visitFormCallbacks, setVisitFormCallbacks] = useVisitFormCallbacks();
   const [extraVisitInfo, setExtraVisitInfo] = useState(null);
 
+  const isDeceased = Boolean(patient?.deceasedDateTime);
   const { visitFormSchema, defaultValues, firstEncounterDateTime, lastEncounterDateTime } =
-    useVisitFormSchemaAndDefaultValues(visitToEdit);
+    useVisitFormSchemaAndDefaultValues(visitToEdit, { isDeceased });
 
   const methods = useForm<VisitFormData>({
     mode: 'all',
@@ -451,8 +452,18 @@ const VisitForm: React.FC<VisitFormProps> = ({
                       </ContentSwitcher>
                     ) : (
                       <ContentSwitcher selectedIndex={selectedIndex} onChange={({ name }) => onChange(name)} size="md">
-                        <Switch name="new" text={t('new', 'New')} />
-                        <Switch name="ongoing" text={t('ongoing', 'Ongoing')} />
+                        <Switch
+                          name="new"
+                          text={t('new', 'New')}
+                          disabled={isDeceased}
+                          title={isDeceased ? t('deceasedPatient', 'This patient is deceased') : ''}
+                        />
+                        <Switch
+                          name="ongoing"
+                          text={t('ongoing', 'Ongoing')}
+                          disabled={isDeceased}
+                          title={isDeceased ? t('deceasedPatient', 'This patient is deceased') : ''}
+                        />
                         <Switch name="past" text={t('inThePast', 'In the past')} />
                       </ContentSwitcher>
                     );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR improves the visit form to correctly handle starting visits for deceased patients. Currently, the functionality introduced here disables the `new` and `ongoing` options of the `visit type` switch. By default, all deceased patient visits will be `past visits`.

## Screenshots
<img width="469" height="537" alt="image" src="https://github.com/user-attachments/assets/2449fa4b-4137-4b98-b7fc-3751133df34f" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3364

## Other
<!-- Anything not covered above -->
