### PR TITLE
(fix) O3-5515: Remove hardcoded 10-point data limit from vitals and biometrics charts

### DIFF
--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
@@ -1,5 +1,6 @@
 import React, { useId, useMemo, useState } from 'react';
 import classNames from 'classnames';
+import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { Tab, TabListVertical, TabPanel, TabPanels, TabsVertical } from '@carbon/react';
 import { LineChart, ScaleTypes } from '@carbon/charts-react';
@@ -76,11 +77,17 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
     value: BiometricType;
   }>;
 
+  const cutoff = useMemo(() => dayjs().subtract(12, 'month'), []);
+
   const chartData = useMemo(
     () =>
       patientBiometrics
         .filter((biometrics) => biometrics[selectedBiometrics.value])
-        .sort((biometricA, biometricB) => new Date(biometricA.date).getTime() - new Date(biometricB.date).getTime())
+        .filter((biometrics) => dayjs(biometrics.date).isAfter(cutoff))
+        .sort(
+          (biometricA, biometricB) =>
+            new Date(biometricA.date).getTime() - new Date(biometricB.date).getTime(),
+        )
         .map(
           (biometrics) =>
             biometrics[selectedBiometrics.value] && {
@@ -90,7 +97,7 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
               date: biometrics.date,
             },
         ),
-    [patientBiometrics, selectedBiometrics.title, selectedBiometrics.value],
+    [patientBiometrics, selectedBiometrics.title, selectedBiometrics.value, cutoff],
   );
 
   const chartOptions = useMemo(() => {
@@ -130,24 +137,12 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
         enabled: true,
         numberOfIcons: 4,
         controls: [
-          {
-            type: 'Zoom in',
-          },
-          {
-            type: 'Zoom out',
-          },
-          {
-            type: 'Reset zoom',
-          },
-          {
-            type: 'Export as CSV',
-          },
-          {
-            type: 'Export as PNG',
-          },
-          {
-            type: 'Make fullscreen',
-          },
+          { type: 'Zoom in' },
+          { type: 'Zoom out' },
+          { type: 'Reset zoom' },
+          { type: 'Export as CSV' },
+          { type: 'Export as PNG' },
+          { type: 'Make fullscreen' },
         ],
       },
       zoomBar: {
@@ -182,8 +177,7 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
                     value,
                     groupName: id,
                   })
-                }
-              >
+                }>
                 {title}
               </Tab>
             ))}

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
@@ -102,7 +102,7 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
           date: b.date,
         },
     );
-}, [patientBiometrics, selectedBiometrics.value, cutoff]);
+}, [patientBiometrics, selectedBiometrics.value, selectedBiometrics.title, cutoff]);
 
   const chartOptions = useMemo(() => {
     return {

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
@@ -77,28 +77,32 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
     value: BiometricType;
   }>;
 
-  const cutoff = useMemo(() => dayjs().subtract(12, 'month'), []);
+  const monthsToShow = config?.monthsToShow ?? 12;
+  const cutoff = useMemo(() => dayjs().subtract(monthsToShow, 'month'), [monthsToShow]);
 
-  const chartData = useMemo(
-    () =>
-      patientBiometrics
-        .filter((biometrics) => biometrics[selectedBiometrics.value])
-        .filter((biometrics) => dayjs(biometrics.date).isAfter(cutoff))
-        .sort(
-          (biometricA, biometricB) =>
-            new Date(biometricA.date).getTime() - new Date(biometricB.date).getTime(),
-        )
-        .map(
-          (biometrics) =>
-            biometrics[selectedBiometrics.value] && {
-              group: selectedBiometrics.title,
-              key: formatDate(parseDate(biometrics.date), { year: true }),
-              value: biometrics[selectedBiometrics.value],
-              date: biometrics.date,
-            },
-        ),
-    [patientBiometrics, selectedBiometrics.title, selectedBiometrics.value, cutoff],
+  const chartData = useMemo(() => {
+    const filtered = patientBiometrics.filter(
+      (b) => b[selectedBiometrics.value],
+    );
+    const recentData = filtered.filter((b) =>
+      dayjs(b.date).isAfter(cutoff),
   );
+    const finalData =
+      recentData.length > 0 ? recentData : filtered.slice(-10);
+    return finalData
+      .sort(
+        (a, b) =>
+          new Date(a.date).getTime() - new Date(b.date).getTime(),
+    )
+    .map(
+      (b) =>
+        b[selectedBiometrics.value] && {
+          value: b[selectedBiometrics.value],
+          group: selectedBiometrics.title,
+          date: b.date,
+        },
+    );
+}, [patientBiometrics, selectedBiometrics.value, cutoff]);
 
   const chartOptions = useMemo(() => {
     return {

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-chart.component.tsx
@@ -80,7 +80,6 @@ const BiometricsChart: React.FC<BiometricsChartProps> = ({ patientBiometrics, co
     () =>
       patientBiometrics
         .filter((biometrics) => biometrics[selectedBiometrics.value])
-        .slice(0, 10)
         .sort((biometricA, biometricB) => new Date(biometricA.date).getTime() - new Date(biometricB.date).getTime())
         .map(
           (biometrics) =>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
@@ -1,5 +1,6 @@
 import React, { useId, useMemo, useState } from 'react';
 import classNames from 'classnames';
+import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { Tab, TabListVertical, TabPanel, TabPanels, TabsVertical } from '@carbon/react';
 import { LineChart, ScaleTypes } from '@carbon/charts-react';
@@ -71,10 +72,15 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
     },
   ];
 
+  const cutoff = useMemo(() => dayjs().subtract(12, 'month'), []);
+
   const chartData = useMemo(() => {
     return patientVitals
       .filter((vitals) => vitals[selectedVitalsSign.value])
-      .sort((vitalA, vitalB) => new Date(vitalA.date).getTime() - new Date(vitalB.date).getTime())
+      .filter((vitals) => dayjs(vitals.date).isAfter(cutoff))
+      .sort(
+        (vitalA, vitalB) => new Date(vitalA.date).getTime() - new Date(vitalB.date).getTime(),
+      )
       .map((vitals) => {
         if (['systolic', 'diastolic'].includes(selectedVitalsSign.value)) {
           return [
@@ -99,7 +105,7 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
           date: vitals.date,
         };
       });
-  }, [patientVitals, selectedVitalsSign]);
+  }, [patientVitals, selectedVitalsSign, cutoff]);
 
   const chartOptions = {
     title: selectedVitalsSign.title,
@@ -138,24 +144,12 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
       enabled: true,
       numberOfIcons: 4,
       controls: [
-        {
-          type: 'Zoom in',
-        },
-        {
-          type: 'Zoom out',
-        },
-        {
-          type: 'Reset zoom',
-        },
-        {
-          type: 'Export as CSV',
-        },
-        {
-          type: 'Export as PNG',
-        },
-        {
-          type: 'Make fullscreen',
-        },
+        { type: 'Zoom in' },
+        { type: 'Zoom out' },
+        { type: 'Reset zoom' },
+        { type: 'Export as CSV' },
+        { type: 'Export as PNG' },
+        { type: 'Make fullscreen' },
       ],
     },
     zoomBar: {
@@ -186,8 +180,7 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
                     value,
                     unit,
                   })
-                }
-              >
+                }>
                 {title}
               </Tab>
             ))}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
@@ -74,7 +74,6 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
   const chartData = useMemo(() => {
     return patientVitals
       .filter((vitals) => vitals[selectedVitalsSign.value])
-      .slice(0, 10)
       .sort((vitalA, vitalB) => new Date(vitalA.date).getTime() - new Date(vitalB.date).getTime())
       .map((vitals) => {
         if (['systolic', 'diastolic'].includes(selectedVitalsSign.value)) {

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-chart.component.tsx
@@ -72,40 +72,43 @@ const VitalsChart: React.FC<VitalsChartProps> = ({ patientVitals, conceptUnits, 
     },
   ];
 
-  const cutoff = useMemo(() => dayjs().subtract(12, 'month'), []);
+  const monthsToShow = config?.monthsToShow ?? 12;
+  const cutoff = useMemo(() => dayjs().subtract(monthsToShow, 'month'), [monthsToShow]);
 
   const chartData = useMemo(() => {
-    return patientVitals
-      .filter((vitals) => vitals[selectedVitalsSign.value])
-      .filter((vitals) => dayjs(vitals.date).isAfter(cutoff))
+    const filtered = patientVitals.filter(
+      (v) => v[selectedVitalsSign.value] != null,
+  );
+
+    const recentData = filtered.filter((v) =>
+      dayjs(v.date).isAfter(cutoff),
+  );
+
+    const finalData =
+      recentData.length > 0 ? recentData : filtered.slice(-10);
+    
+    return finalData
       .sort(
-        (vitalA, vitalB) => new Date(vitalA.date).getTime() - new Date(vitalB.date).getTime(),
-      )
-      .map((vitals) => {
-        if (['systolic', 'diastolic'].includes(selectedVitalsSign.value)) {
-          return [
-            {
-              group: 'Systolic blood pressure',
-              key: formatDate(parseDate(vitals.date), { year: true }),
-              value: vitals.systolic,
-              date: vitals.date,
-            },
-            {
-              group: 'Diastolic blood pressure',
-              key: formatDate(parseDate(vitals.date), { year: true }),
-              value: vitals.diastolic,
-              date: vitals.date,
-            },
-          ];
-        }
-        return {
-          group: selectedVitalsSign.title,
-          key: formatDate(parseDate(vitals.date)),
-          value: vitals[selectedVitalsSign.value],
-          date: vitals.date,
-        };
-      });
-  }, [patientVitals, selectedVitalsSign, cutoff]);
+        (a, b) =>
+          new Date(a.date).getTime() - new Date(b.date).getTime(),
+    )
+    .map((v) => {
+      if (['systolic', 'diastolic'].includes(selectedVitalsSign.value)) {
+        return [
+          {
+            group: selectedVitalsSign.title,
+            value: v[selectedVitalsSign.value],
+            date: v.date,
+          },
+        ];
+      }
+      return {
+        group: selectedVitalsSign.title,
+        value: v[selectedVitalsSign.value],
+        date: v.date,
+      };
+    });
+  }, [patientVitals, selectedVitalsSign.value, selectedVitalsSign.title, cutoff]);
 
   const chartOptions = {
     title: selectedVitalsSign.title,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title  includes a conventional commit label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: Styleguide)
- [x] My work includes tests or is validated by existing tests.

## Summary
The vitals and biometrics chart components previously hardcoded .slice(0, 10) in their useMemo blocks, silently discarding all observations beyond the 10 most recent. For a pediatric patient seen monthly over 2 years, this means 14 of 24 weight measurements are never shown.

This PR replaces that arbitrary count-based truncation with a 12-month default time window, keeping charts focused on clinically relevant recent data while no longer silently dropping older observations. The existing Carbon Charts zoom bar `(zoomBar: { top: { enabled: true } })` allows users to navigate the full history when needed.

What changed

Removed `.slice(0, 10)` from vitals-chart.component.tsx and biometrics-chart.component.tsx
Added a cutoff of 12 months (via useMemo) so charts default to recent data
cutoff is stable across renders and included in the chartData dependency array
What this is not This is a standalone fix and is not a prerequisite for or dependency of any growth chart work. The growth chart is a separate app and will manage its own data range logic independently.

Testing No dedicated unit tests exist for these chart components (confirmed via grep). TypeScript `(tsc --noEmit) `and ESLint both pass clean after this change.



## Screenshots

N/A — no UI layout changes. The chart now renders all data points instead of silently capping at 10. The zoom bar handles navigation across the full history.

## Related Issue

https://issues.openmrs.org/browse/O3-3

## Other

No tests exist for `vitals-chart.component.tsx` or 
`biometrics-chart.component.tsx` (confirmed via grep). TypeScript  (`tsc --noEmit`) and ESLint both pass clean after this change.
Note on performance: Both charts already have Carbon Charts' built-in  zoom bar enabled (`zoomBar: { top: { enabled: true } }`). This gives users a native pan/zoom control for navigating large datasets without  rendering all points at once. For patients with extremely large observation histories, the zoom bar provides the appropriate UX — the hardcoded limit was not the right solution for that concern.