### PR TITLE
(feat): Enable Toggling The Patient Banner in non-workspaces Zones

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -29,6 +29,7 @@ interface FormRendererProps
   closeWorkspaceWithSavedChanges?: DefaultPatientWorkspaceProps['closeWorkspaceWithSavedChanges'];
   setTitle?: DefaultPatientWorkspaceProps['setTitle'];
   hideControls?: boolean;
+  hidePatientBanner?: boolean;
   handlePostResponse?: (encounter: Encounter) => void;
   preFilledQuestions?: Record<string, string>;
 }
@@ -45,6 +46,7 @@ const FormRenderer: React.FC<FormRendererProps> = ({
   visitUuid,
   clinicalFormsWorkspaceName = clinicalFormsWorkspace,
   hideControls,
+  hidePatientBanner,
   handlePostResponse,
   preFilledQuestions,
 }) => {
@@ -127,6 +129,7 @@ const FormRenderer: React.FC<FormRendererProps> = ({
           patientUUID={patientUuid}
           visit={visit}
           hideControls={hideControls}
+          hidePatientBanner={hidePatientBanner}
           preFilledQuestions={preFilledQuestions}
         />
       )}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, the patient banner visibility can only be toggled in workspace zones. However, there are other non-workspace zones, such as the FDE, where we also want this flexibility. This PR introduces a new `hidePatientBanner` prop, which defaults to `false`, allowing the banner to be hidden in these additional contexts.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
