### PR TITLE
(chore) Require @openmrs/esm-framework 7.x in peerDependencies

### DIFF
--- a/packages/esm-form-engine-app/package.json
+++ b/packages/esm-form-engine-app/package.json
@@ -43,7 +43,7 @@
     "react-error-boundary": "^4.0.13"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-form-entry-app/package.json
+++ b/packages/esm-form-entry-app/package.json
@@ -65,7 +65,7 @@
     "zone.js": "~0.14.8"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "single-spa": "6.x"
   },
   "devDependencies": {

--- a/packages/esm-generic-patient-widgets-app/package.json
+++ b/packages/esm-generic-patient-widgets-app/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "^18.2.0",

--- a/packages/esm-patient-allergies-app/package.json
+++ b/packages/esm-patient-allergies-app/package.json
@@ -41,7 +41,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "^18.2.0",

--- a/packages/esm-patient-attachments-app/package.json
+++ b/packages/esm-patient-attachments-app/package.json
@@ -46,7 +46,7 @@
     "react-html5-camera-photo": "^1.5.11"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "^18.2.0",

--- a/packages/esm-patient-banner-app/package.json
+++ b/packages/esm-patient-banner-app/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-patient-chart-app/package.json
+++ b/packages/esm-patient-chart-app/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@carbon/react": "1.x",
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "*",
     "dayjs": "1.x",
     "lodash-es": "4.x",

--- a/packages/esm-patient-common-lib/package.json
+++ b/packages/esm-patient-common-lib/package.json
@@ -34,7 +34,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "react": "18.x",
     "single-spa": "6.x"
   }

--- a/packages/esm-patient-conditions-app/package.json
+++ b/packages/esm-patient-conditions-app/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-patient-flags-app/package.json
+++ b/packages/esm-patient-flags-app/package.json
@@ -40,7 +40,7 @@
     "@carbon/react": "^1.83.0"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-patient-forms-app/package.json
+++ b/packages/esm-patient-forms-app/package.json
@@ -43,7 +43,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-patient-immunizations-app/package.json
+++ b/packages/esm-patient-immunizations-app/package.json
@@ -44,7 +44,7 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-patient-lists-app/package.json
+++ b/packages/esm-patient-lists-app/package.json
@@ -40,7 +40,7 @@
     "@carbon/react": "^1.83.0"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-patient-medications-app/package.json
+++ b/packages/esm-patient-medications-app/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-patient-notes-app/package.json
+++ b/packages/esm-patient-notes-app/package.json
@@ -40,7 +40,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-patient-orders-app/package.json
+++ b/packages/esm-patient-orders-app/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-patient-programs-app/package.json
+++ b/packages/esm-patient-programs-app/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-patient-tests-app/package.json
+++ b/packages/esm-patient-tests-app/package.json
@@ -44,7 +44,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-vitals-app/package.json
+++ b/packages/esm-patient-vitals-app/package.json
@@ -43,7 +43,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "@openmrs/esm-patient-common-lib": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4389,7 +4389,7 @@ __metadata:
     react-error-boundary: "npm:^4.0.13"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4488,7 +4488,7 @@ __metadata:
     webpack: "npm:~5.94.0"
     zone.js: "npm:~0.14.8"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     single-spa: 6.x
   languageName: unknown
   linkType: soft
@@ -4538,7 +4538,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: ^18.2.0
@@ -4597,7 +4597,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: ^18.2.0
@@ -4621,7 +4621,7 @@ __metadata:
     react-html5-camera-photo: "npm:^1.5.11"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: ^18.2.0
@@ -4641,7 +4641,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4663,7 +4663,7 @@ __metadata:
     webpack: "npm:^5.99.9"
   peerDependencies:
     "@carbon/react": 1.x
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": "*"
     dayjs: 1.x
     lodash-es: 4.x
@@ -4752,7 +4752,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     uuid: "npm:^8.3.2"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     react: 18.x
     single-spa: 6.x
   languageName: unknown
@@ -4767,7 +4767,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4786,7 +4786,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": "workspace:*"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4807,7 +4807,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4830,7 +4830,7 @@ __metadata:
     webpack: "npm:^5.99.9"
     zod: "npm:^3.23.8"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4849,7 +4849,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": "workspace:*"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4869,7 +4869,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4888,7 +4888,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4908,7 +4908,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4928,7 +4928,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4950,7 +4950,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     react: 18.x
     react-i18next: 11.x
@@ -4969,7 +4969,7 @@ __metadata:
     "@openmrs/esm-patient-common-lib": "workspace:*"
     lodash-es: "npm:^4.17.21"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     "@openmrs/esm-patient-common-lib": 10.x
     dayjs: 1.x
     react: 18.x


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR updates the peerDependencies for all packages to require @openmrs/esm-framework `7.x` which corresponds to the [latest version of Core](https://github.com/openmrs/openmrs-esm-core/releases/tag/v7.0.0). This change should have been done in https://github.com/openmrs/openmrs-esm-patient-chart/pull/2638.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
