### PR TITLE
(fix) O3-5318: Format dates properly in print and edit lab results modals 

### DIFF
--- a/packages/esm-patient-orders-app/src/lab-results/print-results/print-modal/print-results-modal.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/print-results/print-modal/print-results-modal.tsx
@@ -4,7 +4,7 @@ import { capitalize } from 'lodash-es';
 import { Button, ModalBody, ModalFooter, Checkbox } from '@carbon/react';
 import { useReactToPrint } from 'react-to-print';
 import { useTranslation } from 'react-i18next';
-import { useSession } from '@openmrs/esm-framework';
+import { useSession, formatDatetime, parseDate } from '@openmrs/esm-framework';
 import { type Order } from '@openmrs/esm-patient-common-lib';
 import PrintableReport from '../print-preview/print-preview.component';
 import styles from './print-results-modal.scss';
@@ -104,7 +104,9 @@ const PrintResultsModal: React.FC<PrintResultsModalProps> = ({ orders, closeModa
 
                     <div className={styles.facilityDetails}>
                       <p className={styles.itemLabel}>{capitalize(location)}</p>
-                      <p className={styles.itemLabel}>{firstOrder.dateActivated}</p>
+                      <span className={styles.itemLabel}>
+                        {formatDatetime(parseDate(firstOrder.dateActivated), { mode: 'standard' })}
+                      </span>
                     </div>
                   </div>
                   <p className={styles.testDoneHeader}>{capitalize(t('testDone', 'Test done'))}</p>

--- a/packages/esm-patient-orders-app/src/lab-results/print-results/print-modal/print-results-modal.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/print-results/print-modal/print-results-modal.tsx
@@ -105,7 +105,7 @@ const PrintResultsModal: React.FC<PrintResultsModalProps> = ({ orders, closeModa
                     <div className={styles.facilityDetails}>
                       <p className={styles.itemLabel}>{capitalize(location)}</p>
                       <span className={styles.itemLabel}>
-                        {formatDatetime(parseDate(firstOrder.dateActivated), { mode: 'standard' })}
+                        {formatDatetime(parseDate(firstOrder.dateActivated), { mode: 'standard', noToday: true })}
                       </span>
                     </div>
                   </div>

--- a/packages/esm-patient-tests-app/src/edit-test-results/modal/edit-lab-results.modal.tsx
+++ b/packages/esm-patient-tests-app/src/edit-test-results/modal/edit-lab-results.modal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Button, ModalBody, ModalFooter, ModalHeader, RadioButton, RadioButtonGroup } from '@carbon/react';
-import { launchWorkspace2, useSession } from '@openmrs/esm-framework';
+import { launchWorkspace2, useSession, formatDatetime, parseDate } from '@openmrs/esm-framework';
 import { type Order } from '@openmrs/esm-patient-common-lib';
 import styles from './edit-lab-results.scss';
 
@@ -86,7 +86,9 @@ const EditLabResultModal: React.FC<EditLabResultModalProps> = ({
                     </p>
                     <p className={styles.itemLabel}>
                       <span className={styles.labelKey}>{t('dateOrdered', 'Date ordered')}:</span>
-                      <span className={styles.labelValue}>{selectedOrder.dateActivated}</span>
+                      <span className={styles.labelValue}>
+                        {formatDatetime(parseDate(selectedOrder.dateActivated), { mode: 'standard' })}
+                      </span>
                     </p>
                   </div>
                 </div>

--- a/packages/esm-patient-tests-app/src/edit-test-results/modal/edit-lab-results.modal.tsx
+++ b/packages/esm-patient-tests-app/src/edit-test-results/modal/edit-lab-results.modal.tsx
@@ -87,7 +87,7 @@ const EditLabResultModal: React.FC<EditLabResultModalProps> = ({
                     <p className={styles.itemLabel}>
                       <span className={styles.labelKey}>{t('dateOrdered', 'Date ordered')}:</span>
                       <span className={styles.labelValue}>
-                        {formatDatetime(parseDate(selectedOrder.dateActivated), { mode: 'standard' })}
+                        {formatDatetime(parseDate(selectedOrder.dateActivated), { mode: 'standard', noToday: true })}
                       </span>
                     </p>
                   </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary                                                                                           
                                                                                                     
- Fixes raw ISO date strings (e.g., 2023-08-14T18:23:05.000+0000) being displayed instead of properly formatted dates.                                                                           
- Uses formatDatetime(parseDate(...)) from @openmrs/esm-framework to display dates in a human-readable, localized format.                                            
                                                                                                   
Affected components:                                                                               
- Print results modal (esm-patient-orders-app)                                                     
- Edit lab results modal (esm-patient-tests-app) 

## Screenshots

### Before
<img width="690" height="309" alt="image" src="https://github.com/user-attachments/assets/7411b1e3-4547-43b1-aceb-0b58bd509b67" />

<img width="690" height="309" alt="image" src="https://github.com/user-attachments/assets/870f0c98-f87e-42aa-b2a2-b00afaeccad9" />

### After

<img width="904" height="379" alt="image" src="https://github.com/user-attachments/assets/7e53c62c-c8af-4f2c-8fb6-56c7067e3a6f" />
<img width="904" height="379" alt="image" src="https://github.com/user-attachments/assets/9ac6c7fe-a60d-4524-8056-5f7a0344510c" />
<img width="904" height="379"alt="image" src="https://github.com/user-attachments/assets/8dc4622d-37b8-4c83-acf1-19aa8a4a94e8" />

## Related Issue
https://openmrs.atlassian.net/browse/O3-5318
