### PR TITLE
(fix) O3-4578: Use warning for duplicate immunization doses

### DIFF
--- a/packages/esm-patient-immunizations-app/src/immunizations/components/dose-input.component.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/components/dose-input.component.tsx
@@ -9,9 +9,11 @@ export const DoseInput: React.FC<{
   vaccine: string;
   sequences: ImmunizationSequenceDefinition[];
   control: Control;
-}> = ({ vaccine, sequences, control }) => {
+  warningMessage?: string;
+}> = ({ vaccine, sequences, control, warningMessage }) => {
   const { t } = useTranslation();
   const { field, fieldState } = useController({ name: 'doseNumber', control });
+  const showWarning = !!warningMessage && !fieldState.error;
 
   const vaccineSequences = useMemo(
     () => sequences?.find((sequence) => sequence.vaccineConceptUuid === vaccine)?.sequences || [],
@@ -34,6 +36,8 @@ export const DoseInput: React.FC<{
           id="sequence"
           invalid={!!fieldState.error}
           invalidText={fieldState.error?.message}
+          warn={showWarning}
+          warnText={warningMessage}
           items={vaccineSequences?.map((sequence) => sequence.sequenceNumber) || []}
           itemToString={(item) => vaccineSequences.find((s) => s.sequenceNumber === item)?.sequenceLabel}
           label={t('pleaseSelect', 'Please select')}
@@ -49,6 +53,8 @@ export const DoseInput: React.FC<{
           id="doseNumber"
           invalid={!!fieldState.error}
           invalidText={fieldState.error?.message}
+          warn={showWarning}
+          warnText={warningMessage}
           label={t('doseNumberWithinSeries', 'Dose number within series')}
           min={1}
           onChange={handleChange}

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
@@ -470,7 +470,7 @@ describe('Immunizations Form', () => {
     );
   });
 
-  it('should prevent saving a duplicate dose for the same vaccine', async () => {
+  it('should warn (without blocking save) when a duplicate dose is entered for the same vaccine', async () => {
     const user = userEvent.setup();
 
     mockUseImmunizations.mockReturnValue({
@@ -499,6 +499,12 @@ describe('Immunizations Form', () => {
       mutate: jest.fn(),
     });
 
+    mockSavePatientImmunization.mockResolvedValue({
+      status: 201,
+      ok: true,
+      data: { id: 'new-immunization-id' },
+    });
+
     render(<ImmunizationsForm {...testProps} />);
 
     const vaccineField = screen.getByRole('combobox', { name: /Immunization/i });
@@ -508,13 +514,13 @@ describe('Immunizations Form', () => {
     await user.clear(doseField);
     await user.type(doseField, '1');
 
+    // Inline warning is shown on the form (not in a snackbar) once the duplicate is detected
+    expect(screen.getByText(/Dose 1 has already been recorded for this vaccine/i)).toBeInTheDocument();
+
     await user.click(screen.getByRole('button', { name: /Save/i }));
 
-    // Should NOT save — duplicate blocked
-    expect(mockSavePatientImmunization).not.toHaveBeenCalled();
-
-    // Should show inline error on dose field (not a snackbar)
-    expect(screen.getByText(/Dose 1 has already been recorded for this vaccine/i)).toBeInTheDocument();
+    // Save proceeds — the warning is non-blocking
+    expect(mockSavePatientImmunization).toHaveBeenCalledTimes(1);
   });
 
   it('should allow re-saving when editing an existing immunization record', async () => {

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -93,17 +93,31 @@ const ImmunizationsForm: React.FC<PatientWorkspace2DefinitionProps<{}, {}>> = ({
     control,
     handleSubmit,
     reset,
-    setError,
-    clearErrors,
     formState: { errors, isDirty, isSubmitting },
     watch,
   } = formProps;
   const vaccinationDate = watch('vaccinationDate');
   const vaccineUuid = watch('vaccineUuid');
-  // Clear stale duplicate-dose error when the user switches vaccine
-  useEffect(() => {
-    clearErrors('doseNumber');
-  }, [vaccineUuid, clearErrors]);
+  const doseNumber = watch('doseNumber');
+
+  const duplicateDoseWarning = useMemo(() => {
+    if (!vaccineUuid || doseNumber == null) return undefined;
+    const isDuplicate = existingImmunizations?.some((group) => {
+      if (group.vaccineUuid !== vaccineUuid) {
+        return false;
+      }
+
+      return group.existingDoses.some(
+        (dose) =>
+          dose.doseNumber != null &&
+          Number(dose.doseNumber) === Number(doseNumber) &&
+          dose.immunizationObsUuid !== immunizationToEditMeta?.immunizationObsUuid,
+      );
+    });
+    return isDuplicate
+      ? t('duplicateDoseWarning', 'Dose {{dose}} has already been recorded for this vaccine', { dose: doseNumber })
+      : undefined;
+  }, [vaccineUuid, doseNumber, existingImmunizations, immunizationToEditMeta, t]);
 
   useEffect(() => {
     const sub = immunizationFormSub.subscribe((props) => {
@@ -131,30 +145,6 @@ const ImmunizationsForm: React.FC<PatientWorkspace2DefinitionProps<{}, {}>> = ({
 
   const onSubmit = useCallback(
     async (data: ImmunizationFormInputData) => {
-      // Note: existingImmunizations is undefined while loading, so this check
-      // silently no-ops in that window. The disabled Save button (isLoadingImmunizations)
-      // prevents submission during loading, keeping this safe.
-      const isDuplicate = existingImmunizations?.some((group) => {
-        if (group.vaccineUuid !== data.vaccineUuid) return false;
-        return group.existingDoses.some(
-          (dose) =>
-            dose.doseNumber != null &&
-            data.doseNumber != null &&
-            Number(dose.doseNumber) === Number(data.doseNumber) &&
-            dose.immunizationObsUuid !== immunizationToEditMeta?.immunizationObsUuid,
-        );
-      });
-
-      if (isDuplicate) {
-        setError('doseNumber', {
-          type: 'manual',
-          message: t('duplicateDoseError', 'Dose {{dose}} has already been recorded for this vaccine', {
-            dose: data.doseNumber,
-          }),
-        });
-        return;
-      }
-
       try {
         const {
           vaccineUuid,
@@ -215,8 +205,6 @@ const ImmunizationsForm: React.FC<PatientWorkspace2DefinitionProps<{}, {}>> = ({
       visitContext?.uuid,
       immunizationToEditMeta,
       immunizationsConceptSet,
-      existingImmunizations,
-      setError,
       closeWorkspace,
       t,
       mutate,
@@ -269,7 +257,12 @@ const ImmunizationsForm: React.FC<PatientWorkspace2DefinitionProps<{}, {}>> = ({
             </ResponsiveWrapper>
             {vaccineUuid && (
               <ResponsiveWrapper>
-                <DoseInput vaccine={vaccineUuid} sequences={config.sequenceDefinitions} control={control} />
+                <DoseInput
+                  vaccine={vaccineUuid}
+                  sequences={config.sequenceDefinitions}
+                  control={control}
+                  warningMessage={duplicateDoseWarning}
+                />
               </ResponsiveWrapper>
             )}
             <div className={styles.vaccineBatchHeading}>

--- a/packages/esm-patient-immunizations-app/translations/en.json
+++ b/packages/esm-patient-immunizations-app/translations/en.json
@@ -8,7 +8,7 @@
   "doseNumberWithinSeries": "Dose number within series",
   "doses": "Doses",
   "due": "Due",
-  "duplicateDoseError": "Dose {{dose}} has already been recorded for this vaccine",
+  "duplicateDoseWarning": "Dose {{dose}} has already been recorded for this vaccine",
   "error": "Error",
   "errorSaving": "Error saving vaccination",
   "expirationDate": "Expiration Date",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

This is a fix for O3-4578 / #3265 which makes it a validation error to enter the same dose number for the same vaccine. This switches things so that a warning is shown to the user, but the warning is non-blocking.

The "dose number" for vaccinations is a sequence number in a schedule and not an incrementing counter of the number of times a patient has been given a dose. As Andy Kanter has repeatedly pointed out as we've developed immunization-related functionality, ["just because a person gets a shot doesn't mean the shot was valid"](https://talk.openmrs.org/t/immunization-vs-vaccination/30144/9).  Consequently, blocking users from submitting a record of a second application of the same dose forces users to record clinically incorrect data. Presumably, we should have some way of marking known-bad or known-erroneous doses as such, but that's beyond the scope of this ticket.

## Screenshots
<!-- Required if you are making UI changes. -->

<img width="422" height="746" alt="Immunization" src="https://github.com/user-attachments/assets/69ea597c-0340-40f4-9512-a32a0095786c" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4578

## Other
<!-- Anything not covered above -->
