### PR TITLE
(feat) Isolate Angular module per parcel mount to support multiple concurrent form instances

### DIFF
--- a/packages/esm-form-entry-app/angular.json
+++ b/packages/esm-form-entry-app/angular.json
@@ -27,14 +27,25 @@
           "builder": "ngx-build-plus:browser",
           "options": {
             "allowedCommonJsDependencies": [
+              "classnames",
+              "copy-to-clipboard",
               "core-js",
               "dayjs",
               "dompurify",
+              "flatpickr/dist/l10n/index",
+              "geopattern",
               "html2canvas",
+              "invariant",
               "lodash",
               "moment",
+              "path-to-regexp",
+              "prop-types",
               "raf",
-              "rgbcolor"
+              "react-fast-compare",
+              "rgbcolor",
+              "rxjs/operators/index.js",
+              "semver",
+              "void-elements"
             ],
             "preserveSymlinks": true,
             "outputPath": "dist",

--- a/packages/esm-form-entry-app/src/app/app.component.spec.ts
+++ b/packages/esm-form-entry-app/src/app/app.component.spec.ts
@@ -9,13 +9,20 @@ import { OpenmrsApiModule } from './openmrs-api/openmrs-api.module';
 import { LocalStorageService } from './local-storage/local-storage.service';
 import { FormDataSourceService } from './form-data-source/form-data-source.service';
 import { FormSubmissionService } from './form-submission/form-submission.service';
+import { SingleSpaPropsService } from './single-spa-props/single-spa-props.service';
 
 describe('AppComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, FormEntryModule, ReactiveFormsModule, OpenmrsApiModule],
       declarations: [AppComponent, FeWrapperComponent],
-      providers: [FormSchemaService, LocalStorageService, FormDataSourceService, FormSubmissionService],
+      providers: [
+        FormSchemaService,
+        LocalStorageService,
+        FormDataSourceService,
+        FormSubmissionService,
+        SingleSpaPropsService,
+      ],
     }).compileComponents();
   }));
 

--- a/packages/esm-form-entry-app/src/app/app.component.ts
+++ b/packages/esm-form-entry-app/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { singleSpaPropsSubject } from '../single-spa-props';
+import { SingleSpaPropsService } from './single-spa-props/single-spa-props.service';
 
 @Component({
   selector: 'my-app-root',
@@ -11,10 +11,12 @@ import { singleSpaPropsSubject } from '../single-spa-props';
 export class AppComponent implements OnInit, OnDestroy {
   title = 'openmrs-esm-form-entry';
   view: string;
-  sub: Subscription;
-  constructor() {}
+  private sub: Subscription;
+
+  constructor(private readonly singleSpaPropsService: SingleSpaPropsService) {}
+
   ngOnInit(): void {
-    this.sub = singleSpaPropsSubject.subscribe({
+    this.sub = this.singleSpaPropsService.props$.subscribe({
       next: (prop) => {
         this.view = prop.view;
       },
@@ -22,8 +24,6 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    if (this.sub) {
-      this.sub.unsubscribe();
-    }
+    this.sub?.unsubscribe();
   }
 }

--- a/packages/esm-form-entry-app/src/app/app.module.ts
+++ b/packages/esm-form-entry-app/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { LOCALE_ID, NgModule } from '@angular/core';
+import { ApplicationRef, LOCALE_ID, NgModule, DoBootstrap } from '@angular/core';
 import { TranslateLoader, TranslateModule, TranslateService, TranslateStore } from '@ngx-translate/core';
 import { HttpClient } from '@angular/common/http';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -22,6 +22,7 @@ import { SingleSpaPropsService } from './single-spa-props/single-spa-props.servi
 import { FormCreationService } from './form-creation/form-creation.service';
 import { JsonLoader } from './loaders/json-loader';
 import { ProgramResourceService } from './openmrs-api/program-resource.service';
+import { dequeueContainerElement } from '../single-spa-props';
 
 @NgModule({
   declarations: [AppComponent, EmptyRouteComponent, FeWrapperComponent, LoaderComponent],
@@ -57,6 +58,14 @@ import { ProgramResourceService } from './openmrs-api/program-resource.service';
     },
     ProgramResourceService,
   ],
-  bootstrap: [AppComponent],
 })
-export class AppModule {}
+export class AppModule implements DoBootstrap {
+  // ngDoBootstrap runs synchronously during bootstrapModule resolution.
+  // At that point the container element is already queued, so we can safely
+  // target the exact DOM element that belongs to this parcel instance.
+  ngDoBootstrap(appRef: ApplicationRef): void {
+    const containerElement = dequeueContainerElement();
+    const rootElement = containerElement?.querySelector('my-app-root') as HTMLElement | null;
+    appRef.bootstrap(AppComponent, rootElement ?? undefined);
+  }
+}

--- a/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-creation/form-creation.service.ts
@@ -308,6 +308,7 @@ export class FormCreationService {
         form.valueProcessingInfo.patientUuid = patientUuid;
         form.valueProcessingInfo.formUuid = formUuid;
         form.valueProcessingInfo.providerUuid = session.currentProvider?.uuid;
+        form.valueProcessingInfo.visit = this.singleSpaPropsService.getProp('visit');
 
         if (formSchema.encounterType) {
           form.valueProcessingInfo.encounterTypeUuid = formSchema.encounterType.uuid;

--- a/packages/esm-form-entry-app/src/app/single-spa-props/single-spa-props.service.ts
+++ b/packages/esm-form-entry-app/src/app/single-spa-props/single-spa-props.service.ts
@@ -1,24 +1,44 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { Subscription } from 'rxjs';
-import { SingleSpaProps, singleSpaPropsSubject } from '../../single-spa-props';
+import { Observable, ReplaySubject, Subscription } from 'rxjs';
+import { SingleSpaProps, dequeueInstanceSubject } from '../../single-spa-props';
 
 /**
  * A utility service simplifying common interactions with the MFs single SPA props.
+ *
+ * Each Angular app instance created by a parcel mount gets its own service
+ * instance (Angular creates a new injector per `bootstrapModule` call). The
+ * service subscribes to the per-instance `ReplaySubject` that was enqueued in
+ * `bootstrap.ts` just before this module was bootstrapped, so it only ever
+ * sees the props that belong to *this* instance. Multiple concurrent form
+ * instances therefore never overwrite each other's props.
  */
 @Injectable()
 export class SingleSpaPropsService implements OnDestroy {
   /**
-   * The most recent {@link SingleSpaProps} value pushed to the MF module.
+   * The most recent {@link SingleSpaProps} value pushed to this instance.
    */
   public lastProps?: SingleSpaProps = undefined;
+
+  private readonly subject: ReplaySubject<SingleSpaProps> | null;
   private readonly lastPropsSubscription?: Subscription;
 
   constructor() {
-    this.lastPropsSubscription = singleSpaPropsSubject.subscribe((props) => (this.lastProps = props));
+    this.subject = dequeueInstanceSubject();
+    if (this.subject) {
+      this.lastPropsSubscription = this.subject.subscribe((props) => (this.lastProps = props));
+    }
   }
 
   public ngOnDestroy() {
     this.lastPropsSubscription?.unsubscribe();
+  }
+
+  /**
+   * Observable of props updates for this instance. Components can subscribe
+   * reactively instead of polling `lastProps`.
+   */
+  public get props$(): Observable<SingleSpaProps> {
+    return this.subject?.asObservable() ?? new Observable<SingleSpaProps>();
   }
 
   /**

--- a/packages/esm-form-entry-app/src/bootstrap.ts
+++ b/packages/esm-form-entry-app/src/bootstrap.ts
@@ -3,21 +3,34 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { singleSpaAngular, getSingleSpaExtraProviders } from 'single-spa-angular';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
-import { singleSpaPropsSubject, SingleSpaProps } from './single-spa-props';
+import { enqueueContainerElement, enqueueInstanceSubject, SingleSpaProps } from './single-spa-props';
 
 if (environment.production) {
   enableProdMode();
 }
 
-const lifecycles = singleSpaAngular({
-  bootstrapFunction: (singleSpaProps) => {
-    singleSpaPropsSubject.next(singleSpaProps as SingleSpaProps);
-    return platformBrowserDynamic(getSingleSpaExtraProviders()).bootstrapModule(AppModule);
-  },
-  template: '<my-app-root />',
-  NgZone,
-});
+/**
+ * Creates a fresh set of single-spa lifecycle functions for one parcel instance.
+ *
+ * Each call produces its own `options` object inside single-spa-angular, so
+ * `options.bootstrappedNgModuleRefOrAppRef` is never shared between instances.
+ * Without this, a second mount would overwrite the first mount's module ref and
+ * unmounting either parcel would destroy the wrong Angular application.
+ */
+export function createLifecycles() {
+  return singleSpaAngular({
+    bootstrapFunction: async (singleSpaProps) => {
+      // Enqueue props and container element before Angular starts instantiating
+      // services. ngDoBootstrap dequeues the element and calls appRef.bootstrap
+      // synchronously during module initialisation, guaranteeing that
+      // AppComponent is always attached to the correct DOM element.
+      enqueueInstanceSubject(singleSpaProps as SingleSpaProps);
+      const containerElement = (singleSpaProps as any).domElement as HTMLElement | undefined;
+      enqueueContainerElement(containerElement ?? null);
 
-export const bootstrap = lifecycles.bootstrap;
-export const mount = lifecycles.mount;
-export const unmount = lifecycles.unmount;
+      return await platformBrowserDynamic(getSingleSpaExtraProviders()).bootstrapModule(AppModule);
+    },
+    template: '<my-app-root />',
+    NgZone,
+  });
+}

--- a/packages/esm-form-entry-app/src/index.ts
+++ b/packages/esm-form-entry-app/src/index.ts
@@ -63,4 +63,12 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const formWidget = () => import('./bootstrap');
+/**
+ * Returns a fresh set of single-spa lifecycle functions for each call so that
+ * multiple concurrent form instances each get their own independent Angular
+ * application, DOM binding, and props context.
+ */
+export const formWidget = async () => {
+  const { createLifecycles } = await import('./bootstrap');
+  return createLifecycles();
+};

--- a/packages/esm-form-entry-app/src/single-spa-props.ts
+++ b/packages/esm-form-entry-app/src/single-spa-props.ts
@@ -1,11 +1,58 @@
 import { ReplaySubject } from 'rxjs';
 import { AppProps } from 'single-spa';
 import { Encounter, EncounterCreate } from './app/types';
-import { DefaultWorkspaceProps } from '@openmrs/esm-framework';
+import { DefaultWorkspaceProps, type Visit } from '@openmrs/esm-framework';
 
-export const singleSpaPropsSubject = new ReplaySubject<SingleSpaProps>(1);
+/**
+ * Queue of per-instance subjects. Each call to `enqueueInstanceSubject` (from
+ * bootstrap.ts) pushes a fresh ReplaySubject onto the queue before Angular
+ * bootstraps a new module. Each `SingleSpaPropsService` constructor call
+ * dequeues the front subject, binding that service instance to exactly the
+ * props that were passed to *its* bootstrap call.
+ *
+ * This is safe because:
+ * - JavaScript is single-threaded, so enqueue→bootstrap→dequeue is sequential.
+ * - Angular's bootstrapModule resolves microtasks in FIFO order.
+ * - Each Angular ApplicationRef (module instance) has its own service tree.
+ */
+const _instanceSubjectQueue: Array<ReplaySubject<SingleSpaProps>> = [];
+
+/**
+ * Called from bootstrap.ts once per parcel mount, immediately before
+ * `platformBrowserDynamic().bootstrapModule(AppModule)`.
+ */
+export function enqueueInstanceSubject(props: SingleSpaProps): void {
+  const subject = new ReplaySubject<SingleSpaProps>(1);
+  subject.next(props);
+  _instanceSubjectQueue.push(subject);
+}
+
+/**
+ * Called from SingleSpaPropsService constructor during Angular module
+ * initialisation. Returns the subject that belongs to this instance, or
+ * `null` when the queue is empty (e.g. in unit tests).
+ */
+export function dequeueInstanceSubject(): ReplaySubject<SingleSpaProps> | null {
+  return _instanceSubjectQueue.shift() ?? null;
+}
+
+/**
+ * Queue of container DOM elements, one per in-flight bootstrap call.
+ * Enqueued in bootstrap.ts before bootstrapModule; dequeued in
+ * AppModule.ngDoBootstrap (which runs synchronously during module init).
+ */
+const _containerElementQueue: Array<HTMLElement | null> = [];
+
+export function enqueueContainerElement(el: HTMLElement | null): void {
+  _containerElementQueue.push(el);
+}
+
+export function dequeueContainerElement(): HTMLElement | null {
+  return _containerElementQueue.shift() ?? null;
+}
 
 type VisitProperties = {
+  visit?: Visit;
   visitTypeUuid?: string;
   visitUuid?: string;
   visitStartDatetime: string;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR replaces the shared global `singleSpaPropsSubject` with per-instance FIFO queues for both props and container DOM elements. Each `formWidget` call now returns a fresh set of single-spa lifecycle functions via `createLifecycles()`, so every parcel mount bootstraps its own independent Angular application with its own injector and DOM binding. Also passes `visit` through to `valueProcessingInfo` during form creation.

## Screenshots
https://github.com/user-attachments/assets/91dfab8f-718e-47a4-b94c-1dba589a8570

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
