### PR TITLE
fix(attachments): show Add button as icon-only on tablet and mobile

### DIFF
--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
@@ -134,11 +134,13 @@ const AttachmentsOverview: React.FC<AttachmentsOverviewProps> = ({ patientUuid }
 
   if (!attachments.length) {
     return (
-      <EmptyState
-        displayText={t('attachmentsInLowerCase', 'attachments')}
-        headerTitle={t('attachmentsInProperFormat', 'Attachments')}
-        launchForm={showAddAttachmentModal}
-      />
+      <UserHasAccess privilege="Create Attachments">
+        <EmptyState
+          displayText={t('attachmentsInLowerCase', 'attachments')}
+          headerTitle={t('attachmentsInProperFormat', 'Attachments')}
+          launchForm={showAddAttachmentModal}
+        />
+      </UserHasAccess>
     );
   }
 
@@ -162,16 +164,18 @@ const AttachmentsOverview: React.FC<AttachmentsOverviewProps> = ({ patientUuid }
                 </IconSwitch>
               </ContentSwitcher>
               <div className={styles.divider} />
-              <Button
-                kind="ghost"
-                renderIcon={AddIcon}
-                iconDescription={t('addAttachment', 'Add attachment')}
-                onClick={showAddAttachmentModal}
-                size={desktop ? 'sm' : 'md'}
-                hasIconOnly={!desktop}
-              >
-                {desktop && t('add', 'Add')}
-              </Button>
+              <UserHasAccess privilege="Create Attachments">
+                <Button
+                  kind="ghost"
+                  renderIcon={AddIcon}
+                  iconDescription={t('addAttachment', 'Add attachment')}
+                  onClick={showAddAttachmentModal}
+                  size={desktop ? 'sm' : 'md'}
+                  hasIconOnly={!desktop}
+                >
+                  {desktop && t('add', 'Add')}
+                </Button>
+              </UserHasAccess>
             </div>
           </CardHeader>
           {view === 'grid' ? (

--- a/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
+++ b/packages/esm-patient-attachments-app/src/attachments/attachments-overview.component.tsx
@@ -6,6 +6,7 @@ import {
   AddIcon,
   createAttachment,
   deleteAttachmentPermanently,
+  isDesktop,
   showModal,
   showSnackbar,
   type Attachment,
@@ -35,7 +36,8 @@ interface SwitchEventHandlersParams {
 type ViewType = 'grid' | 'table';
 
 const AttachmentsOverview: React.FC<AttachmentsOverviewProps> = ({ patientUuid }) => {
-  const isTablet = useLayoutType() === 'tablet';
+  const layoutType = useLayoutType();
+  const desktop = isDesktop(layoutType);
   const { t } = useTranslation();
   const { data, mutate, isValidating, isLoading } = useAttachments(patientUuid, true);
   const { allowedFileExtensions } = useAllowedFileExtensions();
@@ -150,7 +152,7 @@ const AttachmentsOverview: React.FC<AttachmentsOverviewProps> = ({ patientUuid }
               <ContentSwitcher
                 onChange={(event: SwitchEventHandlersParams) => setView(event.name.toString() as ViewType)}
                 selectedIndex={view === 'grid' ? 0 : 1}
-                size={isTablet ? 'md' : 'sm'}
+                size={desktop ? 'sm' : 'md'}
               >
                 <IconSwitch name="grid" text={t('gridView', 'Grid view')}>
                   <Thumbnail_2 size={16} />
@@ -163,10 +165,12 @@ const AttachmentsOverview: React.FC<AttachmentsOverviewProps> = ({ patientUuid }
               <Button
                 kind="ghost"
                 renderIcon={AddIcon}
-                iconDescription="Add attachment"
+                iconDescription={t('addAttachment', 'Add attachment')}
                 onClick={showAddAttachmentModal}
+                size={desktop ? 'sm' : 'md'}
+                hasIconOnly={!desktop}
               >
-                {t('add', 'Add')}
+                {desktop && t('add', 'Add')}
               </Button>
             </div>
           </CardHeader>

--- a/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
+++ b/packages/esm-patient-attachments-app/src/camera-media-uploader/file-review.component.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAllowedFileExtensions } from '@openmrs/esm-patient-common-lib';
-import { getCoreTranslation, type UploadedFile, UserHasAccess } from '@openmrs/esm-framework';
+import { getCoreTranslation, type UploadedFile } from '@openmrs/esm-framework';
 import CameraMediaUploaderContext from './camera-media-uploader-context.resources';
 import styles from './file-review.scss';
 
@@ -222,14 +222,12 @@ const FilePreview: React.FC<FilePreviewProps> = ({
         </div>
       </ModalBody>
       <ModalFooter>
-        <UserHasAccess privilege="Create Attachments">
-          <Button kind="secondary" onClick={handleCancelUpload} size="lg">
-            {getCoreTranslation('cancel')}
-          </Button>
-          <Button type="submit" size="lg">
-            {title || t('addAttachment', 'Add attachment')}
-          </Button>
-        </UserHasAccess>
+        <Button kind="secondary" onClick={handleCancelUpload} size="lg">
+          {getCoreTranslation('cancel')}
+        </Button>
+        <Button type="submit" size="lg">
+          {title || t('addAttachment', 'Add attachment')}
+        </Button>
       </ModalFooter>
     </Form>
   );


### PR DESCRIPTION
## Requirements
- [x] My code follows the guidelines for [contributing to this project](https://o3-docs.openmrs.org/docs/frontend-modules/contributing)
- [x] I have performed a self-review of my own code

## Summary

Two bugs fixed in the Attachments widget:

**1. Upload modal buttons missing on mobile/tablet**  
The Cancel and "Add attachment" submit buttons in the upload modal 
(`file-review.component.tsx`) were wrapped in `<UserHasAccess privilege="Create Attachments">`. 
Because `UserHasAccess` renders null on its first render (before the session 
observable emits), the buttons were invisible on mobile/tablet devices where 
slower networks mean the session hasn't loaded by the time the modal opens. 
A user who has already passed the entry-point privilege check to open the 
modal should never have their in-modal controls hidden.

Fix: removed `UserHasAccess` from inside the modal footer. The privilege 
check is now correctly placed at the two entry points that open the modal 
(the Add button in the CardHeader and the EmptyState launch button).

**2. Add button not visible on tablet/phone viewports**  
The CardHeader Add button was always rendered as text+icon regardless of 
screen size, causing it to be clipped or missing on smaller viewports.

Fix: use `isDesktop(useLayoutType())` to render the button as icon-only 
(`hasIconOnly`) on non-desktop viewports, matching the Carbon Design System 
pattern used elsewhere in the app.

## Screenshots

<!-- Add before/after screenshots here -->

## Related Issue

<!-- Add issue link if one exists, otherwise N/A -->
N/A

## Other

The root cause of the modal button bug (first-render null in `UserHasAccess`) 
is fixed upstream in a companion PR against `openmrs-esm-core`. This PR 
fixes the symptom by moving the privilege gate to the correct location 
regardless.