### PR TITLE
(feat) O3-4995: Generic obs across encounters widget should support multiple lines in one graph

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/config-schema-obs-switchable.ts
+++ b/packages/esm-generic-patient-widgets-app/src/config-schema-obs-switchable.ts
@@ -30,13 +30,18 @@ export const configSchemaSwitchable = {
       },
       label: {
         _type: Type.String,
-        _default: '',
-        _description: 'The text to display. Defaults to the concept display name.',
+        _description: 'Label to display for the concept.',
       },
       color: {
         _type: Type.String,
         _default: 'blue',
         _description: 'The color of the line to display in the line graph.',
+      },
+      graphGroup: {
+        _type: Type.String,
+        _default: '',
+        _description:
+          'For showing multiple lines on the same graph. If multiple obs should be shown together, give them the same `graphGroup`. The value of `graphGroup` will be used as the label (or translation key) in the graph view menu panel.',
       },
       decimalPlaces: {
         _type: Type.Number,
@@ -97,6 +102,7 @@ export interface ConfigObjectSwitchable {
     concept: string;
     label: string;
     color: string;
+    graphGroup: string;
     decimalPlaces: number;
   }>;
   table: {

--- a/packages/esm-generic-patient-widgets-app/src/config-schema-obs-switchable.ts
+++ b/packages/esm-generic-patient-widgets-app/src/config-schema-obs-switchable.ts
@@ -30,7 +30,8 @@ export const configSchemaSwitchable = {
       },
       label: {
         _type: Type.String,
-        _description: 'Label to display for the concept.',
+        _default: '',
+        _description: 'Label to display for the concept. If not provided, the concept display name will be used.',
       },
       color: {
         _type: Type.String,

--- a/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-graph/obs-graph.component.tsx
@@ -18,7 +18,6 @@ interface ObsGraphProps {
 }
 
 const ObsGraph: React.FC<ObsGraphProps> = ({ patientUuid }) => {
-  const { t } = useTranslation();
   const config = useConfig<ConfigObjectSwitchable>();
   const { data: observations } = useObs(patientUuid);
 
@@ -27,7 +26,7 @@ const ObsGraph: React.FC<ObsGraphProps> = ({ patientUuid }) => {
       config.data.reduce((acc, curr) => {
         if (!curr.graphGroup) {
           acc.push({
-            groupLabel: curr.label || observations.find((o) => o.conceptUuid == curr.concept)?.conceptUuid,
+            groupLabel: curr.label || observations.find((o) => o.conceptUuid == curr.concept)?.code.text,
             concepts: [curr],
           });
         } else if (acc.find((a) => a.groupLabel == curr.graphGroup)) {
@@ -50,7 +49,7 @@ const ObsGraph: React.FC<ObsGraphProps> = ({ patientUuid }) => {
       const chartRecords = observations
         .filter((obs) => concepts.some((c) => c.concept == obs.conceptUuid) && obs.dataType === 'Number')
         .map((obs) => ({
-          group: obs.conceptUuid,
+          group: obs.code.text,
           key: formatDate(new Date(obs.effectiveDateTime), { year: true, time: false }),
           value: obs.valueQuantity.value,
         }));

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.component.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { type ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, DataTableSkeleton, InlineLoading } from '@carbon/react';
-import { ChartLineSmooth, Table } from '@carbon/react/icons';
+import { Button, ContentSwitcher, DataTableSkeleton, IconSwitch, InlineLoading } from '@carbon/react';
+import { Analytics, ChartLineSmooth, Table } from '@carbon/react/icons';
 import { CardHeader, EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
-import { useConfig } from '@openmrs/esm-framework';
+import { isDesktop, useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { useObs } from '../resources/useObs';
 import { type ConfigObjectSwitchable } from '../config-schema-obs-switchable';
 import ObsGraph from '../obs-graph/obs-graph.component';
@@ -18,6 +18,7 @@ const ObsSwitchable: React.FC<ObsSwitchableProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const config = useConfig<ConfigObjectSwitchable>();
   const [chartView, setChartView] = React.useState<boolean>(config.showGraphByDefault);
+  const isTablet = !isDesktop(useLayoutType());
 
   const { data: obss, error, isLoading, isValidating } = useObs(patientUuid);
 
@@ -37,26 +38,20 @@ const ObsSwitchable: React.FC<ObsSwitchableProps> = ({ patientUuid }) => {
                 </div>
                 {hasNumberType ? (
                   <div className={styles.headerActionItems}>
-                    <div className={styles.toggleButtons}>
-                      <Button
-                        className={styles.toggle}
-                        size="md"
-                        kind={chartView ? 'ghost' : 'tertiary'}
-                        hasIconOnly
-                        renderIcon={(props) => <Table size={16} {...props} />}
-                        iconDescription={t('tableView', 'Table View')}
-                        onClick={() => setChartView(false)}
-                      />
-                      <Button
-                        className={styles.toggle}
-                        size="md"
-                        kind={chartView ? 'tertiary' : 'ghost'}
-                        hasIconOnly
-                        renderIcon={(props) => <ChartLineSmooth size={16} {...props} />}
-                        iconDescription={t('chartView', 'Chart View')}
-                        onClick={() => setChartView(true)}
-                      />
-                    </div>
+                    <ContentSwitcher
+                      onChange={(evt: ChangeEvent<HTMLButtonElement> & { name: string }) =>
+                        setChartView(evt.name === 'chartView')
+                      }
+                      size={isTablet ? 'md' : 'sm'}
+                      selectedIndex={chartView ? 1 : 0}
+                    >
+                      <IconSwitch name="tableView" text="Table view">
+                        <Table size={16} />
+                      </IconSwitch>
+                      <IconSwitch name="chartView" text="Chart view">
+                        <Analytics size={16} />
+                      </IconSwitch>
+                    </ContentSwitcher>
                   </div>
                 ) : null}
               </CardHeader>

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.scss
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.scss
@@ -14,7 +14,7 @@
   padding: layout.$spacing-04 0 layout.$spacing-04 layout.$spacing-05;
 }
 
-.toggleButtons {
+.headerActionItems {
   width: fit-content;
   margin: 0 layout.$spacing-03;
 }

--- a/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-switchable/obs-switchable.test.tsx
@@ -1,0 +1,246 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LineChart } from '@carbon/charts-react';
+import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import ObsSwitchable from './obs-switchable.component';
+import { useObs , type ObsResult } from '../resources/useObs';
+import { configSchemaSwitchable } from '../config-schema-obs-switchable';
+
+jest.mock('../resources/useObs', () => ({
+  useObs: jest.fn(),
+}));
+
+const mockLineChart = jest.mocked(LineChart);
+
+const mockUseConfig = jest.mocked(useConfig);
+
+const mockObsData = [
+  {
+    code: { text: 'Height' },
+    conceptUuid: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    dataType: 'Number',
+    effectiveDateTime: '2021-01-01T00:00:00Z',
+    valueQuantity: { value: 180 },
+    encounter: { reference: 'Encounter/123' },
+  },
+  {
+    code: { text: 'Height' },
+    conceptUuid: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    dataType: 'Number',
+    effectiveDateTime: '2021-02-01T00:00:00Z',
+    valueQuantity: { value: 182 },
+    encounter: { reference: 'Encounter/234' },
+  },
+  {
+    code: { text: 'Weight' },
+    conceptUuid: '2154AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    dataType: 'Number',
+    effectiveDateTime: '2021-01-01T00:00:00Z',
+    valueQuantity: { value: 70 },
+    encounter: { reference: 'Encounter/123' },
+  },
+  {
+    code: { text: 'Weight' },
+    conceptUuid: '2154AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    dataType: 'Number',
+    effectiveDateTime: '2021-02-01T00:00:00Z',
+    valueQuantity: { value: 72 },
+    encounter: { reference: 'Encounter/234' },
+  },
+  {
+    code: { text: 'Chief Complaint' },
+    conceptUuid: '164162AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    dataType: 'Text',
+    effectiveDateTime: '2021-01-01T00:00:00Z',
+    valueString: 'Too strong',
+    encounter: { reference: 'Encounter/123' },
+  },
+  {
+    code: { text: 'Power Level' },
+    conceptUuid: '164163AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    dataType: 'Number',
+    effectiveDateTime: '2021-01-01T00:00:00Z',
+    valueQuantity: { value: 9001 },
+    encounter: { reference: 'Encounter/123' },
+  },
+];
+
+const mockUseObs = jest.mocked(useObs);
+
+describe('ObsSwitchable', () => {
+  it('should render all obs in table and numeric obs in graph', async () => {
+    mockUseObs.mockReturnValue({
+      data: mockObsData as Array<ObsResult>,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+    });
+    mockUseConfig.mockReturnValue({
+      ...(getDefaultsFromConfigSchema(configSchemaSwitchable) as Object),
+      title: 'My Stats',
+      data: [
+        {
+          concept: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+          label: 'Tallitude',
+        },
+        {
+          concept: '2154AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        },
+        { concept: '164162AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+        { concept: '164163AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+      ],
+    });
+
+    render(<ObsSwitchable patientUuid="123" />);
+
+    // Check table
+    expect(screen.getAllByRole('row')).toHaveLength(3);
+    const headerRow = screen.getAllByRole('row')[0];
+    expect(headerRow).toHaveTextContent('Tallitude');
+    expect(headerRow).toHaveTextContent('Weight');
+    expect(headerRow).toHaveTextContent('Chief Complaint');
+    expect(headerRow).toHaveTextContent('Power Level');
+    const firstRow = screen.getAllByRole('row')[1];
+    expect(firstRow).toHaveTextContent('180');
+    expect(firstRow).toHaveTextContent('70');
+    expect(firstRow).toHaveTextContent('Too strong');
+    expect(firstRow).toHaveTextContent('9001');
+    const secondRow = screen.getAllByRole('row')[2];
+    expect(secondRow).toHaveTextContent('182');
+    expect(secondRow).toHaveTextContent('72');
+    expect(secondRow).toHaveTextContent('--');
+    expect(secondRow).toHaveTextContent('--');
+
+    const user = userEvent.setup();
+    const chartViewButton = screen.getByLabelText('Chart view');
+    expect(chartViewButton).toBeInTheDocument();
+    await user.click(chartViewButton);
+
+    const tabs = screen.getByLabelText('Obs tabs');
+    expect(tabs).toHaveTextContent('Tallitude');
+    expect(tabs).toHaveTextContent('Weight');
+    expect(tabs).not.toHaveTextContent('Chief Complaint');
+    expect(tabs).toHaveTextContent('Power Level');
+
+    expect(mockLineChart).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        data: [
+          { group: 'Tallitude', key: '01-Jan-2021', value: 180 },
+          { group: 'Tallitude', key: '01-Feb-2021', value: 182 },
+        ],
+        options: expect.any(Object),
+      }),
+      {},
+    );
+
+    expect(mockLineChart).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: [
+          { group: 'Weight', key: '01-Jan-2021', value: 70 },
+          { group: 'Weight', key: '01-Feb-2021', value: 72 },
+        ],
+        options: expect.any(Object),
+      }),
+      {},
+    );
+
+    expect(mockLineChart).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [expect.objectContaining({ group: 'Chief Complaint' })],
+        options: expect.any(Object),
+      }),
+      {},
+    );
+
+    expect(mockLineChart).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        data: [{ group: 'Power Level', key: '01-Jan-2021', value: 9001 }],
+        options: expect.any(Object),
+      }),
+      {},
+    );
+  });
+
+  it('should support showing graph tab by default', async () => {
+    mockUseObs.mockReturnValue({
+      data: mockObsData as Array<ObsResult>,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+    });
+    mockUseConfig.mockReturnValue({
+      ...(getDefaultsFromConfigSchema(configSchemaSwitchable) as Object),
+      title: 'My Stats',
+      data: [{ concept: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' }],
+      showGraphByDefault: true,
+    });
+
+    render(<ObsSwitchable patientUuid="123" />);
+
+    const tabs = screen.getByLabelText('Obs tabs');
+    expect(tabs).toHaveTextContent('Height');
+
+    expect(mockLineChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [
+          { group: 'Height', key: '01-Jan-2021', value: 180 },
+          { group: 'Height', key: '01-Feb-2021', value: 182 },
+        ],
+        options: expect.any(Object),
+      }),
+      {},
+    );
+  });
+
+  it('should support grouping into multiline graphs', async () => {
+    mockUseObs.mockReturnValue({
+      data: mockObsData as Array<ObsResult>,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+    });
+    mockUseConfig.mockReturnValue({
+      ...(getDefaultsFromConfigSchema(configSchemaSwitchable) as Object),
+      title: 'My Stats',
+      showGraphByDefault: true,
+      data: [
+        { concept: '164163AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', graphGroup: 'Power Level' },
+        { concept: '5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', graphGroup: 'Biometrics' },
+        { concept: '2154AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', graphGroup: 'Biometrics' },
+      ],
+    });
+
+    render(<ObsSwitchable patientUuid="123" />);
+
+    const tabs = screen.getByLabelText('Obs tabs');
+    expect(tabs).toHaveTextContent('Power Level');
+    expect(tabs).toHaveTextContent('Biometrics');
+
+    expect(mockLineChart).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        data: [{ group: 'Power Level', key: '01-Jan-2021', value: 9001 }],
+        options: expect.any(Object),
+      }),
+      {},
+    );
+
+    expect(mockLineChart).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: [
+          { group: 'Height', key: '01-Jan-2021', value: 180 },
+          { group: 'Height', key: '01-Feb-2021', value: 182 },
+          { group: 'Weight', key: '01-Jan-2021', value: 70 },
+          { group: 'Weight', key: '01-Feb-2021', value: 72 },
+        ],
+        options: expect.any(Object),
+      }),
+      {},
+    );
+  });
+});

--- a/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
+++ b/packages/esm-generic-patient-widgets-app/src/obs-table/obs-table.component.tsx
@@ -33,7 +33,7 @@ const ObsTable: React.FC<ObsTableProps> = ({ patientUuid }) => {
     { key: 'date', header: t('dateAndTime', 'Date and time'), isSortable: true },
     ...config.data.map(({ concept, label }) => ({
       key: concept,
-      header: label,
+      header: label || obss.find((o) => o.conceptUuid == concept)?.code.text,
     })),
   ];
 

--- a/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
+++ b/packages/esm-generic-patient-widgets-app/src/resources/useObs.ts
@@ -12,7 +12,7 @@ export interface UseObsResult {
   isValidating: boolean;
 }
 
-type ObsResult = fhir.Observation & {
+export type ObsResult = fhir.Observation & {
   conceptUuid: string;
   dataType?: string;
   valueDateTime?: string;

--- a/packages/esm-generic-patient-widgets-app/translations/en.json
+++ b/packages/esm-generic-patient-widgets-app/translations/en.json
@@ -1,7 +1,4 @@
 {
-  "chartView": "Chart View",
   "dateAndTime": "Date and time",
-  "displaying": "Displaying",
-  "encounterType": "Encounter type",
-  "tableView": "Table View"
+  "encounterType": "Encounter type"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Adds support for multiline graphs using the generic obs graph widget. This is accomplished by adding a `graphGroup` config element to the config's data specification. Any concepts with the same `graphGroup` are graphed together, and the `graphGroup` labels the tab.

I have also added support for using the concept name as the label, so concept labels are no longer required to be specified in config.

I also made it so that when there would only be one tab in the graph view, no tabs are shown, and the graph takes up the whole widget pane.

I wrote some tests that cover a substantial portion of the widget's functionality.

Example config:

```
{
  "@openmrs/esm-patient-chart-app": {
    "extensionSlots": {
      "patient-chart-summary-dashboard-slot": {
        "add": [
          "obs-by-encounter-widget"
        ],
        "order": [
          "obs-by-encounter-widget"
        ],
        "configure": {
          "obs-by-encounter-widget": {
            "title": "My test widget",
            "resultsName": "Widget testing data",
            "showGraphByDefault": true,
            "data": [
              {
                "concept": "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                "graphGroup": "Biometrics"
              },
              {
                "concept": "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                "graphGroup": "Biometrics"
              },
              {
                "concept": "5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
              }
            ]
          }
        }
      }
    }
  }
}
```

## Screenshots

https://github.com/user-attachments/assets/7b8c2676-3117-44ca-b667-f1810439367e


## Related Issue

https://openmrs.atlassian.net/browse/O3-4995

