### PR TITLE
(fix) O3-5691: Persist medication renewals with action=RENEW

### DIFF
--- a/packages/esm-patient-medications-app/src/api/api.ts
+++ b/packages/esm-patient-medications-app/src/api/api.ts
@@ -176,7 +176,7 @@ export const prepMedicationOrderPostData: PostDataPrepFunction = (
     };
   } else if (order.action === 'RENEW') {
     return {
-      action: 'NEW',
+      action: 'RENEW',
       previousOrder: order.previousOrder,
       patient: patientUuid,
       type: 'drugorder',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

When the clinician clicks **Renew** on a medication tile, `prepMedicationOrderPostData` was rewriting the basket item's `action: 'RENEW'` to `action: 'NEW'` before POSTing to `/encounter`. The resulting `DrugOrder` was persisted with `order_action='NEW'` and `previous_order_id` set, instead of `order_action='RENEW'`.

This change flips the one constant at `api.ts:179` so the user-selected action is preserved end-to-end:

- Renewals in the database carry `order_action='RENEW'`, making renewals distinguishable from prospective new orders without joining on `previous_order_id`.
- The FHIR API's existing `RENEW → basedOn` branch in `MedicationRequestTranslatorImpl` now fires for O3-placed renewals, so external consumers can walk the chain. Once [FM2-680](https://openmrs.atlassian.net/browse/FM2-680) lands, the canonical `priorPrescription` field will also populate.
- The wiki's "internal translation in O3" gotcha [Order Entry in O3: A PM Reference](https://openmrs.atlassian.net/wiki/spaces/docs/pages/1031766039/Order+Entry+in+O3+A+PM+Reference) goes away for new renewals.

### Backend behaviour

Verified against my local distro running O3 v3.6.0:

- `OrderServiceImpl.saveOrder` treats `action=NEW` (with `previousOrder` set) and `action=RENEW` identically for the save path — same auto-stop logic (neither stops the previous order), same orderable-match check, same active-orders ambiguity check. The rewrite was never satisfying a backend constraint.
- End-to-end renewal placed via the patched UI lands as `ORD-393 RENEW previous=392`, original keeps running. FHIR returns `basedOn: [{ reference, identifier: "ORD-392" }]`.

## Screenshots

<img width="635" height="299" alt="Screenshot 2026-05-14 at 16 03 12" src="https://github.com/user-attachments/assets/e78ad363-1a4a-49ae-a641-3facb96cf68f" />

## Related Issue

https://openmrs.atlassian.net/browse/O3-5691

Also related:
- [FM2-680](https://openmrs.atlassian.net/browse/FM2-680) — FHIR translator populates `priorPrescription` for any order with `previousOrder`. Complementary fix on the backend side.
- [O3-5169](https://openmrs.atlassian.net/browse/O3-5169) / #2949 — the PR that originally introduced the rewrite.

## Other

### Note for implementations

Reports or dashboards filtering on `order_action='NEW'` will start excluding renewals after this change. Implementations that rely on the previous behaviour can adjust to `order_action IN ('NEW','RENEW')`. Historical renewals placed before this fix remain stored as `order_action='NEW'` with `previous_order_id` set.

### Follow-up not addressed here

1. `packages/esm-patient-orders-app/src/order-basket/general-order-type/resources.ts:32-46` has a similar pattern for non-drug orders. Its NEW-or-RENEW branch doesn't include `previousOrder` at all — a deeper, separate bug worth its own ticket.

2. [FM2-680](https://openmrs.atlassian.net/browse/FM2-680)

[FM2-680]: https://openmrs.atlassian.net/browse/FM2-680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ