### PR TITLE
(test) O3-4779: Add e2e test for editing a past visit start date

### DIFF
--- a/e2e/specs/edit-past-visit-start-date.spec.ts
+++ b/e2e/specs/edit-past-visit-start-date.spec.ts
@@ -1,0 +1,56 @@
+import { expect } from '@playwright/test';
+import dayjs from 'dayjs';
+import { getVisit, endVisit, visitStartDatetime } from '../commands';
+import { test } from '../core';
+import { ChartPage, VisitsPage } from '../pages';
+
+test('Edit start date of a past visit', async ({ page, api, patient, visit }) => {
+  const chartPage = new ChartPage(page);
+  const visitsPage = new VisitsPage(page);
+
+  await test.step('Given the current visit is ended (past visit)', async () => {
+    await endVisit(api, visit);
+  });
+
+  await test.step('When I navigate to the Visits page', async () => {
+    await visitsPage.goTo(patient.uuid);
+  });
+
+  await test.step('And I click Edit on the past visit', async () => {
+    await visitsPage.page.getByRole('button', { name: /edit/i }).click();
+  });
+
+  await test.step('Then I see the Edit Visit form with visit status tabs', async () => {
+    await expect(visitsPage.page.getByRole('tab', { name: /ongoing/i })).toBeVisible();
+    await expect(visitsPage.page.getByRole('tab', { name: /ended/i })).toBeVisible();
+  });
+
+  await test.step('When I change the visit start date to two days ago', async () => {
+    const newStartDate = visitStartDatetime.subtract(1, 'day');
+    await visitsPage.page.getByRole('tab', { name: /ongoing/i }).click();
+
+    await expect(chartPage.page.getByTestId('visitStartDateInput')).toBeVisible();
+
+    const startDateInput = chartPage.page.getByTestId('visitStartDateInput');
+    const startDateDayInput = startDateInput.getByRole('spinbutton', { name: /day/i });
+    const startDateMonthInput = startDateInput.getByRole('spinbutton', { name: /month/i });
+    const startDateYearInput = startDateInput.getByRole('spinbutton', { name: /year/i });
+
+    await startDateDayInput.fill(newStartDate.format('DD'));
+    await startDateMonthInput.fill(newStartDate.format('MM'));
+    await startDateYearInput.fill(newStartDate.format('YYYY'));
+
+    await chartPage.page.getByRole('button', { name: /update visit/i }).click();
+  });
+
+  await test.step('Then I should see a success notification', async () => {
+    await expect(chartPage.page.getByText(/visit details updated/i)).toBeVisible();
+  });
+
+  await test.step('And the visit start date should be updated in the backend', async () => {
+    const updated = await getVisit(api, visit.uuid);
+    const updatedStart = dayjs(updated.startDatetime).format('YYYY-MM-DD');
+    const expectedStart = visitStartDatetime.subtract(1, 'day').format('YYYY-MM-DD');
+    expect(updatedStart).toBe(expectedStart);
+  });
+});

--- a/e2e/specs/edit-past-visit-start-date.spec.ts
+++ b/e2e/specs/edit-past-visit-start-date.spec.ts
@@ -7,7 +7,7 @@ import { ChartPage, VisitsPage } from '../pages';
 test('Edit start date of a past visit', async ({ page, api, patient, visit }) => {
   const chartPage = new ChartPage(page);
   const visitsPage = new VisitsPage(page);
-
+  const targetStartDate = visitStartDatetime.subtract(1, 'day');
   await test.step('Given the current visit is ended (past visit)', async () => {
     await endVisit(api, visit);
   });
@@ -17,7 +17,9 @@ test('Edit start date of a past visit', async ({ page, api, patient, visit }) =>
   });
 
   await test.step('And I click Edit on the past visit', async () => {
-    await visitsPage.page.getByRole('button', { name: /edit/i }).click();
+    const editButton = visitsPage.page.getByRole('button', { name: /^edit$/i }).first();
+    await expect(editButton).toBeVisible();
+    await editButton.click();
   });
 
   await test.step('Then I see the Edit Visit form with visit status tabs', async () => {
@@ -26,9 +28,9 @@ test('Edit start date of a past visit', async ({ page, api, patient, visit }) =>
   });
 
   await test.step('When I change the visit start date to two days ago', async () => {
-    const newStartDate = visitStartDatetime.subtract(1, 'day');
+    const newStartDate = targetStartDate;
     await visitsPage.page.getByRole('tab', { name: /ongoing/i }).click();
-
+    await expect(chartPage.page.getByRole('button', { name: /update visit/i })).toBeVisible();
     await expect(chartPage.page.getByTestId('visitStartDateInput')).toBeVisible();
 
     const startDateInput = chartPage.page.getByTestId('visitStartDateInput');
@@ -36,9 +38,30 @@ test('Edit start date of a past visit', async ({ page, api, patient, visit }) =>
     const startDateMonthInput = startDateInput.getByRole('spinbutton', { name: /month/i });
     const startDateYearInput = startDateInput.getByRole('spinbutton', { name: /year/i });
 
-    await startDateDayInput.fill(newStartDate.format('DD'));
-    await startDateMonthInput.fill(newStartDate.format('MM'));
-    await startDateYearInput.fill(newStartDate.format('YYYY'));
+    await startDateDayInput.click();
+    await startDateDayInput.press('Control+A');
+    await startDateDayInput.type(newStartDate.format('DD'));
+
+    await startDateMonthInput.click();
+    await startDateMonthInput.press('Control+A');
+    await startDateMonthInput.type(newStartDate.format('MM'));
+
+    await startDateYearInput.click();
+    await startDateYearInput.press('Control+A');
+    await startDateYearInput.type(newStartDate.format('YYYY'));
+
+    const startTimeInput = chartPage.page.getByRole('textbox', { name: /start time/i });
+    await expect(startTimeInput).toBeVisible();
+    await startTimeInput.click();
+    await startTimeInput.fill('12:00');
+    await chartPage.page.getByLabel(/start time format/i).selectOption('AM');
+
+    const dayText = await startDateDayInput.textContent();
+    const monthText = await startDateMonthInput.textContent();
+    const yearText = await startDateYearInput.textContent();
+    expect(dayText).toBe(newStartDate.format('DD'));
+    expect(monthText).toBe(newStartDate.format('MM'));
+    expect(yearText).toBe(newStartDate.format('YYYY'));
 
     await chartPage.page.getByRole('button', { name: /update visit/i }).click();
   });
@@ -50,7 +73,7 @@ test('Edit start date of a past visit', async ({ page, api, patient, visit }) =>
   await test.step('And the visit start date should be updated in the backend', async () => {
     const updated = await getVisit(api, visit.uuid);
     const updatedStart = dayjs(updated.startDatetime).format('YYYY-MM-DD');
-    const expectedStart = visitStartDatetime.subtract(1, 'day').format('YYYY-MM-DD');
+    const expectedStart = targetStartDate.format('YYYY-MM-DD');
     expect(updatedStart).toBe(expectedStart);
   });
 });

--- a/e2e/specs/edit-past-visit-start-date.spec.ts
+++ b/e2e/specs/edit-past-visit-start-date.spec.ts
@@ -4,10 +4,11 @@ import { getVisit, endVisit, visitStartDatetime } from '../commands';
 import { test } from '../core';
 import { VisitsPage } from '../pages';
 
-test('Edit start date of a past visit', async ({ page, api, patient, visit }) => {
+test('Edit start date and time of a past visit', async ({ page, api, patient, visit }) => {
   const visitsPage = new VisitsPage(page);
   const targetStartDate = visitStartDatetime.subtract(1, 'day');
-  await test.step('Given the current visit is ended (past visit)', async () => {
+
+  await test.step('Given there is a past visit for the patient', async () => {
     await endVisit(api, visit);
   });
 
@@ -26,7 +27,7 @@ test('Edit start date of a past visit', async ({ page, api, patient, visit }) =>
     await expect(visitsPage.page.getByRole('tab', { name: /ended/i })).toBeVisible();
   });
 
-  await test.step('When I change the visit start date to two days ago', async () => {
+  await test.step('When I change the visit start date and time', async () => {
     await visitsPage.page.getByRole('tab', { name: /ongoing/i }).click();
     await expect(visitsPage.page.getByRole('button', { name: /update visit/i })).toBeVisible();
     await expect(visitsPage.page.getByTestId('visitStartDateInput')).toBeVisible();
@@ -51,16 +52,16 @@ test('Edit start date of a past visit', async ({ page, api, patient, visit }) =>
     expect(dayText).toBe(targetStartDate.format('DD'));
     expect(monthText).toBe(targetStartDate.format('MM'));
     expect(yearText).toBe(targetStartDate.format('YYYY'));
-    await visitsPage.page.keyboard.press('Enter');
 
+    await visitsPage.page.keyboard.press('Enter');
     await visitsPage.page.getByRole('button', { name: /update visit/i }).click();
   });
 
-  await test.step('Then I should see a success notification', async () => {
+  await test.step('Then I should see a success notification indicating that the visit details have been updated', async () => {
     await expect(visitsPage.page.getByText(/visit details updated/i)).toBeVisible();
   });
 
-  await test.step('And the visit start date should be updated in the backend', async () => {
+  await test.step('And the visit start date and time should be updated in the backend', async () => {
     const updated = await getVisit(api, visit.uuid);
     const updatedStart = dayjs(updated.startDatetime).format('YYYY-MM-DD');
     const expectedStart = targetStartDate.format('YYYY-MM-DD');


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

Adds an E2E test to verify editing start date of past visits, including form interaction, date/time updates, and backend validation.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-4779

## Other
<!-- Anything not covered above -->
