### PR TITLE
(fix) O3-5056: Remove arbitrary maximum duration limit for medication dispensing

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -361,7 +361,6 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
   const [showStickyMedicationHeader, setShowMedicationHeader] = useState(false);
   const { patient } = usePatientChartStore();
   const patientName = patient ? getPatientName(patient) : '';
-  const { maxDispenseDurationInDays } = useConfig<ConfigObject>();
 
   const observer = useRef(null);
   const medicationInfoHeaderRef = useCallback(
@@ -635,7 +634,6 @@ export function DrugOrderForm({ initialOrderBasketItem, onSave, onCancel, prompt
                       label={t('duration', 'Duration')}
                       min={0}
                       step={1}
-                      max={maxDispenseDurationInDays}
                       allowEmpty
                     />
                   ) : (
@@ -773,7 +771,6 @@ interface CustomNumberInputProps {
 
 const CustomNumberInput = ({ setValue, control, name, labelText, isTablet, ...inputProps }: CustomNumberInputProps) => {
   const { t } = useTranslation();
-  const { maxDispenseDurationInDays } = useConfig();
   const responsiveSize = isTablet ? 'md' : 'sm';
 
   const {
@@ -789,7 +786,7 @@ const CustomNumberInput = ({ setValue, control, name, labelText, isTablet, ...in
   );
 
   const increment = () => {
-    setValue(name, Math.min(Number(value) + 1, maxDispenseDurationInDays));
+    setValue(name, Number(value) + 1);
   };
 
   const decrement = () => {

--- a/packages/esm-patient-medications-app/src/config-schema.ts
+++ b/packages/esm-patient-medications-app/src/config-schema.ts
@@ -25,11 +25,6 @@ export const configSchema = {
     _description:
       'Determines whether or not to display the Print button in both the active and past medications datatable headers. If set to true, a Print button gets shown in both the active and past medications table headers. When clicked, this button enables the user to print out the contents of the table',
   },
-  maxDispenseDurationInDays: {
-    _type: Type.Number,
-    _default: 99,
-    _description: 'The maximum number of days for medication dispensing.',
-  },
   debounceDelayInMs: {
     _type: Type.Number,
     _description:
@@ -51,7 +46,6 @@ export interface ConfigObject {
   };
   drugOrderTypeUUID: string;
   showPrintButton: boolean;
-  maxDispenseDurationInDays: number;
   debounceDelayInMs: number;
   requireIndication: boolean;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary

Removes `maxDispenseDurationInDays` constraint from the Medications app's config schema to allow clinically appropriate durations without arbitrary limits.

The constraint is arbitrary, not backed by backend business rules, and disrupts legitimate clinical workflows. If duration limits are needed, they should be drug-specific and enforced at the backend level.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-5056

## Other
<!-- Anything not covered above -->
