### PR TITLE
(fix) Remove misleading zero defaults from drug order form

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -187,7 +187,7 @@ function MedicationInfoHeader({
   orderBasketItem: DrugOrderBasketItem;
   routeValue: string;
   unitValue: string;
-  dosage: number;
+  dosage: number | null;
 }) {
   const { t } = useTranslation();
 
@@ -251,7 +251,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
     defaultValues: {
       isFreeTextDosage: initialOrderBasketItem?.isFreeTextDosage,
       freeTextDosage: initialOrderBasketItem?.freeTextDosage,
-      dosage: initialOrderBasketItem?.dosage,
+      dosage: initialOrderBasketItem?.dosage ?? null,
       unit: initialOrderBasketItem?.unit,
       route: initialOrderBasketItem?.route,
       patientInstructions: initialOrderBasketItem?.patientInstructions,
@@ -259,9 +259,9 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
       asNeededCondition: initialOrderBasketItem?.asNeededCondition,
       duration: initialOrderBasketItem?.duration,
       durationUnit: initialOrderBasketItem?.durationUnit,
-      pillsDispensed: initialOrderBasketItem?.pillsDispensed,
+      pillsDispensed: initialOrderBasketItem?.pillsDispensed ?? null,
       quantityUnits: initialOrderBasketItem?.quantityUnits,
-      numRefills: initialOrderBasketItem?.numRefills,
+      numRefills: initialOrderBasketItem?.numRefills ?? null,
       indication: initialOrderBasketItem?.indication,
       frequency: initialOrderBasketItem?.frequency,
       startDate: defaultStartDate,
@@ -632,7 +632,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                       min={0}
                       step={1}
                       max={maxDispenseDurationInDays}
-                      allowEmpty={true}
+                      allowEmpty
                     />
                   ) : (
                     <CustomNumberInput
@@ -897,6 +897,7 @@ const ControlledFieldInput = ({
       const numberInputProps = restProps as ComponentProps<typeof NumberInput>;
       return (
         <NumberInput
+          allowEmpty
           className={fieldErrorStyles}
           disableWheel
           onBlur={onBlur}
@@ -906,7 +907,7 @@ const ControlledFieldInput = ({
           }}
           ref={ref}
           size={isTablet ? 'md' : 'sm'}
-          value={typeof value === 'number' ? value : undefined}
+          value={typeof value === 'number' ? value : ''}
           {...numberInputProps}
         />
       );

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.resource.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-search/drug-search.resource.tsx
@@ -114,8 +114,8 @@ export function getTemplateOrderBasketItem(
               valueCoded: configDefaultDurationConcept?.uuid,
             }
           : null,
-        pillsDispensed: 0,
-        numRefills: 0,
+        pillsDispensed: null,
+        numRefills: null,
         freeTextDosage: '',
         indication: '',
         template: template.template,
@@ -155,8 +155,8 @@ export function getTemplateOrderBasketItem(
               valueCoded: configDefaultDurationConcept?.uuid,
             }
           : null,
-        pillsDispensed: 0,
-        numRefills: 0,
+        pillsDispensed: null,
+        numRefills: null,
         freeTextDosage: '',
         indication: '',
         orderer: null,

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.test.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.test.tsx
@@ -42,7 +42,7 @@ describe('OrderBasketPanel', () => {
     const { rerender } = render(<DrugOrderBasketPanel />);
     expect(screen.getByText(/Drug orders \(4\)/i)).toBeInTheDocument();
     expect(getByTextWithMarkup(/New\s*Aspirin 81mg — 81mg — Tablet/i)).toBeVisible();
-    expect(getByTextWithMarkup(/DOSE\s*Tablet.*— REFILLS 0 QUANTITY 0/i)).toBeVisible();
+    expect(getByTextWithMarkup(/DOSE\s*Tablet/i)).toBeVisible();
     expect(getByTextWithMarkup(/Renew\s*Sulfacetamide 0.1 — 10%/i)).toBeVisible();
     expect(getByTextWithMarkup(/Modify\s*Aspirin 162.5mg — 162.5mg — tablet/i)).toBeVisible();
     expect(getByTextWithMarkup(/Discontinue\s*Acetaminophen 325 mg — 325mg — tablet/i)).toBeVisible();

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.component.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/order-basket-item-tile.component.tsx
@@ -61,9 +61,17 @@ export default function OrderBasketItemTile({ orderBasketItem, onItemClick, onRe
             <span className={styles.dosageInfo}>
               &mdash; {orderBasketItem.route?.value ? <>{orderBasketItem.route.value} &mdash; </> : null}
               {orderBasketItem.frequency?.value ? <>{orderBasketItem.frequency.value} &mdash; </> : null}
-              {t('refills', 'Refills').toUpperCase()} {orderBasketItem.numRefills}{' '}
-              {t('quantity', 'Quantity').toUpperCase()}{' '}
-              {`${orderBasketItem.pillsDispensed} ${orderBasketItem.quantityUnits?.value?.toLowerCase() ?? ''}`}
+              {orderBasketItem.numRefills ? (
+                <>
+                  {t('refills', 'Refills').toUpperCase()} {orderBasketItem.numRefills} &mdash;{' '}
+                </>
+              ) : null}
+              {orderBasketItem.pillsDispensed ? (
+                <>
+                  {t('quantity', 'Quantity').toUpperCase()} {orderBasketItem.pillsDispensed}{' '}
+                  {orderBasketItem.quantityUnits?.value?.toLowerCase()} &mdash;{' '}
+                </>
+              ) : null}
               {orderBasketItem.patientInstructions && <>&mdash; {orderBasketItem.patientInstructions}</>}
             </span>
           </span>

--- a/packages/esm-patient-medications-app/src/types.ts
+++ b/packages/esm-patient-medications-app/src/types.ts
@@ -14,8 +14,8 @@ export interface DrugOrderBasketItem extends OrderBasketItem {
   startDate: Date | string;
   durationUnit: DurationUnit;
   duration: number | null;
-  pillsDispensed: number;
-  numRefills: number;
+  pillsDispensed: number | null;
+  numRefills: number | null;
   indication: string;
   isFreeTextDosage: boolean;
   freeTextDosage: string;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR changes the default values of the `dosage`, `pillsDispensed`, and `numRefills` fields to `null`. This makes it so that the form now shows empty fields instead of confusing zero values. This maintains validation requirements while improving the user experience.

## Screenshots

### Bug

https://github.com/user-attachments/assets/51e309d1-05a0-444c-840b-dd9980a94659

### Fix

https://github.com/user-attachments/assets/a0a223bb-7b1a-4d18-bc1b-2d06d3d699ca

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
