### PR TITLE
(feat) O3-4508: Integrate Custom API for Efficient Visit Data Fetching

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-history-table/visit-diagnoses-cell.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-history-table/visit-diagnoses-cell.component.tsx
@@ -1,18 +1,38 @@
 import { DiagnosisTags, type Visit } from '@openmrs/esm-framework';
 import React from 'react';
+import type { LightweightVisit } from '../visits-widget/visit.resource';
 
 interface Props {
-  visit: Visit;
+  visit: Visit | LightweightVisit;
   patient: fhir.Patient;
 }
 
+/**
+ * Renders diagnosis tags for a visit.
+ * Supports both:
+ * - Lightweight API response: diagnoses at visit level (visit.diagnoses)
+ * - Full API response: diagnoses nested inside encounters (visit.encounters[].diagnoses)
+ */
 const VisitDiagnosisCell: React.FC<Props> = ({ visit }) => {
-  const diagnoses = visit.encounters
-    .flatMap((encounter) => encounter.diagnoses)
-    .filter((diagnosis) => !diagnosis.voided)
-    .sort((a, b) => a.rank - b.rank);
-
+  const diagnoses = getDiagnosesFromVisit(visit);
   return <DiagnosisTags diagnoses={diagnoses} />;
 };
+
+function getDiagnosesFromVisit(visit: Visit | LightweightVisit) {
+  // Lightweight API: diagnoses directly on the visit object
+  if ('diagnoses' in visit && Array.isArray(visit.diagnoses) && visit.diagnoses.length > 0) {
+    return visit.diagnoses.filter((diagnosis) => !diagnosis.voided).sort((a, b) => a.rank - b.rank);
+  }
+
+  // Full API: diagnoses nested inside encounters
+  if ('encounters' in visit && Array.isArray(visit.encounters)) {
+    return visit.encounters
+      .flatMap((encounter) => encounter.diagnoses)
+      .filter((diagnosis) => !diagnosis.voided)
+      .sort((a, b) => a.rank - b.rank);
+  }
+
+  return [];
+}
 
 export default VisitDiagnosisCell;

--- a/packages/esm-patient-chart-app/src/visit/visit-history-table/visit-history-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-history-table/visit-history-table.component.tsx
@@ -17,7 +17,7 @@ import {
 } from '@carbon/react';
 import { ErrorState, isDesktop, useLayoutType } from '@openmrs/esm-framework';
 import { EmptyState } from '@openmrs/esm-patient-common-lib';
-import { usePaginatedVisits } from '../visits-widget/visit.resource';
+import { useLightweightVisits } from '../visits-widget/visit.resource';
 import VisitActionsCell from './visit-actions-cell.component';
 import VisitDateCell from './visit-date-cell.component';
 import VisitDiagnosisCell from './visit-diagnoses-cell.component';
@@ -31,14 +31,16 @@ interface VisitHistoryTableProps {
 }
 
 /**
- * This show a list of visit histories in the visit tab in patient chart
+ * This shows a list of visit histories in the visit tab in patient chart.
+ * Uses the lightweight emrapi endpoint for initial load (only basic details + diagnoses + notes).
+ * Full visit data is fetched on-demand when a row is expanded (handled by VisitSummary).
  */
 const VisitHistoryTable: React.FC<VisitHistoryTableProps> = ({ patientUuid, patient }) => {
   const defaultPageSize = 10;
   const [pageSize, setPageSize] = useState(defaultPageSize);
   const pageSizes = [10, 20, 30, 40, 50];
 
-  const { data: visits, currentPage, error, isLoading, totalCount, goTo } = usePaginatedVisits(patientUuid, pageSize);
+  const { visits, currentPage, error, isLoading, totalCount, goTo } = useLightweightVisits(patientUuid, pageSize);
   const { t } = useTranslation();
   const desktopLayout = isDesktop(useLayoutType());
 
@@ -110,6 +112,7 @@ const VisitHistoryTable: React.FC<VisitHistoryTableProps> = ({ patientUuid, pati
                         </TableExpandRow>
                         {row.isExpanded ? (
                           <TableExpandedRow {...getExpandedRowProps({ row })} colSpan={headers.length + 2}>
+                            {/* VisitSummary will fetch full visit data on-demand */}
                             <VisitSummary visit={visit} patientUuid={patientUuid} />
                           </TableExpandedRow>
                         ) : (

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -1,7 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@carbon/react';
+import { Tab, TabList, TabPanel, TabPanels, Tabs, InlineLoading } from '@carbon/react';
 import {
   type Diagnosis,
   DiagnosisTags,
@@ -13,9 +13,12 @@ import {
   useConfig,
   type Visit,
 } from '@openmrs/esm-framework';
+
 import type { ChartConfig } from '../../../config-schema';
 import type { ExternalOverviewProps } from '@openmrs/esm-patient-common-lib';
-import type { Note, Order, OrderItem } from '../visit.resource';
+import type { Note, Order, OrderItem, LightweightVisit } from '../visit.resource';
+import { useFullVisit } from '../visit.resource';
+
 import { encounterHasJsonSchemaForm } from './encounters-table/encounters-table.resource';
 import MedicationSummary from './medications-summary.component';
 import NotesSummary from './notes-summary.component';
@@ -26,53 +29,80 @@ import VisitTimeline from '../single-visit-details/visit-timeline/visit-timeline
 import styles from './visit-summary.scss';
 
 interface VisitSummaryProps {
-  visit: Visit;
+  visit: Visit | LightweightVisit;
   patientUuid: string;
 }
 
 const visitSummaryPanelSlot = 'visit-summary-panels';
+
+/**
+ * Tabs that require full visit data (encounters, obs, orders).
+ * When user navigates to these tabs, we fetch the full visit on-demand.
+ */
+const TABS_REQUIRING_FULL_DATA = new Set([
+  'timeline-tab',
+  'tests-tab',
+  'medications-tab',
+  'completed-forms-tab',
+  'encounters-tab',
+]);
 
 const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
   const config = useConfig<ChartConfig>();
   const { t } = useTranslation();
   const extensions = useAssignedExtensions(visitSummaryPanelSlot);
 
-  const [diagnoses, notes, medications]: [Array<Diagnosis>, Array<Note>, Array<OrderItem>] = useMemo(() => {
-    // Medication Tab
-    const medications: Array<OrderItem> = [];
-    // Diagnoses in a Visit
-    const diagnoses: Array<Diagnosis> = [];
-    // Notes Tab
-    const notes: Array<Note> = [];
+  // Track whether user has requested full data (by clicking a tab that needs it)
+  const [fullDataRequested, setFullDataRequested] = useState(false);
 
-    visit?.encounters?.forEach((enc) => {
-      if (enc.hasOwnProperty('orders')) {
-        medications.push(
-          ...enc.orders.map((order: Order) => ({
-            order,
-            provider: {
-              name: enc.encounterProviders.length ? enc.encounterProviders[0].provider.person.display : '',
-              role: enc.encounterProviders.length ? enc.encounterProviders[0].encounterRole.display : '',
-            },
-          })),
-        );
-      }
+  // On-demand fetch: only fires when fullDataRequested is true
+  const { visit: fullVisit, isLoading: isLoadingFullVisit } = useFullVisit(fullDataRequested ? visit.uuid : null);
 
-      // Check if there is a diagnosis associated with this encounter
-      if (enc.hasOwnProperty('diagnoses')) {
-        if (enc.diagnoses.length > 0) {
-          const validDiagnoses = enc.diagnoses.filter((diagnosis) => !diagnosis.voided);
-          diagnoses.push(...validDiagnoses);
-        }
-      }
+  // Determine which visit object to use for heavy processing
+  const resolvedVisit: Visit | null =
+    fullVisit ?? ('encounters' in visit && visit.encounters ? (visit as Visit) : null);
 
-      // Check for Visit Diagnoses and Notes
-      if (enc.hasOwnProperty('obs')) {
-        enc.obs.forEach((obs) => {
+  // Extract diagnoses from lightweight visit (visit-level) or full visit (encounter-level)
+  const diagnoses: Array<Diagnosis> = useMemo(() => {
+    // Lightweight API: diagnoses at visit level
+    if ('diagnoses' in visit && Array.isArray(visit.diagnoses) && visit.diagnoses.length > 0) {
+      return visit.diagnoses.filter((d) => !d.voided).sort((a, b) => a.rank - b.rank);
+    }
+
+    // Full API: diagnoses nested in encounters
+    if (resolvedVisit?.encounters) {
+      return resolvedVisit.encounters
+        .flatMap((enc) => enc.diagnoses ?? [])
+        .filter((d) => !d.voided)
+        .sort((a, b) => a.rank - b.rank);
+    }
+
+    return [];
+  }, [visit, resolvedVisit]);
+
+  // Extract notes from lightweight visit or full visit
+  const notes: Array<Note> = useMemo(() => {
+    // Lightweight API: notes at visit level
+    if ('notes' in visit && Array.isArray(visit.notes) && visit.notes.length > 0) {
+      return visit.notes.map((note) => ({
+        note: note.value ?? note.display,
+        provider: {
+          name: note.provider?.display ?? '',
+          role: '',
+        },
+        time: note.obsDatetime ? formatTime(parseDate(note.obsDatetime)) : '',
+        concept: { uuid: '', display: '' },
+      }));
+    }
+
+    // Full API: notes from encounter obs
+    if (resolvedVisit?.encounters) {
+      const extractedNotes: Array<Note> = [];
+      resolvedVisit.encounters.forEach((enc) => {
+        enc.obs?.forEach((obs) => {
           if (config.notesConceptUuids?.includes(obs.concept.uuid)) {
-            // Putting all notes in a single array.
-            notes.push({
-              note: obs.value as string, // TODO: add better typing check
+            extractedNotes.push({
+              note: obs.value as string,
               provider: {
                 name: enc.encounterProviders.length ? enc.encounterProviders[0].provider.person.display : '',
                 role: enc.encounterProviders.length ? enc.encounterProviders[0].encounterRole.display : '',
@@ -82,19 +112,40 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
             });
           }
         });
+      });
+      return extractedNotes;
+    }
+
+    return [];
+  }, [visit, resolvedVisit, config.notesConceptUuids]);
+
+  // Medications - only available from full visit
+  const medications: Array<OrderItem> = useMemo(() => {
+    if (!resolvedVisit?.encounters) return [];
+
+    const meds: Array<OrderItem> = [];
+    resolvedVisit.encounters.forEach((enc) => {
+      if (enc.orders) {
+        meds.push(
+          ...enc.orders.map((order: Order) => ({
+            order,
+            provider: {
+              name: enc.encounterProviders.length ? enc.encounterProviders[0].provider.person.display : '',
+              role: enc.encounterProviders.length ? enc.encounterProviders[0].encounterRole.display : '',
+            },
+          })),
+        );
       }
     });
 
-    // Sort the diagnoses by rank, so that primary diagnoses come first
-    diagnoses.sort((a, b) => a.rank - b.rank);
+    meds.sort((a, b) => new Date(b.order.dateActivated).getTime() - new Date(a.order.dateActivated).getTime());
+    return meds;
+  }, [resolvedVisit]);
 
-    // Sort medications by dateActivated DESC (newest first) to align with backend ordering
-    medications.sort((a, b) => new Date(b.order.dateActivated).getTime() - new Date(a.order.dateActivated).getTime());
-
-    return [diagnoses, notes, medications];
-  }, [config.notesConceptUuids, visit?.encounters]);
-
-  const encounterIds = useMemo(() => visit?.encounters?.map((e) => `Encounter/${e.uuid}`) ?? [], [visit?.encounters]);
+  const encounterIds = useMemo(
+    () => resolvedVisit?.encounters?.map((e) => `Encounter/${e.uuid}`) ?? [],
+    [resolvedVisit?.encounters],
+  );
 
   const testsFilter = useMemo<ExternalOverviewProps['filter']>(
     () =>
@@ -104,9 +155,29 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
   );
 
   const hasCompletedForms = useMemo(
-    () => visit?.encounters?.some(encounterHasJsonSchemaForm) ?? false,
-    [visit?.encounters],
+    () => resolvedVisit?.encounters?.some(encounterHasJsonSchemaForm) ?? false,
+    [resolvedVisit?.encounters],
   );
+
+  // Handle tab change - trigger full data fetch when needed
+  const handleTabChange = (evt: { selectedIndex: number }) => {
+    const tabIds = [
+      'timeline-tab',
+      'notes-tab',
+      'tests-tab',
+      'medications-tab',
+      'completed-forms-tab',
+      'encounters-tab',
+    ];
+    const selectedTabId = tabIds[evt.selectedIndex];
+
+    if (TABS_REQUIRING_FULL_DATA.has(selectedTabId) && !fullDataRequested) {
+      setFullDataRequested(true);
+    }
+  };
+
+  // Loading state for tabs that need full data
+  const FullDataLoading = () => <InlineLoading description={t('loadingVisitDetails', 'Loading visit details...')} />;
 
   return (
     <div className={styles.summaryContainer}>
@@ -120,7 +191,7 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
           </p>
         )}
       </div>
-      <Tabs>
+      <Tabs onChange={handleTabChange}>
         <TabList aria-label="Visit summary tabs" className={styles.tablist}>
           <Tab className={classNames(styles.tab, styles.bodyLong01)} id="timeline-tab">
             {t('timeline', 'Timeline')}
@@ -132,23 +203,31 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
           >
             {t('notes', 'Notes')}
           </Tab>
-          <Tab className={styles.tab} id="tests-tab" disabled={encounterIds.length === 0 && config.disableEmptyTabs}>
+          <Tab
+            className={styles.tab}
+            id="tests-tab"
+            disabled={encounterIds.length === 0 && !fullDataRequested && config.disableEmptyTabs}
+          >
             {t('tests', 'Tests')}
           </Tab>
           <Tab
             className={styles.tab}
             id="medications-tab"
-            disabled={medications.length <= 0 && config.disableEmptyTabs}
+            disabled={medications.length <= 0 && !fullDataRequested && config.disableEmptyTabs}
           >
             {t('medications', 'Medications')}
           </Tab>
-          <Tab className={styles.tab} id="completed-forms-tab" disabled={!hasCompletedForms && config.disableEmptyTabs}>
+          <Tab
+            className={styles.tab}
+            id="completed-forms-tab"
+            disabled={!hasCompletedForms && !fullDataRequested && config.disableEmptyTabs}
+          >
             {t('completedForms', 'Completed forms')}
           </Tab>
           <Tab
             className={styles.tab}
             id="encounters-tab"
-            disabled={visit?.encounters.length <= 0 && config.disableEmptyTabs}
+            disabled={!resolvedVisit?.encounters?.length && !fullDataRequested && config.disableEmptyTabs}
           >
             {t('encounters_title', 'Encounters')}
           </Tab>
@@ -163,26 +242,48 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
         </TabList>
         <TabPanels>
           <TabPanel>
-            <VisitTimeline visitUuid={visit.uuid} patientUuid={patientUuid} />
+            {isLoadingFullVisit ? (
+              <FullDataLoading />
+            ) : (
+              <VisitTimeline visitUuid={visit.uuid} patientUuid={patientUuid} />
+            )}
           </TabPanel>
           <TabPanel>
             <NotesSummary notes={notes} />
           </TabPanel>
           <TabPanel>
-            <TestsSummary patientUuid={patientUuid} encounters={visit?.encounters} />
+            {isLoadingFullVisit ? (
+              <FullDataLoading />
+            ) : resolvedVisit ? (
+              <TestsSummary patientUuid={patientUuid} encounters={resolvedVisit.encounters} />
+            ) : (
+              <FullDataLoading />
+            )}
           </TabPanel>
           <TabPanel>
-            <MedicationSummary medications={medications} />
+            {isLoadingFullVisit ? <FullDataLoading /> : <MedicationSummary medications={medications} />}
           </TabPanel>
           <TabPanel>
-            <VisitCompletedFormsTable visit={visit} patientUuid={patientUuid} />
+            {isLoadingFullVisit ? (
+              <FullDataLoading />
+            ) : resolvedVisit ? (
+              <VisitCompletedFormsTable visit={resolvedVisit} patientUuid={patientUuid} />
+            ) : (
+              <FullDataLoading />
+            )}
           </TabPanel>
           <TabPanel>
-            <VisitEncountersTable visit={visit} patientUuid={patientUuid} />
+            {isLoadingFullVisit ? (
+              <FullDataLoading />
+            ) : resolvedVisit ? (
+              <VisitEncountersTable visit={resolvedVisit} patientUuid={patientUuid} />
+            ) : (
+              <FullDataLoading />
+            )}
           </TabPanel>
           <ExtensionSlot name={visitSummaryPanelSlot}>
             <TabPanel>
-              <Extension state={{ patientUuid, visit }} />
+              <Extension state={{ patientUuid, visit: resolvedVisit ?? visit }} />
             </TabPanel>
           </ExtensionSlot>
         </TabPanels>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.test.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
-import { vi, describe, it, expect, test, beforeEach, type Mock } from 'vitest';
+import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { screen, render } from '@testing-library/react';
+import { screen, render, waitFor } from '@testing-library/react';
 import { ExtensionSlot, getConfig, getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
 import { type ChartConfig, esmPatientChartSchema } from '../../../config-schema';
 import { mockPatient } from 'tools';
 import { visitOverviewDetailMockData, visitOverviewDetailMockDataNotEmpty } from '__mocks__';
 import VisitSummary from './visit-summary.component';
+import { useFullVisit } from '../visit.resource';
+
+vi.mock('../visit.resource', async () => ({
+  ...((await vi.importActual('../visit.resource')) as object),
+  useFullVisit: vi.fn(),
+}));
 
 const mockExtensionSlot = ExtensionSlot as Mock;
 const mockGetConfig = vi.mocked(getConfig);
 const mockUseConfig = vi.mocked(useConfig<ChartConfig>);
+const mockUseFullVisit = vi.mocked(useFullVisit);
 const mockVisit = visitOverviewDetailMockData.data.results[0];
 
 describe('VisitSummary', () => {
@@ -21,11 +28,26 @@ describe('VisitSummary', () => {
       notesConceptUuids: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'some-uuid2'],
       visitDiagnosisConceptUuid: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     });
+    mockUseFullVisit.mockReturnValue({
+      visit: null,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    });
   });
 
   it('should display empty state for notes, test and medication summary', async () => {
     const user = userEvent.setup();
     mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
+
+    mockUseFullVisit.mockReturnValue({
+      visit: mockVisit,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    });
 
     render(<VisitSummary patientUuid={mockPatient.id} visit={mockVisit} />);
 
@@ -35,30 +57,36 @@ describe('VisitSummary', () => {
     expect(screen.getByRole('tab', { name: /Tests/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /Notes/i })).toBeInTheDocument();
 
-    //should display notes tab panel
     const notesTab = screen.getByRole('tab', { name: /Notes/i });
-
     await user.click(notesTab);
 
     expect(screen.getByText(/^There are no notes to display for this patient$/)).toBeInTheDocument();
 
-    // should display medication panel
     const medicationTab = screen.getByRole('tab', { name: /Medication/i });
-
     await user.click(medicationTab);
 
-    expect(screen.getByText(/^There are no medications to display for this patient$/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/^There are no medications to display for this patient$/)).toBeInTheDocument();
+    });
 
-    // should display tests panel with test panel extension
     const testsTab = screen.getByRole('tab', { name: /Tests/i });
-
     await user.click(testsTab);
 
-    expect(screen.getByText(/test-results-filtered-overview/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/test-results-filtered-overview/)).toBeInTheDocument();
+    });
   });
 
   it('renders diagnoses tags when there are diagnoses', () => {
     const mockVisit = visitOverviewDetailMockDataNotEmpty.data.results[0];
+
+    mockUseFullVisit.mockReturnValue({
+      visit: mockVisit,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    });
 
     render(<VisitSummary patientUuid={mockPatient.id} visit={mockVisit} />);
 
@@ -75,6 +103,14 @@ describe('VisitSummary', () => {
 
     const mockVisit = visitOverviewDetailMockDataNotEmpty.data.results[0];
 
+    mockUseFullVisit.mockReturnValue({
+      visit: mockVisit,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    });
+
     render(<VisitSummary patientUuid={mockPatient.id} visit={mockVisit} />);
 
     expect(screen.getByText(/^Diagnoses$/i)).toBeInTheDocument();
@@ -84,7 +120,6 @@ describe('VisitSummary', () => {
     expect(screen.getByRole('tab', { name: /Tests/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /Notes/i })).toBeInTheDocument();
 
-    //should display notes tab panel
     const notesTab = screen.getByRole('tab', { name: /Notes/i });
     await user.click(notesTab);
 
@@ -92,14 +127,40 @@ describe('VisitSummary', () => {
     expect(screen.getAllByText(/Admin/i)[0]).toBeInTheDocument();
     expect(screen.getByText(/^Patient seems very unwell$/i)).toBeInTheDocument();
 
-    // should display medication panel
     const medicationTab = screen.getByRole('tab', { name: /Medication/i });
     await user.click(medicationTab);
 
-    // should display tests panel with test panel extension
+    await waitFor(() => {
+      expect(screen.getByRole('tabpanel', { name: /Medication/i })).toBeInTheDocument();
+    });
+
     const testsTab = screen.getByRole('tab', { name: /Tests/i });
     await user.click(testsTab);
 
-    expect(screen.getByText(/test-results-filtered-overview/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/test-results-filtered-overview/)).toBeInTheDocument();
+    });
+  });
+
+  it('should show loading state when full visit data is being fetched', async () => {
+    const user = userEvent.setup();
+
+    mockUseFullVisit.mockReturnValue({
+      visit: null,
+      error: undefined,
+      isLoading: true,
+      isValidating: true,
+      mutate: vi.fn(),
+    });
+
+    render(<VisitSummary patientUuid={mockPatient.id} visit={mockVisit} />);
+
+    const medicationTab = screen.getByRole('tab', { name: /Medication/i });
+    await user.click(medicationTab);
+
+    await waitFor(() => {
+      const loadingElements = screen.getAllByText(/Loading visit details/i);
+      expect(loadingElements.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit-detail-overview.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { vi, describe, it, expect, type Mock } from 'vitest';
+import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getConfig, getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
@@ -7,7 +7,7 @@ import { mockEncounterTypes, visitOverviewDetailMockData } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
 import { esmPatientChartSchema, type ChartConfig } from '../../config-schema';
 import VisitDetailOverview from './visit-detail-overview.component';
-import { usePaginatedVisits } from './visit.resource';
+import { useLightweightVisits, useFullVisit } from './visit.resource';
 import {
   useEncounterTypes,
   usePaginatedEncounters,
@@ -23,8 +23,8 @@ const mockUseAllEncounters = vi.fn(useAllEncounters).mockReturnValue({
   error: undefined,
 } as any);
 
-const mockPaginatedVisitsData: ReturnType<typeof usePaginatedVisits> = {
-  data: visitOverviewDetailMockData.data.results,
+const mockLightweightVisitsData: ReturnType<typeof useLightweightVisits> = {
+  visits: visitOverviewDetailMockData.data.results,
   error: null,
   mutate: vi.fn(),
   isValidating: false,
@@ -42,9 +42,17 @@ const mockPaginatedVisitsData: ReturnType<typeof usePaginatedVisits> = {
 };
 vi.mock('./visit.resource', async () => ({
   ...((await vi.importActual('./visit.resource')) as object),
-  usePaginatedVisits: vi.fn().mockImplementation(() => mockPaginatedVisitsData),
+  useLightweightVisits: vi.fn().mockImplementation(() => mockLightweightVisitsData),
+  useFullVisit: vi.fn().mockReturnValue({
+    visit: null,
+    isLoading: false,
+    error: undefined,
+    isValidating: false,
+    mutate: vi.fn(),
+  }),
 }));
-const mockUsePaginatedVisits = vi.mocked(usePaginatedVisits);
+const mockUseLightweightVisits = vi.mocked(useLightweightVisits);
+const mockUseFullVisit = vi.mocked(useFullVisit);
 
 const mockUsePaginatedEncounters = vi.fn(usePaginatedEncounters).mockReturnValue({
   error: null,
@@ -84,10 +92,20 @@ vi.mock('./past-visits-components/encounters-table/encounters-table.resource', a
 }));
 
 describe('VisitDetailOverview', () => {
+  beforeEach(() => {
+    mockUseFullVisit.mockReturnValue({
+      visit: visitOverviewDetailMockData.data.results[0],
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+      mutate: vi.fn(),
+    });
+  });
+
   it('renders an empty state view if encounters data is unavailable', async () => {
-    mockUsePaginatedVisits.mockReturnValueOnce({
-      ...mockPaginatedVisitsData,
-      data: [],
+    mockUseLightweightVisits.mockReturnValueOnce({
+      ...mockLightweightVisitsData,
+      visits: [],
     });
     mockGetConfig.mockResolvedValue({ htmlFormEntryForms: [] });
 
@@ -95,7 +113,6 @@ describe('VisitDetailOverview', () => {
 
     await waitForLoadingToFinish();
 
-    // visits table view
     expect(screen.getByRole('heading', { name: /past visits/i })).toBeInTheDocument();
     expect(screen.getAllByTitle(/Empty data illustration/i)[0]).toBeInTheDocument();
     expect(screen.getAllByText(/There are no visits to display for this patient/i)[0]).toBeInTheDocument();
@@ -109,9 +126,9 @@ describe('VisitDetailOverview', () => {
         statusText: 'Unauthorized',
       },
     };
-    mockUsePaginatedVisits.mockReturnValue({
-      ...mockPaginatedVisitsData,
-      data: null,
+    mockUseLightweightVisits.mockReturnValue({
+      ...mockLightweightVisitsData,
+      visits: null,
       error,
     });
 
@@ -119,7 +136,6 @@ describe('VisitDetailOverview', () => {
 
     await waitForLoadingToFinish();
 
-    // visits table view
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
     expect(screen.getAllByText(/visits/i)[0]).toBeInTheDocument();
     expect(screen.getByText(/Error State/i)).toBeInTheDocument();
@@ -132,7 +148,7 @@ describe('VisitDetailOverview', () => {
       ...getDefaultsFromConfigSchema(esmPatientChartSchema),
       showAllEncountersTab: true,
     });
-    mockUsePaginatedVisits.mockReturnValue(mockPaginatedVisitsData);
+    mockUseLightweightVisits.mockReturnValue(mockLightweightVisitsData);
 
     renderWithSwr(<VisitDetailOverview patientUuid={mockPatient.id} patient={mockPatient} />);
 
@@ -168,7 +184,7 @@ describe('VisitDetailOverview', () => {
       ...getDefaultsFromConfigSchema(esmPatientChartSchema),
       showAllEncountersTab: false,
     });
-    mockUsePaginatedVisits.mockReturnValue(mockPaginatedVisitsData);
+    mockUseLightweightVisits.mockReturnValue(mockLightweightVisitsData);
 
     renderWithSwr(<VisitDetailOverview patientUuid={mockPatient.id} patient={mockPatient} />);
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/visit.resource.tsx
@@ -6,9 +6,43 @@ import {
   useOpenmrsInfinite,
   useOpenmrsPagination,
 } from '@openmrs/esm-framework';
+import useSWR from 'swr';
 
 const customRepresentation =
   'custom:(uuid,location,encounters:(uuid,diagnoses:(uuid,display,rank,diagnosis,voided),form:(uuid,display,name,description,encounterType,version,resources:(uuid,display,name,valueReference)),encounterDatetime,orders:full,obs:(uuid,concept:(uuid,display,conceptClass:(uuid,display)),display,groupMembers:(uuid,concept:(uuid,display),value:(uuid,display),display),value,obsDatetime),encounterType:(uuid,display,viewPrivilege,editPrivilege),encounterProviders:(uuid,display,encounterRole:(uuid,display),provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient,attributes:(attributeType:ref,display,uuid,value)';
+
+/**
+ * Lightweight visit hook that fetches only basic visit details, diagnoses, and notes.
+ * Used for the initial UI load to improve performance.
+ * Uses the custom emrapi endpoint introduced in EA-207.
+ */
+export function useLightweightVisits(patientUuid: string, pageSize: number = 10) {
+  const url = patientUuid
+    ? new URL(`${window.openmrsBase}${restBaseUrl}/emrapi/patient/${patientUuid}/visit`, window.location.toString())
+    : null;
+
+  const { data, mutate, ...rest } = useOpenmrsPagination<LightweightVisit>(url, pageSize);
+
+  return { visits: data, mutate, ...rest };
+}
+
+/**
+ * On-demand hook to fetch full visit details (encounters, obs, orders, etc.)
+ * Only fetches when visitUuid is provided (i.e., when user clicks Tests/Medications/Encounters tabs).
+ */
+export function useFullVisit(visitUuid: string | null) {
+  const url = visitUuid ? `${restBaseUrl}/visit/${visitUuid}?v=${customRepresentation}` : null;
+
+  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: Visit }>(url, openmrsFetch);
+
+  return {
+    visit: data?.data ?? null,
+    error,
+    isLoading,
+    isValidating,
+    mutate,
+  };
+}
 
 export function useInfiniteVisits(
   patientUuid: string,
@@ -16,7 +50,7 @@ export function useInfiniteVisits(
   rep: string = customRepresentation,
 ) {
   const url = new URL(
-    `${window.openmrsBase}/${restBaseUrl}/visit?patient=${patientUuid}&v=${rep}`,
+    `${window.openmrsBase}${restBaseUrl}/visit?patient=${patientUuid}&v=${rep}`,
     window.location.toString(),
   );
   for (const key in params) {
@@ -34,7 +68,7 @@ export function usePaginatedVisits(
   params: Record<string, number | string> = {},
 ) {
   const url = new URL(
-    `${window.openmrsBase}/${restBaseUrl}/visit?patient=${patientUuid}&v=${customRepresentation}`,
+    `${window.openmrsBase}${restBaseUrl}/visit?patient=${patientUuid}&v=${customRepresentation}`,
     window.location.toString(),
   );
   for (const key in params) {
@@ -60,6 +94,34 @@ export function restoreVisit(visitUuid: string) {
     method: 'POST',
     body: { voided: false },
   });
+}
+
+// ============ Types ============
+
+export interface LightweightVisit {
+  uuid: string;
+  startDatetime: string;
+  stopDatetime: string | null;
+  visitType: {
+    uuid: string;
+    name: string;
+    display: string;
+  };
+  location: OpenmrsResource;
+  patient: OpenmrsResource;
+  diagnoses: Diagnosis[];
+  notes: LightweightNote[];
+}
+
+export interface LightweightNote {
+  uuid: string;
+  display: string;
+  value: string;
+  obsDatetime: string;
+  provider?: {
+    uuid: string;
+    display: string;
+  };
 }
 
 export interface Order {

--- a/packages/esm-patient-chart-app/translations/en.json
+++ b/packages/esm-patient-chart-app/translations/en.json
@@ -91,6 +91,7 @@
   "indication": "Indication",
   "inThePast": "In the past",
   "loading": "Loading",
+  "loadingVisitDetails": "Loading visit details...",
   "markAliveSuccessfully": "Patient marked alive successfully",
   "markDeceasedSuccessfully": "Patient marked deceased successfully",
   "markDeceasedWarning": "Marking the patient as deceased updates this patient's death information",


### PR DESCRIPTION
…data fetching

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
Integrates the custom emrapi endpoint for fetching visits with only essential data needed for the initial UI load. This significantly reduces payload size and improves page performance.

### Problem
The current visit-fetching mechanism loads all visit data upfront (encounters, obs, orders, diagnoses, forms) via a heavy custom REST representation. For patients with many visits, this results in large payloads (~150KB+) and slow initial renders.

### Solution
Implements a two-phase loading strategy:
1. **Initial load (lightweight):** Uses `/rest/v1/emrapi/patient/{patientUuid}/visit` which returns only basic visit details, diagnoses, and notes — enough to render the visit list immediately.
2. **On-demand loading (full):** When a user expands a visit and clicks Tests, Medications, or Encounters tabs, the full visit data is fetched. SWR handles deduplication — switching between tabs does not trigger additional API calls.

## Related Issue
https://openmrs.atlassian.net/browse/O3-4508

## Screenshots
<!-- Required if you are making UI changes. -->

## Other
<!-- Anything not covered above -->
