### PR TITLE
(feat) O3-5091 : Hide empty Lab orderable tree items when no test results exist

### DIFF
--- a/packages/esm-patient-tests-app/src/test-results/grouped-timeline/useObstreeData.ts
+++ b/packages/esm-patient-tests-app/src/test-results/grouped-timeline/useObstreeData.ts
@@ -9,7 +9,7 @@ export const getName = (prefix: string | undefined, name: string) => {
   return prefix ? `${prefix}-${name}` : name;
 };
 
-interface ObsTreeNode {
+export interface ObsTreeNode {
   flatName?: string;
   display: string;
   hasData: boolean;
@@ -111,7 +111,35 @@ const useGetManyObstreeData = (uuidArray: Array<string>) => {
       ]
     );
   }, [data]);
-  const roots = result.map((item) => item.data);
+
+  const filterNodesWithData = (node: ObsTreeNode): ObsTreeNode | null => {
+    // If this node has obs data, include it
+    if (node.obs && node.obs.length > 0) {
+      return node;
+    }
+
+    // If this node has subSets, recursively filter them
+    if (node.subSets && node.subSets.length > 0) {
+      const filteredSubSets = node.subSets
+        .map((subSet) => filterNodesWithData(subSet))
+        .filter((subSet): subSet is ObsTreeNode => subSet !== null);
+
+      // Only include this node if it has valid subSets after filtering
+      if (filteredSubSets.length > 0) {
+        return { ...node, subSets: filteredSubSets };
+      }
+    }
+
+    // No data found in this branch
+    return null;
+  };
+
+  const roots = result
+    .map((item) => item.data)
+    .filter((data): data is ObsTreeNode => 'display' in data)
+    .map((data) => filterNodesWithData(data))
+    .filter((data): data is ObsTreeNode => data !== null);
+
   const isLoading = result.some((item) => item.loading);
 
   return { roots, isLoading, error };

--- a/packages/esm-patient-tests-app/src/test-results/tree-view/tree-view.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/tree-view/tree-view.test.tsx
@@ -7,6 +7,7 @@ import { type ConfigObject, configSchema } from '../../config-schema';
 import { useGetManyObstreeData } from '../grouped-timeline';
 import TreeView from './tree-view.component';
 import { FilterProvider, type Roots } from '../filter/filter-context';
+import { type ObsTreeNode } from '../grouped-timeline/useObstreeData';
 
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
 const mockUseLayoutType = jest.mocked(useLayoutType);
@@ -93,7 +94,7 @@ describe('TreeView', () => {
 
   it('renders the tree view when test data is successfully fetched', async () => {
     mockUseGetManyObstreeData.mockReturnValue({
-      roots: mockResults,
+      roots: mockResults as unknown as Array<ObsTreeNode>,
       isLoading: false,
       error: null,
     });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
See https://openmrs.atlassian.net/browse/O3-5091

## Screenshots
### Current state
https://github.com/user-attachments/assets/ed4c0bc7-1751-4bcb-accf-52eb1640b8f7

### Fixed state
https://github.com/user-attachments/assets/3b76343c-15ee-4a06-917d-0b9935686be4

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
