### PR TITLE
(fix) Lower task list backend dependency

### DIFF
--- a/packages/esm-patient-task-list-app/src/routes.json
+++ b/packages/esm-patient-task-list-app/src/routes.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.openmrs.org/routes.schema.json",
   "backendDependencies": {
-    "tasks": ">=2.0.0",
+    "tasks": ">=1.1.0-SNAPSHOT",
     "webservices.rest": ">=3.1.0"
   },
   "modals": [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Lowers the patient task list app backend dependency from the unreleased `tasks >=2.0.0` requirement to `tasks >=1.1.0-SNAPSHOT`. Reviewing `openmrs-module-tasks` showed that `1.1.0-SNAPSHOT` is the published backend version that supports the current rationale payload shape in `activity.detail.reasonCode`.

This keeps the frontend dependency metadata aligned with the backend module that is available to the reference application distro. It also unblocks adding `@openmrs/esm-patient-task-list-app` to the core E2E environment in openmrs/openmrs-esm-core#1779, where implementer tools currently reports the unsatisfied `tasks >=2.0.0` requirement as an unresolved backend dependency toast.

## Screenshots

## Related Issue

## Other