### PR TITLE
(fix) Fix tablet results viewer overlay issues

### DIFF
--- a/packages/esm-patient-tests-app/src/test-results/grouped-timeline/grouped-timeline-types.ts
+++ b/packages/esm-patient-tests-app/src/test-results/grouped-timeline/grouped-timeline-types.ts
@@ -25,6 +25,7 @@ export interface TimelineDataGroupProps {
   xScroll: number;
   setXScroll: (x: number) => void;
   groupNumber: number;
+  inOverlay?: boolean;
 }
 
 export interface DataRowsProps {

--- a/packages/esm-patient-tests-app/src/test-results/grouped-timeline/grouped-timeline.scss
+++ b/packages/esm-patient-tests-app/src/test-results/grouped-timeline/grouped-timeline.scss
@@ -159,6 +159,10 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+.panelHeaderOverlay {
+  top: 0;
+}
+
 .panelHeader + div .grid > div:first-child {
   border-top: none;
 }

--- a/packages/esm-patient-tests-app/src/test-results/grouped-timeline/grouped-timeline.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/grouped-timeline/grouped-timeline.test.tsx
@@ -175,6 +175,66 @@ describe('GroupedTimeline', () => {
     expect(normalCell).not.toHaveClass('low');
   });
 
+  it('renders values correctly when entries are indexed against a global time array', () => {
+    // This tests the fix for a bug where GridItems used index-based lookup (obs[i])
+    // but row.entries was indexed against the global allTimes array while sortedTimes
+    // was panel-local. When a panel had fewer time columns than the global array,
+    // the indices wouldn't align and values would be missing.
+    const globalTimes = [
+      '2024-05-31 01:39:03.0',
+      '2024-03-15 10:00:00.0', // time from a different panel
+      '2023-11-09 23:15:03.0',
+    ];
+
+    const contextWithMismatchedEntries: FilterContextProps = {
+      ...mockFilterContext,
+      timelineData: {
+        ...mockFilterContext.timelineData,
+        data: {
+          ...mockFilterContext.timelineData.data,
+          rowData: [
+            {
+              ...mockFilterContext.timelineData.data.rowData[0],
+              // entries indexed against global allTimes (3 entries, middle one is undefined)
+              entries: [
+                {
+                  obsDatetime: '2024-05-31 01:39:03.0',
+                  value: '261.9',
+                  interpretation: 'NORMAL' as const,
+                },
+                undefined,
+                {
+                  obsDatetime: '2023-11-09 23:15:03.0',
+                  value: '21.5',
+                  interpretation: 'NORMAL' as const,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    renderGroupedTimeline(contextWithMismatchedEntries);
+
+    // Values should render correctly even though entries[1] is undefined
+    // because GridItems matches by obsDatetime, not by array index
+    expect(screen.getByText('261.9')).toBeInTheDocument();
+    expect(screen.getByText('21.5')).toBeInTheDocument();
+  });
+
+  it('applies panelHeaderOverlay class when inOverlay is true', () => {
+    // This is tested indirectly through the overlay rendering in
+    // individual-results-table-tablet, but we verify the CSS class exists
+    renderGroupedTimeline();
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const panelHeader = screen.getByText('Serum chemistry panel').closest('[data-panel-name]');
+    expect(panelHeader).toBeInTheDocument();
+    // In the normal (non-overlay) context, panelHeaderOverlay should NOT be applied
+    expect(panelHeader).not.toHaveClass('panelHeaderOverlay');
+  });
+
   it('launches a modal when a non-string result is clicked', async () => {
     const user = userEvent.setup();
     renderGroupedTimeline();

--- a/packages/esm-patient-tests-app/src/test-results/grouped-timeline/timeline-data-group.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/grouped-timeline/timeline-data-group.component.tsx
@@ -74,9 +74,13 @@ function usePanelDates(subRows: any[]) {
 const PanelHeader: React.FC<{
   panelName: string;
   panelDates: ReturnType<typeof usePanelDates>;
-}> = ({ panelName, panelDates }) => {
+  inOverlay?: boolean;
+}> = ({ panelName, panelDates, inOverlay }) => {
   return (
-    <div className={styles.panelHeader} data-panel-name={panelName}>
+    <div
+      className={classNames(styles.panelHeader, { [styles.panelHeaderOverlay]: inOverlay })}
+      data-panel-name={panelName}
+    >
       <div className={styles.dateHeaderContainer}>
         <div className={styles.dateHeaderInner} style={{ overflowX: 'auto' }}>
           <Grid
@@ -183,12 +187,13 @@ const GridItems = React.memo<{
   zebra: boolean;
 }>(({ sortedTimes, obs, zebra }) => (
   <>
-    {sortedTimes.map((_, i) => {
-      if (!obs[i]) {
+    {sortedTimes.map((time, i) => {
+      const entry = obs.find((o: any) => o?.obsDatetime === time);
+      if (!entry) {
         return <TimelineCell key={i} text={''} zebra={zebra} />;
       }
 
-      return <TimelineCell key={i} text={obs[i].value} interpretation={obs[i].interpretation} zebra={zebra} />;
+      return <TimelineCell key={i} text={entry.value} interpretation={entry.interpretation} zebra={zebra} />;
     })}
   </>
 ));
@@ -234,6 +239,7 @@ export default function TimelineDataGroup({
   subRows,
   xScroll,
   setXScroll,
+  inOverlay,
 }: TimelineDataGroupProps) {
   const panelDates = usePanelDates(subRows);
 
@@ -259,7 +265,7 @@ export default function TimelineDataGroup({
   return (
     <>
       <div>
-        <PanelHeader panelName={parent.display} panelDates={panelDates} />
+        <PanelHeader panelName={parent.display} panelDates={panelDates} inOverlay={inOverlay} />
         <div className={styles.gridContainer} ref={ref}>
           <DataRows
             patientUuid={patientUuid}

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table-tablet/individual-results-table-tablet.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table-tablet/individual-results-table-tablet.component.tsx
@@ -100,6 +100,7 @@ const IndividualResultsTableTablet: React.FC<IndividualResultsTableTabletProps> 
             <div className={styles.overlay}>
               <TimelineDataGroup
                 groupNumber={1}
+                inOverlay
                 parent={activeTimelineParent}
                 patientUuid={patientUuid}
                 setXScroll={() => {}}

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table-tablet/individual-results-table-tablet.scss
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table-tablet/individual-results-table-tablet.scss
@@ -63,4 +63,8 @@
 
 .overlay {
   padding: layout.$spacing-05;
+
+  > div {
+    border: 0.5px solid colors.$gray-50;
+  }
 }

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table-tablet/individual-results-table-tablet.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table-tablet/individual-results-table-tablet.test.tsx
@@ -110,4 +110,27 @@ describe('PanelView', () => {
     expect(backButton).not.toBeInTheDocument();
     expect(screen.getByRole('row', { name: /hiv viral load 600/i })).toBeInTheDocument();
   });
+
+  it('applies the overlay sticky header fix when opening a panel overlay on tablet', async () => {
+    const user = userEvent.setup();
+
+    mockUseLayoutType.mockReturnValue('tablet');
+    mockIsDesktop.mockReturnValue(false);
+
+    render(
+      <FilterProvider roots={mockResults as Roots} isLoading={false}>
+        <IndividualResultsTableTablet expanded={false} patientUuid="test-patient" />
+      </FilterProvider>,
+    );
+
+    const hivViralLoadCell = screen.getByRole('cell', { name: /hiv viral load/i });
+    await user.click(hivViralLoadCell);
+
+    // The panel header in the overlay should have the panelHeaderOverlay class
+    // which sets top: 0 instead of the default top: 6rem
+    // eslint-disable-next-line testing-library/no-node-access
+    const panelHeader = document.querySelector('[data-panel-name="HIV viral load"]');
+    expect(panelHeader).toBeInTheDocument();
+    expect(panelHeader).toHaveClass('panelHeaderOverlay');
+  });
 });

--- a/packages/esm-patient-tests-app/src/test-results/tablet-overlay/tablet-overlay.scss
+++ b/packages/esm-patient-tests-app/src/test-results/tablet-overlay/tablet-overlay.scss
@@ -28,6 +28,7 @@
   }
   .headerContent {
     color: $ui-02;
+    margin-left: layout.$spacing-05;
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Fixes three bugs in the tablet "Over time" panel overlay in the results viewer:

1. **Sticky header covering data rows**: The panel header used `position: sticky; top: 6rem`, designed for the main page layout. In the overlay context, this pushed the header over the data rows, hiding them. Added an `inOverlay` prop to use `top: 0` instead.

2. **Missing values in timeline cells**: `GridItems` matched entries to time columns by array index (`obs[i]`), but `row.entries` was indexed against a global `allTimes` array from the filter context while `sortedTimes` was panel-local. When a panel had fewer time columns than the global array, the indices didn't align and values were missing. Switched to matching by `obsDatetime`.

3. **Missing borders**: The overlay wrapper was missing the border styles that the main `timelineDataContainer` provides, leaving grid cells without visible borders.

Also adds `margin-left` to the overlay header content for spacing between the back button and the title.

## Screenshots

### Before

Panel header covers data rows, values are missing, no borders:

<img width="1900" height="610" alt="CleanShot 2026-04-15 at 20 38 49@2x" src="https://github.com/user-attachments/assets/eba95b58-9878-457a-b197-298cb1775480" />

The "Over time" overlay showed only the header (year/date/time) with no visible data rows below it. When data rows were present in the DOM, values were empty due to the index mismatch.

<img width="1902" height="1326" alt="CleanShot 2026-04-15 at 20 39 11@2x" src="https://github.com/user-attachments/assets/67745cf7-2bc6-48e4-8e3b-1db8c3d862b8" />

<img width="1900" height="1816" alt="CleanShot 2026-04-15 at 20 38 58@2x" src="https://github.com/user-attachments/assets/3abd979e-3331-4493-b23c-e21cf9432e0f" />

### After

Data rows visible with correct values and borders.

<img width="1902" height="480" alt="CleanShot 2026-04-15 at 20 37 06@2x" src="https://github.com/user-attachments/assets/2497ead2-2216-4bcb-aca8-c5cb9d2aec72" />

<img width="1898" height="512" alt="CleanShot 2026-04-15 at 20 37 23@2x" src="https://github.com/user-attachments/assets/7c34b2ee-50bf-4b9b-9694-51e5a1d4dfbe" />

<img width="1902" height="834" alt="CleanShot 2026-04-15 at 20 37 53@2x" src="https://github.com/user-attachments/assets/586468e9-bd0e-410e-9954-f349f8ec3772" />

## Related Issue

## Other

- Adds 3 new tests covering the value matching and overlay class application.