### PR TITLE
(fix) O3-5319: Refresh test results viewer after saving lab results

### DIFF
--- a/e2e/specs/lab-orders.spec.ts
+++ b/e2e/specs/lab-orders.spec.ts
@@ -3,7 +3,7 @@ import { type Order } from '@openmrs/esm-patient-common-lib';
 import { generateRandomTestOrder, deleteTestOrder, createEncounter, deleteEncounter, getProvider } from '../commands';
 import { type Encounter, type Provider } from '../commands/types';
 import { test } from '../core';
-import { OrdersPage } from '../pages';
+import { OrdersPage, ResultsViewerPage } from '../pages';
 
 let testOrder: Order;
 let encounter: Encounter;
@@ -111,6 +111,20 @@ test.describe('Modify and discontinue laboratory order tests sequentially', () =
 
     await test.step('And a confirmation message should be displayed indicating that the result was saved', async () => {
       await expect(page.getByText(/Lab results for .* have been successfully updated/i)).toBeVisible();
+    });
+
+    await test.step('When I navigate to the Results Viewer page', async () => {
+      const resultsViewerPage = new ResultsViewerPage(page);
+      await resultsViewerPage.goTo(patient.uuid);
+    });
+
+    await test.step('And I click on the Individual tests tab', async () => {
+      await page.getByRole('tab', { name: /individual tests/i }).click();
+    });
+
+    await test.step('Then I should see the saved lab result in the results viewer', async () => {
+      const row = page.locator('tr:has-text("Serum glucose"):has(td:has-text("55"))').first();
+      await expect(row).toBeVisible();
     });
   });
 

--- a/packages/esm-patient-tests-app/src/test-results/filter/filter-context.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/filter/filter-context.tsx
@@ -192,10 +192,10 @@ const FilterProvider = ({ roots, isLoading, children }: FilterProviderProps) => 
   }, [state.tests]);
 
   useEffect(() => {
-    if (roots.length && !Object.keys(state.parents).length) {
-      actions.initialize(roots);
+    if (roots.length) {
+      actions.initialize(roots); //ensures ui updates when new data comes up
     }
-  }, [actions, state.parents, roots]);
+  }, [actions, roots]);
 
   const totalResultsCount: number = useMemo(() => {
     let count = 0;

--- a/packages/esm-patient-tests-app/src/test-results/filter/filter-reducer.test.ts
+++ b/packages/esm-patient-tests-app/src/test-results/filter/filter-reducer.test.ts
@@ -253,6 +253,55 @@ describe('filterReducer', () => {
       expect(newState.lowestParents[0].flatName).toBe('CBC');
     });
 
+    it('should preserve existing checkbox selections when re-initialized with new data', () => {
+      const stateWithSelections: ReducerState = {
+        ...initialState,
+        checkboxes: {
+          'CBC: Hemoglobin': true,
+          'CBC: Hematocrit': false,
+        },
+      };
+
+      const updatedTrees: Array<TreeNode> = [
+        {
+          flatName: 'CBC',
+          display: 'Complete Blood Count',
+          subSets: [
+            {
+              flatName: 'CBC: Hemoglobin',
+              display: 'Hemoglobin',
+              obs: [{ obsDatetime: '2024-01-01', value: '12', interpretation: 'NORMAL' }],
+              hasData: true,
+            },
+            {
+              flatName: 'CBC: Hematocrit',
+              display: 'Hematocrit',
+              obs: [{ obsDatetime: '2024-01-01', value: '36', interpretation: 'NORMAL' }],
+              hasData: true,
+            },
+            {
+              flatName: 'CBC: WBC',
+              display: 'White Blood Cell Count',
+              obs: [{ obsDatetime: '2024-01-01', value: '7.5', interpretation: 'NORMAL' }],
+              hasData: true,
+            },
+          ],
+          hasData: true,
+        },
+      ];
+
+      const newState = reducer(stateWithSelections, {
+        type: ReducerActionType.INITIALIZE,
+        trees: updatedTrees,
+      });
+
+      expect(newState.checkboxes).toEqual({
+        'CBC: Hemoglobin': true,
+        'CBC: Hematocrit': false,
+        'CBC: WBC': false,
+      });
+    });
+
     it('should handle leaf nodes without subSets', () => {
       const mockTrees: Array<TreeNode> = [
         {

--- a/packages/esm-patient-tests-app/src/test-results/filter/filter-reducer.ts
+++ b/packages/esm-patient-tests-app/src/test-results/filter/filter-reducer.ts
@@ -112,7 +112,7 @@ function reducer(state: ReducerState, action: ReducerAction): ReducerState {
       });
 
       return {
-        checkboxes: Object.fromEntries(leaves.map((leaf) => [leaf, false])),
+        checkboxes: Object.fromEntries(leaves.map((leaf) => [leaf, state.checkboxes[leaf] ?? false])),
         parents: parents,
         roots: action.trees,
         tests: flatTests,

--- a/packages/esm-patient-tests-app/src/test-results/grouped-timeline/useObstreeData.ts
+++ b/packages/esm-patient-tests-app/src/test-results/grouped-timeline/useObstreeData.ts
@@ -168,9 +168,9 @@ const useGetManyObstreeData = (patientUuid: string, uuidArray: Array<string>) =>
   };
   const { data, error } = useSWRInfinite(getObstreeUrl, openmrsFetch, {
     initialSize: uuidArray.length,
-    revalidateIfStale: false,
+    revalidateIfStale: true,
     revalidateOnFocus: false,
-    revalidateOnReconnect: false,
+    revalidateOnReconnect: true,
   });
 
   const result = useMemo(() => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

After saving lab results via the orders workspace, the test results viewer didn't update to show the newly 
saved values. Three compounding issues prevented the UI from refreshing:                                   
                                                                                                            
1. The obstree SWR cache was never invalidated after save            
2. `useSWRInfinite` was configured with `revalidateIfStale: false`, so even stale-marked cache wasn't
refetched                           
3. `FilterProvider` only initialized once and ignored subsequent data changes

### Changes made

- Invalidate the obstree SWR cache after saving lab results so the test results viewer reflects newly saved
  values
- Reorder cache invalidation to run before `closeWorkspace()` to prevent a race where stale data flashes
briefly
- Restore SWR defaults (`revalidateIfStale`, `revalidateOnReconnect`) on the obstree hook so invalidated
data is actually refetched
- Remove one-shot initialization guard in `FilterProvider` so the filter tree processes new data on
revalidation
- Preserve user filter checkbox selections across re-initializations

## Screenshots

### Before

https://github.com/user-attachments/assets/17c21c49-5003-4123-a539-d5876414d2a3



### After

https://github.com/user-attachments/assets/b67a231b-d320-4db1-83e6-5ed83f92fd64



## Related Issue

[O3-5319](https://openmrs.atlassian.net/browse/O3-5319)


[O3-5319]: https://openmrs.atlassian.net/browse/O3-5319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ