### PR TITLE
(fix) Correct casing of editCondition label

### DIFF
--- a/packages/esm-patient-conditions-app/src/conditions/conditions-action-menu.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-action-menu.component.tsx
@@ -17,7 +17,7 @@ export const ConditionsActionMenu = ({ condition, patientUuid }: conditionsActio
   const launchEditConditionsForm = useCallback(
     () =>
       launchWorkspace2('conditions-form-workspace', {
-        workspaceTitle: t('editCondition', 'Edit a Condition'),
+        workspaceTitle: t('editCondition', 'Edit condition'),
         condition,
         formContext: 'editing',
       }),

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-action-menu.test.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-action-menu.test.tsx
@@ -73,7 +73,7 @@ describe('ConditionsActionMenu', () => {
     await user.click(screen.getByText('Edit'));
 
     expect(mockLaunchWorkspace2).toHaveBeenCalledWith('conditions-form-workspace', {
-      workspaceTitle: 'Edit a Condition',
+      workspaceTitle: 'Edit condition',
       condition: specificCondition,
       formContext: 'editing',
     });

--- a/packages/esm-patient-conditions-app/translations/en.json
+++ b/packages/esm-patient-conditions-app/translations/en.json
@@ -24,7 +24,7 @@
   "duplicateActiveConditionSubtitle": "{{conditionName}} is already on this patient's active problem list. Saving will create a duplicate.",
   "duplicateInactiveConditionSubtitle": "{{conditionName}} was previously recorded and is now inactive. Consider reactivating the existing record instead of creating a new one.",
   "edit": "Edit",
-  "editCondition": "Edit a Condition",
+  "editCondition": "Edit condition",
   "endDate": "End date",
   "enterCondition": "Enter condition",
   "errorCreatingCondition": "Error creating condition",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

`"Edit a Condition"` was inconsistent with the casing pattern used by other action labels in the conditions app (e.g. `"Delete condition"`). This corrects the label across all three places that need to agree:

- `translations/en.json` — source of truth for i18next-parser extraction
- `conditions-action-menu.component.tsx` — source code default in the `t()` call
- `conditions-action-menu.test.tsx` — test assertion for the workspace title

## Screenshots

## Related Issue

## Other
