### PR TITLE
(test) O3-4627:  Added camera upload functionality to attachments e2e test

### DIFF
--- a/e2e/specs/attachments.spec.ts
+++ b/e2e/specs/attachments.spec.ts
@@ -87,6 +87,17 @@ test('Add and remove an attachment', async ({ page, patient }) => {
     await page.getByRole('tab', { name: 'Webcam' }).click();
   });
 
+  const video = page.locator('video');
+  await expect(video).toBeVisible({ timeout: 1000 });
+
+  await page.waitForFunction(
+    () => {
+      const video = document.querySelector('video');
+      return video && video.readyState === 4;
+    },
+    { timeout: 1000 },
+  );
+
   await test.step('And I capture a photo from webcam', async () => {
     await page.locator('#inner-circle').click();
   });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- This PR adds an E2E test for the patient attachments feature, specifically covering the camera upload workflow. The test ensures that users can:

`attachments.spec`
- Grant camera permissions and open the “Record attachments” modal.

- Switch to the Webcam tab and capture a photo using the device camera.

- Add a description for the captured image.

- Save the attachment and verify that it appears in the attachments table.

- Delete the captured attachment and confirm that it is removed from the list.

## In Progress

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[jira ticket](https://openmrs.atlassian.net/browse/O3-4627)

## Other
<!-- Anything not covered above -->
