### PR TITLE
(feat) O3-4975: Visit editable duration should be controlled by frontend config

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -16,6 +16,19 @@ export const esmPatientChartSchema = {
     _default: false,
     _description: 'Disable notes/tests/medications/encounters tabs when empty',
   },
+  encounterEditableDuration: {
+    _type: Type.Number,
+    _default: 0,
+    _description: 'The number of minutes an encounter is editable after it is created. 0 means the encounter is editable forever.',
+  },
+  encounterEditableDurationOverridePrivileges: {
+    _type: Type.Array,
+    _elements: {
+      _type: Type.String,
+    },
+    _default: [],
+    _description: 'The privileges that allow users to edit encounters even after the editable duration (set by `encounterEditableDuration`) has expired. Any privilege in the list is sufficient to edit the encounter.',
+  },
   freeTextFieldConceptUuid: {
     _type: Type.ConceptUuid,
     _default: '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
@@ -157,6 +170,9 @@ export const esmPatientChartSchema = {
 export interface ChartConfig {
   defaultFacilityUrl: string;
   disableChangingVisitLocation: boolean;
+  disableEmptyTabs: boolean;
+  encounterEditableDuration: number;
+  encounterEditableDurationOverridePrivileges: Array<string>;
   freeTextFieldConceptUuid: string;
   logo: {
     alt: string;

--- a/packages/esm-patient-chart-app/src/visit/visit-action-items/delete-visit-action-item.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-action-items/delete-visit-action-item.component.tsx
@@ -40,7 +40,13 @@ const DeleteVisitActionItem: React.FC<DeleteVisitActionItemProps> = ({ patientUu
   return (
     <UserHasAccess privilege="Delete Visits">
       {compact ? (
-        <IconButton onClick={deleteVisit} label={getCoreTranslation('delete')} kind="ghost" size={responsiveSize}>
+        <IconButton
+          onClick={deleteVisit}
+          label={getCoreTranslation('delete')}
+          kind="ghost"
+          size={responsiveSize}
+          align="top-end"
+        >
           <TrashCanIcon size={16} />
         </IconButton>
       ) : (

--- a/packages/esm-patient-chart-app/src/visit/visit-action-items/edit-visit-details.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-action-items/edit-visit-details.component.tsx
@@ -37,7 +37,13 @@ const EditVisitDetailsActionItem: React.FC<EditVisitDetailsActionItemProps> = ({
   return (
     <UserHasAccess privilege="Edit Visits">
       {compact ? (
-        <IconButton onClick={editVisitDetails} label={getCoreTranslation('edit')} size={responsiveSize} kind="ghost">
+        <IconButton
+          onClick={editVisitDetails}
+          label={getCoreTranslation('edit')}
+          size={responsiveSize}
+          kind="ghost"
+          align="top-end"
+        >
           <EditIcon size={16} />
         </IconButton>
       ) : (

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
@@ -55,7 +55,7 @@ import {
 } from './encounters-table.resource';
 import EncounterObservations from '../../encounter-observations';
 import styles from './encounters-table.scss';
-import { ChartConfig } from '../../../../config-schema';
+import { type ChartConfig } from '../../../../config-schema';
 
 /**
  * This components is used by the AllEncountersTable and VisitEncountersTable to display
@@ -83,10 +83,10 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
   const { mutate: mutateCurrentVisit } = useVisit(patientUuid);
   const { mutate } = useSWRConfig();
   const responsiveSize = desktopLayout ? 'sm' : 'lg';
-  const { encounterEditableDuration, encounterEditableDurationOverridePrivileges } = useConfig<ChartConfig>();
   const { data: encounterTypes, isLoading: isLoadingEncounterTypes } = useEncounterTypes();
   const enableEmbeddedFormView = useFeatureFlag('enable-embedded-form-view');
 
+  const { encounterEditableDuration, encounterEditableDurationOverridePrivileges } = useConfig<ChartConfig>();
   const formsConfig: { htmlFormEntryForms: HtmlFormEntryForm[] } = useConfig({
     externalModuleName: '@openmrs/esm-patient-forms-app',
   });
@@ -235,12 +235,18 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
                       encounter.form?.uuid &&
                       encounter.form.resources?.some((resource) => resource.name === jsonSchemaResourceName);
 
-                    const encounterAgeInMinutes = (new Date().getTime() - new Date(encounter.datetime).getTime()) / (1000 * 60);
+                    const encounterAgeInMinutes = (Date.now() - new Date(encounter.datetime).getTime()) / (1000 * 60);
 
-                    const canEditEncounter = userHasAccess(encounter.editPrivilege, session?.user) && 
+                    const canDeleteEncounter =
+                      userHasAccess(encounter.editPrivilege, session?.user) &&
                       (encounterEditableDuration === 0 ||
-                      (encounterEditableDuration > 0 && encounterAgeInMinutes <= encounterEditableDuration) ||
-                      encounterEditableDurationOverridePrivileges.some((privilege) => userHasAccess(privilege, session?.user)))
+                        (encounterEditableDuration > 0 && encounterAgeInMinutes <= encounterEditableDuration) ||
+                        encounterEditableDurationOverridePrivileges.some((privilege) =>
+                          userHasAccess(privilege, session?.user),
+                        ));
+
+                    const canEditEncounter =
+                      canDeleteEncounter && (encounter.form?.uuid || isVisitNoteEncounter(encounter));
 
                     return (
                       <React.Fragment key={encounter.id}>
@@ -250,13 +256,14 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
                           ))}
                           <TableCell className="cds--table-column-menu">
                             <Layer className={styles.layer}>
-                              <OverflowMenu
-                                aria-label={t('encounterTableActionsMenu', 'Encounter table actions menu')}
-                                flipped
-                                size={responsiveSize}
-                              >
-                                {canEditEncounter &&
-                                  (encounter.form?.uuid || isVisitNoteEncounter(encounter)) && (
+                              {canDeleteEncounter && ( // equivalent to canDeleteEncounter || canEditEncounter
+                                <OverflowMenu
+                                  aria-label={t('encounterTableActionsMenu', 'Encounter table actions menu')}
+                                  flipped
+                                  size={responsiveSize}
+                                  align="left"
+                                >
+                                  {canEditEncounter && (
                                     <OverflowMenuItem
                                       className={styles.menuItem}
                                       itemText={t('editThisEncounter', 'Edit this encounter')}
@@ -282,16 +289,17 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
                                       }}
                                     />
                                   )}
-                                {canEditEncounter && (
-                                  <OverflowMenuItem
-                                    className={styles.menuItem}
-                                    hasDivider
-                                    isDelete
-                                    itemText={t('deleteThisEncounter', 'Delete this encounter')}
-                                    onClick={() => handleDeleteEncounter(encounter.id, encounter.form?.display)}
-                                  />
-                                )}
-                              </OverflowMenu>
+                                  {canDeleteEncounter && (
+                                    <OverflowMenuItem
+                                      className={styles.menuItem}
+                                      hasDivider
+                                      isDelete
+                                      itemText={t('deleteThisEncounter', 'Delete this encounter')}
+                                      onClick={() => handleDeleteEncounter(encounter.id, encounter.form?.display)}
+                                    />
+                                  )}
+                                </OverflowMenu>
+                              )}
                             </Layer>
                           </TableCell>
                         </TableExpandRow>
@@ -312,38 +320,38 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
                               ) : (
                                 <EncounterObservations observations={encounter.obs} />
                               )}
-                              {canEditEncounter && (
-                                <>
-                                  {(encounter.form?.uuid || isVisitNoteEncounter(encounter)) && (
-                                    <Button
-                                      kind="ghost"
-                                      onClick={() => {
-                                        if (isVisitNoteEncounter(encounter)) {
-                                          launchWorkspace('visit-notes-form-workspace', {
-                                            encounter,
-                                            formContext: 'editing',
-                                            patientUuid,
-                                          });
-                                        } else {
-                                          launchFormEntryOrHtmlForms(
-                                            htmlFormEntryForms,
-                                            patientUuid,
-                                            encounter.form,
-                                            encounter.visitUuid,
-                                            encounter.id,
-                                            encounter.visitTypeUuid,
-                                            encounter.visitStartDatetime,
-                                            encounter.visitStopDatetime,
-                                          );
-                                        }
-                                      }}
-                                      renderIcon={(props: ComponentProps<typeof EditIcon>) => (
-                                        <EditIcon size={16} {...props} />
-                                      )}
-                                    >
-                                      {t('editThisEncounter', 'Edit this encounter')}
-                                    </Button>
-                                  )}
+                              <>
+                                {canEditEncounter && (
+                                  <Button
+                                    kind="ghost"
+                                    onClick={() => {
+                                      if (isVisitNoteEncounter(encounter)) {
+                                        launchWorkspace('visit-notes-form-workspace', {
+                                          encounter,
+                                          formContext: 'editing',
+                                          patientUuid,
+                                        });
+                                      } else {
+                                        launchFormEntryOrHtmlForms(
+                                          htmlFormEntryForms,
+                                          patientUuid,
+                                          encounter.form,
+                                          encounter.visitUuid,
+                                          encounter.id,
+                                          encounter.visitTypeUuid,
+                                          encounter.visitStartDatetime,
+                                          encounter.visitStopDatetime,
+                                        );
+                                      }
+                                    }}
+                                    renderIcon={(props: ComponentProps<typeof EditIcon>) => (
+                                      <EditIcon size={16} {...props} />
+                                    )}
+                                  >
+                                    {t('editThisEncounter', 'Edit this encounter')}
+                                  </Button>
+                                )}
+                                {canDeleteEncounter && (
                                   <Button
                                     kind="danger--ghost"
                                     onClick={() => handleDeleteEncounter(encounter.id, encounter.form?.display)}
@@ -353,8 +361,8 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
                                   >
                                     {t('deleteThisEncounter', 'Delete this encounter')}
                                   </Button>
-                                </>
-                              )}
+                                )}
+                              </>
                             </>
                           </TableExpandedRow>
                         ) : (

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.test.tsx
@@ -1,12 +1,16 @@
+/* eslint-disable testing-library/no-node-access */
+/* Please re-enable this ESLint rule if you are able to find a practical way to test the overflow menu buttons
+   without using parentElement and the expanded row functionality without using nextElementSibling. */
+
 import React from 'react';
 import { getConfig, getDefaultsFromConfigSchema, showModal, useConfig, userHasAccess } from '@openmrs/esm-framework';
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mockEncountersAlice, mockEncounterTypes, mockPatientAlice } from '__mocks__';
 import { renderWithSwr } from 'tools';
 import EncountersTable from './encounters-table.component';
 import { type EncountersTableProps, useEncounterTypes } from './encounters-table.resource';
-import { ChartConfig, esmPatientChartSchema } from '../../../../config-schema';
+import { type ChartConfig, esmPatientChartSchema } from '../../../../config-schema';
 
 const testProps: EncountersTableProps = {
   patientUuid: mockPatientAlice.uuid,
@@ -22,8 +26,7 @@ const testProps: EncountersTableProps = {
 };
 
 const mockShowModal = jest.mocked(showModal);
-const mockGetConfig = jest.mocked(getConfig);
-const mockUserHasAccess = jest.mocked(userHasAccess);
+const mockUserHasAccess = jest.mocked(userHasAccess).mockReturnValue(true);
 
 const mockUseEncounterTypes = jest.fn(useEncounterTypes).mockReturnValue({
   data: mockEncounterTypes,
@@ -37,7 +40,7 @@ const mockUseEncounterTypes = jest.fn(useEncounterTypes).mockReturnValue({
   nextUri: '',
 });
 
-const mockUseConfig = jest.mocked(useConfig<ChartConfig>);
+const mockUseConfig = jest.mocked(useConfig);
 
 jest.mock('./encounters-table.resource', () => ({
   ...jest.requireActual('./encounters-table.resource'),
@@ -46,7 +49,12 @@ jest.mock('./encounters-table.resource', () => ({
 
 describe('EncountersTable', () => {
   it('renders an empty state when no encounters are available', async () => {
-    mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
+    mockUseConfig.mockImplementation((options) => {
+      if (options?.externalModuleName === '@openmrs/esm-patient-forms-app') {
+        return { htmlFormEntryForms: [] };
+      }
+      return getDefaultsFromConfigSchema(esmPatientChartSchema);
+    });
     renderEncountersTable({ totalCount: 0, paginatedEncounters: [] });
 
     expect(screen.getByText(/No encounters to display/i)).toBeInTheDocument();
@@ -74,18 +82,16 @@ describe('EncountersTable', () => {
 });
 
 describe('Encounter editability', () => {
-
   beforeEach(() => {
-    jest.spyOn(Date, 'now').mockImplementation(() => 
-      new Date('2022-01-18T20:00:00.000Z').getTime()
-    );
+    jest.spyOn(Date, 'now').mockImplementation(() => new Date('2022-01-18T20:00:00.000Z').getTime());
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('displays an edit encounter button by default', async () => {
+  it('displays edit and delete encounter buttons by default', async () => {
+    mockUserHasAccess.mockImplementation((privilege) => privilege == null);
     const user = userEvent.setup();
 
     renderEncountersTable();
@@ -94,41 +100,122 @@ describe('Encounter editability', () => {
       name: /18-Jan-2022, 04:25 PM Facility Visit Admission POC Consent Form -- Options/i,
     });
 
+    // Check overflow menu buttons
+    await user.click(within(row).getByRole('button', { name: /options/i }));
+    const overflowMenu = screen.getAllByText('Focus sentinel')[0].parentElement;
+    expect(within(overflowMenu).getByText(/edit this encounter/i)).toBeInTheDocument();
+    expect(within(overflowMenu).getByText(/Delete this encounter/i)).toBeInTheDocument();
+    await user.click(within(row).getByRole('button', { name: /options/i }));
+    expect(screen.queryByText('Focus sentinel')).not.toBeInTheDocument();
+
+    // Check big buttons in expanded row
     await user.click(within(row).getByRole('button', { name: /expand current row/i }));
-    expect(within(row).getByRole('button', { name: /edit this encounter/i })).toBeInTheDocument();
+    const expandedRow = row.nextElementSibling as HTMLElement;
+    expect(within(expandedRow).getByRole('button', { name: /edit this encounter/i })).toBeInTheDocument();
+    expect(within(expandedRow).getByRole('button', { name: /danger Delete this encounter/i })).toBeInTheDocument();
   });
 
-  it('displays an edit encounter button only if the encounter is within editable duration', async () => {
-    mockUseConfig.mockReturnValue({
-      ...getDefaultsFromConfigSchema(esmPatientChartSchema),
-      encounterEditableDuration: 1440,
-      encounterEditableDurationOverridePrivileges: [],
+  it('displays an edit and delete encounter buttons only if the encounter is within editable duration', async () => {
+    mockUseConfig.mockImplementation((options) => {
+      if (options?.externalModuleName === '@openmrs/esm-patient-forms-app') {
+        return { htmlFormEntryForms: [] };
+      }
+      return {
+        ...(getDefaultsFromConfigSchema(esmPatientChartSchema) as ChartConfig),
+        encounterEditableDuration: 1440,
+        encounterEditableDurationOverridePrivileges: ['Super Edit Encounter', 'Magic Superpowers'],
+      };
     });
+    mockUserHasAccess.mockImplementation((privilege) => privilege == null);
 
     const user = userEvent.setup();
 
     renderEncountersTable();
 
+    // Check today's encounter -- should be editable
     const todayRow = screen.getByRole('row', {
       name: /18-Jan-2022, 04:25 PM Facility Visit Admission POC Consent Form -- Options/i,
     });
+
+    // Check overflow menu buttons
+    await user.click(within(todayRow).getByRole('button', { name: /options/i }));
+    const overflowMenu = screen.getAllByText('Focus sentinel')[0].parentElement;
+    expect(within(overflowMenu).getByText(/edit this encounter/i)).toBeInTheDocument();
+    expect(within(overflowMenu).getByText(/Delete this encounter/i)).toBeInTheDocument();
+    await user.click(within(todayRow).getByRole('button', { name: /options/i }));
+    expect(screen.queryByText('Focus sentinel')).not.toBeInTheDocument();
+
+    // Check big buttons in expanded row
     await user.click(within(todayRow).getByRole('button', { name: /expand current row/i }));
-    expect(within(todayRow).getByRole('button', { name: /edit this encounter/i })).toBeInTheDocument();
+    const expandedTodayRow = todayRow.nextElementSibling as HTMLElement;
+    await user.click(within(expandedTodayRow).getByRole('button', { name: /edit this encounter/i }));
+    expect(within(expandedTodayRow).getByRole('button', { name: /edit this encounter/i })).toBeInTheDocument();
+    expect(within(expandedTodayRow).getByRole('button', { name: /danger Delete this encounter/i })).toBeInTheDocument();
+
+    // Check old encounter -- should not be editable
+    const oldRow = screen.getByRole('row', {
+      name: /03-Aug-2021, 12:47 AM Facility Visit Visit Note -- User One/i,
+    });
+    expect(within(oldRow).queryByRole('button', { name: /options/i })).not.toBeInTheDocument();
+    await user.click(within(oldRow).getByRole('button', { name: /expand current row/i }));
+    const expandedOldRow = oldRow.nextElementSibling as HTMLElement;
+    expect(within(expandedOldRow).queryByRole('button', { name: /edit this encounter/i })).not.toBeInTheDocument();
+    expect(
+      within(expandedOldRow).queryByRole('button', { name: /danger Delete this encounter/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays edit and delete buttons if the user has the override privilege, even if the encounter is outside the editable duration', async () => {
+    mockUseConfig.mockImplementation((options) => {
+      if (options?.externalModuleName === '@openmrs/esm-patient-forms-app') {
+        return { htmlFormEntryForms: [] };
+      }
+      return {
+        ...(getDefaultsFromConfigSchema(esmPatientChartSchema) as ChartConfig),
+        encounterEditableDuration: 1440,
+        encounterEditableDurationOverridePrivileges: ['Super Edit Encounter', 'Magic Superpowers'],
+      };
+    });
+
+    mockUserHasAccess.mockImplementation((privilege) => privilege == null || privilege === 'Magic Superpowers');
+
+    const user = userEvent.setup();
+
+    renderEncountersTable();
 
     const oldRow = screen.getByRole('row', {
       name: /03-Aug-2021, 12:47 AM Facility Visit Visit Note -- User One Options/i,
     });
+
+    // Check overflow menu buttons
+    await user.click(within(oldRow).getByRole('button', { name: /options/i }));
+    const overflowMenu = screen.getAllByText('Focus sentinel')[0].parentElement;
+    expect(within(overflowMenu).getByText(/edit this encounter/i)).toBeInTheDocument();
+    expect(within(overflowMenu).getByText(/Delete this encounter/i)).toBeInTheDocument();
+    await user.click(within(oldRow).getByRole('button', { name: /options/i }));
+    expect(screen.queryByText('Focus sentinel')).not.toBeInTheDocument();
+
+    // Check big buttons in expanded row
     await user.click(within(oldRow).getByRole('button', { name: /expand current row/i }));
-    expect(within(oldRow).queryByRole('button', { name: /edit this encounter/i })).not.toBeInTheDocument();
+    const expandedOldRow = oldRow.nextElementSibling as HTMLElement;
+    expect(within(expandedOldRow).getByRole('button', { name: /edit this encounter/i })).toBeInTheDocument();
+    expect(within(expandedOldRow).getByRole('button', { name: /danger Delete this encounter/i })).toBeInTheDocument();
   });
 });
 
-
 describe('Delete Encounter', () => {
+  beforeEach(() => {
+    mockUseConfig.mockImplementation((options) => {
+      if (options?.externalModuleName === '@openmrs/esm-patient-forms-app') {
+        return { htmlFormEntryForms: [] };
+      }
+      return getDefaultsFromConfigSchema(esmPatientChartSchema);
+    });
+    mockUserHasAccess.mockReturnValue(true);
+  });
+
   it('Clicking the `Delete` button deletes an encounter', async () => {
     const user = userEvent.setup();
-
-    mockUserHasAccess.mockReturnValue(true);
 
     renderEncountersTable();
 
@@ -140,7 +227,8 @@ describe('Delete Encounter', () => {
     });
 
     await user.click(within(row).getByRole('button', { name: /expand current row/i }));
-    await user.click(screen.getByRole('button', { name: /danger Delete this encounter/i }));
+    const expandedRow = row.nextElementSibling as HTMLElement;
+    await user.click(within(expandedRow).getByRole('button', { name: /danger Delete this encounter/i }));
 
     expect(mockShowModal).toHaveBeenCalledTimes(1);
     expect(mockShowModal).toHaveBeenCalledWith(

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -20,6 +20,7 @@ import NotesSummary from './notes-summary.component';
 import TestsSummary from './tests-summary.component';
 import VisitEncountersTable from './encounters-table/visit-encounters-table.component';
 import styles from './visit-summary.scss';
+import { ChartConfig } from '../../../config-schema';
 
 interface VisitSummaryProps {
   visit: Visit;
@@ -29,7 +30,7 @@ interface VisitSummaryProps {
 const visitSummaryPanelSlot = 'visit-summary-panels';
 
 const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
-  const config = useConfig();
+  const config = useConfig<ChartConfig>();
   const { t } = useTranslation();
   const extensions = useAssignedExtensions(visitSummaryPanelSlot);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Adds two config elements that set a maximum editable duration for encounters, and a set of privileges for users that can override that maximum.

## Screenshots

https://github.com/user-attachments/assets/ded05534-d80e-40b5-a250-1962f99709d8

## Related Issue

https://openmrs.atlassian.net/browse/O3-4975

## Other
<!-- Anything not covered above -->
