### PR TITLE
(fix) O3-4989: Fix type property mapping in usePatientLists hook

### DIFF
--- a/packages/esm-patient-lists-app/src/patient-lists.resource.ts
+++ b/packages/esm-patient-lists-app/src/patient-lists.resource.ts
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import useSWR from 'swr';
-import { formatDate, openmrsFetch, parseDate, restBaseUrl } from '@openmrs/esm-framework';
+import useSWRInfinite from 'swr/infinite';
+import { type FetchResponse, formatDate, openmrsFetch, parseDate, restBaseUrl } from '@openmrs/esm-framework';
 
 /**
  * Represents a cohort object returned by the OpenMRS Cohort resource https://github.com/openmrs/openmrs-module-cohort#readme.
@@ -25,6 +27,12 @@ export interface Cohort {
   uuid: string;
   voided: boolean;
   voidReason: string | null;
+}
+
+export interface CohortResponse<T> {
+  results: Array<T>;
+  error: any;
+  totalCount: number;
 }
 
 export interface CohortMember {
@@ -53,6 +61,11 @@ export interface CohortMember {
   voided: boolean;
 }
 
+export interface CohortType {
+  display: string;
+  uuid: string;
+}
+
 export interface MappedList {
   attributes: Array<unknown>;
   description: string;
@@ -72,43 +85,94 @@ export interface MappedListMembers {
   patientUuid: string;
 }
 
+export interface OpenmrsCohort {
+  uuid: string;
+  resourceVersion: string;
+  name: string;
+  description: string;
+  attributes: Array<any>;
+  links: Array<any>;
+  location: Location | null;
+  groupCohort: boolean | null;
+  startDate: string | null;
+  endDate: string | null;
+  voidReason: string | null;
+  voided: boolean;
+  isStarred?: boolean;
+  type?: string;
+  size: number;
+  cohortType?: CohortType;
+}
+
+interface PatientListResponse {
+  results: CohortResponse<OpenmrsCohort>;
+  links: Array<{ rel: 'prev' | 'next' }>;
+  totalCount: number;
+}
+
 /**
  * Fetches patient lists from the OpenMRS Cohort resource.
  * @returns An object containing the patient lists, loading state, and error state.
  */
+
 export function usePatientLists() {
-  // Custom representation of the cohort object to fetch only the required properties.
-  const customRepresentation = `custom:(uuid,name,description,display,size,attributes,cohortType,startDate,endDate)`;
+  const custom = 'custom:(uuid,name,description,display,size,attributes,cohortType,startDate,endDate)';
+  const query: Array<[string, string]> = [
+    ['v', custom],
+    ['totalCount', 'true'],
+  ];
 
-  const listsUrl = `${restBaseUrl}/cohortm/cohort?`;
+  const params = query.map(([key, value]) => `${key}=${encodeURIComponent(value)}`).join('&');
 
-  const urlSearchParams = new URLSearchParams({
-    v: customRepresentation,
-    totalCount: 'true',
-  });
+  const getUrl = (pageIndex, previousPageData: FetchResponse<PatientListResponse>) => {
+    if (pageIndex && !previousPageData?.data?.links?.some((link) => link.rel === 'next')) {
+      return null;
+    }
 
-  const { data, error, isLoading } = useSWR<{ data: { results: Array<Cohort> } }, Error>(
-    listsUrl + urlSearchParams,
-    openmrsFetch,
-  );
+    let url = `${restBaseUrl}/cohortm/cohort?${params}`;
 
-  // Map the properties of the fetched patient lists to a simpler object.
-  const mapProperties = (cohort: Cohort): MappedList => ({
+    if (pageIndex) {
+      url += `&startIndex=${pageIndex * 50}`;
+    }
+
+    return url;
+  };
+
+  const {
+    data,
+    error,
+    mutate,
+    isValidating,
+    isLoading,
+    size: pageNumber,
+    setSize,
+  } = useSWRInfinite<FetchResponse<PatientListResponse>, Error>(getUrl, openmrsFetch);
+
+  useEffect(() => {
+    if (data && data?.[pageNumber - 1]?.data?.links?.some((link) => link.rel === 'next')) {
+      setSize((currentSize) => currentSize + 1);
+    }
+  }, [data, pageNumber, setSize]);
+
+  // Map the properties to match the MappedList interface
+  const mapProperties = (cohort: OpenmrsCohort) => ({
     attributes: cohort.attributes,
     description: cohort.description,
     id: cohort.uuid,
     name: cohort.name,
     size: cohort.size,
-    startDate: cohort.startDate,
-    type: cohort.cohortType.display,
+    startDate: cohort.startDate || '',
+    type: cohort.cohortType?.display || '',
   });
 
-  const patientLists = data?.data?.results ? data.data.results.map(mapProperties) : [];
+  const patientLists = (data?.flatMap((res) => res?.data?.results ?? []) ?? []).map(mapProperties);
 
   return {
     patientLists,
     isLoading,
     error,
+    mutate,
+    isValidating,
   };
 }
 

--- a/packages/esm-patient-lists-app/src/workspaces/patient-list-details-table.component.tsx
+++ b/packages/esm-patient-lists-app/src/workspaces/patient-list-details-table.component.tsx
@@ -15,7 +15,7 @@ import {
   TableRow,
   Tile,
 } from '@carbon/react';
-import { useLayoutType, isDesktop, useDebounce, ConfigurableLink } from '@openmrs/esm-framework';
+import { useLayoutType, isDesktop, ConfigurableLink } from '@openmrs/esm-framework';
 import { EmptyDataIllustration } from '@openmrs/esm-patient-common-lib';
 import { type MappedListMembers } from '../patient-lists.resource';
 import styles from './patient-list-details-table.scss';
@@ -31,7 +31,6 @@ const PatientListDetailsTable: React.FC<PatientListDetailsTableProps> = ({ listM
   const layout = useLayoutType();
   const responsiveSize = isDesktop(layout) ? 'sm' : 'lg';
   const [searchTerm, setSearchTerm] = useState('');
-  const debouncedSearchTerm = useDebounce(searchTerm);
 
   const tableHeaders = useMemo(
     () => [
@@ -56,19 +55,17 @@ const PatientListDetailsTable: React.FC<PatientListDetailsTableProps> = ({ listM
   );
 
   const filteredListMembers = useMemo(() => {
-    if (!debouncedSearchTerm) {
+    if (!searchTerm) {
       return listMembers;
     }
 
-    return debouncedSearchTerm
-      ? fuzzy
-          .filter(debouncedSearchTerm, listMembers, {
-            extract: (member) => `${member.name} ${member.identifier} ${member.sex}`,
-          })
-          .sort((r1, r2) => r1.score - r2.score)
-          .map((result) => result.original)
-      : listMembers;
-  }, [debouncedSearchTerm, listMembers]);
+    return fuzzy
+      .filter(searchTerm, listMembers, {
+        extract: (member) => `${member.name} ${member.identifier} ${member.sex}`,
+      })
+      .sort((r1, r2) => r1.score - r2.score)
+      .map((result) => result.original);
+  }, [searchTerm, listMembers]);
 
   const tableRows = useMemo(
     () =>
@@ -116,6 +113,7 @@ const PatientListDetailsTable: React.FC<PatientListDetailsTableProps> = ({ listM
                     <TableRow>
                       {headers.map((header) => (
                         <TableHeader
+                          key={header.key}
                           {...getHeaderProps({
                             header,
                           })}

--- a/packages/esm-patient-lists-app/src/workspaces/patient-lists.scss
+++ b/packages/esm-patient-lists-app/src/workspaces/patient-lists.scss
@@ -22,7 +22,6 @@
   padding: 0;
 
   :global(.cds--data-table-content) {
-    border: 1px solid colors.$gray-20;
     border-bottom: none;
     overflow: visible;
   }
@@ -54,6 +53,7 @@
 
 .search {
   input {
+    background-color: colors.$gray-10 !important;
     padding: 0 layout.$spacing-10 !important;
   }
 

--- a/packages/esm-patient-lists-app/src/workspaces/patient-lists.workspace.test.tsx
+++ b/packages/esm-patient-lists-app/src/workspaces/patient-lists.workspace.test.tsx
@@ -20,6 +20,8 @@ it('renders an empty state if patient list data is unavailable', async () => {
     isLoading: false,
     error: null,
     patientLists: [],
+    mutate: jest.fn(),
+    isValidating: false,
   });
 
   render(<PatientListsWorkspace />);
@@ -46,6 +48,8 @@ it('renders a tabular overview of the available patient lists', async () => {
         type: 'My List',
       },
     ],
+    mutate: jest.fn(),
+    isValidating: false,
   });
 
   render(<PatientListsWorkspace />);

--- a/packages/esm-patient-lists-app/src/workspaces/patient-lists.workspace.tsx
+++ b/packages/esm-patient-lists-app/src/workspaces/patient-lists.workspace.tsx
@@ -19,8 +19,8 @@ import {
   Tile,
 } from '@carbon/react';
 import { EmptyDataIllustration } from '@openmrs/esm-patient-common-lib';
-import { launchWorkspace, useDebounce, useLayoutType } from '@openmrs/esm-framework';
-import { usePatientLists } from '../patient-lists.resource';
+import { launchWorkspace, useLayoutType } from '@openmrs/esm-framework';
+import { usePatientLists, type MappedList } from '../patient-lists.resource';
 import styles from './patient-lists.scss';
 
 function PatientListsWorkspace() {
@@ -28,10 +28,9 @@ function PatientListsWorkspace() {
   const layout = useLayoutType();
   const responsiveSize = layout === 'tablet' ? 'lg' : 'sm';
   const [searchTerm, setSearchTerm] = useState('');
-  const debouncedSearchTerm = useDebounce(searchTerm);
   const { patientLists, isLoading } = usePatientLists();
 
-  const launchListDetailsWorkspace = useCallback((list) => {
+  const launchListDetailsWorkspace = useCallback((list: MappedList) => {
     launchWorkspace('patient-list-details', { list, workspaceTitle: list.name });
   }, []);
 
@@ -51,28 +50,17 @@ function PatientListsWorkspace() {
   ];
 
   const filteredLists = useMemo(() => {
-    if (!debouncedSearchTerm) {
+    if (!searchTerm) {
       return patientLists;
     }
 
-    return debouncedSearchTerm
-      ? fuzzy
-          .filter(debouncedSearchTerm, patientLists, {
-            extract: (list) => `${list.name} ${list.type}`,
-          })
-          .sort((r1, r2) => r1.score - r2.score)
-          .map((result) => result.original)
-      : patientLists;
-  }, [debouncedSearchTerm, patientLists]);
-
-  const tableRows = useMemo(
-    () =>
-      filteredLists?.map((list) => ({
-        ...list,
-        numberOfPatients: list.size,
-      })) ?? [],
-    [filteredLists],
-  );
+    return fuzzy
+      .filter(searchTerm, patientLists, {
+        extract: (list) => `${list.name} ${list.type}`,
+      })
+      .sort((r1, r2) => r1.score - r2.score)
+      .map((result) => result.original);
+  }, [searchTerm, patientLists]);
 
   const handleSearchTermChange = (e: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value);
 
@@ -86,7 +74,7 @@ function PatientListsWorkspace() {
   if (patientLists?.length > 0) {
     return (
       <section className={styles.container}>
-        <DataTable headers={tableHeaders} rows={tableRows} size={responsiveSize} useZebraStyles>
+        <DataTable headers={tableHeaders} rows={filteredLists || []} size={responsiveSize} useZebraStyles>
           {({ rows, headers, getTableProps, getHeaderProps, getRowProps }) => (
             <>
               <TableContainer className={styles.tableContainer}>
@@ -98,7 +86,7 @@ function PatientListsWorkspace() {
                         expanded
                         onChange={handleSearchTermChange}
                         placeholder={t('searchThisList', 'Search this list')}
-                        size={responsiveSize}
+                        size="sm"
                       />
                     </TableToolbarContent>
                   </TableToolbar>
@@ -108,7 +96,9 @@ function PatientListsWorkspace() {
                     <TableHead>
                       <TableRow>
                         {headers.map((header) => (
-                          <TableHeader {...getHeaderProps({ header })}>{header.header}</TableHeader>
+                          <TableHeader key={header.key} {...getHeaderProps({ header })}>
+                            {header.header}
+                          </TableHeader>
                         ))}
                       </TableRow>
                     </TableHead>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the following issues in the patient lists workspace:

- Fix type property mapping from `cohort.cohortType?.display` to prevent runtime errors
- Remove unnecessary debouncing from client-side search for instant results
- Fix missing key props in TableHeader components to eliminate React warnings
- Add proper TypeScript typing for MappedList parameters

The main issue was that patient list types weren't being displayed due to runtime errors when accessing cohortType.display on null values. This PR aligns the hook with the logic we use in the Patient List Management app in the Patient Management repository.

## Screenshots

### Before
<img width="1978" height="1694" alt="CleanShot 2025-08-20 at 23 25 31@2x" src="https://github.com/user-attachments/assets/415d0057-9814-4d9b-963a-d1d5687aa5d9" />

### After

<img width="1128" height="1428" alt="CleanShot 2025-08-20 at 23 26 08@2x" src="https://github.com/user-attachments/assets/a33f2985-8a2b-4553-96f8-aab42e93304c" />

## Related Issue

https://openmrs.atlassian.net/browse/O3-4989

## Other
<!-- Anything not covered above -->
