### PR TITLE
(feat) O3-5065 add configuration to show prescribing clinician dropdo…

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.workspace.tsx
@@ -50,7 +50,7 @@ export default function AddDrugOrderWorkspace({
   const saveDrugOrder = useCallback(
     (finalizedOrder: DrugOrderBasketItem) => {
       finalizedOrder.careSetting = careSettingUuid;
-      finalizedOrder.orderer = session.currentProvider.uuid;
+      finalizedOrder.orderer ??= session.currentProvider.uuid;
       const newOrders = [...orders];
       const existingOrder = orders.find((order) => ordersEqual(order, finalizedOrder));
       if (existingOrder) {

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
 import useSWRImmutable from 'swr/immutable';
-import { openmrsFetch, restBaseUrl, useConfig, type FetchResponse } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, useConfig, useOpenmrsFetchAll, type FetchResponse } from '@openmrs/esm-framework';
 import type { DrugOrderPost, PatientOrderFetchResponse, Order } from '@openmrs/esm-patient-common-lib';
 import { type ConfigObject } from '../config-schema';
 import { type DrugOrderBasketItem } from '../types';
@@ -228,4 +228,20 @@ export function useRequireOutpatientQuantity(): {
   );
 
   return results;
+}
+export interface Provider {
+  uuid: string;
+  person: {
+    display?: string;
+  };
+}
+
+export function useProviders(providerRoles: Array<string>) {
+  const rep = 'custom:(uuid,person:(display)';
+  const ret = useOpenmrsFetchAll<Provider>(
+    providerRoles?.length > 0 ? `${restBaseUrl}/provider?providerRoles=${providerRoles.join(',')}&v=${rep})` : null,
+  );
+
+  ret.data?.sort((a, b) => a.person?.display.localeCompare(b.person?.display));
+  return ret;
 }

--- a/packages/esm-patient-medications-app/src/config-schema.ts
+++ b/packages/esm-patient-medications-app/src/config-schema.ts
@@ -2,11 +2,10 @@ import { Type, validator } from '@openmrs/esm-framework';
 
 export const configSchema = {
   daysDurationUnit: {
-    _description:
-      'The default medication duration unit is days. The concept for that medication duration unit is specified here.',
     uuid: {
       _type: Type.ConceptUuid,
       _default: '1072AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      _description: 'The uuid of the concept of medication duration unit in days',
     },
     display: {
       _type: Type.String,
@@ -42,6 +41,12 @@ export const configSchema = {
     _description: 'Whether to require an indication when placing a medication order',
     _default: true,
   },
+  prescriberProviderRoles: {
+    _type: Type.Array,
+    _description:
+      'Array of provider roles uuids. If specified, the drug order form shows the "Prescribing Clinician" dropdown listing all providers with one of the specified roles. (The dropdown is hidden if no providers match the role criteria.) This feature requires the providermanagement backend module. Note that, in any case, any user who can submit the drug order form may still do so with themselves as the prescriber.',
+    _default: [],
+  },
 };
 
 export interface ConfigObject {
@@ -54,4 +59,5 @@ export interface ConfigObject {
   maxDispenseDurationInDays: number;
   debounceDelayInMs: number;
   requireIndication: boolean;
+  prescriberProviderRoles: Array<string>;
 }

--- a/packages/esm-patient-medications-app/src/index.ts
+++ b/packages/esm-patient-medications-app/src/index.ts
@@ -39,3 +39,5 @@ export const addDrugOrderWorkspace = getAsyncLifecycle(
   () => import('./add-drug-order/add-drug-order.workspace'),
   options,
 );
+
+export const drugOrderForm = getAsyncLifecycle(() => import('./add-drug-order/drug-order-form.component'), options);

--- a/packages/esm-patient-medications-app/src/routes.json
+++ b/packages/esm-patient-medications-app/src/routes.json
@@ -3,6 +3,9 @@
   "backendDependencies": {
     "webservices.rest": "^2.2.0"
   },
+  "optionalBackendDependencies": {
+    "providermanagement": "^2.16.0"
+  },
   "extensions": [
     {
       "name": "medications-details-widget",
@@ -36,6 +39,10 @@
       "component": "drugOrderPanel",
       "slot": "order-basket-slot",
       "order": 1
+    },
+    {
+      "name": "drug-order-form",
+      "component": "drugOrderForm"
     }
   ],
   "workspaces": [

--- a/packages/esm-patient-medications-app/translations/en.json
+++ b/packages/esm-patient-medications-app/translations/en.json
@@ -63,6 +63,7 @@
   "patientInstructions": "Patient instructions",
   "patientInstructionsPlaceholder": "Additional dosing instructions (e.g. \"Take after eating\")",
   "pillDispensedErrorMessage": "Quantity to dispense is required",
+  "prescribingClinician": "Prescribing Clinician",
   "prescriptionDuration": "2. Prescription duration",
   "prescriptionRefills": "Prescription refills",
   "print": "Print",


### PR DESCRIPTION
…wn in drug order form

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds a way to configure the drug order form to show a "Prescribing Clinician" dropdown. It is not shown by default, but can be configured to show a list of providers with given provider roles. The feature requires the `providermangement` module installed.

## Screenshots
<!-- Required if you are making UI changes. -->
PIH EMR, with `providermangement` module installed, and frontend configuration to show providers with a few roles:
https://github.com/user-attachments/assets/1432b930-dd53-4356-9a44-ce5e273e5d83

Refapp, with no `providermanagement` module installed (notice there is no dropdown):
<img width="1380" height="812" alt="圖片" src="https://github.com/user-attachments/assets/decd3039-56c1-4873-acf0-b743a4136dd9" />



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-5065

## Other
<!-- Anything not covered above -->
As discussed [here](https://talk.openmrs.org/t/adding-prescrbing-clinician-field-to-o3-drug-order-form/47121/4), we should also enable the dropdown in other order forms. This PR only changes the drug form, with the remaining work documented in 
https://openmrs.atlassian.net/browse/O3-5065