### PR TITLE
(fix) O3-4987: Ensure visit history table is invalidated after adding a medication

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -84,6 +84,9 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
     // Sort the diagnoses by rank, so that primary diagnoses come first
     diagnoses.sort((a, b) => a.rank - b.rank);
 
+    // Sort medications by dateActivated DESC (newest first) to align with backend ordering
+    medications.sort((a, b) => new Date(b.order.dateActivated).getTime() - new Date(a.order.dateActivated).getTime());
+
     return [diagnoses, notes, medications];
   }, [config.notesConceptUuids, visit?.encounters]);
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -64,8 +64,11 @@ export function restoreVisit(visitUuid: string) {
 
 export interface Order {
   uuid: string;
+  action?: string | null;
+  autoExpireDate?: Date | null;
   dateActivated: string;
   dateStopped?: Date | null;
+  fulfillerStatus?: string | null;
   dose: number;
   dosingInstructions: string | null;
   dosingType?: 'org.openmrs.FreeTextDosingInstructions' | 'org.openmrs.SimpleDosingInstructions';
@@ -92,13 +95,7 @@ export interface Order {
   orderNumber: string;
   orderReason: string | null;
   orderReasonNonCoded: string | null;
-  orderer: {
-    uuid: string;
-    person: {
-      uuid: string;
-      display: string;
-    };
-  };
+  orderer: OpenmrsResource;
   orderType: {
     uuid: string;
     display: string;

--- a/packages/esm-patient-medications-app/src/active-medications/active-medications.component.tsx
+++ b/packages/esm-patient-medications-app/src/active-medications/active-medications.component.tsx
@@ -18,9 +18,13 @@ const ActiveMedications: React.FC<ActiveMedicationsProps> = ({ patient }) => {
 
   const launchAddDrugWorkspace = useLaunchWorkspaceRequiringVisit('add-drug-order');
 
-  if (isLoading) return <DataTableSkeleton role="progressbar" />;
+  if (isLoading) {
+    return <DataTableSkeleton role="progressbar" />;
+  }
 
-  if (error) return <ErrorState error={error} headerTitle={headerTitle} />;
+  if (error) {
+    return <ErrorState error={error} headerTitle={headerTitle} />;
+  }
 
   if (activePatientOrders?.length) {
     return (

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -12,7 +12,7 @@ const customRepresentation =
   'custom:(uuid,dosingType,orderNumber,accessionNumber,' +
   'patient:ref,action,careSetting:ref,previousOrder:ref,dateActivated,scheduledDate,dateStopped,autoExpireDate,' +
   'orderType:ref,encounter:ref,orderer:(uuid,display,person:(display)),orderReason,orderReasonNonCoded,orderType,urgency,instructions,' +
-  'commentToFulfiller,drug:(uuid,display,strength,dosageForm:(display,uuid),concept),dose,doseUnits:ref,' +
+  'commentToFulfiller,fulfillerStatus,drug:(uuid,display,strength,dosageForm:(display,uuid),concept),dose,doseUnits:ref,' +
   'frequency:ref,asNeeded,asNeededCondition,quantity,quantityUnits:ref,numRefills,dosingInstructions,' +
   'duration,durationUnits:ref,route:ref,brandName,dispenseAsWritten)';
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR resolves an issue where the visit history table data was not being invalidated when adding a medication via the order basket. It does so by adding cache invalidation logic to the order basket submission logic. Other useful changes in the diff include:

- Augmenting the MedicationSummary component in the VisitHistoryTable to:
 - Filter out discontinued, expired and cancelled orders (aligns with the ActiveMedications widget)
 - Sort orders by dateActivated DESC (newest first) to align with backend ordering
 - Adding the orderer to the MedicationsSummary component (aligns with the MedicationsDetailsTable)

## Screenshots

https://github.com/user-attachments/assets/e2d1144b-fc3f-450c-b8a1-a432efb2879f

## Related Issue
https://openmrs.atlassian.net/browse/O3-4987

## Other
<!-- Anything not covered above -->
