### PR TITLE
(fix) Form Engine App should retain the standard aliases

### DIFF
--- a/packages/esm-form-engine-app/webpack.config.js
+++ b/packages/esm-form-engine-app/webpack.config.js
@@ -1,11 +1,14 @@
-const path = require('path');
-const config = (module.exports = require('openmrs/default-webpack-config'));
-config.scriptRuleConfig.exclude = /(node_modules(?![\/\\]@(?:openmrs|ohri)))/;
+const config = require('openmrs/default-webpack-config');
 // Temporary fix to resolve webpack issues with imports from the libraries below
 config.overrides.resolve = {
   extensions: ['.tsx', '.ts', '.jsx', '.js', '.scss'],
   alias: {
+    '@openmrs/esm-framework': '@openmrs/esm-framework/src/internal',
     '@openmrs/esm-form-engine-lib': '@openmrs/esm-form-engine-lib/src/index',
+    'lodash.debounce': 'lodash-es/debounce',
+    'lodash.findlast': 'lodash-es/findLast',
+    'lodash.omit': 'lodash-es/omit',
+    'lodash.throttle': 'lodash-es/throttle',
   },
 };
 module.exports = config;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

This adds back in the standard aliases to ensure that the framework is not loaded twice

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
