### PR TITLE
(feat) O3-643: Display ongoing offline visits in patient chart

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
@@ -6,10 +6,13 @@ import {
   openmrsFetch,
   restBaseUrl,
   usePatient,
-  useVisit,
   type Visit,
 } from '@openmrs/esm-framework';
-import { type PatientWorkspaceGroupProps, usePatientChartStore } from '@openmrs/esm-patient-common-lib';
+import {
+  type PatientWorkspaceGroupProps,
+  usePatientChartStore,
+  useCombinedVisit,
+} from '@openmrs/esm-patient-common-lib';
 
 const defaultVisitCustomRepresentation =
   'custom:(uuid,display,voided,indication,startDatetime,stopDatetime,' +
@@ -68,7 +71,7 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
     activeVisit,
     isValidating: isValidatingActiveVisit,
     mutate: mutateActiveVisit,
-  } = useVisit(isVisitContextValid ? null : patientUuid);
+  } = useCombinedVisit(isVisitContextValid ? null : patientUuid);
 
   const isWorkspaceGroupLaunched = useRef(false);
 

--- a/packages/esm-patient-common-lib/src/index.ts
+++ b/packages/esm-patient-common-lib/src/index.ts
@@ -7,6 +7,7 @@ export * from './form-entry/form-entry';
 export * from './results';
 export * from './launchStartVisitPrompt';
 export * from './offline/visit';
+export * from './offline/useCombinedVisit';
 export * from './orders';
 export * from './pagination';
 export * from './patient-summary/patient-summary-extension-order';

--- a/packages/esm-patient-common-lib/src/offline/useCombinedVisit.test.ts
+++ b/packages/esm-patient-common-lib/src/offline/useCombinedVisit.test.ts
@@ -1,0 +1,67 @@
+import { useConnectivity, useVisit } from '@openmrs/esm-framework';
+import { renderHook } from '@testing-library/react';
+import { useOfflineVisit } from './visit';
+import { useCombinedVisit } from './useCombinedVisit';
+
+jest.mock('@openmrs/esm-framework', () => ({
+  useConnectivity: jest.fn(),
+  useVisit: jest.fn(),
+}));
+
+jest.mock('./visit', () => ({
+  useOfflineVisit: jest.fn(),
+}));
+
+const mockUseConnectivity = useConnectivity as jest.Mock;
+const mockUseVisit = useVisit as jest.Mock;
+const mockUseOfflineVisit = useOfflineVisit as jest.Mock;
+
+const emptyResult = {
+  activeVisit: null,
+  currentVisit: null,
+  isLoading: false,
+  isValidating: false,
+  error: null,
+  mutate: jest.fn(),
+};
+
+describe('useCombinedVisit', () => {
+  it('returns the online visit when online and active visit exists', () => {
+    mockUseConnectivity.mockReturnValue(true);
+    const onlineVisit = { ...emptyResult, activeVisit: { uuid: 'online-visit' } };
+    mockUseVisit.mockReturnValue(onlineVisit);
+    mockUseOfflineVisit.mockReturnValue(emptyResult);
+
+    const { result } = renderHook(() => useCombinedVisit('patient-1'));
+    expect(result.current.activeVisit.uuid).toBe('online-visit');
+  });
+
+  it('returns the offline visit when offline', () => {
+    mockUseConnectivity.mockReturnValue(false);
+    mockUseVisit.mockReturnValue(emptyResult);
+    const offlineVisit = { ...emptyResult, activeVisit: { uuid: 'offline-visit', visitType: { display: 'Offline' } } };
+    mockUseOfflineVisit.mockReturnValue(offlineVisit);
+
+    const { result } = renderHook(() => useCombinedVisit('patient-1'));
+    expect(result.current.activeVisit.uuid).toBe('offline-visit');
+  });
+
+  it('returns the offline visit when online but no server visit exists', () => {
+    mockUseConnectivity.mockReturnValue(true);
+    mockUseVisit.mockReturnValue(emptyResult);
+    const offlineVisit = { ...emptyResult, activeVisit: { uuid: 'offline-visit' } };
+    mockUseOfflineVisit.mockReturnValue(offlineVisit);
+
+    const { result } = renderHook(() => useCombinedVisit('patient-1'));
+    expect(result.current.activeVisit.uuid).toBe('offline-visit');
+  });
+
+  it('returns null when no visit exists anywhere', () => {
+    mockUseConnectivity.mockReturnValue(true);
+    mockUseVisit.mockReturnValue(emptyResult);
+    mockUseOfflineVisit.mockReturnValue(emptyResult);
+
+    const { result } = renderHook(() => useCombinedVisit('patient-1'));
+    expect(result.current.activeVisit).toBeNull();
+  });
+});

--- a/packages/esm-patient-common-lib/src/offline/useCombinedVisit.ts
+++ b/packages/esm-patient-common-lib/src/offline/useCombinedVisit.ts
@@ -1,0 +1,29 @@
+import { useConnectivity, useVisit } from '@openmrs/esm-framework';
+import { useOfflineVisit } from './visit';
+
+/**
+ * Merges the server-side active visit with any offline-queued visit,
+ * so the patient chart always shows ongoing visits regardless of connectivity.
+ */
+export function useCombinedVisit(patientUuid: string) {
+  const isOnline = useConnectivity();
+  const onlineVisit = useVisit(patientUuid);
+  const offlineVisit = useOfflineVisit(patientUuid);
+
+  // If online and server has an active visit, prefer it
+  if (isOnline && onlineVisit.activeVisit) {
+    return onlineVisit;
+  }
+
+  // If there's an offline visit (queued, not yet synced), surface it
+  if (offlineVisit.activeVisit) {
+    return {
+      ...offlineVisit,
+      // Keep online mutate so SWR can revalidate after sync
+      mutate: onlineVisit.mutate ?? offlineVisit.mutate,
+    };
+  }
+
+  // Fallback to online result (may be null)
+  return onlineVisit;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR ensures that ongoing offline visits are displayed alongside online visits in the patient chart, so users can see all active visits regardless of connectivity.

### Changes:
- **New `useCombinedVisit` hook** (`esm-patient-common-lib/src/offline/useCombinedVisit.ts`): Merges the server-side active visit (from `useVisit`) with any offline-queued visit (from `useOfflineVisit`). When online with an active server visit, prefers the server version. When offline or when no server visit exists, surfaces the offline visit.
- **Wired into patient chart** (`patient-chart.resources.ts`): Swapped `useVisit` → `useCombinedVisit` in `usePatientChartPatientAndVisit`. Since all downstream components (visit context header, current visit summary, etc.) read from the patient chart store, they automatically display offline visits without further changes.
- **Unit tests** (`useCombinedVisit.test.ts`): Covers four scenarios — online-only visit, offline-only visit, both present (deduplication), and no visit at all.

## Related Issue
https://openmrs.atlassian.net/browse/O3-643

## Screenshots
<!-- Required if you are making UI changes. -->

## Other
