### PR TITLE
O3-5090 : Fix medication summary crash by removing external config dependency

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -19,7 +19,8 @@ export const esmPatientChartSchema = {
   encounterEditableDuration: {
     _type: Type.Number,
     _default: 0,
-    _description: 'The number of minutes an encounter is editable after it is created. 0 means the encounter is editable forever.',
+    _description:
+      'The number of minutes an encounter is editable after it is created. 0 means the encounter is editable forever.',
   },
   encounterEditableDurationOverridePrivileges: {
     _type: Type.Array,
@@ -27,7 +28,8 @@ export const esmPatientChartSchema = {
       _type: Type.String,
     },
     _default: [],
-    _description: 'The privileges that allow users to edit encounters even after the editable duration (set by `encounterEditableDuration`) has expired. Any privilege in the list is sufficient to edit the encounter.',
+    _description:
+      'The privileges that allow users to edit encounters even after the editable duration (set by `encounterEditableDuration`) has expired. Any privilege in the list is sufficient to edit the encounter.',
   },
   freeTextFieldConceptUuid: {
     _type: Type.ConceptUuid,
@@ -188,6 +190,11 @@ export const esmPatientChartSchema = {
     _description: 'Whether to require an active visit for the encounter tile',
     _default: true,
   },
+  drugOrderTypeUUID: {
+    _type: Type.UUID,
+    _description: "UUID for the 'Drug' order type to fetch medications",
+    _default: '131168f4-15f5-102d-96e4-000c29c2a5d7',
+  },
 };
 
 export interface ChartConfig {
@@ -231,4 +238,5 @@ export interface ChartConfig {
     }>;
   }>;
   otherConceptUuid: string;
+  drugOrderTypeUUID: string;
 }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/medications-summary.component.tsx
@@ -6,6 +6,7 @@ import { Tag, Tooltip } from '@carbon/react';
 import { formatDate, useConfig } from '@openmrs/esm-framework';
 import type { OrderItem } from '../visit.resource';
 import styles from '../visit-detail-overview.scss';
+import { type ChartConfig } from '../../../config-schema';
 
 interface MedicationSummaryProps {
   medications: Array<OrderItem>;
@@ -13,9 +14,7 @@ interface MedicationSummaryProps {
 
 const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications }) => {
   const { t } = useTranslation();
-  const { drugOrderTypeUUID } = useConfig({
-    externalModuleName: '@openmrs/esm-patient-medications-app',
-  });
+  const { drugOrderTypeUUID } = useConfig<ChartConfig>();
 
   const isPastMedication = (order: OrderItem['order']) => {
     if (!order) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes issue where the Medication Summary widget in Past Visits was loading configuration from `@openmrs/esm-patient-medications-app` using `useConfig({ externalModuleName })`. This caused silent failures in distributions like KenyaEMR that don't load the  medications app directly, resulting in `drugOrderTypeUUID` being undefined and  breaking medication summary component.

## Screenshots
### Error state
https://github.com/user-attachments/assets/1d0f9e14-ca27-4a79-8d4f-84a015c34e5d

### Fixed
https://github.com/user-attachments/assets/2102a317-9865-47d7-87dd-c8235e94d9cf

## Related Issue
https://thepalladiumgroup.atlassian.net/browse/KHP3-8548

## Other
<!-- Anything not covered above -->
