### PR TITLE
(fix) Restore drug tile tablet bottom border and remove dead selectors

### DIFF
--- a/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
+++ b/packages/esm-patient-medications-app/src/drug-order-basket-panel/drug-order-basket-panel.scss
@@ -1,6 +1,5 @@
 @use '@carbon/colors';
 @use '@carbon/layout';
-@use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
 .desktopContainer {
@@ -48,24 +47,8 @@
   }
 }
 
-.tabletTile .collapsedTile {
+.tabletTile.collapsedTile {
   border-bottom: 1px solid $grey-2;
-}
-
-.desktopTile .container {
-  h4 {
-    @include type.type-style('heading-compact-02');
-    color: $text-02;
-  }
-}
-
-.tabletTile .container {
-  padding: layout.$spacing-03;
-
-  h4 {
-    @include type.type-style('heading-03');
-    color: $ui-05;
-  }
 }
 
 .heading {

--- a/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-panel.scss
+++ b/packages/esm-patient-tests-app/src/test-orders/lab-order-basket-panel/lab-order-basket-panel.scss
@@ -1,6 +1,5 @@
 @use '@carbon/colors';
 @use '@carbon/layout';
-@use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
 .desktopContainer {
@@ -54,22 +53,6 @@
 
 .tabletTile.collapsedTile {
   border-bottom: 1px solid $grey-2;
-}
-
-.desktopTile .container {
-  h4 {
-    @include type.type-style('heading-compact-02');
-    color: $text-02;
-  }
-}
-
-.tabletTile .container {
-  padding: layout.$spacing-03;
-
-  h4 {
-    @include type.type-style('heading-03');
-    color: $ui-05;
-  }
 }
 
 .heading {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

Follow-up to #3263. Two cleanups in `esm-patient-medications-app` and `esm-patient-tests-app`:

1. **Drug's tablet bottom border was dead.** `drug-order-basket-panel.scss` used `.tabletTile .collapsedTile` (descendant), but both classes sit on the same element, so the rule never matched. Changed to the compound `.tabletTile.collapsedTile` so the 1px grey bottom border now renders, matching lab and the general order panels.
2. **Removed dead h4 rules** in both drug and lab that target `.desktopTile .container h4` / `.tabletTile .container h4`. Those components render `.desktopContainer` / `.tabletContainer`, so the selectors never matched. h4 already falls through to Carbon's `heading-03` default, so removal is a no-op visually. The `@use '@carbon/type'` import is dropped in both files since nothing references it anymore.

## Screenshots

No visible change on desktop. Drug tile gains a 1px grey bottom border on tablet (previously absent).

## Related Issue

None. Follow-up to #3263.

## Other

Thanks to @NethmiRodrigo for spotting the dead h4 rules during review of #3263.