### PR TITLE
(fix) O3-5653: Wire body site and status concepts in config schema

### DIFF
--- a/packages/esm-patient-procedures-app/src/config-schema.ts
+++ b/packages/esm-patient-procedures-app/src/config-schema.ts
@@ -32,12 +32,12 @@ export const configSchema = {
     _type: Type.UUID,
     _description:
       'Value used to constrain the body-site concept search. Its meaning is determined by `bodySiteConceptSourceType`. For `Concept classs`, provide the concept class name.',
-    _default: '8d491c7a-c2cc-11de-8d13-0010c6dffd0f',
+    _default: '8d491c7a-c2cc-11de-8d13-0010c6dffd0f', // Anatomy concept class
   },
   bodySiteConceptSourceType: {
     _type: Type.String,
     _description: sourceTypeDescription,
-    _default: 'Concept set',
+    _default: 'Concept class',
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
   // TODO: Update the following value once the concept set is available for procedure status, currently using

--- a/packages/esm-patient-procedures-app/src/config-schema.ts
+++ b/packages/esm-patient-procedures-app/src/config-schema.ts
@@ -40,16 +40,17 @@ export const configSchema = {
     _default: 'conceptClass',
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
+  // TODO: Update the following value once the procedure-status concept set is available.
   statusConceptUuid: {
     _type: Type.UUID,
     _description:
       'UUID used to constrain the procedure-status concept search. Its meaning is determined by `statusConceptSourceType`.',
-    _default: '167157AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    _default: '365b8d02-2786-4ac4-a8b6-2bb4f22e4bc2',
   },
   statusConceptSourceType: {
     _type: Type.String,
     _description: sourceTypeDescription,
-    _default: 'conceptSet',
+    _default: 'answerTo',
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
   durationUnitConceptUuid: {

--- a/packages/esm-patient-procedures-app/src/config-schema.ts
+++ b/packages/esm-patient-procedures-app/src/config-schema.ts
@@ -28,7 +28,7 @@ export const configSchema = {
     _default: 'Concept class',
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
-  bodySiteConceptSource: {
+  bodySiteConceptUuid: {
     _type: Type.UUID,
     _description:
       'Value used to constrain the body-site concept search. Its meaning is determined by `bodySiteConceptSourceType`. For `Concept classs`, provide the concept class name.',

--- a/packages/esm-patient-procedures-app/src/config-schema.ts
+++ b/packages/esm-patient-procedures-app/src/config-schema.ts
@@ -29,29 +29,27 @@ export const configSchema = {
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
   bodySiteConceptUuid: {
-    _type: Type.UUID,
+    _type: Type.String,
     _description:
-      'UUID used to constrain the body-site concept search. Its meaning is determined by `bodySiteConceptSourceType`.',
-    _default: '',
+      'UUID or concept class name used to constrain the body-site concept search. Its meaning is determined by `bodySiteConceptSourceType`.',
+    _default: 'Anatomy',
   },
   bodySiteConceptSourceType: {
     _type: Type.String,
     _description: sourceTypeDescription,
-    _default: 'any',
+    _default: 'conceptClass',
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
-  // TODO: Update the following value once the concept set is available, currently using
-  //  https://app.openconceptlab.org/#/orgs/CIEL/sources/CIEL/concepts/168857/ for demo
   statusConceptUuid: {
     _type: Type.UUID,
     _description:
       'UUID used to constrain the procedure-status concept search. Its meaning is determined by `statusConceptSourceType`.',
-    _default: '365b8d02-2786-4ac4-a8b6-2bb4f22e4bc2',
+    _default: '167157AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   },
   statusConceptSourceType: {
     _type: Type.String,
     _description: sourceTypeDescription,
-    _default: 'answerTo',
+    _default: 'conceptSet',
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
   durationUnitConceptUuid: {

--- a/packages/esm-patient-procedures-app/src/config-schema.ts
+++ b/packages/esm-patient-procedures-app/src/config-schema.ts
@@ -1,13 +1,13 @@
 import { Type, validators } from '@openmrs/esm-framework';
 
-export const conceptSourceTypes = ['conceptClass', 'conceptSet', 'answerTo', 'any'] as const;
+export const conceptSourceTypes = ['Concept class', 'Concept set', 'Answer to', 'any'] as const;
 export type ConceptSourceType = (typeof conceptSourceTypes)[number];
 
 const sourceTypeDescription =
   'How the paired UUID filters concept search results: ' +
-  '"conceptClass" filters by concept class (REST `class`); ' +
-  '"conceptSet" returns set members (REST `memberOf`); ' +
-  '"answerTo" returns answers to the given coded question (REST `answerTo`); ' +
+  '"Concept class" filters by concept class (REST `class`); ' +
+  '"Concept set" returns set members (REST `memberOf`); ' +
+  '"Answer to" returns answers to the given coded question (REST `answerTo`); ' +
   '"any" ignores the UUID and searches all concepts.';
 
 export const configSchema = {
@@ -25,32 +25,33 @@ export const configSchema = {
   procedureConceptSourceType: {
     _type: Type.String,
     _description: sourceTypeDescription,
-    _default: 'conceptClass',
+    _default: 'Concept class',
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
-  bodySiteConceptUuid: {
+  bodySiteConceptSource: {
     _type: Type.UUID,
     _description:
-      'UUID used to constrain the body-site concept search. Its meaning is determined by `bodySiteConceptSourceType`.',
+      'Value used to constrain the body-site concept search. Its meaning is determined by `bodySiteConceptSourceType`. For `Concept classs`, provide the concept class name.',
     _default: '8d491c7a-c2cc-11de-8d13-0010c6dffd0f',
   },
   bodySiteConceptSourceType: {
     _type: Type.String,
     _description: sourceTypeDescription,
-    _default: 'conceptClass',
+    _default: 'Concept set',
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
-  // TODO: Update the following value once the procedure-status concept set is available.
+  // TODO: Update the following value once the concept set is available for procedure status, currently using
+  // https://app.openconceptlab.org/#/orgs/CIEL/sources/CIEL/concepts/167157/ (Medication dispense status)
   statusConceptUuid: {
     _type: Type.UUID,
     _description:
       'UUID used to constrain the procedure-status concept search. Its meaning is determined by `statusConceptSourceType`.',
-    _default: '365b8d02-2786-4ac4-a8b6-2bb4f22e4bc2',
+    _default: '167157AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   },
   statusConceptSourceType: {
     _type: Type.String,
     _description: sourceTypeDescription,
-    _default: 'answerTo',
+    _default: 'Concept set',
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
   durationUnitConceptUuid: {
@@ -62,7 +63,7 @@ export const configSchema = {
   durationUnitConceptSourceType: {
     _type: Type.String,
     _description: sourceTypeDescription,
-    _default: 'answerTo',
+    _default: 'Answer to',
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
 };

--- a/packages/esm-patient-procedures-app/src/config-schema.ts
+++ b/packages/esm-patient-procedures-app/src/config-schema.ts
@@ -29,10 +29,10 @@ export const configSchema = {
     _validators: [validators.oneOf(conceptSourceTypes)],
   },
   bodySiteConceptUuid: {
-    _type: Type.String,
+    _type: Type.UUID,
     _description:
-      'UUID or concept class name used to constrain the body-site concept search. Its meaning is determined by `bodySiteConceptSourceType`.',
-    _default: 'Anatomy',
+      'UUID used to constrain the body-site concept search. Its meaning is determined by `bodySiteConceptSourceType`.',
+    _default: '8d491c7a-c2cc-11de-8d13-0010c6dffd0f',
   },
   bodySiteConceptSourceType: {
     _type: Type.String,

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-form.component.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-form.component.tsx
@@ -128,14 +128,25 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
     { uuid: bodySiteConceptUuid, sourceType: bodySiteConceptSourceType },
     getValues('bodySite'),
   );
-  const { searchResults: statusOptions } = useConceptSearch('', {
+  const { searchResults: rawStatusOptions } = useConceptSearch('', {
     uuid: statusConceptUuid,
     sourceType: statusConceptSourceType,
   });
-  const { searchResults: durationUnitOptions } = useConceptSearch('', {
+  const statusOptions = useMemo(() => {
+    const map = new Map<string, ConceptReference>();
+    rawStatusOptions.forEach((option) => map.set(option.uuid, option));
+    return Array.from(map.values());
+  }, [rawStatusOptions]);
+
+  const { searchResults: rawDurationUnitOptions } = useConceptSearch('', {
     uuid: durationUnitConceptUuid,
     sourceType: durationUnitConceptSourceType,
   });
+  const durationUnitOptions = useMemo(() => {
+    const map = new Map<string, ConceptReference>();
+    rawDurationUnitOptions.forEach((option) => map.set(option.uuid, option));
+    return Array.from(map.values());
+  }, [rawDurationUnitOptions]);
 
   const [errorSaving, setErrorSaving] = useState(null);
 

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-form.component.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-form.component.tsx
@@ -128,29 +128,15 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
     { uuid: bodySiteConceptUuid, sourceType: bodySiteConceptSourceType },
     getValues('bodySite'),
   );
-  const { searchResults: rawStatusOptions } = useConceptSearch('', {
+  const { searchResults: statusOptions } = useConceptSearch('', {
     uuid: statusConceptUuid,
     sourceType: statusConceptSourceType,
   });
-  // Deduplicate results by UUID. The OpenMRS REST API can sometimes return duplicate concepts in searches.
-  // This prevents Carbon ComboBox from throwing key errors.
-  const statusOptions = useMemo(() => {
-    const map = new Map<string, ConceptReference>();
-    rawStatusOptions.forEach((option) => map.set(option.uuid, option));
-    return Array.from(map.values());
-  }, [rawStatusOptions]);
 
-  const { searchResults: rawDurationUnitOptions } = useConceptSearch('', {
+  const { searchResults: durationUnitOptions } = useConceptSearch('', {
     uuid: durationUnitConceptUuid,
     sourceType: durationUnitConceptSourceType,
   });
-
-  // Deduplicate duration unit results identically to statusOptions above
-  const durationUnitOptions = useMemo(() => {
-    const map = new Map<string, ConceptReference>();
-    rawDurationUnitOptions.forEach((option) => map.set(option.uuid, option));
-    return Array.from(map.values());
-  }, [rawDurationUnitOptions]);
 
   const [errorSaving, setErrorSaving] = useState(null);
 

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-form.component.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-form.component.tsx
@@ -132,6 +132,8 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
     uuid: statusConceptUuid,
     sourceType: statusConceptSourceType,
   });
+  // Deduplicate results by UUID. The OpenMRS REST API can sometimes return duplicate concepts in searches.
+  // This prevents Carbon ComboBox from throwing key errors.
   const statusOptions = useMemo(() => {
     const map = new Map<string, ConceptReference>();
     rawStatusOptions.forEach((option) => map.set(option.uuid, option));
@@ -142,6 +144,8 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
     uuid: durationUnitConceptUuid,
     sourceType: durationUnitConceptSourceType,
   });
+
+  // Deduplicate duration unit results identically to statusOptions above
   const durationUnitOptions = useMemo(() => {
     const map = new Map<string, ConceptReference>();
     rawDurationUnitOptions.forEach((option) => map.set(option.uuid, option));

--- a/packages/esm-patient-procedures-app/src/procedures/procedures.resource.ts
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures.resource.ts
@@ -12,9 +12,9 @@ import {
 export type ConceptSource = { uuid: string; sourceType: ConceptSourceType };
 
 const sourceTypeToRestParam: Record<Exclude<ConceptSourceType, 'any'>, string> = {
-  conceptClass: 'class',
-  conceptSet: 'memberOf',
-  answerTo: 'answerTo',
+  'Concept class': 'class',
+  'Concept set': 'memberOf',
+  'Answer to': 'answerTo',
 };
 
 function buildConceptSearchUrl(query: string, source: ConceptSource): string {

--- a/packages/esm-patient-procedures-app/src/procedures/procedures.resource.ts
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures.resource.ts
@@ -31,21 +31,21 @@ function buildConceptSearchUrl(query: string, source: ConceptSource): string {
 
 export function useProcedureTypes() {
   const url = `${restBaseUrl}/proceduretype?v=full`;
-  const { data, error, isLoading } = useSWR<{ data: ProcedureTypeApiResponse }, Error>(url, openmrsFetch);
-  return { procedureTypes: data?.data?.results ?? [], isLoading, error };
+  const { data, isLoading } = useSWR<{ data: ProcedureTypeApiResponse }, Error>(url, openmrsFetch);
+  return { procedureTypes: data?.data?.results ?? [], isLoading };
 }
 
 export function useConceptSearch(query: string, source: ConceptSource) {
   const hasSourceFilter = Boolean(source.uuid) && source.sourceType !== 'any';
   const url = query || hasSourceFilter ? buildConceptSearchUrl(query, source) : null;
-  const { data, error, isLoading } = useSWR<{ data: { results: ConceptReference[] } }, Error>(url, openmrsFetch);
+  const { data, isLoading } = useSWR<{ data: { results: ConceptReference[] } }, Error>(url, openmrsFetch);
 
   const results = data?.data?.results ?? [];
 
   // TODO: RESTWS-1035: Currently the API returns duplicated results, remove the following once the bug is fixed
   const uniqueSearchResults = Array.from(new Map(results.map((concept) => [concept.uuid, concept])).values());
 
-  return { searchResults: uniqueSearchResults, isSearching: isLoading, error };
+  return { searchResults: uniqueSearchResults, isSearching: isLoading };
 }
 
 export async function saveProcedure(payload: RawProcedure) {

--- a/packages/esm-patient-procedures-app/src/procedures/procedures.resource.ts
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures.resource.ts
@@ -32,14 +32,20 @@ function buildConceptSearchUrl(query: string, source: ConceptSource): string {
 export function useProcedureTypes() {
   const url = `${restBaseUrl}/proceduretype?v=full`;
   const { data, error, isLoading } = useSWR<{ data: ProcedureTypeApiResponse }, Error>(url, openmrsFetch);
-  return { procedureTypes: data?.data?.results ?? [], isLoading };
+  return { procedureTypes: data?.data?.results ?? [], isLoading, error };
 }
 
 export function useConceptSearch(query: string, source: ConceptSource) {
   const hasSourceFilter = Boolean(source.uuid) && source.sourceType !== 'any';
   const url = query || hasSourceFilter ? buildConceptSearchUrl(query, source) : null;
   const { data, error, isLoading } = useSWR<{ data: { results: ConceptReference[] } }, Error>(url, openmrsFetch);
-  return { searchResults: data?.data?.results ?? [], isSearching: isLoading };
+
+  const results = data?.data?.results ?? [];
+
+  // TODO: RESTWS-1035: Currently the API returns duplicated results, remove the following once the bug is fixed
+  const uniqueSearchResults = Array.from(new Map(results.map((concept) => [concept.uuid, concept])).values());
+
+  return { searchResults: uniqueSearchResults, isSearching: isLoading, error };
 }
 
 export async function saveProcedure(payload: RawProcedure) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR is for wire the `bodySiteConceptUuid` and the `statusConceptUuid` in the config schema.

## Screenshots
<!-- Required if you are making UI changes. -->
1. Body site
<img width="564" height="238" alt="Screenshot 2026-05-15 at 10 14 25" src="https://github.com/user-attachments/assets/17ceb9a5-4155-4926-9c9d-d55fe45b4d09" />

2. Status
<img width="564" height="303" alt="Screenshot 2026-05-15 at 10 14 34" src="https://github.com/user-attachments/assets/d3bc685f-a868-4101-921e-d04baeb82aee" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-5653

## Other
<!-- Anything not covered above -->
N/A