### PR TITLE
(fix) O3-5656: Make submit buttons sticky on procedure history form

### DIFF
--- a/packages/esm-patient-procedures-app/src/procedures/procedures-form.component.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-form.component.tsx
@@ -381,7 +381,7 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
           </FormGroup>
         </Stack>
       </div>
-      <div>
+      <div className={styles.submitButtons}>
         {errorSaving ? (
           <div className={styles.errorContainer}>
             <InlineNotification

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-form.scss
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-form.scss
@@ -104,3 +104,9 @@
   gap: layout.$spacing-05;
   align-items: end;
 }
+
+.submitButtons {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+}

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-form.workspace.test.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-form.workspace.test.tsx
@@ -78,8 +78,9 @@ async function fillRequiredFields(user: ReturnType<typeof userEvent.setup>) {
   await user.type(screen.getByRole('searchbox', { name: /enter body site/i }), 'Site');
   await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
 
-  await user.type(screen.getByRole('searchbox', { name: /enter status/i }), 'Done');
-  await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+  const statusGroup = screen.getByRole('group', { name: /^status/i });
+  await user.click(within(statusGroup).getByRole('combobox'));
+  await user.click(screen.getByRole('option', { name: /appendectomy/i }));
 
   const procedureTypeGroup = screen.getByRole('group', { name: /procedure type/i });
   await user.click(within(procedureTypeGroup).getByRole('combobox'));
@@ -315,8 +316,9 @@ describe('ProceduresForm', () => {
     const durationInput = screen.getByRole('spinbutton', { name: /^duration$/i });
     await user.type(durationInput, '30');
 
-    const unitSelect = screen.getByLabelText(/duration unit/i);
-    await user.selectOptions(unitSelect, 'proc-concept-uuid-1');
+    const unitCombobox = screen.getByRole('combobox', { name: /duration unit/i });
+    await user.click(unitCombobox);
+    await user.click(screen.getByRole('option', { name: /appendectomy/i }));
 
     await user.click(screen.getByRole('button', { name: /save & close/i }));
 
@@ -390,8 +392,9 @@ describe('ProceduresForm', () => {
     await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
     await user.type(screen.getByRole('searchbox', { name: /enter body site/i }), 'Site');
     await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
-    await user.type(screen.getByRole('searchbox', { name: /enter status/i }), 'Done');
-    await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+    const statusGroup = screen.getByRole('group', { name: /^status/i });
+    await user.click(within(statusGroup).getByRole('combobox'));
+    await user.click(screen.getByRole('option', { name: /appendectomy/i }));
 
     const procedureTypeGroup = screen.getByRole('group', { name: /procedure type/i });
     await user.click(within(procedureTypeGroup).getByRole('combobox'));


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Right now when we open the procedure form, the submit buttons are scrolls with the form content, requiring users to scroll to reach it. This PR is to fix that and now those buttons will stick to the form.

## Screenshots
<!-- Required if you are making UI changes. -->
1. Before the fix:

https://github.com/user-attachments/assets/adc1ad83-43c4-4cef-a625-7b8b10221560


2. After the fix:

https://github.com/user-attachments/assets/cb0a6026-a038-4444-8892-1260b169cf59



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-5656

## Other
<!-- Anything not covered above -->
Updated the `procedures-form.workspace.test.tsx` file to interact with the new ComboBox components. Instead of searching for the input search boxes