### PR TITLE
(fix) O3-5025: Improve visibility of attachment preview options button

### DIFF
--- a/packages/esm-patient-attachments-app/src/attachments/attachment-preview.scss
+++ b/packages/esm-patient-attachments-app/src/attachments/attachment-preview.scss
@@ -51,13 +51,13 @@
 }
 
 .overflowMenu {
-  background-color: $ui-04;
+  background-color: colors.$gray-80;
   &:hover {
-    background-color: $ui-03 !important;
+    background-color: colors.$gray-50;
   }
 
   svg {
-    fill: white;
+    fill: white !important;
   }
 }
 

--- a/packages/esm-patient-attachments-app/src/attachments/attachment-preview.scss
+++ b/packages/esm-patient-attachments-app/src/attachments/attachment-preview.scss
@@ -51,8 +51,9 @@
 }
 
 .overflowMenu {
+  background-color: $ui-04;
   &:hover {
-    background-color: hsla(0, 0%, 55%, 0.12) !important;
+    background-color: $ui-03 !important;
   }
 
   svg {


### PR DESCRIPTION
## Requirements

* [x] This PR has a title that briefly describes the work done, including the ticket number. If there is a ticket, the PR title follows [[conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines)](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) conventions.
* [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
* [x] My work includes tests or is validated by existing tests.

---

## Summary

This PR fixes an issue where the options button (overflow menu) in the attachment preview becomes invisible against dark backgrounds (e.g., dark images or PDFs).

Previously, the button had a transparent background, causing it to blend in with the content. This update applies a solid background color using Carbon Design System tokens:

* `$ui-04` for the base state
* `$ui-03` for the hover state

This ensures the button remains visible and accessible in all contexts, while staying consistent with the design system’s principles for interactive elements.

---

## Screenshots

**Before** – The options button is invisible against a dark attachment.
<img width="167" height="77" alt="before" src="https://github.com/user-attachments/assets/a40d7563-0b7e-4959-be6b-1cc06eec3510" />

**After** – The options button is now clearly visible with a solid light grey background.
<img width="167" height="77" alt="after" src="https://github.com/user-attachments/assets/d9636183-1afd-4b16-a7f2-5928aee8c5b6" />

---

## Related Issue

[[O3-5025](https://openmrs.atlassian.net/browse/O3-5025)](https://openmrs.atlassian.net/browse/O3-5025)





[O3-5025]: https://openmrs.atlassian.net/browse/O3-5025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ