### PR TITLE
(test) O3-5556: Create a Workflow to run OWASP dependency checks

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -1,0 +1,17 @@
+name: OWASP Dependency Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build:
+    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/owasp-dependency-check.yml@main
+    secrets:
+      NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+      BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

Adds OWASP Dependency Check workflow to scan frontend dependencies in CI. Based on the updated shared workflow from openmrs/openmrs-contrib-gha-workflows#25.

Reference implementation: https://github.com/openmrs/openmrs-esm-patient-management/pull/2410

Results will be available at: https://openmrs.github.io/openmrs-contrib-dependency-vulnerability-dashboard/

## Screenshots

N/A (no UI changes — this is a CI workflow addition)

## Related Issue

https://openmrs.atlassian.net/browse/O3-5556

## Other

N/A
