### PR TITLE
(fix) O3-5041: Heading semantics across patient chart

### DIFF
--- a/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.extension.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.extension.tsx
@@ -21,7 +21,7 @@ const DeceasedPatientBannerTag: React.FC<DeceasedPatientBannerTagProps> = ({ pat
       align="bottom-left"
       definition={
         <div role="tooltip" className={styles.tooltipPadding}>
-          <h6 style={{ marginBottom: '0.5rem' }}>{t('deceased', 'Deceased')}</h6>
+          <span className={styles.heading}>{t('deceased', 'Deceased')}</span>
           <span>
             {formatDatetime(parseDate(patient?.deceasedDateTime))}
             {nonCodedCauseOfDeath || causeOfDeath

--- a/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.scss
+++ b/packages/esm-patient-banner-app/src/banner-tags/deceased-patient-tag.scss
@@ -9,6 +9,12 @@
   font-size: 80%;
 }
 
+.heading {
+  display: block;
+  font-weight: 600;
+  margin-bottom: layout.$spacing-03;
+}
+
 .tagOverride {
   background-color: colors.$gray-80;
   color: colors.$gray-20;

--- a/packages/esm-patient-banner-app/src/banner-tags/visit-tag.extension.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/visit-tag.extension.tsx
@@ -28,7 +28,7 @@ const ActiveVisitTag: React.FC<ActiveVisitTagProps> = ({ activeVisit }) => {
       </ToggletipButton>
       <ToggletipContent>
         <div role="tooltip">
-          <h6 className={styles.heading}>{activeVisit?.visitType?.display}</h6>
+          <span className={styles.heading}>{activeVisit?.visitType?.display}</span>
           <span>
             <span className={styles.tooltipSmallText}>{t('started', 'Started')}: </span>
             <span>{formatDatetime(parseDate(activeVisit?.startDatetime), { mode: 'wide' })}</span>

--- a/packages/esm-patient-banner-app/src/banner-tags/visit-tag.scss
+++ b/packages/esm-patient-banner-app/src/banner-tags/visit-tag.scss
@@ -9,6 +9,8 @@
 }
 
 .heading {
+  display: block;
+  font-weight: 600;
   margin-bottom: layout.$spacing-03;
 }
 

--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list.component.tsx
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list.component.tsx
@@ -274,7 +274,7 @@ export const EncounterList: React.FC<EncounterListProps> = ({
         <>
           <div className={styles.widgetContainer}>
             <div className={styles.widgetHeaderContainer}>
-              <h4 className={classNames(styles.productiveHeading03)}>{t(headerTitle)}</h4>
+              <h2 className={classNames(styles.productiveHeading03)}>{t(headerTitle)}</h2>
               {!(hideFormLauncher ?? deathStatus) && <div className={styles.toggleButtons}>{formLauncher}</div>}
             </div>
             <EncounterListDataTable tableHeaders={headers} tableRows={tableRows} />

--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list.scss
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-list/encounter-list.scss
@@ -15,7 +15,7 @@
   padding: layout.$spacing-04 0 layout.$spacing-04 layout.$spacing-05;
 }
 
-.widgetHeaderContainer > h4:after {
+.widgetHeaderContainer > h2:after {
   content: '';
   display: block;
   width: 2rem;

--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-tile/encounter-tile.component.tsx
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-tile/encounter-tile.component.tsx
@@ -16,7 +16,7 @@ export const EncounterTile = memo(({ patientUuid, columns, headerTitle }: Encoun
     <Layer className={styles.layer}>
       <Tile className={styles.tile}>
         <div className={isTablet ? styles.tabletHeading : styles.desktopHeading}>
-          <h4 className={styles.title}>{headerTitle}</h4>
+          <h2 className={styles.title}>{headerTitle}</h2>
         </div>
         <Grid fullWidth>
           {columns.map((column, index) => (

--- a/packages/esm-patient-chart-app/src/clinical-views/encounter-tile/tile.scss
+++ b/packages/esm-patient-chart-app/src/clinical-views/encounter-tile/tile.scss
@@ -36,14 +36,14 @@
 }
 
 .desktopHeading {
-  h4 {
+  h2 {
     @include type.type-style('heading-compact-02');
     color: $text-02;
   }
 }
 
 .tabletHeading {
-  h4 {
+  h2 {
     @include type.type-style('heading-03');
     color: $text-02;
   }
@@ -55,7 +55,7 @@
   text-transform: capitalize;
   margin-bottom: layout.$spacing-05;
 
-  h4:after {
+  h2:after {
     content: '';
     display: block;
     width: layout.$spacing-07;

--- a/packages/esm-patient-chart-app/src/visit/visit-form/exported-visit-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/exported-visit-form.workspace.tsx
@@ -551,7 +551,7 @@ const ExportedVisitForm: React.FC<Workspace2DefinitionProps<ExportedVisitFormPro
                 to true. */}
                   {config.showRecommendedVisitTypeTab && (
                     <section>
-                      <h1 className={styles.sectionTitle}>{t('program', 'Program')}</h1>
+                      <h2 className={styles.sectionTitle}>{t('program', 'Program')}</h2>
                       <FormGroup
                         legendText={t('selectProgramType', 'Select program type')}
                         className={styles.sectionField}
@@ -586,7 +586,7 @@ const ExportedVisitForm: React.FC<Workspace2DefinitionProps<ExportedVisitFormPro
                   {/* Lists available visit types if no atFacilityVisitType enabled. The content switcher only gets shown when recommended visit types are enabled */}
                   {!emrConfiguration?.atFacilityVisitType && (
                     <section>
-                      <h1 className={styles.sectionTitle}>{t('visitType_title', 'Visit Type')}</h1>
+                      <h2 className={styles.sectionTitle}>{t('visitType_title', 'Visit Type')}</h2>
                       <div className={styles.sectionField}>
                         {config.showRecommendedVisitTypeTab ? (
                           <>
@@ -638,7 +638,7 @@ const ExportedVisitForm: React.FC<Workspace2DefinitionProps<ExportedVisitFormPro
 
                   {/* Visit type attribute fields. These get shown when visit attribute types are configured */}
                   <section>
-                    <h1 className={styles.sectionTitle}>{isTablet && t('visitAttributes', 'Visit attributes')}</h1>
+                    <h2 className={styles.sectionTitle}>{isTablet && t('visitAttributes', 'Visit attributes')}</h2>
                     <div className={styles.sectionField}>
                       <VisitAttributeTypeFields setErrorFetchingResources={setErrorFetchingResources} />
                     </div>

--- a/packages/esm-patient-common-lib/src/cards/card-header.component.tsx
+++ b/packages/esm-patient-common-lib/src/cards/card-header.component.tsx
@@ -13,7 +13,7 @@ export function CardHeader({ title, children }: CardHeaderProps) {
 
   return (
     <div className={classNames(isTablet ? styles.tabletHeader : styles.desktopHeader)}>
-      <h4>{title}</h4>
+      <h2>{title}</h2>
       {children}
     </div>
   );

--- a/packages/esm-patient-common-lib/src/cards/card-header.scss
+++ b/packages/esm-patient-common-lib/src/cards/card-header.scss
@@ -10,7 +10,7 @@
   padding: layout.$spacing-04 0 layout.$spacing-04 layout.$spacing-05;
   background-color: $ui-background;
 
-  h4:after {
+  h2:after {
     content: '';
     display: block;
     width: layout.$spacing-07;
@@ -21,7 +21,7 @@
 
 .desktopHeader {
   height: layout.$spacing-09;
-  h4 {
+  h2 {
     @include type.type-style('heading-compact-02');
     color: $text-02;
   }
@@ -29,7 +29,7 @@
 
 .tabletHeader {
   height: 4.5rem;
-  h4 {
+  h2 {
     @include type.type-style('heading-03');
     color: $text-02;
   }

--- a/packages/esm-patient-common-lib/src/empty-state/empty-state.component.tsx
+++ b/packages/esm-patient-common-lib/src/empty-state/empty-state.component.tsx
@@ -19,7 +19,7 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
     <Layer className={styles.layer}>
       <Tile className={styles.tile}>
         <div className={isTablet ? styles.tabletHeading : styles.desktopHeading}>
-          <h4>{props.headerTitle}</h4>
+          <h2>{props.headerTitle}</h2>
         </div>
         <EmptyDataIllustration />
         <p className={styles.content}>

--- a/packages/esm-patient-common-lib/src/empty-state/empty-state.scss
+++ b/packages/esm-patient-common-lib/src/empty-state/empty-state.scss
@@ -14,14 +14,14 @@
 }
 
 .desktopHeading {
-  h4 {
+  h2 {
     @include type.type-style('heading-compact-02');
     color: $text-02;
   }
 }
 
 .tabletHeading {
-  h4 {
+  h2 {
     @include type.type-style('heading-03');
     color: $text-02;
   }
@@ -33,7 +33,7 @@
   text-transform: capitalize;
   margin-bottom: layout.$spacing-05;
 
-  h4:after {
+  h2:after {
     content: '';
     display: block;
     width: layout.$spacing-07;

--- a/packages/esm-patient-forms-app/src/forms/empty-form.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/empty-form.component.tsx
@@ -17,7 +17,7 @@ const EmptyFormView: React.FC<EmptyFormViewProps> = ({ content }) => {
     <Layer>
       <Tile className={styles.tile}>
         <div className={isDesktop(layout) ? styles.desktopHeading : styles.tabletHeading}>
-          <h4>{t('forms', 'Forms')}</h4>
+          <h2>{t('forms', 'Forms')}</h2>
         </div>
         <EmptyDataIllustration />
         <p className={styles.content}>{content}</p>

--- a/packages/esm-patient-forms-app/src/forms/empty-form.scss
+++ b/packages/esm-patient-forms-app/src/forms/empty-form.scss
@@ -21,14 +21,14 @@
 }
 
 .desktopHeading {
-  h4 {
+  h2 {
     @include type.type-style('heading-compact-02');
     color: $text-02;
   }
 }
 
 .tabletHeading {
-  h4 {
+  h2 {
     @include type.type-style('heading-03');
     color: $text-02;
   }
@@ -40,7 +40,7 @@
   text-transform: capitalize;
   margin-bottom: layout.$spacing-05;
 
-  h4:after {
+  h2:after {
     content: '';
     display: block;
     width: layout.$spacing-07;

--- a/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.component.tsx
@@ -78,7 +78,7 @@ const FormsList: React.FC<FormsListProps> = ({ forms, error, sectionName, handle
     <ResponsiveWrapper>
       {sectionName && (
         <div className={isTablet ? styles.tabletHeading : styles.desktopHeading}>
-          <h4>{t(sectionName)}</h4>
+          <h2>{t(sectionName)}</h2>
         </div>
       )}
       <FormsTable

--- a/packages/esm-patient-forms-app/src/forms/forms-list.scss
+++ b/packages/esm-patient-forms-app/src/forms/forms-list.scss
@@ -15,14 +15,14 @@
 }
 
 .desktopHeading {
-  h4 {
+  h2 {
     @include type.type-style('heading-compact-02');
     color: $text-02;
   }
 }
 
 .tabletHeading {
-  h4 {
+  h2 {
     @include type.type-style('heading-03');
     color: $text-02;
   }
@@ -36,7 +36,7 @@
   margin-left: layout.$spacing-03;
   margin-bottom: layout.$spacing-05;
 
-  h4:after {
+  h2:after {
     content: '';
     display: block;
     width: layout.$spacing-07;

--- a/packages/esm-patient-forms-app/src/offline-forms/offline-forms-overview-card.component.tsx
+++ b/packages/esm-patient-forms-app/src/offline-forms/offline-forms-overview-card.component.tsx
@@ -13,7 +13,7 @@ const OfflineFormsOverviewCard: React.FC = () => {
     <Layer>
       <Tile className={styles.overviewCard}>
         <div className={styles.headerContainer}>
-          <h3 className={styles.heading}>{t('forms', 'Forms')}</h3>
+          <h2 className={styles.heading}>{t('forms', 'Forms')}</h2>
           <Button
             className={styles.viewButton}
             kind="ghost"
@@ -46,7 +46,7 @@ export interface HeaderedQuickInfoProps {
 const HeaderedQuickInfo: React.FC<HeaderedQuickInfoProps> = ({ header, children, isLoading = false }) => {
   return (
     <div>
-      <h4 className={styles.label}>{header}</h4>
+      <h3 className={styles.label}>{header}</h3>
       {isLoading ? <SkeletonText heading /> : <span className={styles.heading}>{children}</span>}
     </div>
   );

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -430,7 +430,7 @@ export function DrugOrderForm({
             <section className={styles.formSection}>
               <Grid className={styles.gridRow}>
                 <Column lg={12} md={6} sm={4}>
-                  <h3 className={styles.sectionHeader}>{t('dosageInstructions', 'Dosage instructions')}</h3>
+                  <h2 className={styles.sectionHeader}>{t('dosageInstructions', 'Dosage instructions')}</h2>
                 </Column>
                 <Column className={styles.freeTextDosageToggle} lg={4} md={2} sm={4}>
                   <ControlledFieldInput
@@ -583,7 +583,7 @@ export function DrugOrderForm({
               )}
             </section>
             <section className={styles.formSection}>
-              <h3 className={styles.sectionHeader}>{t('prescriptionDuration', 'Prescription duration')}</h3>
+              <h2 className={styles.sectionHeader}>{t('prescriptionDuration', 'Prescription duration')}</h2>
               <Grid className={classNames(styles.gridRow, styles.topAlignedGridRow)}>
                 {/* TODO: This input does nothing */}
                 <Column lg={16} md={4} sm={4}>
@@ -649,7 +649,7 @@ export function DrugOrderForm({
               </Grid>
             </section>
             <section className={styles.formSection}>
-              <h3 className={styles.sectionHeader}>{t('dispensingInformation', 'Dispensing instructions')}</h3>
+              <h2 className={styles.sectionHeader}>{t('dispensingInformation', 'Dispensing instructions')}</h2>
               <Grid className={classNames(styles.gridRow, styles.topAlignedGridRow)}>
                 <Column lg={8} md={3} sm={4}>
                   <InputWrapper>

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
@@ -40,7 +40,7 @@
 
   counter-reset: section;
 
-  h3 {
+  h2 {
     counter-increment: section;
 
     &::before {

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.extension.tsx
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.extension.tsx
@@ -94,7 +94,7 @@ function DrugOrderBasketPanelExtension({ patient, launchDrugOrderForm }: OrderBa
       <div className={classNames(isTablet ? styles.tabletContainer : styles.desktopContainer)}>
         <div className={styles.iconAndLabel}>
           <RxIcon isTablet={isTablet} />
-          <h4 className={styles.heading}>{`${t('drugOrders', 'Drug orders')} (${orders.length})`}</h4>
+          <h2 className={styles.heading}>{`${t('drugOrders', 'Drug orders')} (${orders.length})`}</h2>
         </div>
         <div className={styles.buttonContainer}>
           <Button

--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
@@ -53,7 +53,7 @@
 }
 
 .desktopTile .container {
-  h4 {
+  h2 {
     @include type.type-style('heading-compact-02');
     color: $text-02;
   }
@@ -62,7 +62,7 @@
 .tabletTile .container {
   padding: layout.$spacing-03;
 
-  h4 {
+  h2 {
     @include type.type-style('heading-03');
     color: $ui-05;
   }

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/add-general-order/search-results.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/add-general-order/search-results.component.tsx
@@ -52,11 +52,11 @@ const OrderableConceptSearchResults: React.FC<OrderableConceptSearchResultsProps
     return (
       <Tile className={styles.emptyState}>
         <div>
-          <h4 className={styles.heading}>
+          <h2 className={styles.heading}>
             {t('errorFetchingTestTypes', 'Error fetching results for "{{searchTerm}}"', {
               searchTerm,
             })}
-          </h4>
+          </h2>
           <p className={styles.bodyShort01}>
             <span>{t('trySearchingAgain', 'Please try searching again')}</span>
           </p>
@@ -103,11 +103,11 @@ const OrderableConceptSearchResults: React.FC<OrderableConceptSearchResultsProps
   return (
     <Tile className={styles.emptyState}>
       <div>
-        <h4 className={styles.heading}>
+        <h2 className={styles.heading}>
           {t('noResultsForTestTypeSearch', 'No results to display for "{{searchTerm}}"', {
             searchTerm,
           })}
-        </h4>
+        </h2>
         <p className={styles.bodyShort01}>
           <span>{t('tryTo', 'Try to')}</span>{' '}
           <span className={styles.link} role="link" tabIndex={0} onClick={focusAndClearSearchInput}>

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-panel.component.tsx
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-panel.component.tsx
@@ -94,7 +94,7 @@ const GeneralOrderPanel: React.FC<GeneralOrderTypeProps> = ({
       <div className={styles.container}>
         <div className={styles.iconAndLabel}>
           <MaybeIcon icon={icon ? icon : 'omrs-icon-generic-order-type'} size={isTablet ? 40 : 24} />
-          <h4 className={styles.heading}>{`${label ? t(label) : orderType?.display} (${orders.length})`}</h4>
+          <h2 className={styles.heading}>{`${label ? t(label) : orderType?.display} (${orders.length})`}</h2>
         </div>
         <div className={styles.buttonContainer}>
           <Button

--- a/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-panel.scss
+++ b/packages/esm-patient-orders-app/src/order-basket/general-order-type/general-order-panel.scss
@@ -38,7 +38,7 @@
 }
 
 .desktopTile .container {
-  h4 {
+  h2 {
     @include type.type-style('heading-compact-02');
     color: $text-02;
   }
@@ -47,7 +47,7 @@
 .tabletTile .container {
   padding: layout.$spacing-03;
 
-  h4 {
+  h2 {
     @include type.type-style('heading-03');
     color: $ui-05;
   }

--- a/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-panel.extension.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-panel.extension.tsx
@@ -137,7 +137,7 @@ function LabOrderBasketPanel({ orderTypeUuid, label, icon, patient, launchLabOrd
           ) : (
             <MaybeIcon icon={icon ? icon : 'omrs-icon-generic-order-type'} size={isTablet ? 40 : 24} />
           )}
-          <h4 className={styles.heading}>{`${label ? t(label) : orderType?.display} (${orders.length})`}</h4>
+          <h2 className={styles.heading}>{`${label ? t(label) : orderType?.display} (${orders.length})`}</h2>
         </div>
         <div className={styles.buttonContainer}>
           <Button

--- a/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-panel.scss
+++ b/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-panel.scss
@@ -57,7 +57,7 @@
 }
 
 .desktopTile .container {
-  h4 {
+  h2 {
     @include type.type-style('heading-compact-02');
     color: $text-02;
   }
@@ -66,7 +66,7 @@
 .tabletTile .container {
   padding: layout.$spacing-03;
 
-  h4 {
+  h2 {
     @include type.type-style('heading-03');
     color: $ui-05;
   }

--- a/packages/esm-patient-tests-app/src/test-results/filter/filter-set.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/filter/filter-set.component.tsx
@@ -135,7 +135,7 @@ const FilterNodeParent = ({ root, itemNumber }: FilterNodeParentProps) => {
   return (
     <div>
       <div className={classNames(styles.treeNodeHeader, { [styles.treeNodeHeaderTablet]: tablet })}>
-        <h5>{t(root.display)}</h5>
+        <h4>{t(root.display)}</h4>
         {hasChildren && (
           <Button
             className={styles.button}

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table-tablet/individual-results-table-tablet.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table-tablet/individual-results-table-tablet.component.tsx
@@ -205,12 +205,12 @@ const IndividualResultsTableTabletHeader: React.FC<IndividualResultsTableTabletH
         <>
           <div className={styles.flexBaseline}>
             {searchTerm && totalSearchResults > 0 && (
-              <h4 className={styles.heading}>
+              <h3 className={styles.heading}>
                 {t('searchResultsTextFor', '{{count}} search results for {{searchTerm}}', {
                   searchTerm,
                   count: totalSearchResults,
                 })}
-              </h4>
+              </h3>
             )}
             {searchTerm ? (
               <Button className={styles.clearButton} kind="ghost" size={isTablet ? 'md' : 'sm'} onClick={handleClear}>

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.component.tsx
@@ -139,7 +139,7 @@ const IndividualResultsTable: React.FC<IndividualResultsTableProps> = ({
         {({ rows, headers, getHeaderProps, getTableProps }) => (
           <TableContainer>
             <div className={styles.cardTitle}>
-              <h4 className={styles.resultType}>{headerTitle}</h4>
+              <h3 className={styles.resultType}>{headerTitle}</h3>
               <div className={styles.displayFlex}>
                 <span className={styles.date}>
                   {formatDate(parseDate(subRows.date), { mode: 'standard', time: false })}

--- a/packages/esm-patient-tests-app/src/test-results/overview/external-overview.extension.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/overview/external-overview.extension.tsx
@@ -60,7 +60,7 @@ const ExternalOverview: React.FC<ExternalOverviewProps> = ({ patientUuid, filter
               return (
                 <div className={styles.widgetCard}>
                   <div className={styles.externalOverviewHeader}>
-                    <h4 className={classNames(styles.productiveHeading03, styles.text02)}>{cardTitle}</h4>
+                    <h2 className={classNames(styles.productiveHeading03, styles.text02)}>{cardTitle}</h2>
                     <Button
                       kind="ghost"
                       renderIcon={(props: ComponentProps<typeof ArrowRightIcon>) => (

--- a/packages/esm-patient-tests-app/src/test-results/results-viewer/results-viewer.extension.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/results-viewer/results-viewer.extension.tsx
@@ -100,9 +100,9 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid }) => {
       <div className={styles.resultsContainer}>
         <div ref={headerRef} className={styles.headerSentinel} />
         <div className={classNames(styles.resultsHeader, { [styles.resultsHeaderScrolled]: !isHeaderVisible })}>
-          <h4 style={{ flexGrow: 1 }}>{`${t('results', 'Results')} ${
+          <h2 style={{ flexGrow: 1 }}>{`${t('results', 'Results')} ${
             filteredResultsCount ? `(${filteredResultsCount})` : ''
-          }`}</h4>
+          }`}</h2>
           <div className={styles.leftHeaderActions}>
             <RefreshDataButton isTablet={isTablet} patientUuid={patientUuid} t={t} />
             <span className={styles.contentSwitcherLabel}>{t('view', 'View')}: </span>
@@ -130,16 +130,16 @@ const ResultsViewer: React.FC<ResultsViewerProps> = ({ patientUuid }) => {
       <div className={styles.headerSentinel} ref={headerRef} />
       <div className={classNames(styles.resultsHeader, { [styles.resultsHeaderScrolled]: !isHeaderVisible })}>
         <div className={classNames(styles.leftSection, styles.leftHeaderSection)}>
-          <h4>{t('tests', 'Tests')}</h4>
+          <h2>{t('tests', 'Tests')}</h2>
           <Button className={styles.button} kind="ghost" onClick={resetTree} size={isTablet ? 'md' : 'sm'}>
             <span>{t('reset', 'Reset')}</span>
           </Button>
         </div>
         <div className={styles.rightSectionHeader}>
           <div className={styles.viewOptsContentSwitcherContainer}>
-            <h4 className={styles.viewOptionsText}>{`${t('results', 'Results')} ${
+            <h2 className={styles.viewOptionsText}>{`${t('results', 'Results')} ${
               filteredResultsCount ? `(${filteredResultsCount})` : ''
-            }`}</h4>
+            }`}</h2>
             <div className={styles.buttonsContainer}>
               <RefreshDataButton isTablet={isTablet} patientUuid={patientUuid} t={t} />
               <span className={styles.contentSwitcherLabel}>{t('view', 'View')}: </span>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Fixes heading semantics across the patient chart to address WCAG accessibility violations where heading levels were being skipped. Each context (dashboard page, workspace, tooltip) was audited individually per feedback on #3002.

### Dashboard pages (h1 title → h2 widgets)
- CardHeader, EmptyState, encounter-list, encounter-tile, forms-list, empty-form: `h4` → `h2` with matching SCSS updates
- external-overview, results-viewer: `h4` → `h2`
- individual-results-table/tablet: `h4` → `h3` (nested under h2)
- filter-set: `h5` → `h4`, offline-forms-overview-card: `h3` → `h2`, `h4` → `h3`

### Workspaces (Workspace2 renders no semantic heading)
- Visit form: `h1` → `h2` for section titles (Program, Visit Type, Visit attributes) — matches existing visit-notes-form pattern
- Drug order form: **kept `h1` Order Form** (only semantic heading), changed section headers `h3` → `h2`
- Order basket panels (drug, general, lab): `h4` → `h2`
- Order search results: `h4` → `h2`

### Tooltips (non-heading content)
- visit-tag, deceased-patient-tag: `h6` → `span` with CSS class for visual parity

### Not changed
- Drug order form `h1` — must remain as the only semantic heading in the workspace
- `ErrorState` — lives in esm-styleguide, needs a separate fix
- `common-datatable.scss` — targets Carbon's internal `h4` from TableContainer, can't change
- `retrospective-date-time-picker` — registered extension slot is never rendered

## Screenshots

## Related Issue
[O3-5041](https://openmrs.atlassian.net/browse/O3-5041)

## Other
<!-- Anything not covered above -->
Related PRs' [here](https://github.com/openmrs/openmrs-esm-patient-management/pull/2251) and [here](https://github.com/openmrs/openmrs-esm-patient-chart/pull/3002)

[O3-5041]: https://openmrs.atlassian.net/browse/O3-5041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ