### PR TITLE
(fix) Prevent order action crashes when encounter visit data is missing

### DIFF
--- a/packages/esm-patient-common-lib/src/orders/types/order.ts
+++ b/packages/esm-patient-common-lib/src/orders/types/order.ts
@@ -70,7 +70,7 @@ export interface OrderBasketItem {
   orderNumber?: string;
   scheduledDate?: Date;
   encounterUuid?: string;
-  visit: Visit;
+  visit: Visit | null;
 }
 
 export type OrderUrgency = 'ROUTINE' | 'STAT' | 'ON_SCHEDULED_DATE';
@@ -142,7 +142,7 @@ export interface Order {
   drug: Drug | null;
   duration: number | null;
   durationUnits: OpenmrsResource | null;
-  encounter: Encounter;
+  encounter: Encounter | null;
   frequency: OpenmrsResource | null;
   instructions?: string | null;
   numRefills: number | null;
@@ -317,19 +317,19 @@ export interface TestOrderBasketItem extends OrderBasketItem {
 }
 
 export interface OrderBasketWindowProps {
-  encounterUuid: string;
+  encounterUuid: string | null;
   onOrderBasketSubmitted?: (encounterUuid: string, postedOrders: Array<Order>) => void;
 }
 
 export interface ExportedOrderBasketWindowProps {
-  encounterUuid: string;
+  encounterUuid: string | null;
   drugOrderWorkspaceName: string;
   labOrderWorkspaceName: string;
   generalOrderWorkspaceName: string;
   patient: fhir.Patient;
   patientUuid: string;
-  visitContext: Visit;
-  mutateVisitContext: () => void;
+  visitContext: Visit | null;
+  mutateVisitContext: (() => void) | null;
   onOrderBasketSubmitted?: (encounterUuid: string, postedOrders: Array<Order>) => void;
   /**
    * An optional array of order type UUIDs to display. If not provided, all panels are shown.

--- a/packages/esm-patient-common-lib/src/orders/types/order.ts
+++ b/packages/esm-patient-common-lib/src/orders/types/order.ts
@@ -70,7 +70,7 @@ export interface OrderBasketItem {
   orderNumber?: string;
   scheduledDate?: Date;
   encounterUuid?: string;
-  visit: Visit;
+  visit: Visit | null;
 }
 
 export type OrderUrgency = 'ROUTINE' | 'STAT' | 'ON_SCHEDULED_DATE';
@@ -142,7 +142,7 @@ export interface Order {
   drug: Drug | null;
   duration: number | null;
   durationUnits: OpenmrsResource | null;
-  encounter: Encounter;
+  encounter: Encounter | null;
   frequency: OpenmrsResource | null;
   instructions?: string | null;
   numRefills: number | null;
@@ -322,12 +322,12 @@ export interface TestOrderBasketItem extends OrderBasketItem {
 }
 
 export interface OrderBasketWindowProps {
-  encounterUuid: string;
+  encounterUuid: string | null;
   onOrderBasketSubmitted?: (encounterUuid: string, postedOrders: Array<Order>) => void;
 }
 
 export interface ExportedOrderBasketWindowProps {
-  encounterUuid: string;
+  encounterUuid: string | null;
   drugOrderWorkspaceName: string;
   labOrderWorkspaceName: string;
   generalOrderWorkspaceName: string;
@@ -339,8 +339,8 @@ export interface ExportedOrderBasketWindowProps {
   allergyFormWorkspaceName?: string;
   patient: fhir.Patient;
   patientUuid: string;
-  visitContext: Visit;
-  mutateVisitContext: () => void;
+  visitContext: Visit | null;
+  mutateVisitContext: (() => void) | null;
   onOrderBasketSubmitted?: (encounterUuid: string, postedOrders: Array<Order>) => void;
   /**
    * An optional array of order type UUIDs to display. If not provided, all panels are shown.

--- a/packages/esm-patient-common-lib/src/orders/types/order.ts
+++ b/packages/esm-patient-common-lib/src/orders/types/order.ts
@@ -142,7 +142,7 @@ export interface Order {
   drug: Drug | null;
   duration: number | null;
   durationUnits: OpenmrsResource | null;
-  encounter: Encounter | null;
+  encounter: Encounter;
   frequency: OpenmrsResource | null;
   instructions?: string | null;
   numRefills: number | null;

--- a/packages/esm-patient-common-lib/src/orders/types/order.ts
+++ b/packages/esm-patient-common-lib/src/orders/types/order.ts
@@ -322,12 +322,12 @@ export interface TestOrderBasketItem extends OrderBasketItem {
 }
 
 export interface OrderBasketWindowProps {
-  encounterUuid: string | null;
+  encounterUuid: string;
   onOrderBasketSubmitted?: (encounterUuid: string, postedOrders: Array<Order>) => void;
 }
 
 export interface ExportedOrderBasketWindowProps {
-  encounterUuid: string | null;
+  encounterUuid: string;
   drugOrderWorkspaceName: string;
   labOrderWorkspaceName: string;
   generalOrderWorkspaceName: string;

--- a/packages/esm-patient-common-lib/src/store/patient-chart-store.ts
+++ b/packages/esm-patient-common-lib/src/store/patient-chart-store.ts
@@ -3,8 +3,8 @@ import { type Actions, createGlobalStore, useStoreWithActions, type Visit } from
 export interface PatientChartStore {
   patientUuid: string;
   patient: fhir.Patient;
-  visitContext: Visit;
-  mutateVisitContext: () => void;
+  visitContext: Visit | null;
+  mutateVisitContext: (() => void) | null;
 }
 
 const patientChartStoreName = 'patient-chart-global-store';
@@ -20,7 +20,7 @@ const patientChartStoreActions = {
   setPatient(_, patient: fhir.Patient) {
     return { patient, patientUuid: patient?.id ?? null };
   },
-  setVisitContext(_, visitContext: Visit, mutateVisitContext: () => void) {
+  setVisitContext(_, visitContext: Visit | null, mutateVisitContext: (() => void) | null) {
     return { visitContext, mutateVisitContext };
   },
 } satisfies Actions<PatientChartStore>;

--- a/packages/esm-patient-common-lib/src/workspaces.ts
+++ b/packages/esm-patient-common-lib/src/workspaces.ts
@@ -13,8 +13,8 @@ import { useSystemVisitSetting } from './useSystemVisitSetting';
 export interface PatientWorkspaceGroupProps {
   patient: fhir.Patient;
   patientUuid: string;
-  visitContext: Visit;
-  mutateVisitContext: () => void;
+  visitContext: Visit | null;
+  mutateVisitContext: (() => void) | null;
 }
 
 export interface PatientChartWorkspaceActionButtonProps {

--- a/packages/esm-patient-medications-app/src/api/api.test.ts
+++ b/packages/esm-patient-medications-app/src/api/api.test.ts
@@ -1,0 +1,35 @@
+import { buildMedicationOrder } from './api';
+import { mockOrders } from '__mocks__';
+
+describe('buildMedicationOrder', () => {
+  it('returns a basket item with a null visit when the source order has no encounter visit', () => {
+    const orderWithoutVisit = {
+      ...mockOrders[0],
+      encounter: {
+        ...mockOrders[0].encounter,
+        visit: null,
+      },
+    };
+
+    expect(buildMedicationOrder(orderWithoutVisit as any, 'REVISE')).toEqual(
+      expect.objectContaining({
+        encounterUuid: mockOrders[0].encounter.uuid,
+        visit: null,
+      }),
+    );
+  });
+
+  it('returns a basket item with no encounter UUID when the source order has no encounter', () => {
+    const orderWithoutEncounter = {
+      ...mockOrders[0],
+      encounter: null,
+    };
+
+    expect(buildMedicationOrder(orderWithoutEncounter as any, 'DISCONTINUE')).toEqual(
+      expect.objectContaining({
+        encounterUuid: undefined,
+        visit: null,
+      }),
+    );
+  });
+});

--- a/packages/esm-patient-medications-app/src/api/api.test.ts
+++ b/packages/esm-patient-medications-app/src/api/api.test.ts
@@ -2,7 +2,6 @@ import { toOmrsIsoString } from '@openmrs/esm-framework';
 import { describe, it, expect } from 'vitest';
 import { prepMedicationOrderPostData, buildMedicationOrder, bucketMedicationOrders } from './api';
 import type { DrugOrderBasketItem, Order } from '@openmrs/esm-patient-common-lib';
-import { mockOrders } from '__mocks__';
 
 const selectedStartDate = new Date('2026-04-01T10:15:00.000Z');
 
@@ -25,7 +24,7 @@ const drugOrderBasketItem: DrugOrderBasketItem = {
   unit: {
     value: 'tablet',
     valueCoded: 'unit-uuid',
-    },
+  },
   commonMedicationName: 'Aspirin 81 mg',
   dosage: 1,
   frequency: {
@@ -326,41 +325,27 @@ describe('buildMedicationOrder', () => {
     },
   );
 
+  it('returns a basket item with a null visit when the source order has no encounter visit', () => {
+    const orderWithoutVisit = {
+      ...medicationOrder,
+      encounter: {
+        ...medicationOrder.encounter,
+        visit: null,
+      },
+    } as Order;
+
+    expect(buildMedicationOrder(orderWithoutVisit, 'REVISE')).toEqual(
+      expect.objectContaining({
+        encounterUuid: medicationOrder.encounter.uuid,
+        visit: null,
+      }),
+    );
+  });
+
   it('uses the original activation date when building a DISCONTINUE basket item', () => {
     const result = buildMedicationOrder(medicationOrder, 'DISCONTINUE');
 
     expect(result.scheduledDate).toBeInstanceOf(Date);
     expect((result.scheduledDate as Date).toISOString()).toBe(new Date(medicationOrder.dateActivated).toISOString());
-  });
-
-  it('returns a basket item with a null visit when the source order has no encounter visit', () => {
-    const orderWithoutVisit = {
-      ...mockOrders[0],
-      encounter: {
-        ...mockOrders[0].encounter,
-        visit: null,
-      },
-    };
-
-    expect(buildMedicationOrder(orderWithoutVisit as any, 'REVISE')).toEqual(
-      expect.objectContaining({
-        encounterUuid: mockOrders[0].encounter.uuid,
-        visit: null,
-      }),
-    );
-  });
-
-  it('returns a basket item with no encounter UUID when the source order has no encounter', () => {
-    const orderWithoutEncounter = {
-      ...mockOrders[0],
-      encounter: null,
-    };
-
-    expect(buildMedicationOrder(orderWithoutEncounter as any, 'DISCONTINUE')).toEqual(
-      expect.objectContaining({
-        encounterUuid: undefined,
-        visit: null,
-      }),
-    );
   });
 });

--- a/packages/esm-patient-medications-app/src/api/api.test.ts
+++ b/packages/esm-patient-medications-app/src/api/api.test.ts
@@ -2,6 +2,7 @@ import { toOmrsIsoString } from '@openmrs/esm-framework';
 import { describe, it, expect } from 'vitest';
 import { prepMedicationOrderPostData, buildMedicationOrder, bucketMedicationOrders } from './api';
 import type { DrugOrderBasketItem, Order } from '@openmrs/esm-patient-common-lib';
+import { mockOrders } from '__mocks__';
 
 const selectedStartDate = new Date('2026-04-01T10:15:00.000Z');
 
@@ -24,7 +25,7 @@ const drugOrderBasketItem: DrugOrderBasketItem = {
   unit: {
     value: 'tablet',
     valueCoded: 'unit-uuid',
-  },
+    },
   commonMedicationName: 'Aspirin 81 mg',
   dosage: 1,
   frequency: {
@@ -330,5 +331,36 @@ describe('buildMedicationOrder', () => {
 
     expect(result.scheduledDate).toBeInstanceOf(Date);
     expect((result.scheduledDate as Date).toISOString()).toBe(new Date(medicationOrder.dateActivated).toISOString());
+  });
+
+  it('returns a basket item with a null visit when the source order has no encounter visit', () => {
+    const orderWithoutVisit = {
+      ...mockOrders[0],
+      encounter: {
+        ...mockOrders[0].encounter,
+        visit: null,
+      },
+    };
+
+    expect(buildMedicationOrder(orderWithoutVisit as any, 'REVISE')).toEqual(
+      expect.objectContaining({
+        encounterUuid: mockOrders[0].encounter.uuid,
+        visit: null,
+      }),
+    );
+  });
+
+  it('returns a basket item with no encounter UUID when the source order has no encounter', () => {
+    const orderWithoutEncounter = {
+      ...mockOrders[0],
+      encounter: null,
+    };
+
+    expect(buildMedicationOrder(orderWithoutEncounter as any, 'DISCONTINUE')).toEqual(
+      expect.objectContaining({
+        encounterUuid: undefined,
+        visit: null,
+      }),
+    );
   });
 });

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -301,7 +301,7 @@ export function buildMedicationOrder(order: Order, action: OrderAction): DrugOrd
         }
       : null,
     encounterUuid: order.encounter?.uuid,
-    visit: order.encounter.visit,
+    visit: order.encounter?.visit ?? null,
   };
 }
 

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -297,7 +297,7 @@ export function buildMedicationOrder(order: Order, action: OrderAction): DrugOrd
       : null,
     encounterUuid: order.encounter?.uuid,
     previousOrderDateActivated: action === 'REVISE' ? order.dateActivated : undefined,
-    visit: order.encounter.visit,
+    visit: order.encounter.visit ?? null,
   };
 }
 

--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -295,7 +295,7 @@ export function buildMedicationOrder(order: Order, action: OrderAction): DrugOrd
           valueCoded: order.quantityUnits.uuid,
         }
       : null,
-    encounterUuid: order.encounter?.uuid,
+    encounterUuid: order.encounter.uuid,
     previousOrderDateActivated: action === 'REVISE' ? order.dateActivated : undefined,
     visit: order.encounter.visit ?? null,
   };

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -401,50 +401,68 @@ function OrderBasketItemActions({
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const alreadyInBasket = items.some((x) => x.uuid === medication.uuid);
+  const encounterUuid = medication.encounter?.uuid ?? null;
+  const visitContext = medication.encounter?.visit ?? null;
+  const visitUuid = visitContext?.uuid;
+  const hasVisitContext = Boolean(encounterUuid && visitUuid);
 
   const workspaceGroupProps: PatientWorkspaceGroupProps = useMemo(
     () => ({
       patient,
       patientUuid: patient.id,
-      visitContext: medication.encounter.visit,
-      mutateVisitContext: () => {
-        invalidateVisitByUuid(globalMutate, medication.encounter.visit?.uuid);
-        invalidateVisitAndEncounterData(globalMutate, patient.id);
-      },
+      visitContext,
+      mutateVisitContext: visitUuid
+        ? () => {
+            invalidateVisitByUuid(globalMutate, visitUuid);
+            invalidateVisitAndEncounterData(globalMutate, patient.id);
+          }
+        : null,
     }),
-    [patient, medication, globalMutate],
+    [globalMutate, patient, visitContext, visitUuid],
   );
   const handleDiscontinueClick = useCallback(() => {
+    if (!hasVisitContext) {
+      return;
+    }
+
     setItems([...items, buildMedicationOrder(medication, 'DISCONTINUE')]);
     launchWorkspace2<{}, OrderBasketWindowProps, PatientWorkspaceGroupProps>(
       'order-basket',
       {},
-      { encounterUuid: medication.encounter.uuid },
+      { encounterUuid },
       workspaceGroupProps,
     );
-  }, [items, setItems, medication, workspaceGroupProps]);
+  }, [encounterUuid, hasVisitContext, items, medication, setItems, workspaceGroupProps]);
 
   const handleModifyClick = useCallback(() => {
+    if (!hasVisitContext) {
+      return;
+    }
+
     launchWorkspace2<AddDrugOrderWorkspaceProps, OrderBasketWindowProps, PatientWorkspaceGroupProps>(
       'add-drug-order',
       {
         order: buildMedicationOrder(medication, 'REVISE'),
         orderToEditOrdererUuid: medication.orderer.uuid,
       },
-      { encounterUuid: medication.encounter.uuid },
+      { encounterUuid },
       workspaceGroupProps,
     );
-  }, [medication, workspaceGroupProps]);
+  }, [encounterUuid, hasVisitContext, medication, workspaceGroupProps]);
 
   const handleRenewClick = useCallback(() => {
+    if (!hasVisitContext) {
+      return;
+    }
+
     setItems([...items, buildMedicationOrder(medication, 'RENEW')]);
     launchWorkspace2<{}, OrderBasketWindowProps, PatientWorkspaceGroupProps>(
       'order-basket',
       {},
-      { encounterUuid: medication.encounter.uuid },
+      { encounterUuid },
       workspaceGroupProps,
     );
-  }, [items, setItems, medication, workspaceGroupProps]);
+  }, [encounterUuid, hasVisitContext, items, medication, setItems, workspaceGroupProps]);
 
   return (
     <OverflowMenu
@@ -460,13 +478,13 @@ function OrderBasketItemActions({
           id="modify"
           itemText={t('modify', 'Modify')}
           onClick={handleModifyClick}
-          disabled={alreadyInBasket}
+          disabled={alreadyInBasket || !hasVisitContext}
         />
       )}
       {showRenewButton && (
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket}
+          disabled={alreadyInBasket || !hasVisitContext}
           id="renew"
           itemText={t('orderActionRenew', 'Renew')}
           onClick={handleRenewClick}
@@ -475,7 +493,7 @@ function OrderBasketItemActions({
       {showDiscontinueButton && (
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket}
+          disabled={alreadyInBasket || !hasVisitContext}
           hasDivider
           id="discontinue"
           isDelete

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -436,10 +436,6 @@ function OrderBasketItemActions({
   }, [encounterUuid, items, medication, setItems, visitContext, visitRequired, workspaceGroupProps]);
 
   const handleModifyClick = useCallback(() => {
-    if (visitRequired && !visitContext) {
-      return;
-    }
-
     launchWorkspace2<AddDrugOrderWorkspaceProps, OrderBasketWindowProps, PatientWorkspaceGroupProps>(
       'add-drug-order',
       {
@@ -449,7 +445,7 @@ function OrderBasketItemActions({
       { encounterUuid },
       workspaceGroupProps,
     );
-  }, [encounterUuid, medication, visitContext, visitRequired, workspaceGroupProps]);
+  }, [encounterUuid, medication, workspaceGroupProps]);
 
   const handleRenewClick = useCallback(() => {
     if (visitRequired && !visitContext) {
@@ -480,7 +476,7 @@ function OrderBasketItemActions({
           id="modify"
           itemText={t('modify', 'Modify')}
           onClick={handleModifyClick}
-          disabled={alreadyInBasket || (visitRequired && !visitContext)}
+          disabled={alreadyInBasket}
         />
       )}
       {showRenewButton && (

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -401,50 +401,68 @@ function OrderBasketItemActions({
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const alreadyInBasket = items.some((x) => x.uuid === medication.uuid);
+  const encounterUuid = medication.encounter?.uuid ?? null;
+  const visitContext = medication.encounter?.visit ?? null;
+  const visitUuid = visitContext?.uuid;
+  const hasVisitContext = Boolean(encounterUuid && visitUuid);
 
   const workspaceGroupProps: PatientWorkspaceGroupProps = useMemo(
     () => ({
       patient,
       patientUuid: patient.id,
-      visitContext: medication.encounter.visit,
-      mutateVisitContext: () => {
-        invalidateVisitByUuid(globalMutate, medication.encounter.visit?.uuid);
-        invalidateVisitAndEncounterData(globalMutate, patient.id);
-      },
+      visitContext,
+      mutateVisitContext: visitUuid
+        ? () => {
+            invalidateVisitByUuid(globalMutate, visitUuid);
+            invalidateVisitAndEncounterData(globalMutate, patient.id);
+          }
+        : null,
     }),
-    [patient, medication, globalMutate],
+    [globalMutate, patient, visitContext, visitUuid],
   );
   const handleDiscontinueClick = useCallback(() => {
+    if (!hasVisitContext) {
+      return;
+    }
+
     setItems([...items, buildMedicationOrder(medication, 'DISCONTINUE')]);
     launchWorkspace2<{}, OrderBasketWindowProps, PatientWorkspaceGroupProps>(
       'order-basket',
       {},
-      { encounterUuid: medication.encounter.uuid },
+      { encounterUuid },
       workspaceGroupProps,
     );
-  }, [items, setItems, medication, workspaceGroupProps]);
+  }, [encounterUuid, hasVisitContext, items, medication, setItems, workspaceGroupProps]);
 
   const handleModifyClick = useCallback(() => {
+    if (!hasVisitContext) {
+      return;
+    }
+
     launchWorkspace2<AddDrugOrderWorkspaceProps, OrderBasketWindowProps, PatientWorkspaceGroupProps>(
       'add-drug-order',
       {
         order: buildMedicationOrder(medication, 'REVISE'),
         orderToEditOrdererUuid: medication.orderer.uuid,
       },
-      { encounterUuid: medication.encounter.uuid },
+      { encounterUuid },
       workspaceGroupProps,
     );
-  }, [medication, workspaceGroupProps]);
+  }, [encounterUuid, hasVisitContext, medication, workspaceGroupProps]);
 
   const handleRenewClick = useCallback(() => {
+    if (!hasVisitContext) {
+      return;
+    }
+
     setItems([...items, buildMedicationOrder(medication, 'RENEW')]);
     launchWorkspace2<{}, OrderBasketWindowProps, PatientWorkspaceGroupProps>(
       'order-basket',
       {},
-      { encounterUuid: medication.encounter.uuid },
+      { encounterUuid },
       workspaceGroupProps,
     );
-  }, [items, setItems, medication, workspaceGroupProps]);
+  }, [encounterUuid, hasVisitContext, items, medication, setItems, workspaceGroupProps]);
 
   return (
     <OverflowMenu
@@ -461,13 +479,13 @@ function OrderBasketItemActions({
           id="modify"
           itemText={t('modify', 'Modify')}
           onClick={handleModifyClick}
-          disabled={alreadyInBasket}
+          disabled={alreadyInBasket || !hasVisitContext}
         />
       )}
       {showRenewButton && (
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket}
+          disabled={alreadyInBasket || !hasVisitContext}
           id="renew"
           itemText={t('orderActionRenew', 'Renew')}
           onClick={handleRenewClick}
@@ -476,7 +494,7 @@ function OrderBasketItemActions({
       {showDiscontinueButton && (
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket}
+          disabled={alreadyInBasket || !hasVisitContext}
           hasDivider
           id="discontinue"
           isDelete

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.component.tsx
@@ -31,6 +31,7 @@ import {
   type Order,
   type OrderBasketWindowProps,
   type PatientWorkspaceGroupProps,
+  useSystemVisitSetting,
   useLaunchWorkspaceRequiringVisit,
   useOrderBasket,
 } from '@openmrs/esm-patient-common-lib';
@@ -401,10 +402,10 @@ function OrderBasketItemActions({
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const alreadyInBasket = items.some((x) => x.uuid === medication.uuid);
-  const encounterUuid = medication.encounter?.uuid ?? null;
-  const visitContext = medication.encounter?.visit ?? null;
+  const { systemVisitEnabled: visitRequired } = useSystemVisitSetting();
+  const encounterUuid = medication.encounter.uuid;
+  const visitContext = medication.encounter.visit ?? null;
   const visitUuid = visitContext?.uuid;
-  const hasVisitContext = Boolean(encounterUuid && visitUuid);
 
   const workspaceGroupProps: PatientWorkspaceGroupProps = useMemo(
     () => ({
@@ -421,7 +422,7 @@ function OrderBasketItemActions({
     [globalMutate, patient, visitContext, visitUuid],
   );
   const handleDiscontinueClick = useCallback(() => {
-    if (!hasVisitContext) {
+    if (visitRequired && !visitContext) {
       return;
     }
 
@@ -432,10 +433,10 @@ function OrderBasketItemActions({
       { encounterUuid },
       workspaceGroupProps,
     );
-  }, [encounterUuid, hasVisitContext, items, medication, setItems, workspaceGroupProps]);
+  }, [encounterUuid, items, medication, setItems, visitContext, visitRequired, workspaceGroupProps]);
 
   const handleModifyClick = useCallback(() => {
-    if (!hasVisitContext) {
+    if (visitRequired && !visitContext) {
       return;
     }
 
@@ -448,10 +449,10 @@ function OrderBasketItemActions({
       { encounterUuid },
       workspaceGroupProps,
     );
-  }, [encounterUuid, hasVisitContext, medication, workspaceGroupProps]);
+  }, [encounterUuid, medication, visitContext, visitRequired, workspaceGroupProps]);
 
   const handleRenewClick = useCallback(() => {
-    if (!hasVisitContext) {
+    if (visitRequired && !visitContext) {
       return;
     }
 
@@ -462,7 +463,7 @@ function OrderBasketItemActions({
       { encounterUuid },
       workspaceGroupProps,
     );
-  }, [encounterUuid, hasVisitContext, items, medication, setItems, workspaceGroupProps]);
+  }, [encounterUuid, items, medication, setItems, visitContext, visitRequired, workspaceGroupProps]);
 
   return (
     <OverflowMenu
@@ -479,13 +480,13 @@ function OrderBasketItemActions({
           id="modify"
           itemText={t('modify', 'Modify')}
           onClick={handleModifyClick}
-          disabled={alreadyInBasket || !hasVisitContext}
+          disabled={alreadyInBasket || (visitRequired && !visitContext)}
         />
       )}
       {showRenewButton && (
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket || !hasVisitContext}
+          disabled={alreadyInBasket || (visitRequired && !visitContext)}
           id="renew"
           itemText={t('orderActionRenew', 'Renew')}
           onClick={handleRenewClick}
@@ -494,7 +495,7 @@ function OrderBasketItemActions({
       {showDiscontinueButton && (
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket || !hasVisitContext}
+          disabled={alreadyInBasket || (visitRequired && !visitContext)}
           hasDivider
           id="discontinue"
           isDelete

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.test.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useConfig, useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { useLaunchWorkspaceRequiringVisit, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import { mockFhirPatient, mockOrders } from '__mocks__';
+import MedicationsDetailsTable from './medications-details-table.component';
+
+const mockUseOrderBasket = jest.mocked(useOrderBasket);
+const mockUseConfig = jest.mocked(useConfig);
+const mockUseLayoutType = jest.mocked(useLayoutType);
+const mockUsePagination = jest.mocked(usePagination);
+const mockUseLaunchWorkspaceRequiringVisit = jest.mocked(useLaunchWorkspaceRequiringVisit);
+
+jest.mock('@openmrs/esm-framework', () => ({
+  ...jest.requireActual('@openmrs/esm-framework'),
+  useConfig: jest.fn(),
+  useLayoutType: jest.fn(),
+  usePagination: jest.fn(),
+}));
+
+jest.mock('@openmrs/esm-patient-common-lib', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
+
+  return {
+    ...originalModule,
+    useLaunchWorkspaceRequiringVisit: jest.fn(),
+    useOrderBasket: jest.fn(),
+  };
+});
+
+jest.mock('../print/print.component', () => ({
+  __esModule: true,
+  default: function MockPrintComponent() {
+    return 'PrintComponent';
+  },
+}));
+
+describe('MedicationsDetailsTable', () => {
+  beforeEach(() => {
+    mockUseOrderBasket.mockReturnValue({
+      orders: [],
+      setOrders: jest.fn(),
+      clearOrders: jest.fn(),
+    });
+    mockUseConfig.mockReturnValue({
+      excludePatientIdentifierCodeTypes: { uuids: [] },
+      showPrintButton: false,
+    } as any);
+    mockUseLayoutType.mockReturnValue('desktop');
+    mockUsePagination.mockImplementation((items) => ({
+      currentPage: 1,
+      goTo: jest.fn(),
+      results: items,
+    }));
+    mockUseLaunchWorkspaceRequiringVisit.mockReturnValue(jest.fn());
+  });
+
+  it('disables modify, renew, and discontinue actions when a medication has no visit context', async () => {
+    const user = userEvent.setup();
+    const medicationWithoutVisitContext = {
+      ...mockOrders[0],
+      encounter: null,
+    };
+
+    render(
+      <MedicationsDetailsTable
+        patient={mockFhirPatient}
+        medications={[medicationWithoutVisitContext] as any}
+        showAddButton={false}
+        showDiscontinueButton
+        showModifyButton
+        showRenewButton
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /options/i }));
+
+    expect(screen.getByText(/modify/i).closest('button')).toBeDisabled();
+    expect(screen.getByText(/renew/i).closest('button')).toBeDisabled();
+    expect(screen.getByText(/discontinue/i).closest('button')).toBeDisabled();
+  });
+});

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.test.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useConfig, useLayoutType, usePagination } from '@openmrs/esm-framework';
@@ -6,30 +7,33 @@ import { useLaunchWorkspaceRequiringVisit, useOrderBasket } from '@openmrs/esm-p
 import { mockFhirPatient, mockOrders } from '__mocks__';
 import MedicationsDetailsTable from './medications-details-table.component';
 
-const mockUseOrderBasket = jest.mocked(useOrderBasket);
-const mockUseConfig = jest.mocked(useConfig);
-const mockUseLayoutType = jest.mocked(useLayoutType);
-const mockUsePagination = jest.mocked(usePagination);
-const mockUseLaunchWorkspaceRequiringVisit = jest.mocked(useLaunchWorkspaceRequiringVisit);
+const mockUseOrderBasket = vi.mocked(useOrderBasket);
+const mockUseConfig = vi.mocked(useConfig);
+const mockUseLayoutType = vi.mocked(useLayoutType);
+const mockUsePagination = vi.mocked(usePagination);
+const mockUseLaunchWorkspaceRequiringVisit = vi.mocked(useLaunchWorkspaceRequiringVisit);
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  useConfig: jest.fn(),
-  useLayoutType: jest.fn(),
-  usePagination: jest.fn(),
-}));
-
-jest.mock('@openmrs/esm-patient-common-lib', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-patient-common-lib');
-
+vi.mock('@openmrs/esm-framework', async () => {
+  const originalModule = (await vi.importActual('@openmrs/esm-framework')) as object;
   return {
     ...originalModule,
-    useLaunchWorkspaceRequiringVisit: jest.fn(),
-    useOrderBasket: jest.fn(),
+    useConfig: vi.fn(),
+    useLayoutType: vi.fn(),
+    usePagination: vi.fn(),
   };
 });
 
-jest.mock('../print/print.component', () => ({
+vi.mock('@openmrs/esm-patient-common-lib', async () => {
+  const originalModule = (await vi.importActual('@openmrs/esm-patient-common-lib')) as object;
+
+  return {
+    ...originalModule,
+    useLaunchWorkspaceRequiringVisit: vi.fn(),
+    useOrderBasket: vi.fn(),
+  };
+});
+
+vi.mock('../print/print.component', () => ({
   __esModule: true,
   default: function MockPrintComponent() {
     return 'PrintComponent';
@@ -40,20 +44,23 @@ describe('MedicationsDetailsTable', () => {
   beforeEach(() => {
     mockUseOrderBasket.mockReturnValue({
       orders: [],
-      setOrders: jest.fn(),
-      clearOrders: jest.fn(),
+      setOrders: vi.fn(),
+      clearOrders: vi.fn(),
     });
     mockUseConfig.mockReturnValue({
       excludePatientIdentifierCodeTypes: { uuids: [] },
       showPrintButton: false,
     } as any);
-    mockUseLayoutType.mockReturnValue('desktop');
-    mockUsePagination.mockImplementation((items) => ({
-      currentPage: 1,
-      goTo: jest.fn(),
-      results: items,
-    }));
-    mockUseLaunchWorkspaceRequiringVisit.mockReturnValue(jest.fn());
+    mockUseLayoutType.mockReturnValue('desktop' as any);
+    mockUsePagination.mockImplementation(
+      (items) =>
+        ({
+          currentPage: 1,
+          goTo: vi.fn(),
+          results: items,
+        }) as any,
+    );
+    mockUseLaunchWorkspaceRequiringVisit.mockReturnValue(vi.fn());
   });
 
   it('disables modify, renew, and discontinue actions when a medication has no visit context', async () => {

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.test.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.test.tsx
@@ -3,7 +3,11 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useConfig, useLayoutType, usePagination } from '@openmrs/esm-framework';
-import { useLaunchWorkspaceRequiringVisit, useOrderBasket } from '@openmrs/esm-patient-common-lib';
+import {
+  useLaunchWorkspaceRequiringVisit,
+  useOrderBasket,
+  useSystemVisitSetting,
+} from '@openmrs/esm-patient-common-lib';
 import { mockFhirPatient, mockOrders } from '__mocks__';
 import MedicationsDetailsTable from './medications-details-table.component';
 
@@ -12,6 +16,7 @@ const mockUseConfig = vi.mocked(useConfig);
 const mockUseLayoutType = vi.mocked(useLayoutType);
 const mockUsePagination = vi.mocked(usePagination);
 const mockUseLaunchWorkspaceRequiringVisit = vi.mocked(useLaunchWorkspaceRequiringVisit);
+const mockUseSystemVisitSetting = vi.mocked(useSystemVisitSetting);
 
 vi.mock('@openmrs/esm-framework', async () => {
   const originalModule = (await vi.importActual('@openmrs/esm-framework')) as object;
@@ -30,6 +35,32 @@ vi.mock('@openmrs/esm-patient-common-lib', async () => {
     ...originalModule,
     useLaunchWorkspaceRequiringVisit: vi.fn(),
     useOrderBasket: vi.fn(),
+    useSystemVisitSetting: vi.fn(),
+  };
+});
+
+vi.mock('@carbon/react', async () => {
+  const React = await vi.importActual('react');
+  const originalModule = (await vi.importActual('@carbon/react')) as Record<string, unknown>;
+  const OverflowMenu = ({ children, ...props }: any) => (
+    <div>
+      <button aria-label={props['aria-label'] ?? 'Options'} type="button">
+        Options
+      </button>
+      {children}
+    </div>
+  );
+  const OverflowMenuItem = (React as any).forwardRef(({ disabled, itemText, onClick }: any, ref) => (
+    <button disabled={disabled} onClick={onClick} ref={ref} type="button">
+      {itemText}
+    </button>
+  ));
+  OverflowMenuItem.displayName = 'OverflowMenuItem';
+
+  return {
+    ...originalModule,
+    OverflowMenu,
+    OverflowMenuItem,
   };
 });
 
@@ -61,13 +92,21 @@ describe('MedicationsDetailsTable', () => {
         }) as any,
     );
     mockUseLaunchWorkspaceRequiringVisit.mockReturnValue(vi.fn());
+    mockUseSystemVisitSetting.mockReturnValue({
+      systemVisitEnabled: true,
+      isLoadingSystemVisitSetting: false,
+      errorFetchingSystemVisitSetting: null,
+    });
   });
 
-  it('disables modify, renew, and discontinue actions when a medication has no visit context', async () => {
+  it('disables modify, renew, and discontinue actions when visits are required and a medication has no visit context', async () => {
     const user = userEvent.setup();
     const medicationWithoutVisitContext = {
       ...mockOrders[0],
-      encounter: null,
+      encounter: {
+        ...mockOrders[0].encounter,
+        visit: null,
+      },
     };
 
     render(
@@ -81,10 +120,40 @@ describe('MedicationsDetailsTable', () => {
       />,
     );
 
-    await user.click(screen.getByRole('button', { name: /options/i }));
+    expect(screen.getByRole('button', { name: /modify/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /renew/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /discontinue/i })).toBeDisabled();
+  });
 
-    expect(screen.getByText(/modify/i).closest('button')).toBeDisabled();
-    expect(screen.getByText(/renew/i).closest('button')).toBeDisabled();
-    expect(screen.getByText(/discontinue/i).closest('button')).toBeDisabled();
+  it('keeps modify, renew, and discontinue actions enabled when visits are not required and a medication has no visit', async () => {
+    const user = userEvent.setup();
+    const medicationWithoutVisitContext = {
+      ...mockOrders[0],
+      encounter: {
+        ...mockOrders[0].encounter,
+        visit: null,
+      },
+    };
+
+    mockUseSystemVisitSetting.mockReturnValue({
+      systemVisitEnabled: false,
+      isLoadingSystemVisitSetting: false,
+      errorFetchingSystemVisitSetting: null,
+    });
+
+    render(
+      <MedicationsDetailsTable
+        patient={mockFhirPatient}
+        medications={[medicationWithoutVisitContext] as any}
+        showAddButton={false}
+        showDiscontinueButton
+        showModifyButton
+        showRenewButton
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /modify/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /renew/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /discontinue/i })).toBeEnabled();
   });
 });

--- a/packages/esm-patient-medications-app/src/components/medications-details-table.test.tsx
+++ b/packages/esm-patient-medications-app/src/components/medications-details-table.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { screen, render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useConfig, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import {
@@ -39,31 +39,6 @@ vi.mock('@openmrs/esm-patient-common-lib', async () => {
   };
 });
 
-vi.mock('@carbon/react', async () => {
-  const React = await vi.importActual('react');
-  const originalModule = (await vi.importActual('@carbon/react')) as Record<string, unknown>;
-  const OverflowMenu = ({ children, ...props }: any) => (
-    <div>
-      <button aria-label={props['aria-label'] ?? 'Options'} type="button">
-        Options
-      </button>
-      {children}
-    </div>
-  );
-  const OverflowMenuItem = (React as any).forwardRef(({ disabled, itemText, onClick }: any, ref) => (
-    <button disabled={disabled} onClick={onClick} ref={ref} type="button">
-      {itemText}
-    </button>
-  ));
-  OverflowMenuItem.displayName = 'OverflowMenuItem';
-
-  return {
-    ...originalModule,
-    OverflowMenu,
-    OverflowMenuItem,
-  };
-});
-
 vi.mock('../print/print.component', () => ({
   __esModule: true,
   default: function MockPrintComponent() {
@@ -99,7 +74,7 @@ describe('MedicationsDetailsTable', () => {
     });
   });
 
-  it('disables modify, renew, and discontinue actions when visits are required and a medication has no visit context', async () => {
+  it('disables renew and discontinue actions while keeping modify enabled when visits are required and a medication has no visit context', async () => {
     const user = userEvent.setup();
     const medicationWithoutVisitContext = {
       ...mockOrders[0],
@@ -120,9 +95,16 @@ describe('MedicationsDetailsTable', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: /modify/i })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /renew/i })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /discontinue/i })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: /actions menu/i }));
+
+    const actionsMenu = await screen.findByRole('menu', { hidden: true });
+    const modifyItem = findMenuItemByText(actionsMenu, /modify/i);
+    const renewItem = findMenuItemByText(actionsMenu, /renew/i);
+    const discontinueItem = findMenuItemByText(actionsMenu, /discontinue/i);
+
+    expect(modifyItem).toBeEnabled();
+    expect(renewItem).toBeDisabled();
+    expect(discontinueItem).toBeDisabled();
   });
 
   it('keeps modify, renew, and discontinue actions enabled when visits are not required and a medication has no visit', async () => {
@@ -152,8 +134,21 @@ describe('MedicationsDetailsTable', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: /modify/i })).toBeEnabled();
-    expect(screen.getByRole('button', { name: /renew/i })).toBeEnabled();
-    expect(screen.getByRole('button', { name: /discontinue/i })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: /actions menu/i }));
+
+    const actionsMenu = await screen.findByRole('menu', { hidden: true });
+    const modifyItem = findMenuItemByText(actionsMenu, /modify/i);
+    const renewItem = findMenuItemByText(actionsMenu, /renew/i);
+    const discontinueItem = findMenuItemByText(actionsMenu, /discontinue/i);
+
+    expect(modifyItem).toBeEnabled();
+    expect(renewItem).toBeEnabled();
+    expect(discontinueItem).toBeEnabled();
   });
 });
+
+function findMenuItemByText(menu: HTMLElement, textRegex: RegExp) {
+  return within(menu)
+    .getAllByRole('menuitem', { hidden: true })
+    .find((item) => textRegex.test(item.textContent));
+}

--- a/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
@@ -613,19 +613,27 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
   const { orders, setOrders } = useOrderBasket<OrderBasketItem>(patient, grouping, postDataPrepFn);
   const alreadyInBasket = orders.some((x) => x.uuid === orderItem.uuid);
   const { mutate: globalMutate } = useSWRConfig();
+  const encounterUuid = orderItem.encounter?.uuid ?? null;
+  const visitContext = orderItem.encounter?.visit ?? null;
+  const visitUuid = visitContext?.uuid;
+  const hasVisitContext = Boolean(encounterUuid && visitUuid);
 
-  const windowProps = useMemo(() => ({ encounterUuid: orderItem.encounter.uuid }), [orderItem.encounter.uuid]);
+  const windowProps = useMemo(() => ({ encounterUuid }), [encounterUuid]);
   const groupProps = useMemo(
     () => ({
       patient,
       patientUuid: patient.id,
-      visitContext: orderItem.encounter.visit,
-      mutateVisitContext: invalidateVisitByUuid(globalMutate, orderItem.encounter.visit.uuid),
+      visitContext,
+      mutateVisitContext: visitUuid ? () => invalidateVisitByUuid(globalMutate, visitUuid) : null,
     }),
-    [patient, orderItem.encounter.visit, globalMutate],
+    [globalMutate, patient, visitContext, visitUuid],
   );
 
   const handleCancelOrder = useCallback(() => {
+    if (!hasVisitContext) {
+      return;
+    }
+
     if (orderItem.type === ORDER_TYPES.DRUG_ORDER) {
       getDrugOrderByUuid(orderItem.uuid)
         .then((res) => {
@@ -646,9 +654,13 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
       setOrders([...orders, order]);
       launchWorkspace2('order-basket', {}, windowProps, groupProps);
     }
-  }, [orderItem, setOrders, orders, windowProps, groupProps]);
+  }, [groupProps, hasVisitContext, orderItem, orders, setOrders, windowProps]);
 
   const handleModifyOrder = useCallback(() => {
+    if (!hasVisitContext) {
+      return;
+    }
+
     if (orderItem.type === ORDER_TYPES.DRUG_ORDER) {
       // make another call to fetch the order,
       // this time with custom rep to include the drug field
@@ -685,7 +697,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
         groupProps,
       );
     }
-  }, [orderItem, windowProps, groupProps]);
+  }, [groupProps, hasVisitContext, orderItem, windowProps]);
 
   const handleAddOrEditTestResults = useCallback(() => {
     launchWorkspace2('test-results-form-workspace', { order: orderItem, patient });
@@ -701,7 +713,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
       <OverflowMenu aria-label={t('actionsMenu', 'Actions menu')} align="left" flipped selectorPrimaryFocus="#modify">
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket}
+          disabled={alreadyInBasket || !hasVisitContext}
           id="modify"
           itemText={t('modifyOrder', 'Modify order')}
           onClick={handleModifyOrder}
@@ -721,7 +733,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
         )}
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket || orderItem?.action === 'DISCONTINUE'}
+          disabled={alreadyInBasket || orderItem?.action === 'DISCONTINUE' || !hasVisitContext}
           hasDivider
           id="discontinue"
           isDelete

--- a/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
@@ -613,19 +613,27 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
   const { orders, setOrders } = useOrderBasket<OrderBasketItem>(patient, grouping, postDataPrepFn);
   const alreadyInBasket = orders.some((x) => x.uuid === orderItem.uuid);
   const { mutate: globalMutate } = useSWRConfig();
+  const encounterUuid = orderItem.encounter?.uuid ?? null;
+  const visitContext = orderItem.encounter?.visit ?? null;
+  const visitUuid = visitContext?.uuid;
+  const hasVisitContext = Boolean(encounterUuid && visitUuid);
 
-  const windowProps = useMemo(() => ({ encounterUuid: orderItem.encounter.uuid }), [orderItem.encounter.uuid]);
+  const windowProps = useMemo(() => ({ encounterUuid }), [encounterUuid]);
   const groupProps = useMemo(
     () => ({
       patient,
       patientUuid: patient.id,
-      visitContext: orderItem.encounter.visit,
-      mutateVisitContext: invalidateVisitByUuid(globalMutate, orderItem.encounter.visit.uuid),
+      visitContext,
+      mutateVisitContext: visitUuid ? () => invalidateVisitByUuid(globalMutate, visitUuid) : null,
     }),
-    [patient, orderItem.encounter.visit, globalMutate],
+    [globalMutate, patient, visitContext, visitUuid],
   );
 
   const handleCancelOrder = useCallback(() => {
+    if (!hasVisitContext) {
+      return;
+    }
+
     if (orderItem.type === ORDER_TYPES.DRUG_ORDER) {
       getDrugOrderByUuid(orderItem.uuid)
         .then((res) => {
@@ -646,9 +654,13 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
       setOrders([...orders, order]);
       launchWorkspace2('order-basket', {}, windowProps, groupProps);
     }
-  }, [orderItem, setOrders, orders, windowProps, groupProps]);
+  }, [groupProps, hasVisitContext, orderItem, orders, setOrders, windowProps]);
 
   const handleModifyOrder = useCallback(() => {
+    if (!hasVisitContext) {
+      return;
+    }
+
     if (orderItem.type === ORDER_TYPES.DRUG_ORDER) {
       // make another call to fetch the order,
       // this time with custom rep to include the drug field
@@ -685,7 +697,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
         groupProps,
       );
     }
-  }, [orderItem, windowProps, groupProps]);
+  }, [groupProps, hasVisitContext, orderItem, windowProps]);
 
   const handleAddOrEditTestResults = useCallback(() => {
     launchWorkspace2('test-results-form-workspace', { order: orderItem, patient });
@@ -707,7 +719,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
       >
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket}
+          disabled={alreadyInBasket || !hasVisitContext}
           id="modify"
           itemText={t('modifyOrder', 'Modify order')}
           onClick={handleModifyOrder}
@@ -727,7 +739,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
         )}
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket || orderItem?.action === 'DISCONTINUE'}
+          disabled={alreadyInBasket || orderItem?.action === 'DISCONTINUE' || !hasVisitContext}
           hasDivider
           id="discontinue"
           isDelete

--- a/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
@@ -658,10 +658,6 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
   }, [groupProps, orderItem, orders, setOrders, visitContext, visitRequired, windowProps]);
 
   const handleModifyOrder = useCallback(() => {
-    if (visitRequired && !visitContext) {
-      return;
-    }
-
     if (orderItem.type === ORDER_TYPES.DRUG_ORDER) {
       // make another call to fetch the order,
       // this time with custom rep to include the drug field
@@ -698,7 +694,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
         groupProps,
       );
     }
-  }, [groupProps, orderItem, visitContext, visitRequired, windowProps]);
+  }, [groupProps, orderItem, windowProps]);
 
   const handleAddOrEditTestResults = useCallback(() => {
     launchWorkspace2('test-results-form-workspace', { order: orderItem, patient });
@@ -720,7 +716,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
       >
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket || (visitRequired && !visitContext)}
+          disabled={alreadyInBasket}
           id="modify"
           itemText={t('modifyOrder', 'Modify order')}
           onClick={handleModifyOrder}

--- a/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
@@ -44,6 +44,7 @@ import {
   useOrderBasket,
   useOrderTypes,
   usePatientOrders,
+  useSystemVisitSetting,
 } from '@openmrs/esm-patient-common-lib';
 import { prepMedicationOrderPostData } from '@openmrs/esm-patient-medications-app/src/api/api';
 import { prepTestOrderPostData } from '@openmrs/esm-patient-tests-app/src/test-orders/api';
@@ -613,10 +614,10 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
   const { orders, setOrders } = useOrderBasket<OrderBasketItem>(patient, grouping, postDataPrepFn);
   const alreadyInBasket = orders.some((x) => x.uuid === orderItem.uuid);
   const { mutate: globalMutate } = useSWRConfig();
-  const encounterUuid = orderItem.encounter?.uuid ?? null;
-  const visitContext = orderItem.encounter?.visit ?? null;
+  const { systemVisitEnabled: visitRequired } = useSystemVisitSetting();
+  const encounterUuid = orderItem.encounter.uuid;
+  const visitContext = orderItem.encounter.visit ?? null;
   const visitUuid = visitContext?.uuid;
-  const hasVisitContext = Boolean(encounterUuid && visitUuid);
 
   const windowProps = useMemo(() => ({ encounterUuid }), [encounterUuid]);
   const groupProps = useMemo(
@@ -630,7 +631,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
   );
 
   const handleCancelOrder = useCallback(() => {
-    if (!hasVisitContext) {
+    if (visitRequired && !visitContext) {
       return;
     }
 
@@ -654,10 +655,10 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
       setOrders([...orders, order]);
       launchWorkspace2('order-basket', {}, windowProps, groupProps);
     }
-  }, [groupProps, hasVisitContext, orderItem, orders, setOrders, windowProps]);
+  }, [groupProps, orderItem, orders, setOrders, visitContext, visitRequired, windowProps]);
 
   const handleModifyOrder = useCallback(() => {
-    if (!hasVisitContext) {
+    if (visitRequired && !visitContext) {
       return;
     }
 
@@ -697,7 +698,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
         groupProps,
       );
     }
-  }, [groupProps, hasVisitContext, orderItem, windowProps]);
+  }, [groupProps, orderItem, visitContext, visitRequired, windowProps]);
 
   const handleAddOrEditTestResults = useCallback(() => {
     launchWorkspace2('test-results-form-workspace', { order: orderItem, patient });
@@ -719,7 +720,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
       >
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket || !hasVisitContext}
+          disabled={alreadyInBasket || (visitRequired && !visitContext)}
           id="modify"
           itemText={t('modifyOrder', 'Modify order')}
           onClick={handleModifyOrder}
@@ -739,7 +740,7 @@ function OrderBasketItemActions({ orderItem, patient }: OrderBasketItemActionsPr
         )}
         <OverflowMenuItem
           className={styles.menuItem}
-          disabled={alreadyInBasket || orderItem?.action === 'DISCONTINUE' || !hasVisitContext}
+          disabled={alreadyInBasket || orderItem?.action === 'DISCONTINUE' || (visitRequired && !visitContext)}
           hasDivider
           id="discontinue"
           isDelete

--- a/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
@@ -585,6 +585,29 @@ describe('OrderDetailsTable', () => {
 
     expect(screen.getByRole('button', { name: /options/i })).toBeInTheDocument();
   });
+
+  it('disables modify and cancel actions when an order has no visit context', async () => {
+    const orderWithoutVisitContext = {
+      ...mockOrders[0],
+      encounter: null,
+    };
+
+    mockUsePatientOrders.mockReturnValue({
+      data: [orderWithoutVisitContext] as unknown as Array<Order>,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
+    });
+
+    renderOrderDetailsTable();
+
+    await screen.findByRole('table');
+    await user.click(screen.getByRole('button', { name: /options/i }));
+
+    expect(screen.getByText(/modify order/i).closest('button')).toBeDisabled();
+    expect(screen.getByText(/cancel order/i).closest('button')).toBeDisabled();
+  });
 });
 
 function renderOrderDetailsTable() {

--- a/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
@@ -596,7 +596,7 @@ describe('OrderDetailsTable', () => {
       error: undefined,
       isLoading: false,
       isValidating: false,
-      mutate: jest.fn(),
+      mutate: vi.fn(),
     });
 
     renderOrderDetailsTable();

--- a/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
@@ -604,8 +604,8 @@ describe('OrderDetailsTable', () => {
     await screen.findByRole('table');
     await user.click(screen.getByRole('button', { name: /options/i }));
 
-    expect(screen.getByText(/modify order/i).closest('button')).toBeDisabled();
-    expect(screen.getByText(/cancel order/i).closest('button')).toBeDisabled();
+    expect(screen.getByRole('button', { name: /modify order/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /cancel order/i })).toBeDisabled();
   });
 });
 

--- a/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { vi, describe, it, expect, test, beforeEach } from 'vitest';
 import { useReactToPrint } from 'react-to-print';
-import { screen, render } from '@testing-library/react';
+import { screen, render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   type ConfigObject,
@@ -34,31 +34,6 @@ const mockUseReactToPrint = vi.mocked(useReactToPrint);
 
 mockSession.mockReturnValue(mockSessionDataResponse.data);
 mockOpenmrsFetch.mockImplementation(vi.fn());
-
-vi.mock('@carbon/react', async () => {
-  const React = await vi.importActual('react');
-  const originalModule = (await vi.importActual('@carbon/react')) as Record<string, unknown>;
-  const OverflowMenu = ({ children, ...props }: any) => (
-    <div>
-      <button aria-label={props['aria-label'] ?? 'Options'} type="button">
-        Options
-      </button>
-      {children}
-    </div>
-  );
-  const OverflowMenuItem = (React as any).forwardRef(({ disabled, itemText, onClick }: any, ref) => (
-    <button disabled={disabled} onClick={onClick} ref={ref} type="button">
-      {itemText}
-    </button>
-  ));
-  OverflowMenuItem.displayName = 'OverflowMenuItem';
-
-  return {
-    ...originalModule,
-    OverflowMenu,
-    OverflowMenuItem,
-  };
-});
 
 vi.mock('react-to-print', async () => ({
   ...((await vi.importActual('react-to-print')) as object),
@@ -618,7 +593,8 @@ describe('OrderDetailsTable', () => {
     expect(screen.getByRole('button', { name: /actions menu/i })).toBeInTheDocument();
   });
 
-  it('disables modify and cancel actions when visits are required and an order has no visit context', async () => {
+  it('disables cancel action while keeping modify enabled when visits are required and an order has no visit context', async () => {
+    const user = userEvent.setup();
     const orderWithoutVisitContext = {
       ...mockOrders[0],
       encounter: {
@@ -638,11 +614,22 @@ describe('OrderDetailsTable', () => {
     renderOrderDetailsTable();
 
     await screen.findByRole('table');
-    expect(screen.getByRole('button', { name: /modify order/i })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /cancel order/i })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: /actions menu/i }));
+
+    const actionsMenu = await screen.findByRole('menu', { hidden: true });
+    const modifyItem = within(actionsMenu)
+      .getAllByRole('menuitem', { hidden: true })
+      .find((item) => /modify order/i.test(item.textContent));
+    const cancelItem = within(actionsMenu)
+      .getAllByRole('menuitem', { hidden: true })
+      .find((item) => /cancel order/i.test(item.textContent));
+
+    expect(modifyItem).toBeEnabled();
+    expect(cancelItem).toBeDisabled();
   });
 
   it('keeps modify and cancel actions enabled when visits are not required and an order has no visit', async () => {
+    const user = userEvent.setup();
     const orderWithoutVisitContext = {
       ...mockOrders[0],
       encounter: {
@@ -667,8 +654,18 @@ describe('OrderDetailsTable', () => {
     renderOrderDetailsTable();
 
     await screen.findByRole('table');
-    expect(screen.getByRole('button', { name: /modify order/i })).toBeEnabled();
-    expect(screen.getByRole('button', { name: /cancel order/i })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: /actions menu/i }));
+
+    const actionsMenu = await screen.findByRole('menu', { hidden: true });
+    const modifyItem = within(actionsMenu)
+      .getAllByRole('menuitem', { hidden: true })
+      .find((item) => /modify order/i.test(item.textContent));
+    const cancelItem = within(actionsMenu)
+      .getAllByRole('menuitem', { hidden: true })
+      .find((item) => /cancel order/i.test(item.textContent));
+
+    expect(modifyItem).toBeEnabled();
+    expect(cancelItem).toBeEnabled();
   });
 });
 

--- a/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
@@ -16,6 +16,7 @@ import {
   useOrderTypes,
   usePatientOrders,
   useOrderBasket,
+  useSystemVisitSetting,
 } from '@openmrs/esm-patient-common-lib';
 import { configSchema } from '../config-schema';
 import { mockOrders, mockSessionDataResponse } from '__mocks__';
@@ -25,6 +26,7 @@ import OrderDetailsTable from './order-details-table.component';
 const mockUsePatientOrders = vi.mocked(usePatientOrders);
 const mockUseOrderTypes = vi.mocked(useOrderTypes);
 const mockUseOrderBasket = vi.mocked(useOrderBasket);
+const mockUseSystemVisitSetting = vi.mocked(useSystemVisitSetting);
 const mockOpenmrsFetch = vi.mocked(openmrsFetch);
 const mockSession = vi.mocked(useSession);
 const mockUseConfig = vi.mocked(useConfig<ConfigObject>);
@@ -32,6 +34,31 @@ const mockUseReactToPrint = vi.mocked(useReactToPrint);
 
 mockSession.mockReturnValue(mockSessionDataResponse.data);
 mockOpenmrsFetch.mockImplementation(vi.fn());
+
+vi.mock('@carbon/react', async () => {
+  const React = await vi.importActual('react');
+  const originalModule = (await vi.importActual('@carbon/react')) as Record<string, unknown>;
+  const OverflowMenu = ({ children, ...props }: any) => (
+    <div>
+      <button aria-label={props['aria-label'] ?? 'Options'} type="button">
+        Options
+      </button>
+      {children}
+    </div>
+  );
+  const OverflowMenuItem = (React as any).forwardRef(({ disabled, itemText, onClick }: any, ref) => (
+    <button disabled={disabled} onClick={onClick} ref={ref} type="button">
+      {itemText}
+    </button>
+  ));
+  OverflowMenuItem.displayName = 'OverflowMenuItem';
+
+  return {
+    ...originalModule,
+    OverflowMenu,
+    OverflowMenuItem,
+  };
+});
 
 vi.mock('react-to-print', async () => ({
   ...((await vi.importActual('react-to-print')) as object),
@@ -47,6 +74,7 @@ vi.mock('@openmrs/esm-patient-common-lib', async () => {
     useOrderTypes: vi.fn(),
     usePatient: vi.fn(),
     useOrderBasket: vi.fn(),
+    useSystemVisitSetting: vi.fn(),
   };
 });
 
@@ -132,6 +160,11 @@ describe('OrderDetailsTable', () => {
       isLoading: false,
       isValidating: false,
       mutate: vi.fn(),
+    });
+    mockUseSystemVisitSetting.mockReturnValue({
+      systemVisitEnabled: true,
+      isLoadingSystemVisitSetting: false,
+      errorFetchingSystemVisitSetting: null,
     });
   });
 
@@ -462,7 +495,7 @@ describe('OrderDetailsTable', () => {
 
     await screen.findByRole('table');
 
-    const addButton = screen.getByRole('button', { name: /add/i });
+    const addButton = screen.getByRole('button', { name: /add addicon/i });
     expect(addButton).toBeInTheDocument();
   });
 
@@ -479,7 +512,7 @@ describe('OrderDetailsTable', () => {
 
     await screen.findByRole('table');
 
-    const addButton = screen.queryByRole('button', { name: /add/i });
+    const addButton = screen.queryByRole('button', { name: /^add$/i });
     expect(addButton).not.toBeInTheDocument();
   });
 
@@ -585,10 +618,13 @@ describe('OrderDetailsTable', () => {
     expect(screen.getByRole('button', { name: /actions menu/i })).toBeInTheDocument();
   });
 
-  it('disables modify and cancel actions when an order has no visit context', async () => {
+  it('disables modify and cancel actions when visits are required and an order has no visit context', async () => {
     const orderWithoutVisitContext = {
       ...mockOrders[0],
-      encounter: null,
+      encounter: {
+        ...mockOrders[0].encounter,
+        visit: null,
+      },
     };
 
     mockUsePatientOrders.mockReturnValue({
@@ -602,10 +638,37 @@ describe('OrderDetailsTable', () => {
     renderOrderDetailsTable();
 
     await screen.findByRole('table');
-    await user.click(screen.getByRole('button', { name: /options/i }));
-
     expect(screen.getByRole('button', { name: /modify order/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /cancel order/i })).toBeDisabled();
+  });
+
+  it('keeps modify and cancel actions enabled when visits are not required and an order has no visit', async () => {
+    const orderWithoutVisitContext = {
+      ...mockOrders[0],
+      encounter: {
+        ...mockOrders[0].encounter,
+        visit: null,
+      },
+    };
+
+    mockUseSystemVisitSetting.mockReturnValue({
+      systemVisitEnabled: false,
+      isLoadingSystemVisitSetting: false,
+      errorFetchingSystemVisitSetting: null,
+    });
+    mockUsePatientOrders.mockReturnValue({
+      data: [orderWithoutVisitContext] as unknown as Array<Order>,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    });
+
+    renderOrderDetailsTable();
+
+    await screen.findByRole('table');
+    expect(screen.getByRole('button', { name: /modify order/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /cancel order/i })).toBeEnabled();
   });
 });
 

--- a/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.test.tsx
@@ -584,6 +584,29 @@ describe('OrderDetailsTable', () => {
 
     expect(screen.getByRole('button', { name: /actions menu/i })).toBeInTheDocument();
   });
+
+  it('disables modify and cancel actions when an order has no visit context', async () => {
+    const orderWithoutVisitContext = {
+      ...mockOrders[0],
+      encounter: null,
+    };
+
+    mockUsePatientOrders.mockReturnValue({
+      data: [orderWithoutVisitContext] as unknown as Array<Order>,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: jest.fn(),
+    });
+
+    renderOrderDetailsTable();
+
+    await screen.findByRole('table');
+    await user.click(screen.getByRole('button', { name: /options/i }));
+
+    expect(screen.getByText(/modify order/i).closest('button')).toBeDisabled();
+    expect(screen.getByText(/cancel order/i).closest('button')).toBeDisabled();
+  });
 });
 
 function renderOrderDetailsTable() {

--- a/packages/esm-patient-orders-app/src/utils/index.test.ts
+++ b/packages/esm-patient-orders-app/src/utils/index.test.ts
@@ -1,0 +1,42 @@
+import { buildGeneralOrder, buildLabOrder, buildMedicationOrder } from './index';
+import { mockOrders } from '__mocks__';
+
+describe('order builders', () => {
+  it('returns a medication basket item with a null visit when encounter visit is unavailable', () => {
+    const orderWithoutVisit = {
+      ...mockOrders[0],
+      encounter: {
+        ...mockOrders[0].encounter,
+        visit: null,
+      },
+    };
+
+    expect(buildMedicationOrder(orderWithoutVisit as any, 'RENEW')).toEqual(
+      expect.objectContaining({
+        encounterUuid: mockOrders[0].encounter.uuid,
+        visit: null,
+      }),
+    );
+  });
+
+  it('returns lab and general basket items with a null visit when encounter data is unavailable', () => {
+    const orderWithoutEncounter = {
+      ...mockOrders[1],
+      encounter: null,
+    };
+
+    expect(buildLabOrder(orderWithoutEncounter as any, 'REVISE')).toEqual(
+      expect.objectContaining({
+        encounterUuid: undefined,
+        visit: null,
+      }),
+    );
+
+    expect(buildGeneralOrder(orderWithoutEncounter as any, 'DISCONTINUE')).toEqual(
+      expect.objectContaining({
+        encounterUuid: undefined,
+        visit: null,
+      }),
+    );
+  });
+});

--- a/packages/esm-patient-orders-app/src/utils/index.test.ts
+++ b/packages/esm-patient-orders-app/src/utils/index.test.ts
@@ -1,7 +1,6 @@
 import type { Order } from '@openmrs/esm-patient-common-lib';
 import { describe, it, expect } from 'vitest';
 import { buildGeneralOrder, buildLabOrder, buildMedicationOrder } from './index';
-import { mockOrders } from '__mocks__';
 
 const medicationOrder = {
   uuid: 'order-uuid',
@@ -150,42 +149,57 @@ describe('buildMedicationOrder', () => {
 
     expect(result.previousOrderDateActivated).toBe(medicationOrder.dateActivated);
   });
-});
 
-describe('order builders', () => {
   it('returns a medication basket item with a null visit when encounter visit is unavailable', () => {
     const orderWithoutVisit = {
-      ...mockOrders[0],
+      ...medicationOrder,
       encounter: {
-        ...mockOrders[0].encounter,
+        ...medicationOrder.encounter,
         visit: null,
       },
-    };
+    } as Order;
 
-    expect(buildMedicationOrder(orderWithoutVisit as any, 'RENEW')).toEqual(
+    expect(buildMedicationOrder(orderWithoutVisit, 'RENEW')).toEqual(
       expect.objectContaining({
-        encounterUuid: mockOrders[0].encounter.uuid,
+        encounterUuid: medicationOrder.encounter.uuid,
         visit: null,
       }),
     );
   });
+});
 
-  it('returns lab and general basket items with a null visit when encounter data is unavailable', () => {
-    const orderWithoutEncounter = {
-      ...mockOrders[1],
-      encounter: null,
-    };
+describe('buildLabOrder', () => {
+  it('returns a lab basket item with a null visit when encounter visit is unavailable', () => {
+    const orderWithoutVisit = {
+      ...medicationOrder,
+      encounter: {
+        ...medicationOrder.encounter,
+        visit: null,
+      },
+    } as Order;
 
-    expect(buildLabOrder(orderWithoutEncounter as any, 'REVISE')).toEqual(
+    expect(buildLabOrder(orderWithoutVisit, 'REVISE')).toEqual(
       expect.objectContaining({
-        encounterUuid: undefined,
+        encounterUuid: medicationOrder.encounter.uuid,
         visit: null,
       }),
     );
+  });
+});
 
-    expect(buildGeneralOrder(orderWithoutEncounter as any, 'DISCONTINUE')).toEqual(
+describe('buildGeneralOrder', () => {
+  it('returns a general basket item with a null visit when encounter visit is unavailable', () => {
+    const orderWithoutVisit = {
+      ...medicationOrder,
+      encounter: {
+        ...medicationOrder.encounter,
+        visit: null,
+      },
+    } as Order;
+
+    expect(buildGeneralOrder(orderWithoutVisit, 'DISCONTINUE')).toEqual(
       expect.objectContaining({
-        encounterUuid: undefined,
+        encounterUuid: medicationOrder.encounter.uuid,
         visit: null,
       }),
     );

--- a/packages/esm-patient-orders-app/src/utils/index.test.ts
+++ b/packages/esm-patient-orders-app/src/utils/index.test.ts
@@ -1,6 +1,7 @@
 import type { Order } from '@openmrs/esm-patient-common-lib';
 import { describe, it, expect } from 'vitest';
-import { buildMedicationOrder } from './index';
+import { buildGeneralOrder, buildLabOrder, buildMedicationOrder } from './index';
+import { mockOrders } from '__mocks__';
 
 const medicationOrder = {
   uuid: 'order-uuid',
@@ -148,5 +149,45 @@ describe('buildMedicationOrder', () => {
     const result = buildMedicationOrder(medicationOrder, 'REVISE');
 
     expect(result.previousOrderDateActivated).toBe(medicationOrder.dateActivated);
+  });
+});
+
+describe('order builders', () => {
+  it('returns a medication basket item with a null visit when encounter visit is unavailable', () => {
+    const orderWithoutVisit = {
+      ...mockOrders[0],
+      encounter: {
+        ...mockOrders[0].encounter,
+        visit: null,
+      },
+    };
+
+    expect(buildMedicationOrder(orderWithoutVisit as any, 'RENEW')).toEqual(
+      expect.objectContaining({
+        encounterUuid: mockOrders[0].encounter.uuid,
+        visit: null,
+      }),
+    );
+  });
+
+  it('returns lab and general basket items with a null visit when encounter data is unavailable', () => {
+    const orderWithoutEncounter = {
+      ...mockOrders[1],
+      encounter: null,
+    };
+
+    expect(buildLabOrder(orderWithoutEncounter as any, 'REVISE')).toEqual(
+      expect.objectContaining({
+        encounterUuid: undefined,
+        visit: null,
+      }),
+    );
+
+    expect(buildGeneralOrder(orderWithoutEncounter as any, 'DISCONTINUE')).toEqual(
+      expect.objectContaining({
+        encounterUuid: undefined,
+        visit: null,
+      }),
+    );
   });
 });

--- a/packages/esm-patient-orders-app/src/utils/index.ts
+++ b/packages/esm-patient-orders-app/src/utils/index.ts
@@ -89,7 +89,7 @@ export function buildMedicationOrder(order: Order, action?: OrderAction): DrugOr
         }
       : null,
     encounterUuid: order.encounter?.uuid,
-    visit: order.encounter.visit,
+    visit: order.encounter?.visit ?? null,
   };
 }
 
@@ -114,7 +114,7 @@ export function buildLabOrder(order: Order, action?: OrderAction): TestOrderBask
     specimenSource: null,
     scheduledDate: order.scheduledDate ? new Date(order.scheduledDate) : null,
     encounterUuid: order.encounter?.uuid,
-    visit: order.encounter.visit,
+    visit: order.encounter?.visit ?? null,
   };
 }
 
@@ -134,7 +134,7 @@ export function buildGeneralOrder(order: Order, action?: OrderAction): OrderBask
     orderType: order.orderType.uuid,
     scheduledDate: order.scheduledDate ? new Date(order.scheduledDate) : null,
     encounterUuid: order.encounter?.uuid,
-    visit: order.encounter.visit,
+    visit: order.encounter?.visit ?? null,
   };
 }
 

--- a/packages/esm-patient-orders-app/src/utils/index.ts
+++ b/packages/esm-patient-orders-app/src/utils/index.ts
@@ -101,7 +101,7 @@ export function buildMedicationOrder(order: Order, action?: OrderAction): DrugOr
       : null,
     encounterUuid: order.encounter?.uuid,
     previousOrderDateActivated: action === 'REVISE' ? order.dateActivated : undefined,
-    visit: order.encounter.visit,
+    visit: order.encounter.visit ?? null,
   };
 }
 
@@ -126,7 +126,7 @@ export function buildLabOrder(order: Order, action?: OrderAction): TestOrderBask
     specimenSource: null,
     scheduledDate: order.scheduledDate ? new Date(order.scheduledDate) : null,
     encounterUuid: order.encounter?.uuid,
-    visit: order.encounter.visit,
+    visit: order.encounter?.visit ?? null,
   };
 }
 
@@ -146,7 +146,7 @@ export function buildGeneralOrder(order: Order, action?: OrderAction): OrderBask
     orderType: order.orderType.uuid,
     scheduledDate: order.scheduledDate ? new Date(order.scheduledDate) : null,
     encounterUuid: order.encounter?.uuid,
-    visit: order.encounter.visit,
+    visit: order.encounter?.visit ?? null,
   };
 }
 

--- a/packages/esm-patient-orders-app/src/utils/index.ts
+++ b/packages/esm-patient-orders-app/src/utils/index.ts
@@ -99,7 +99,7 @@ export function buildMedicationOrder(order: Order, action?: OrderAction): DrugOr
           valueCoded: order.quantityUnits.uuid,
         }
       : null,
-    encounterUuid: order.encounter?.uuid,
+    encounterUuid: order.encounter.uuid,
     previousOrderDateActivated: action === 'REVISE' ? order.dateActivated : undefined,
     visit: order.encounter.visit ?? null,
   };
@@ -125,8 +125,8 @@ export function buildLabOrder(order: Order, action?: OrderAction): TestOrderBask
     orderType: order.orderType.uuid,
     specimenSource: null,
     scheduledDate: order.scheduledDate ? new Date(order.scheduledDate) : null,
-    encounterUuid: order.encounter?.uuid,
-    visit: order.encounter?.visit ?? null,
+    encounterUuid: order.encounter.uuid,
+    visit: order.encounter.visit ?? null,
   };
 }
 
@@ -145,8 +145,8 @@ export function buildGeneralOrder(order: Order, action?: OrderAction): OrderBask
     orderNumber: order.orderNumber,
     orderType: order.orderType.uuid,
     scheduledDate: order.scheduledDate ? new Date(order.scheduledDate) : null,
-    encounterUuid: order.encounter?.uuid,
-    visit: order.encounter?.visit ?? null,
+    encounterUuid: order.encounter.uuid,
+    visit: order.encounter.visit ?? null,
   };
 }
 

--- a/tools/vitest.shared.ts
+++ b/tools/vitest.shared.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 process.env.TZ = 'UTC';
@@ -11,7 +12,7 @@ export default defineConfig({
     globals: true,
     clearMocks: true,
     testTimeout: 30000,
-    setupFiles: [new URL('./setup-tests.ts', import.meta.url).pathname],
+    setupFiles: [fileURLToPath(new URL('./setup-tests.ts', import.meta.url))],
     exclude: ['**/node_modules/**', '**/e2e/**', '**/dist/**', '**/packages/esm-form-entry-app/**'],
     coverage: {
       provider: 'v8',
@@ -44,16 +45,16 @@ export default defineConfig({
     },
     alias: [
       { find: /^@openmrs\/esm-framework$/, replacement: '@openmrs/esm-framework/mock' },
-      { find: 'react-i18next', replacement: new URL('../__mocks__/react-i18next.js', import.meta.url).pathname },
+      { find: 'react-i18next', replacement: fileURLToPath(new URL('../__mocks__/react-i18next.js', import.meta.url)) },
       {
         find: /^@carbon\/charts-react$/,
-        replacement: new URL('../__mocks__/@carbon__charts-react.ts', import.meta.url).pathname,
+        replacement: fileURLToPath(new URL('../__mocks__/@carbon__charts-react.ts', import.meta.url)),
       },
-      { find: /^tools$/, replacement: new URL('./index.ts', import.meta.url).pathname },
-      { find: /^tools\/(.*)$/, replacement: new URL('./', import.meta.url).pathname + '$1' },
-      { find: /^__mocks__$/, replacement: new URL('../__mocks__/index.ts', import.meta.url).pathname },
-      { find: /^__mocks__\/(.*)$/, replacement: new URL('../__mocks__/', import.meta.url).pathname + '$1' },
-      { find: /^uuid$/, replacement: new URL('../node_modules/uuid/dist/index.js', import.meta.url).pathname },
+      { find: /^tools$/, replacement: fileURLToPath(new URL('./index.ts', import.meta.url)) },
+      { find: /^tools\/(.*)$/, replacement: fileURLToPath(new URL('./', import.meta.url)) + '$1' },
+      { find: /^__mocks__$/, replacement: fileURLToPath(new URL('../__mocks__/index.ts', import.meta.url)) },
+      { find: /^__mocks__\/(.*)$/, replacement: fileURLToPath(new URL('../__mocks__/', import.meta.url)) + '$1' },
+      { find: /^uuid$/, replacement: fileURLToPath(new URL('../node_modules/uuid/dist/index.js', import.meta.url)) },
     ],
   },
 });

--- a/tools/vitest.shared.ts
+++ b/tools/vitest.shared.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 process.env.TZ = 'UTC';
@@ -12,7 +11,7 @@ export default defineConfig({
     globals: true,
     clearMocks: true,
     testTimeout: 30000,
-    setupFiles: [fileURLToPath(new URL('./setup-tests.ts', import.meta.url))],
+    setupFiles: [new URL('./setup-tests.ts', import.meta.url).pathname],
     exclude: ['**/node_modules/**', '**/e2e/**', '**/dist/**', '**/packages/esm-form-entry-app/**'],
     coverage: {
       provider: 'v8',
@@ -45,16 +44,16 @@ export default defineConfig({
     },
     alias: [
       { find: /^@openmrs\/esm-framework$/, replacement: '@openmrs/esm-framework/mock' },
-      { find: 'react-i18next', replacement: fileURLToPath(new URL('../__mocks__/react-i18next.js', import.meta.url)) },
+      { find: 'react-i18next', replacement: new URL('../__mocks__/react-i18next.js', import.meta.url).pathname },
       {
         find: /^@carbon\/charts-react$/,
-        replacement: fileURLToPath(new URL('../__mocks__/@carbon__charts-react.ts', import.meta.url)),
+        replacement: new URL('../__mocks__/@carbon__charts-react.ts', import.meta.url).pathname,
       },
-      { find: /^tools$/, replacement: fileURLToPath(new URL('./index.ts', import.meta.url)) },
-      { find: /^tools\/(.*)$/, replacement: fileURLToPath(new URL('./', import.meta.url)) + '$1' },
-      { find: /^__mocks__$/, replacement: fileURLToPath(new URL('../__mocks__/index.ts', import.meta.url)) },
-      { find: /^__mocks__\/(.*)$/, replacement: fileURLToPath(new URL('../__mocks__/', import.meta.url)) + '$1' },
-      { find: /^uuid$/, replacement: fileURLToPath(new URL('../node_modules/uuid/dist/index.js', import.meta.url)) },
+      { find: /^tools$/, replacement: new URL('./index.ts', import.meta.url).pathname },
+      { find: /^tools\/(.*)$/, replacement: new URL('./', import.meta.url).pathname + '$1' },
+      { find: /^__mocks__$/, replacement: new URL('../__mocks__/index.ts', import.meta.url).pathname },
+      { find: /^__mocks__\/(.*)$/, replacement: new URL('../__mocks__/', import.meta.url).pathname + '$1' },
+      { find: /^uuid$/, replacement: new URL('../node_modules/uuid/dist/index.js', import.meta.url).pathname },
     ],
   },
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a conventional commit label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: Styleguide)
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR prevents order action crashes when order payloads are missing embedded `encounter` or `visit` data.

It updates the medication and shared order basket builders to safely handle missing `encounter.visit`, and disables revise, renew, and discontinue-style actions when the required visit context is unavailable.

Without this change, several code paths guarded `order.encounter?.uuid`, but still directly dereferenced `order.encounter.visit`, which could cause runtime failures in order action flows.

## Screenshots

N/A - this change is in null-safety handling, action guarding, and test coverage. No visible UI change was introduced.

## Related Issue

N/A

## Other

Local test run:

```bash
node .yarn/releases/yarn-4.10.3.cjs jest packages/esm-patient-medications-app/src/api/api.test.ts --runInBand
node .yarn/releases/yarn-4.10.3.cjs jest packages/esm-patient-medications-app/src/components/medications-details-table.test.tsx --runInBand
node .yarn/releases/yarn-4.10.3.cjs jest packages/esm-patient-orders-app/src/utils/index.test.ts --runInBand
node .yarn/releases/yarn-4.10.3.cjs jest packages/esm-patient-orders-app/src/components/order-details-table.test.tsx --runInBand

```
