### PR TITLE
(feat) O3 5026 : Allergy UI in Orders workflow

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-list.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-list.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { InlineLoading } from '@carbon/react';
+import { InlineLoading, Tag } from '@carbon/react';
 import { useAllergies } from './allergy-intolerance.resource';
 import styles from './allergies-tile.scss';
 
@@ -15,20 +15,20 @@ const AllergyList: React.FC<AllergyListInterface> = ({ patientUuid }) => {
   if (isLoading) {
     return <InlineLoading role="progressbar" description={`${t('loading', 'Loading')} ...`} />;
   }
-  return (
-    <div>
-      <div className={styles.label}>
-        {t('allergies', 'Allergies')}:
-        {!allergies ? (
-          ' Unknown'
-        ) : (
-          <span className={styles.content}>
-            <span className={styles.value}>{allergies?.map((allergy) => allergy?.display).join(', ')}</span>
-          </span>
-        )}
+  if (allergies?.length) {
+    return (
+      <div>
+        <div className={styles.label}>
+          {t('allergies', 'Allergies')}:
+          {allergies.map((allergy) => (
+            <Tag className={styles.allergiesTag}>{allergy.reactionToSubstance}</Tag>
+          ))}
+        </div>
       </div>
-    </div>
-  );
+    );
+  } else {
+    return <div className={styles.label}>{t('allergies', 'Allergies')}: Unknown</div>;
+  }
 };
 
 export default AllergyList;

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-list.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-list.component.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { InlineLoading } from '@carbon/react';
+import { useAllergies } from './allergy-intolerance.resource';
+import styles from './allergies-tile.scss';
+
+interface AllergyListInterface {
+  patientUuid: string;
+}
+
+const AllergyList: React.FC<AllergyListInterface> = ({ patientUuid }) => {
+  const { t } = useTranslation();
+  const { allergies, isLoading } = useAllergies(patientUuid);
+
+  if (isLoading) {
+    return <InlineLoading role="progressbar" description={`${t('loading', 'Loading')} ...`} />;
+  }
+  return (
+    <div>
+      <div className={styles.label}>
+        {t('allergies', 'Allergies')}:
+        {!allergies ? (
+          ' Unknown'
+        ) : (
+          <span className={styles.content}>
+            <span className={styles.value}>{allergies?.map((allergy) => allergy?.display).join(', ')}</span>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AllergyList;

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-tile.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-tile.scss
@@ -1,4 +1,5 @@
 @use '@carbon/type';
+@use '@carbon/colors';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
 .label {
@@ -14,4 +15,8 @@
 
 .value {
   @include type.type-style('body-compact-01');
+}
+
+.allergiesTag {
+  background-color: colors.$orange-20;
 }

--- a/packages/esm-patient-allergies-app/src/index.ts
+++ b/packages/esm-patient-allergies-app/src/index.ts
@@ -12,6 +12,7 @@ import { configSchema } from './config-schema';
 import { dashboardMeta } from './dashboard.meta';
 import allergiesDetailedSummaryComponent from './allergies/allergies-detailed-summary.component';
 import allergyTileComponent from './allergies/allergies-tile.component';
+import allergyListComponent from './allergies/allergies-list.component';
 
 const moduleName = '@openmrs/esm-patient-allergies-app';
 
@@ -58,6 +59,8 @@ export const allergyFormWorkspace = getAsyncLifecycle(
 );
 
 export const allergyTile = getSyncLifecycle(allergyTileComponent, options);
+
+export const allergyList = getSyncLifecycle(allergyListComponent, options);
 
 export const allergyDeleteConfirmationDialog = getAsyncLifecycle(
   () => import('./allergies/delete-allergy.modal'),

--- a/packages/esm-patient-allergies-app/src/routes.json
+++ b/packages/esm-patient-allergies-app/src/routes.json
@@ -14,6 +14,11 @@
       "order": 3
     },
     {
+      "name": "allergy-list",
+      "component": "allergyList",
+      "slot": "allergy-list-pills-slot"
+    },
+    {
       "name": "allergies-details-widget",
       "component": "allergiesDetailedSummary",
       "slot": "patient-chart-allergies-dashboard-slot",

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -405,6 +405,7 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
             {capitalize(patient?.gender)} &middot; {age(patient?.birthDate)} &middot;{' '}
             <span>{formatDate(parseDate(patient?.birthDate), { mode: 'wide', time: false })}</span>
           </span>
+          <ExtensionSlot name="allergy-list-pills-slot" state={{ patientUuid: patient?.id }} />
         </div>
       )}
       <Form className={styles.orderForm} onSubmit={handleSubmit(handleFormSubmission)} id="drugOrderForm">
@@ -419,20 +420,21 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
             />
           )}
           {!isTablet && (
-            <div className={styles.backButton}>
-              <Button
-                kind="ghost"
-                renderIcon={(props: ComponentProps<typeof ArrowLeftIcon>) => <ArrowLeftIcon size={24} {...props} />}
-                iconDescription="Return to order basket"
-                size="sm"
-                onClick={onCancel}
-              >
-                <span>{t('backToOrderBasket', 'Back to order basket')}</span>
-              </Button>
+            <div>
+              <div className={styles.backButton}>
+                <Button
+                  kind="ghost"
+                  renderIcon={(props: ComponentProps<typeof ArrowLeftIcon>) => <ArrowLeftIcon size={24} {...props} />}
+                  iconDescription="Return to order basket"
+                  size="sm"
+                  onClick={onCancel}
+                >
+                  <span>{t('backToOrderBasket', 'Back to order basket')}</span>
+                </Button>
+              </div>
+              <ExtensionSlot name="allergy-list-pills-slot" state={{ patientUuid: patient?.id }} />
             </div>
           )}
-
-          <ExtensionSlot name="allergy-list-pills-slot" state={{ patientUuid: patient?.id }} />
 
           <h1 className={styles.orderFormHeading}>{t('orderForm', 'Order Form')}</h1>
           <div ref={medicationInfoHeaderRef}>

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -432,7 +432,6 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
             </div>
           )}
 
-          {/* <h1>{t('allergies', 'Allergies')}</h1> */}
           <ExtensionSlot name="allergy-list-pills-slot" state={{ patientUuid: patient?.id }} />
 
           <h1 className={styles.orderFormHeading}>{t('orderForm', 'Order Form')}</h1>

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -432,6 +432,9 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
             </div>
           )}
 
+          {/* <h1>{t('allergies', 'Allergies')}</h1> */}
+          <ExtensionSlot name="allergy-list-pills-slot" state={{ patientUuid: patient?.id }} />
+
           <h1 className={styles.orderFormHeading}>{t('orderForm', 'Order Form')}</h1>
           <div ref={medicationInfoHeaderRef}>
             <MedicationInfoHeader

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
@@ -90,6 +90,7 @@
 .orderFormHeading {
   @include type.type-style('heading-03');
   margin-bottom: 0;
+  margin-top: 20px;
 }
 
 .formSection {

--- a/packages/esm-patient-medications-app/translations/en.json
+++ b/packages/esm-patient-medications-app/translations/en.json
@@ -5,7 +5,6 @@
   "activeMedicationsTableTitle": "Active Medications",
   "add": "Add",
   "addDrugOrderWorkspaceTitle": "Add drug order",
-  "allergies": "Allergies",
   "backToOrderBasket": "Back to order basket",
   "clearSearchResults": "Clear Results",
   "decrement": "Decrement",

--- a/packages/esm-patient-medications-app/translations/en.json
+++ b/packages/esm-patient-medications-app/translations/en.json
@@ -5,6 +5,7 @@
   "activeMedicationsTableTitle": "Active Medications",
   "add": "Add",
   "addDrugOrderWorkspaceTitle": "Add drug order",
+  "allergies": "Allergies",
   "backToOrderBasket": "Back to order basket",
   "clearSearchResults": "Clear Results",
   "decrement": "Decrement",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary

We've added an `allergy-list-pills-slot` extension to the esm-patient-allergies-app and then used this extension in the esm-patient-medications-app drug-order-form component.  This design allows this feature to be turned off in the config if not needed and also to be reused elsewhere.

## Screenshots

<img width="1536" height="2048" alt="localhost_8090_openmrs_spa_patient_d31269dc-30ac-4cd5-8c37-81847351f78b_chart_Medications(iPad Mini)" src="https://github.com/user-attachments/assets/74d40599-97cf-4cc5-9f6d-39e94d5ad763" />

<img width="601" height="459" alt="Screenshot from 2025-09-16 07-39-24" src="https://github.com/user-attachments/assets/8ec48560-27cf-4a07-bc81-b07aede96e91" />

<img width="601" height="459" alt="Screenshot from 2025-09-16 07-54-02" src="https://github.com/user-attachments/assets/c6eff47f-5a63-475e-bd7d-634497002978" />

https://github.com/user-attachments/assets/73b8380a-12f6-4888-a22e-12b40279744c

## Related Issue

https://openmrs.atlassian.net/browse/O3-5026

## Other

This work was completed at the OpenMRS implementors conference hackathon by:

* Tendo Martyn @tendomart 
* Abert Namanya @abertnamanya 
* Earl Munyua @Munyua123 