### PR TITLE
(fix) Unescape drug name in pinned order snackbar subtitles

### DIFF
--- a/packages/esm-patient-orders-app/src/order-favorites/useFavoritesActions.ts
+++ b/packages/esm-patient-orders-app/src/order-favorites/useFavoritesActions.ts
@@ -82,7 +82,10 @@ export function useFavoritesActions() {
       return persistFavorites(updatedFavorites, {
         successTitle: isSingleDelete ? t('orderUnpinned', 'Order unpinned') : t('ordersUnpinned', 'Orders unpinned'),
         successSubtitle: isSingleDelete
-          ? t('orderUnpinnedSubtitle', '{{drugName}} removed from your pinned orders', { drugName: itemName })
+          ? t('orderUnpinnedSubtitle', '{{drugName}} removed from your pinned orders', {
+              drugName: itemName,
+              interpolation: { escapeValue: false },
+            })
           : t('ordersUnpinnedSubtitle', '{{count}} orders removed from your pinned orders', {
               count: favoritesToDelete.length,
             }),

--- a/packages/esm-patient-orders-app/src/order-favorites/usePinToggle.ts
+++ b/packages/esm-patient-orders-app/src/order-favorites/usePinToggle.ts
@@ -47,6 +47,7 @@ export function usePinToggle(drug: Drug | undefined) {
         successTitle: t('orderPinned', 'Order pinned'),
         successSubtitle: t('orderPinnedSubtitle', '{{drugName}} added to your pinned orders', {
           drugName: newFavorite.displayName,
+          interpolation: { escapeValue: false },
         }),
         errorTitle: t('errorPinningOrder', 'Error pinning order'),
       });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

i18next escapes interpolated values by default to guard against XSS, so a drug name like `Nystatin creme vaginale 100000UI/g` was rendering as `Nystatin creme vaginale 100000UI&#x2F;g` in the "Order pinned" snackbar subtitle, because the subtitle is plain text and the entity is never decoded. The same applies to apostrophes (`&#39;`) in names like `Motrin Children's 100mg/5ml`.

This passes `interpolation: { escapeValue: false }` to the two affected `t()` calls (pin and unpin). The snackbar renders the result as text, not HTML, so disabling escape is safe and the drug name displays verbatim.

Verified locally against a backend with 35 affected drugs (forward slashes and/or apostrophes in names) — all render correctly after the fix.

## Screenshots

### Before:

<img width="680" height="294" alt="CleanShot 2026-04-29 at 11 41 43@2x" src="https://github.com/user-attachments/assets/29127d69-143d-4383-89bb-9467f505a63a" />

<img width="664" height="280" alt="CleanShot 2026-04-29 at 11 54 06@2x" src="https://github.com/user-attachments/assets/21ef650a-937b-4c69-82e5-b842c1ed51c3" />

### After: drug name renders verbatim (e.g. `Nystatin creme vaginale 100000UI/g`, `Motrin Children's 100mg/5ml`).

<img width="802" height="310" alt="CleanShot 2026-04-29 at 11 49 02@2x" src="https://github.com/user-attachments/assets/8ef1cae6-8f19-4978-85a1-7a8864192735" />

<img width="664" height="234" alt="CleanShot 2026-04-29 at 11 51 13@2x" src="https://github.com/user-attachments/assets/82c7f67c-fb68-4e67-a43e-67c3f818df30" />

<img width="720" height="326" alt="CleanShot 2026-04-29 at 11 50 36@2x" src="https://github.com/user-attachments/assets/f581533f-2116-45ea-9135-2d467361ff98" />

## Related Issue


## Other

@VeronicaMuthee we should fix the typo in the `Motrin Children's 100mg/5ml` formulation (it currently reads 'Chilren' instead of 'Children')