### PR TITLE
(chore) Switch test environment from jsdom to happy-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-playwright": "^0.16.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^6.2.2",
+    "happy-dom": "^20.0.0",
     "husky": "^8.0.3",
     "i18next": "^25.0.0",
     "i18next-parser": "^9.3.0",

--- a/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-prompt/end-visit-dialog.test.tsx
@@ -1,3 +1,11 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * happy-dom's `Date` and `AbortController` instances do not satisfy
+ * `instanceof` against the host realm's constructors, which breaks
+ * `expect.any(Date)` and `toHaveBeenCalledWith(new AbortController(), ...)`
+ * matchers used here. Run under jsdom (which shares the host realm's globals).
+ */
 import React from 'react';
 import { vi, describe, expect, test, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
@@ -1,3 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * happy-dom's `Date` instances do not satisfy `instanceof Date` against
+ * the host realm's `Date` constructor, which breaks `expect.objectContaining`
+ * matchers on form payloads that production code builds with `new Date()`.
+ */
 import React from 'react';
 import { vi, describe, it, expect, test, beforeEach, type Mock } from 'vitest';
 import dayjs from 'dayjs';

--- a/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/add-drug-order.test.tsx
@@ -1,3 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * happy-dom's `Date` instances do not satisfy `instanceof Date` against
+ * the host realm's `Date` constructor, which breaks `expect.any(Date)`
+ * matchers on order payloads built with `new Date()` in production code.
+ */
 /* eslint-disable testing-library/no-node-access */
 import { vi, describe, it, expect, test, beforeEach } from 'vitest';
 import React from 'react';

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -1,3 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * happy-dom's `AbortController` instances are not the host realm's
+ * `AbortController`, so `toHaveBeenCalledWith(new AbortController(), ...)`
+ * fails the cross-realm equality check used here.
+ */
 import React from 'react';
 import { vi, expect, test, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/packages/esm-patient-orders-app/src/lab-results/lab-results-form.test.tsx
+++ b/packages/esm-patient-orders-app/src/lab-results/lab-results-form.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, expect, test, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';

--- a/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
+++ b/packages/esm-patient-programs-app/src/programs/programs-form.test.tsx
@@ -1,3 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * happy-dom's `Date` instances do not satisfy `instanceof Date` against
+ * the host realm's `Date` constructor, which breaks `expect.objectContaining`
+ * matchers on payloads built with `new Date()` in production code.
+ */
 import React from 'react';
 import { vi, describe, it, expect } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/tools/vitest.shared.ts
+++ b/tools/vitest.shared.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     alias: [{ find: /^.*\.s?css$/, replacement: 'identity-obj-proxy' }],
   },
   test: {
-    environment: 'jsdom',
+    environment: 'happy-dom',
     globals: true,
     clearMocks: true,
     testTimeout: 30000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5215,6 +5215,7 @@ __metadata:
     eslint-plugin-playwright: "npm:^0.16.0"
     eslint-plugin-react-hooks: "npm:^4.6.0"
     eslint-plugin-testing-library: "npm:^6.2.2"
+    happy-dom: "npm:^20.0.0"
     husky: "npm:^8.0.3"
     i18next: "npm:^25.0.0"
     i18next-parser: "npm:^9.3.0"
@@ -8426,6 +8427,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:>=20.0.0":
+  version: 25.7.0
+  resolution: "@types/node@npm:25.7.0"
+  dependencies:
+    undici-types: "npm:~7.21.0"
+  checksum: 10/1b11c865ea517ab90af870c2f58c100804e3dd8dc25a62b5e5af3aea12ad015f9faf513664babc7e0c755bb1c0744649b2ff19b7b434c1648ad8057f2dc6c71a
+  languageName: node
+  linkType: hard
+
 "@types/pako@npm:^2.0.3":
   version: 2.0.4
   resolution: "@types/pako@npm:2.0.4"
@@ -8643,7 +8653,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8.5.10":
+"@types/whatwg-mimetype@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@types/whatwg-mimetype@npm:3.0.2"
+  checksum: 10/609607beeaa8b50b9e00541d8f571880d651b26b6b006103370099aba00784037de54433627c9fe775a5558e3d1fc09c2a48f54c8af91988e9bebeaf6a698eeb
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.18.1, @types/ws@npm:^8.5.10":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
   dependencies:
@@ -12559,6 +12576,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "entities@npm:7.0.1"
+  checksum: 10/3c0c58d869c45148463e96d21dee2d1b801bd3fe4cf47aa470cd26dfe81d59e9e0a9be92ae083fa02fa441283c883a471486e94538dcfb8544428aa80a55271b
+  languageName: node
+  linkType: hard
+
 "entities@npm:^8.0.0":
   version: 8.0.0
   resolution: "entities@npm:8.0.0"
@@ -14372,6 +14396,20 @@ __metadata:
   version: 2.0.1
   resolution: "handle-thing@npm:2.0.1"
   checksum: 10/441ec98b07f26819c70c702f6c874088eebeb551b242fe8fae4eab325746b82bf84ae7a1f6419547698accb3941fa26806c5f5f93c50e19f90e499065a711d61
+  languageName: node
+  linkType: hard
+
+"happy-dom@npm:^20.0.0":
+  version: 20.9.0
+  resolution: "happy-dom@npm:20.9.0"
+  dependencies:
+    "@types/node": "npm:>=20.0.0"
+    "@types/whatwg-mimetype": "npm:^3.0.2"
+    "@types/ws": "npm:^8.18.1"
+    entities: "npm:^7.0.1"
+    whatwg-mimetype: "npm:^3.0.0"
+    ws: "npm:^8.18.3"
+  checksum: 10/5b54d641b467a8826de995a4541e55d79f58e3513e78209c5ff7ef8aa598c201550a8c2975aad465d5605bcf2788314164402f350eaa9014c0d6d6f896cc30c7
   languageName: node
   linkType: hard
 
@@ -22700,6 +22738,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~7.21.0":
+  version: 7.21.0
+  resolution: "undici-types@npm:7.21.0"
+  checksum: 10/e38c0efbeaeabeb84f5d8a49d127fcae1626af09785b04fde4915e8312b47c5f81106c61e655cb63c59e429522460a313183168913e55b485a36e06d67689798
+  languageName: node
+  linkType: hard
+
 "undici@npm:^7.12.0, undici@npm:^7.21.0":
   version: 7.25.0
   resolution: "undici@npm:7.25.0"
@@ -23713,6 +23758,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"whatwg-mimetype@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "whatwg-mimetype@npm:3.0.0"
+  checksum: 10/96f9f628c663c2ae05412c185ca81b3df54bcb921ab52fe9ebc0081c1720f25d770665401eb2338ab7f48c71568133845638e18a81ed52ab5d4dcef7d22b40ef
+  languageName: node
+  linkType: hard
+
 "whatwg-mimetype@npm:^4.0.0":
   version: 4.0.0
   resolution: "whatwg-mimetype@npm:4.0.0"
@@ -23938,6 +23990,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/018e04ec95561d88248d53a2eaf094b4ae131e9b062f2679e6e8a62f04649bc543448f1e038125225ac6bbb25f54c1e65d7a2cc9dbc1e28b43e5e6b7162ad88e
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.3":
+  version: 8.20.1
+  resolution: "ws@npm:8.20.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/8c4d2b06dc65381b6bfab1f2e584275dabd30a99a5ce058b4dc76f3d03fad1921cef3a21d8f53127d30a808cfd1864aa2fe6890a5d43359f682457315baec873
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Adopts the happy-dom-by-default pattern that `openmrs-esm-core` already uses across its 25 per-package vitest configs, with per-file `/** @vitest-environment jsdom */` docblocks as the escape hatch for tests that hit happy-dom/jsdom divergences. See [`esm-navigation/src/history/history.test.ts`](https://github.com/openmrs/openmrs-esm-core/blob/e1470604dafd40c0e687b75b8838278061c511db/packages/framework/esm-navigation/src/history/history.test.ts#L2) in core for the established precedent — only 1 of 104 test files in core needs the override.

### Changes
- `tools/vitest.shared.ts`: `environment: 'jsdom'` → `'happy-dom'`.
- `package.json`: add `happy-dom@^20.0.0`. Keep `jsdom@^28.0.0` because six test files in this repo still need it via the docblock escape hatch.
- Add `/** @vitest-environment jsdom */` to six test files where happy-dom diverges:
  - `esm-patient-chart-app/.../end-visit-dialog.test.tsx`
  - `esm-patient-immunizations-app/.../immunizations-form.test.tsx`
  - `esm-patient-medications-app/.../add-drug-order.test.tsx`
  - `esm-patient-notes-app/.../visit-notes-form.test.tsx`
  - `esm-patient-orders-app/.../lab-results-form.test.tsx`
  - `esm-patient-programs-app/.../programs-form.test.tsx`

  Most share the same root cause: happy-dom's `Date` and `AbortController` instances do not satisfy `instanceof` against the host realm's constructors, which breaks `expect.any(Date)` and `expect.objectContaining(...)` matchers on payloads that production code constructs with `new Date()` / `new AbortController()`. The `lab-results-form.test.tsx` file fails differently (a form-submit callback never fires under happy-dom) and gets the same escape hatch.

### Why bother

Benchmarked on `esm-patient-chart-app` (27 test files / 144 tests):

| | wall-clock median | tests passing |
|---|---|---|
| jest (pre-migration) | 6.39s | 117/117 |
| vitest + jsdom (status quo) | 9.03s | 143/143 (+ 1 skipped) |
| **vitest + happy-dom (this PR)** | **6.42s** | **143/143** (+ 1 skipped) |

A 29% wall-clock drop versus jsdom, and effectively parity with the pre-migration jest baseline. Savings scale with the number of test files because environment init is a per-file cost.

happy-dom's transitive dep tree is also smaller.

## Screenshots

N/A — tooling change only.

## Related Issue

N/A

## Other

`yarn turbo run typescript` (20 workspaces) and `yarn turbo run lint` (21 workspaces) are both green locally. All 135 test files pass across the 20 testable workspaces.