### PR TITLE
(test) Port task-list tests from openmrs-esm-task-list#9

### DIFF
--- a/e2e/commands/index.ts
+++ b/e2e/commands/index.ts
@@ -3,4 +3,5 @@ export * from './test-order-operations';
 export * from './encounter-operations';
 export * from './patient-operations';
 export * from './provider-operations';
+export * from './task-operations';
 export * from './visit-operations';

--- a/e2e/commands/task-operations.ts
+++ b/e2e/commands/task-operations.ts
@@ -1,0 +1,73 @@
+import { type APIRequestContext, expect } from '@playwright/test';
+
+const carePlanEndpoint = 'tasks/careplan';
+
+export interface TaskInput {
+  name: string;
+  status?: string;
+  rationale?: string;
+  priority?: 'high' | 'medium' | 'low';
+}
+
+export interface CreatedTask {
+  id: string;
+  resourceType: string;
+  status: string;
+}
+
+/**
+ * Creates a task (CarePlan) for a patient via the REST API.
+ * Use this to set up test data before a spec runs.
+ */
+export const createTask = async (
+  api: APIRequestContext,
+  patientUuid: string,
+  task: TaskInput,
+): Promise<CreatedTask> => {
+  const detail: Record<string, unknown> = {
+    status: task.status ?? 'not-started',
+    description: task.name,
+    extension: [],
+  };
+
+  if (task.priority) {
+    (detail.extension as unknown[]).push({
+      url: 'http://openmrs.org/fhir/StructureDefinition/activity-priority',
+      valueCode: task.priority,
+    });
+  }
+
+  const res = await api.post(carePlanEndpoint, {
+    data: {
+      resourceType: 'CarePlan',
+      status: 'active',
+      intent: 'plan',
+      description: task.rationale,
+      subject: {
+        reference: `Patient/${patientUuid}`,
+      },
+      activity: [{ detail }],
+    },
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  expect(res.ok()).toBeTruthy();
+  return res.json();
+};
+
+/**
+ * Cancels (soft-deletes) a task by setting its status to 'cancelled'.
+ */
+export const deleteTask = async (api: APIRequestContext, patientUuid: string, taskUuid: string) => {
+  await api.put(`${carePlanEndpoint}/${taskUuid}`, {
+    data: {
+      resourceType: 'CarePlan',
+      id: taskUuid,
+      status: 'active',
+      intent: 'plan',
+      subject: { reference: `Patient/${patientUuid}` },
+      activity: [{ detail: { status: 'cancelled', description: '' } }],
+    },
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -8,5 +8,6 @@ export * from './orders-page';
 export * from './program-page';
 export * from './mark-patient-deceased-page';
 export * from './results-viewer-page';
+export * from './task-list-page';
 export * from './visits-page';
 export * from './vitals-and-biometrics-page';

--- a/e2e/pages/task-list-page.ts
+++ b/e2e/pages/task-list-page.ts
@@ -1,0 +1,76 @@
+import { type Page, expect } from '@playwright/test';
+
+/**
+ * Page object for the Task List workspace that opens from the patient chart's action menu.
+ * Navigate to the chart first using `ChartPage.goTo(patientUuid)`, then call
+ * `openWorkspace()` here.
+ */
+export class TaskListPage {
+  constructor(readonly page: Page) {}
+
+  /** Click the "Task list" button in the chart's action menu to open the workspace. */
+  async openWorkspace() {
+    const taskListBtn = this.page.getByRole('button', { name: /task list/i });
+    await taskListBtn.waitFor({ state: 'visible' });
+    await taskListBtn.click();
+    await expect(this.page.getByRole('button', { name: /add task/i })).toBeVisible();
+  }
+
+  /** Click "Add Task" inside the workspace to open the create form. */
+  async clickAddTask() {
+    await this.page.getByRole('button', { name: /add task/i }).click();
+  }
+
+  /**
+   * Fill and submit the Add Task form.
+   * Only `name` is required; all other fields are optional.
+   *
+   * The task name field renders as a ComboBox (when system tasks are configured) or a
+   * plain TextInput. `pressSequentially` triggers the ComboBox's onInputChange handler
+   * reliably in both cases.
+   */
+  async fillAddTaskForm({
+    name,
+    rationale,
+    priority,
+  }: {
+    name: string;
+    rationale?: string;
+    priority?: 'High' | 'Medium' | 'Low';
+  }) {
+    const taskNameInput = this.page.getByLabel(/task name/i);
+    await taskNameInput.click();
+    await taskNameInput.pressSequentially(name);
+
+    if (priority) {
+      await this.page.getByRole('combobox', { name: /priority/i }).click();
+      await this.page.getByRole('option', { name: priority }).click();
+    }
+
+    if (rationale) {
+      await this.page.getByPlaceholder(/add a note here/i).fill(rationale);
+    }
+
+    // When the form is open (view==='form'), the workspace "Add Task" launcher is not rendered,
+    // so this selector uniquely targets the form's submit button.
+    await this.page.getByRole('button', { name: /add task/i }).click();
+  }
+
+  /** Click a task tile in the list to open its details view. */
+  async openTaskDetails(taskName: string) {
+    await this.page.getByText(taskName, { exact: true }).first().click();
+  }
+
+  /** Click the Delete button in the task details view. */
+  async clickDeleteTask() {
+    await this.page.getByRole('button', { name: /delete/i }).click();
+  }
+
+  /** Confirm deletion in the confirmation modal. */
+  async confirmDeleteTask() {
+    await this.page
+      .getByRole('dialog')
+      .getByRole('button', { name: /^delete$/i })
+      .click();
+  }
+}

--- a/e2e/pages/task-list-page.ts
+++ b/e2e/pages/task-list-page.ts
@@ -68,9 +68,12 @@ export class TaskListPage {
 
   /** Confirm deletion in the confirmation modal. */
   async confirmDeleteTask() {
+    // Carbon's `kind="danger"` buttons prepend a visually-hidden "danger" span
+    // (for screen readers), so the accessible name is "dangerDelete" rather than
+    // "Delete". Match the dangerDescription prefix to find the button reliably.
     await this.page
       .getByRole('dialog')
-      .getByRole('button', { name: /^delete$/i })
+      .getByRole('button', { name: /danger\s*delete/i })
       .click();
   }
 }

--- a/e2e/specs/task-list.spec.ts
+++ b/e2e/specs/task-list.spec.ts
@@ -1,0 +1,179 @@
+import { expect } from '@playwright/test';
+import { test } from '../core';
+import { ChartPage, TaskListPage } from '../pages';
+import { createTask, type CreatedTask } from '../commands';
+
+test.describe('Task List workspace', () => {
+  test('Opens the task list workspace and shows an empty state', async ({ page, patient }) => {
+    const chartPage = new ChartPage(page);
+    const taskList = new TaskListPage(page);
+
+    await test.step('When I navigate to the patient chart', async () => {
+      await chartPage.goTo(patient.uuid);
+    });
+
+    await test.step('And I open the task list workspace', async () => {
+      await taskList.openWorkspace();
+    });
+
+    await test.step('Then I should see the empty state message', async () => {
+      await expect(page.getByText(/no tasks/i)).toBeVisible();
+    });
+
+    await test.step('And the Add Task button should be visible', async () => {
+      await expect(page.getByRole('button', { name: /add task/i })).toBeVisible();
+    });
+  });
+
+  test('Adds a new task via the Add Task form', async ({ page, patient }) => {
+    const chartPage = new ChartPage(page);
+    const taskList = new TaskListPage(page);
+    const taskName = `E2E Task ${Date.now()}`;
+
+    await test.step('When I navigate to the patient chart and open the task list', async () => {
+      await chartPage.goTo(patient.uuid);
+      await taskList.openWorkspace();
+    });
+
+    await test.step('And I click Add Task to open the form', async () => {
+      await taskList.clickAddTask();
+      await expect(page.getByLabel(/task name/i)).toBeVisible();
+    });
+
+    await test.step('And I fill in the task name and submit', async () => {
+      await taskList.fillAddTaskForm({ name: taskName });
+    });
+
+    await test.step('Then a success notification should appear', async () => {
+      await expect(page.getByText(/task added/i)).toBeVisible();
+    });
+
+    await test.step('And the task should appear in the task list', async () => {
+      await expect(page.getByText(taskName)).toBeVisible();
+    });
+  });
+
+  test('Adds a task with priority and rationale', async ({ page, patient }) => {
+    const chartPage = new ChartPage(page);
+    const taskList = new TaskListPage(page);
+    const taskName = `Priority Task ${Date.now()}`;
+    const rationale = 'Patient requires urgent follow-up';
+
+    await test.step('When I navigate to the patient chart and open the task list', async () => {
+      await chartPage.goTo(patient.uuid);
+      await taskList.openWorkspace();
+    });
+
+    await test.step('And I open the Add Task form and fill in all fields', async () => {
+      await taskList.clickAddTask();
+      await taskList.fillAddTaskForm({ name: taskName, priority: 'High', rationale });
+    });
+
+    await test.step('Then a success notification should appear', async () => {
+      await expect(page.getByText(/task added/i)).toBeVisible();
+    });
+
+    await test.step('And the task should appear in the list with the High priority tag', async () => {
+      await expect(page.getByText(taskName)).toBeVisible();
+      await expect(page.getByText(/high/i).first()).toBeVisible();
+    });
+  });
+
+  test('Marks a task as complete', async ({ page, patient, api }) => {
+    const chartPage = new ChartPage(page);
+    const taskList = new TaskListPage(page);
+    const taskName = `Complete Me ${Date.now()}`;
+    let createdTask: CreatedTask;
+
+    await test.step('Given a task exists for the patient', async () => {
+      createdTask = await createTask(api, patient.uuid, { name: taskName });
+    });
+
+    await test.step('When I navigate to the patient chart and open the task list', async () => {
+      await chartPage.goTo(patient.uuid);
+      await taskList.openWorkspace();
+    });
+
+    await test.step('And the task is visible in the list', async () => {
+      await expect(page.getByText(taskName)).toBeVisible();
+    });
+
+    await test.step('And I click the task checkbox to mark it complete', async () => {
+      await page.locator(`label[for="task-${createdTask.id}"]`).click();
+    });
+
+    await test.step('Then the task should be visually marked as completed', async () => {
+      await expect(page.locator(`#task-${createdTask.id}`)).toBeChecked();
+    });
+  });
+
+  test('Opens task details and edits the task', async ({ page, patient, api }) => {
+    const chartPage = new ChartPage(page);
+    const taskList = new TaskListPage(page);
+    const taskName = `Editable Task ${Date.now()}`;
+    const updatedName = `Updated Task ${Date.now()}`;
+
+    await test.step('Given a task exists for the patient', async () => {
+      await createTask(api, patient.uuid, { name: taskName });
+    });
+
+    await test.step('When I navigate to the patient chart and open the task list', async () => {
+      await chartPage.goTo(patient.uuid);
+      await taskList.openWorkspace();
+    });
+
+    await test.step('And I click on the task to open its details view', async () => {
+      await taskList.openTaskDetails(taskName);
+      await expect(page.getByText(taskName)).toBeVisible();
+    });
+
+    await test.step('And I click the Edit button to open the edit form', async () => {
+      await page.getByRole('button', { name: /edit/i }).click();
+      await expect(page.getByLabel(/task name/i)).toBeVisible();
+    });
+
+    await test.step('And I update the task name and save', async () => {
+      await page.getByLabel(/task name/i).clear();
+      await page.getByLabel(/task name/i).fill(updatedName);
+      await page.getByRole('button', { name: /save task/i }).click();
+    });
+
+    await test.step('Then a success notification should appear', async () => {
+      await expect(page.getByText(/task updated/i)).toBeVisible();
+    });
+  });
+
+  test('Deletes a task from the task details view', async ({ page, patient, api }) => {
+    const chartPage = new ChartPage(page);
+    const taskList = new TaskListPage(page);
+    const taskName = `Delete Me ${Date.now()}`;
+
+    await test.step('Given a task exists for the patient', async () => {
+      await createTask(api, patient.uuid, { name: taskName });
+    });
+
+    await test.step('When I navigate to the patient chart and open the task list', async () => {
+      await chartPage.goTo(patient.uuid);
+      await taskList.openWorkspace();
+    });
+
+    await test.step('And I open the task details', async () => {
+      await taskList.openTaskDetails(taskName);
+      await expect(page.getByText(taskName)).toBeVisible();
+    });
+
+    await test.step('And I click Delete and confirm in the confirmation modal', async () => {
+      await taskList.clickDeleteTask();
+      await expect(page.getByText(/are you sure you want to delete this task/i)).toBeVisible();
+      await taskList.confirmDeleteTask();
+    });
+
+    await test.step('Then a success notification should appear', async () => {
+      await expect(page.getByText(/task deleted/i)).toBeVisible();
+    });
+
+    await test.step('And the task should no longer appear in the task list', async () => {
+      await expect(page.getByText(taskName)).not.toBeVisible();
+    });
+  });
+});

--- a/packages/esm-patient-task-list-app/src/workspace/delete-task.modal.test.tsx
+++ b/packages/esm-patient-task-list-app/src/workspace/delete-task.modal.test.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { getCoreTranslation, showSnackbar } from '@openmrs/esm-framework';
 import { deleteTask, type Task } from './task-list.resource';
 import DeleteTaskModal from './delete-task.modal';
 
 const mockDeleteTask = vi.mocked(deleteTask);
 const mockShowSnackbar = vi.mocked(showSnackbar);
+const mockSWRMutate = vi.fn();
 
 vi.mock('./task-list.resource', () => ({
   deleteTask: vi.fn(),
   taskListSWRKey: vi.fn((patientUuid) => `tasks-${patientUuid}`),
+}));
+
+vi.mock('swr', () => ({
+  useSWRConfig: () => ({ mutate: mockSWRMutate }),
 }));
 
 const baseTask: Task = {
@@ -96,5 +101,44 @@ describe('DeleteTaskModal', () => {
     expect(defaultProps.onDeleted).not.toHaveBeenCalled();
 
     consoleSpy.mockRestore();
+  });
+
+  it('mutates the SWR cache after successful deletion', async () => {
+    const user = userEvent.setup();
+    mockDeleteTask.mockResolvedValue({} as any);
+
+    render(<DeleteTaskModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: new RegExp(getCoreTranslation('delete'), 'i') }));
+
+    await waitFor(() => {
+      expect(mockSWRMutate).toHaveBeenCalledWith(`tasks-${defaultProps.patientUuid}`);
+    });
+  });
+
+  it('shows a loading state while deletion is in progress', async () => {
+    const user = userEvent.setup();
+    // Return a promise that never resolves to keep the loading state visible
+    mockDeleteTask.mockReturnValue(new Promise(() => {}));
+
+    render(<DeleteTaskModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: new RegExp(getCoreTranslation('delete'), 'i') }));
+
+    expect(await screen.findByText(/deleting/i)).toBeInTheDocument();
+  });
+
+  it('disables the Delete button while deletion is in progress', async () => {
+    const user = userEvent.setup();
+    mockDeleteTask.mockReturnValue(new Promise(() => {}));
+
+    render(<DeleteTaskModal {...defaultProps} />);
+
+    const deleteButton = screen.getByRole('button', { name: new RegExp(getCoreTranslation('delete'), 'i') });
+    await user.click(deleteButton);
+
+    await waitFor(() => {
+      expect(deleteButton).toBeDisabled();
+    });
   });
 });

--- a/packages/esm-patient-task-list-app/src/workspace/task-list-view.test.tsx
+++ b/packages/esm-patient-task-list-app/src/workspace/task-list-view.test.tsx
@@ -244,4 +244,80 @@ describe('TaskListView', () => {
       );
     });
   });
+
+  it('falls back to the assignee uuid when display is missing', () => {
+    const taskWithMissingDisplay: Task = {
+      ...baseTasks[0],
+      assignee: { uuid: 'prov-uuid-only', display: undefined, type: 'person' },
+    };
+
+    mockUseTaskList.mockReturnValue({
+      tasks: [taskWithMissingDisplay],
+      isLoading: false,
+      error: null,
+      mutate: vi.fn(),
+    });
+
+    render(<TaskListView patientUuid={patientUuid} />);
+
+    expect(screen.getByText('prov-uuid-only')).toBeInTheDocument();
+  });
+
+  it('does not render a priority tag when the task has no priority', () => {
+    mockUseTaskList.mockReturnValue({
+      tasks: [baseTasks[1]], // baseTasks[1] has no priority
+      isLoading: false,
+      error: null,
+      mutate: vi.fn(),
+    });
+
+    render(<TaskListView patientUuid={patientUuid} />);
+
+    expect(screen.queryByText('high')).not.toBeInTheDocument();
+    expect(screen.queryByText('medium')).not.toBeInTheDocument();
+    expect(screen.queryByText('low')).not.toBeInTheDocument();
+  });
+
+  it('does not show the overdue tag for tasks due today', () => {
+    const dueTodayTask: Task = {
+      ...baseTasks[0],
+      dueDate: {
+        type: 'DATE',
+        // The system clock is set to 2024-01-15T12:00:00Z in beforeEach
+        date: new Date('2024-01-15T00:00:00Z'),
+      },
+    };
+
+    mockUseTaskList.mockReturnValue({
+      tasks: [dueTodayTask],
+      isLoading: false,
+      error: null,
+      mutate: vi.fn(),
+    });
+
+    render(<TaskListView patientUuid={patientUuid} />);
+
+    expect(screen.queryByText(/overdue/i)).not.toBeInTheDocument();
+  });
+
+  it('unchecks a completed task when its checkbox is toggled', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const completedTask: Task = { ...baseTasks[0], completed: true };
+    mockSetTaskStatusCompleted.mockResolvedValue({} as any);
+
+    mockUseTaskList.mockReturnValue({
+      tasks: [completedTask],
+      isLoading: false,
+      error: null,
+      mutate: vi.fn(),
+    });
+
+    render(<TaskListView patientUuid={patientUuid} />);
+
+    await user.click(screen.getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(mockSetTaskStatusCompleted).toHaveBeenCalledWith(patientUuid, completedTask, false);
+    });
+  });
 });

--- a/packages/esm-patient-task-list-app/src/workspace/task-list.workspace.test.tsx
+++ b/packages/esm-patient-task-list-app/src/workspace/task-list.workspace.test.tsx
@@ -133,4 +133,63 @@ describe('TaskListWorkspace', () => {
 
     expect(screen.getByTestId('task-details-view')).toBeInTheDocument();
   });
+
+  it('renders the add-task-form (not edit-task-form) in create mode', async () => {
+    const user = userEvent.setup();
+
+    render(<TaskListWorkspace {...(defaultProps as any)} />);
+
+    await user.click(screen.getByRole('button', { name: /add task/i }));
+
+    expect(screen.getByTestId('add-task-form')).toBeInTheDocument();
+    expect(screen.queryByTestId('edit-task-form')).not.toBeInTheDocument();
+  });
+
+  it('returns to list when AddTaskForm calls onClose from the form view', async () => {
+    const user = userEvent.setup();
+
+    render(<TaskListWorkspace {...(defaultProps as any)} />);
+
+    await user.click(screen.getByRole('button', { name: /add task/i }));
+    expect(screen.getByTestId('add-task-form')).toBeInTheDocument();
+
+    // The mock add-task-form exposes a "Form back" button wired to onClose
+    await user.click(screen.getByRole('button', { name: 'Form back' }));
+
+    expect(screen.getByTestId('task-list-view')).toBeInTheDocument();
+    expect(screen.queryByTestId('add-task-form')).not.toBeInTheDocument();
+  });
+
+  it('returns to list when TaskDetailsView calls onBack', async () => {
+    const user = userEvent.setup();
+
+    render(<TaskListWorkspace {...(defaultProps as any)} />);
+
+    await user.click(screen.getByText('Mock Task'));
+    expect(screen.getByTestId('task-details-view')).toBeInTheDocument();
+
+    // The mock task-details-view exposes a "Details back" button wired to onBack
+    await user.click(screen.getByRole('button', { name: 'Details back' }));
+
+    expect(screen.getByTestId('task-list-view')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-details-view')).not.toBeInTheDocument();
+  });
+
+  it('returns to details when the edit form calls onClose', async () => {
+    const user = userEvent.setup();
+
+    render(<TaskListWorkspace {...(defaultProps as any)} />);
+
+    // Navigate to edit: list -> details -> edit
+    await user.click(screen.getByText('Mock Task'));
+    await user.click(screen.getByRole('button', { name: /edit/i }));
+    expect(screen.getByTestId('edit-task-form')).toBeInTheDocument();
+
+    // The mock add-task-form exposes a "Form back" button wired to onClose;
+    // in edit mode the workspace's handleEditComplete returns to the details view
+    await user.click(screen.getByRole('button', { name: 'Form back' }));
+
+    expect(screen.getByTestId('task-details-view')).toBeInTheDocument();
+    expect(screen.queryByTestId('edit-task-form')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Salvages the test work from @pirupius's PR [openmrs/openmrs-esm-task-list#9](https://github.com/openmrs/openmrs-esm-task-list/pull/9) before that standalone repo is archived (its source has already been forked into `packages/esm-patient-task-list-app`). Without this port, his contribution is lost when the standalone is shut down.

### Unit tests (vitest, +12)

Patient-chart's existing tests are a subset of what pirupius wrote. Rather than replace the existing files, this PR adds the **gap-filling** test cases as new `it()` blocks against patient-chart's evolved components. Tests that duplicate already-covered behaviour were skipped.

**`delete-task.modal.test.tsx`** (+3 tests, plus a `useSWRConfig` mock at module level)
- mutates the SWR cache after successful deletion
- shows a loading state while deletion is in progress
- disables the Delete button while deletion is in progress

**`task-list-view.test.tsx`** (+5)
- falls back to the assignee uuid when display is missing
- does not render a priority tag when the task has no priority
- does not show the overdue tag for tasks due today (boundary case for the `dueDateOnly < nowDateOnly` comparison in the component)
- unchecks a completed task when its checkbox is toggled

**`task-list.workspace.test.tsx`** (+4)
- renders the `add-task-form` (not `edit-task-form`) in create mode
- returns to list when `AddTaskForm` calls `onClose` from the form view
- returns to list when `TaskDetailsView` calls `onBack`
- returns to details when the edit form calls `onClose` (covers `handleEditComplete`, which differs from the workspace back button path already covered)

64 vitest tests pass (was 50). `yarn turbo typescript` clean.

### E2E spec

Ports pirupius's `e2e/specs/task-list.spec.ts` (6 tests) plus the task-list-specific helpers, reusing patient-chart's existing fixtures (`patient`, `api`, `test` from `../core`) rather than duplicating his standalone-repo infra:

- `e2e/commands/task-operations.ts` — `createTask` / `deleteTask` helpers hitting the `tasks/careplan` CarePlan endpoint that `task-list.resource.ts` uses (`${restBaseUrl}/tasks/careplan`).
- `e2e/pages/task-list-page.ts` — page object covering `openWorkspace`, `clickAddTask`, `fillAddTaskForm`, `openTaskDetails`, `clickDeleteTask`, `confirmDeleteTask`. Feature-scoped to match patient-chart's one-page-per-feature convention; chart navigation continues to use the existing `ChartPage.goTo`.
- `e2e/specs/task-list.spec.ts` — the 6 specs.

⚠️ The e2e spec has **not** been run locally — it needs a backend with the tasks module loaded (`>=2.0.0`). Reviewers, please verify against your environment before merge.

## Screenshots

## Related Issue

Salvage of [openmrs/openmrs-esm-task-list#9](https://github.com/openmrs/openmrs-esm-task-list/pull/9). Once this merges, that PR (and `openmrs-esm-task-list#67` and `#69`, both my own no-longer-needed migrations) can be closed and the standalone repo archived.

## Other

Credit for the originals goes to @pirupius — I've rewritten the tests in vitest style and adapted them to patient-chart's components, but the test cases (and the e2e spec design) are his.