### PR TITLE
(fix) O3-4454 Clicking on the Order Basket should not do anything when the order basket is open

### DIFF
--- a/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.extension.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket-action-button/order-basket-action-button.extension.tsx
@@ -1,19 +1,32 @@
-import React, { type ComponentProps } from 'react';
+import React, { type ComponentProps, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ActionMenuButton, ShoppingCartIcon } from '@openmrs/esm-framework';
+import { ActionMenuButton, ShoppingCartIcon, useWorkspaces } from '@openmrs/esm-framework';
 import { useLaunchWorkspaceRequiringVisit, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+
+const formWorkspaceNames = ['add-lab-order', 'add-drug-order'];
 
 const OrderBasketActionButton: React.FC = () => {
   const { t } = useTranslation();
   const { orders } = useOrderBasket();
   const launchOrderBasket = useLaunchWorkspaceRequiringVisit('order-basket');
+  const { workspaces } = useWorkspaces();
+  const isFormWorkspaceActive = useMemo(() => {
+    return workspaces.some((workspace) => formWorkspaceNames.includes(workspace.name));
+  }, [workspaces]);
 
+  const handleOrderbasketClick = () => {
+    if (isFormWorkspaceActive) {
+      //do nothing
+      return;
+    }
+    launchOrderBasket();
+  };
   return (
     <ActionMenuButton
       getIcon={(props: ComponentProps<typeof ShoppingCartIcon>) => <ShoppingCartIcon {...props} />}
       label={t('orderBasket', 'Order basket')}
       iconDescription={t('medications', 'Medications')}
-      handler={launchOrderBasket}
+      handler={handleOrderbasketClick}
       type={'order'}
       tagContent={orders?.length > 0 ? orders?.length : null}
     />


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The ticket ensure that with the order basket open in any state clicking on the order basket side rail does not change the contents of the workspace at all.
## Screenshots
<!-- Required if you are making UI changes. -->
## Before
![orderbasket (1)](https://github.com/user-attachments/assets/23096ea2-32ff-4c74-a468-48043c148c19)

## After
https://github.com/user-attachments/assets/c5efde3f-2314-4942-aeba-179716ce56d5



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
Ticket [o3-4454](https://openmrs.atlassian.net/issues/?filter=-1&selectedIssue=O3-4454l)

## Other
<!-- Anything not covered above -->
@ibacher  please review this PR
