### PR TITLE
(fix) O3-5587: Panel view displays outdated date/value compared to Overtime view

### DIFF
--- a/packages/esm-patient-tests-app/src/test-results/filter/filter-context.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/filter/filter-context.tsx
@@ -135,9 +135,7 @@ const FilterProvider = ({ roots, isLoading, children }: FilterProviderProps) => 
       const test = state.tests[key] as TestResult;
       if (test.obs && Array.isArray(test.obs)) {
         test.obs.forEach((obs) => {
-          // Use a more specific key that includes the test name to avoid over-deduplication
           const testKey = `${test.flatName}_${obs.obsDatetime}_${obs.value}`;
-
           if (!seenTests.has(testKey)) {
             seenTests.add(testKey);
             const flattenedEntry = {
@@ -151,44 +149,44 @@ const FilterProvider = ({ roots, isLoading, children }: FilterProviderProps) => 
       }
     }
 
+    flattenedObs.sort(
+      (a, b) =>
+        new Date((b as MappedObservation).obsDatetime).getTime() -
+        new Date((a as MappedObservation).obsDatetime).getTime(),
+    );
+
     const groupedObs: Record<string, GroupedObservation> = {};
+    const seenConcepts: Record<string, Set<string>> = {};
 
     flattenedObs.forEach((curr: MappedObservation) => {
       const flatNameParts = curr.flatName.split('-');
 
-      // Extract the actual panel name from the flatName
-      // Panel names are at index 1 (second part) like "Lipid panel", "Basic metabolic panel"
-      // This is based on the actual flatName structure we observed
       let groupKey: string;
       if (flatNameParts.length >= 2) {
-        // For names like "Hematology-Lipid panel-Total cholesterol" or "Chemistry-Basic metabolic panel-Serum sodium"
-        // Take the second part (index 1) which is the actual panel name
         groupKey = flatNameParts[1];
       } else {
-        // Fallback to first part if only one part exists
         groupKey = flatNameParts[0];
       }
 
-      const dateKey = new Date(curr.obsDatetime).toISOString().split('T')[0];
-
-      const compositeKey = `${groupKey}__${dateKey}`;
-      if (!groupedObs[compositeKey]) {
-        groupedObs[compositeKey] = {
+      if (!groupedObs[groupKey]) {
+        const dateKey = new Date(curr.obsDatetime).toISOString().split('T')[0];
+        groupedObs[groupKey] = {
           key: groupKey,
           date: dateKey,
           flatName: curr.flatName,
           entries: [],
         };
+        seenConcepts[groupKey] = new Set<string>();
       }
 
-      groupedObs[compositeKey].entries.push(curr);
+      const conceptId = curr.key;
+      if (!seenConcepts[groupKey].has(conceptId)) {
+        seenConcepts[groupKey].add(conceptId);
+        groupedObs[groupKey].entries.push(curr);
+      }
     });
 
-    const resultArray = Object.values(groupedObs).sort(
-      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
-    );
-
-    return resultArray;
+    return Object.values(groupedObs).sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
   }, [state.tests]);
 
   useEffect(() => {

--- a/packages/esm-patient-tests-app/src/test-results/filter/filter-context.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/filter/filter-context.tsx
@@ -135,7 +135,9 @@ const FilterProvider = ({ roots, isLoading, children }: FilterProviderProps) => 
       const test = state.tests[key] as TestResult;
       if (test.obs && Array.isArray(test.obs)) {
         test.obs.forEach((obs) => {
+          // Use a more specific key that includes the test name to avoid over-deduplication
           const testKey = `${test.flatName}_${obs.obsDatetime}_${obs.value}`;
+
           if (!seenTests.has(testKey)) {
             seenTests.add(testKey);
             const flattenedEntry = {
@@ -149,6 +151,7 @@ const FilterProvider = ({ roots, isLoading, children }: FilterProviderProps) => 
       }
     }
 
+    // Sort descending so the first obs per concept we encounter is always the most recent
     flattenedObs.sort(
       (a, b) =>
         new Date((b as MappedObservation).obsDatetime).getTime() -
@@ -161,13 +164,22 @@ const FilterProvider = ({ roots, isLoading, children }: FilterProviderProps) => 
     flattenedObs.forEach((curr: MappedObservation) => {
       const flatNameParts = curr.flatName.split('-');
 
+      // Extract the actual panel name from the flatName
+      // Panel names are at index 1 (second part) like "Lipid panel", "Basic metabolic panel"
+      // This is based on the actual flatName structure we observed
       let groupKey: string;
       if (flatNameParts.length >= 2) {
+        // For names like "Hematology-Lipid panel-Total cholesterol" or "Chemistry-Basic metabolic panel-Serum sodium"
+        // Take the second part (index 1) which is the actual panel name
         groupKey = flatNameParts[1];
       } else {
+        // Fallback to first part if only one part exists
         groupKey = flatNameParts[0];
       }
 
+      // Group by panel name only (not panel+date) so all observations for the
+      // same panel are considered together. We then keep only the most recent
+      // result per individual test concept, matching what the Overtime view shows.
       if (!groupedObs[groupKey]) {
         const dateKey = new Date(curr.obsDatetime).toISOString().split('T')[0];
         groupedObs[groupKey] = {

--- a/packages/esm-patient-tests-app/src/test-results/grouped-timeline/useObstreeData.ts
+++ b/packages/esm-patient-tests-app/src/test-results/grouped-timeline/useObstreeData.ts
@@ -72,10 +72,6 @@ const augmentObstreeData = (node: ObsTreeNode, prefix: string | undefined) => {
   }
 
   if (outData?.obs?.length) {
-    // Sort observations by date descending and keep only the most recent one
-    outData.obs.sort((a, b) => new Date(b.obsDatetime ?? 0).getTime() - new Date(a.obsDatetime ?? 0).getTime());
-    outData.obs = [outData.obs[0]];
-    outData.obs = [outData.obs[0]]; // keep only the most recent
     outData.obs = outData.obs.map((ob) => {
       // Note: Units are only at the concept/node level, not observation-level
       const observationRanges: ReferenceRanges | undefined =

--- a/packages/esm-patient-tests-app/src/test-results/grouped-timeline/useObstreeData.ts
+++ b/packages/esm-patient-tests-app/src/test-results/grouped-timeline/useObstreeData.ts
@@ -72,6 +72,10 @@ const augmentObstreeData = (node: ObsTreeNode, prefix: string | undefined) => {
   }
 
   if (outData?.obs?.length) {
+    // Sort observations by date descending and keep only the most recent one
+    outData.obs.sort((a, b) => new Date(b.obsDatetime ?? 0).getTime() - new Date(a.obsDatetime ?? 0).getTime());
+    outData.obs = [outData.obs[0]];
+    outData.obs = [outData.obs[0]]; // keep only the most recent
     outData.obs = outData.obs.map((ob) => {
       // Note: Units are only at the concept/node level, not observation-level
       const observationRanges: ReferenceRanges | undefined =


### PR DESCRIPTION
## Summary
The panel view (individual tests) was displaying outdated lab result dates and values, while the overtime view correctly showed the most recent data for the same test.

## Requirements
- [x] The panel view should display the most recent observation per concept
- [x] The panel view and Overtime view should show consistent values

## Screenshots
Before: Serum creatinine showed 126.1 umol/L (Apr 4, 2024) in panel view
After: Serum creatinine shows 23.0 umol/L (Mar 31, 2026) in panel view

## Related Issue
Fixes O3-5587

## Other
- Fixed in `useObstreeData.ts` by sorting observations by date descending and keeping only the most recent observation per test node
- Fixed in `filter-context.tsx` by sorting and deduplicating observations by concept before grouping into panels
<img width="1915" height="1027" alt="image (2)" src="https://github.com/user-attachments/assets/5a08f16b-d876-4b54-a868-b186175476a4" />
<img width="1915" height="1029" alt="image (1)" src="https://github.com/user-attachments/assets/040c366d-6adb-410b-8899-a5a2741e12ad" />
<img width="1366" height="768" alt="Screenshot (174)" src="https://github.com/user-attachments/assets/0ad6648a-ff55-41f7-85e7-0f49f0bb2c4e" />
<img width="1366" height="768" alt="Screenshot (175)" src="https://github.com/user-attachments/assets/dfa6f2d4-6714-481e-9b12-ef0d67dcc4ea" />
