### PR TITLE
(fix) Use POST when fetching concept references

### DIFF
--- a/packages/esm-generic-patient-widgets-app/src/resources/useConcepts.ts
+++ b/packages/esm-generic-patient-widgets-app/src/resources/useConcepts.ts
@@ -1,6 +1,7 @@
 import { openmrsFetch, type FetchResponse, restBaseUrl, showSnackbar } from '@openmrs/esm-framework';
-import chunk from 'lodash/chunk';
 import useSWRImmutable from 'swr/immutable';
+
+const conceptRepresentation = 'custom:(uuid,display,datatype,answers)';
 
 export interface ConceptReferenceResponse {
   [key: string]: {
@@ -17,20 +18,24 @@ export interface ConceptReferenceResponse {
 }
 
 export function useConcepts(conceptUuids: Array<string>) {
-  const { data, error, isLoading } = useSWRImmutable<Array<FetchResponse<ConceptReferenceResponse>>, Error>(
-    conceptUuids && conceptUuids.length > 0 ? getConceptReferenceUrls(conceptUuids) : null,
-    (key: Array<string>) => Promise.all(key.map((url) => openmrsFetch<ConceptReferenceResponse>(url))),
+  const { data, error, isLoading } = useSWRImmutable<FetchResponse<ConceptReferenceResponse>, Error>(
+    conceptUuids && conceptUuids.length > 0
+      ? [`${restBaseUrl}/conceptreferences?v=${conceptRepresentation}`, conceptUuids]
+      : null,
+    ([url, refs]) =>
+      openmrsFetch<ConceptReferenceResponse>(url, {
+        headers: { 'Content-Type': 'application/json' },
+        body: { references: refs },
+        method: 'POST',
+      }),
   );
 
-  const res: ConceptReferenceResponse = data?.reduce((acc, response) => ({ ...acc, ...response.data }), {});
-  const concepts = res
-    ? Object.values(res).map((value) => ({
-        uuid: value.uuid,
-        display: value.display,
-        dataType: value.datatype.name,
-        answers: value.answers,
-      }))
-    : [];
+  const concepts = Object.values(data?.data ?? {}).map((value) => ({
+    uuid: value.uuid,
+    display: value.display,
+    dataType: value.datatype.name,
+    answers: value.answers,
+  }));
 
   if (error) {
     showSnackbar({
@@ -41,11 +46,4 @@ export function useConcepts(conceptUuids: Array<string>) {
   }
 
   return { concepts, isLoading };
-}
-
-function getConceptReferenceUrls(conceptUuids: Array<string>) {
-  return chunk(conceptUuids, 10).map(
-    (partition) =>
-      `${restBaseUrl}/conceptreferences?references=${partition.join(',')}&v=custom:(uuid,display,datatype,answers)`,
-  );
 }

--- a/packages/esm-patient-tests-app/src/test-orders/api.ts
+++ b/packages/esm-patient-tests-app/src/test-orders/api.ts
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from 'react';
-import { chunk } from 'lodash-es';
 import useSWR, { useSWRConfig } from 'swr';
 import useSWRImmutable from 'swr/immutable';
 import {
@@ -63,19 +62,25 @@ export function usePatientLabOrders(patientUuid: string, status: 'ACTIVE' | 'any
   };
 }
 
+const conceptRepresentation = 'custom:(uuid,display)';
+
 export function useOrderReasons(conceptUuids: Array<string>) {
-  const { data, error, isLoading } = useSWRImmutable<Array<FetchResponse<ConceptReferenceResponse>>, Error>(
-    conceptUuids && conceptUuids.length > 0 ? getConceptReferenceUrls(conceptUuids) : null,
-    (key: Array<string>) => Promise.all(key.map((url) => openmrsFetch<ConceptReferenceResponse>(url))),
+  const { data, error, isLoading } = useSWRImmutable<FetchResponse<ConceptReferenceResponse>, Error>(
+    conceptUuids && conceptUuids.length > 0
+      ? [`${restBaseUrl}/conceptreferences?v=${conceptRepresentation}`, conceptUuids]
+      : null,
+    ([url, refs]) =>
+      openmrsFetch<ConceptReferenceResponse>(url, {
+        headers: { 'Content-Type': 'application/json' },
+        body: { references: refs },
+        method: 'POST',
+      }),
   );
 
-  const ob: ConceptReferenceResponse = data?.reduce((acc, response) => ({ ...acc, ...response.data }), {});
-  const orderReasons = ob
-    ? Object.values(ob).map((value) => ({
-        uuid: value.uuid,
-        display: value.display,
-      }))
-    : [];
+  const orderReasons = Object.values(data?.data ?? {}).map((value) => ({
+    uuid: value.uuid,
+    display: value.display,
+  }));
 
   if (error) {
     showSnackbar({
@@ -86,12 +91,6 @@ export function useOrderReasons(conceptUuids: Array<string>) {
   }
 
   return { orderReasons: orderReasons, isLoading };
-}
-
-function getConceptReferenceUrls(conceptUuids: Array<string>) {
-  return chunk(conceptUuids, 10).map(
-    (partition) => `${restBaseUrl}/conceptreferences?references=${partition.join(',')}&v=custom:(uuid,display)`,
-  );
 }
 
 export const prepTestOrderPostData: PostDataPrepFunction = (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Mirrors openmrs/openmrs-esm-form-engine-lib#669 in patient-chart. Migrates the two remaining `/conceptreferences` callers from a chunked GET pattern (`chunk(uuids, 10)` plus `Promise.all` over N requests) to a single POST that takes the references array in the body.

Affected hooks:

- `esm-generic-patient-widgets-app`: `useConcepts`
- `esm-patient-tests-app`: `useOrderReasons`

Benefits:

- One round trip per render instead of `ceil(N / 10)`. A widget configured with 50 concepts goes from 5 sequential SWR fetches to 1.
- Removes the implicit cap from chunking against an unstated URL-length limit. POST sidesteps URL-length concerns entirely.
- Cleaner failure semantics: one request, one error path, no risk of silently merging partial results from multiple chunks.

Behavior preserved end-to-end: both hooks return the same `{ concepts, isLoading }` / `{ orderReasons, isLoading }` shape, the empty-input short-circuit (`null` SWR key) still applies, and consumers (`useObs`, `test-order-form`) are untouched.

## Screenshots

## Related Issue

## Other

Requires REST API >= 4.0.0, when `POST /conceptreferences` landed. No formal floor declaration mechanism exists in patient-chart (none was added for the form-engine-lib precedent either), so this is documented here rather than enforced.