### PR TITLE
(feat) O3-4677: Make visit note encounter detection configurable

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -59,6 +59,14 @@ export const esmPatientChartSchema = {
     },
     _default: ['162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'],
   },
+  visitNoteEncounterTypes: {
+    _type: Type.Array,
+    _elements: {
+      _type: Type.String,
+    },
+    _default: ['Visit Note'],
+    _description: 'Encounter type names that should be treated as visit notes for encounter edit flows.',
+  },
   obsConceptUuidsToHide: {
     _type: Type.Array,
     _elements: {
@@ -204,6 +212,7 @@ export interface ChartConfig {
     src: string;
   };
   notesConceptUuids: string[];
+  visitNoteEncounterTypes: Array<string>;
   offlineVisitTypeUuid: string;
   restrictByVisitLocationTag: boolean;
   showAllEncountersTab: boolean;

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.component.tsx
@@ -86,7 +86,8 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
   const responsiveSize = desktopLayout ? 'sm' : 'lg';
   const { data: encounterTypes, isLoading: isLoadingEncounterTypes } = useEncounterTypes();
   const enableEmbeddedFormView = useFeatureFlag('enable-embedded-form-view');
-  const { encounterEditableDuration, encounterEditableDurationOverridePrivileges } = useConfig<ChartConfig>();
+  const { encounterEditableDuration, encounterEditableDurationOverridePrivileges, visitNoteEncounterTypes } =
+    useConfig<ChartConfig>();
   const [isPrinting, setIsPrinting] = useState(false);
 
   const paginatedMappedEncounters = useMemo(
@@ -253,7 +254,7 @@ const EncountersTable: React.FC<EncountersTableProps> = ({
                     if (!encounter) return null;
 
                     const isVisitNoteEncounter = (encounter: MappedEncounter) =>
-                      encounter.encounterType === 'Visit Note' && !encounter.form;
+                      visitNoteEncounterTypes.includes(encounter.encounterType) && !encounter.form;
 
                     const supportsEmbeddedFormView = (encounter: MappedEncounter) =>
                       encounter.form?.uuid &&

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/encounters-table/encounters-table.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import {
   ExtensionSlot,
   getDefaultsFromConfigSchema,
+  launchWorkspace2,
   showModal,
   useConfig,
   useFeatureFlag,
@@ -42,6 +43,7 @@ const mockUserHasAccess = vi.mocked(userHasAccess).mockReturnValue(true);
 const mockUseFeatureFlag = vi.mocked(useFeatureFlag);
 const mockExtensionSlot = vi.mocked(ExtensionSlot);
 const mockUsePatientChartStore = vi.mocked(usePatientChartStore);
+const mockLaunchWorkspace2 = vi.mocked(launchWorkspace2);
 
 const mockUseEncounterTypes = vi.fn(useEncounterTypes).mockReturnValue({
   data: mockEncounterTypes,
@@ -205,6 +207,60 @@ describe('EncountersTable', () => {
         patient: mockFhirPatient,
       }),
     );
+  });
+
+  it('uses visitNoteEncounterTypes config for edit workspace routing', async () => {
+    const user = userEvent.setup();
+    mockUseConfig.mockImplementation((options) => {
+      if (options?.externalModuleName === '@openmrs/esm-patient-forms-app') {
+        return { htmlFormEntryForms: [] };
+      }
+      return {
+        ...(getDefaultsFromConfigSchema(esmPatientChartSchema) as ChartConfig),
+        visitNoteEncounterTypes: ['Custom Visit Note Type'],
+      };
+    });
+    mockUserHasAccess.mockImplementation((privilege) => privilege == null);
+
+    const customVisitNoteEncounter = {
+      ...mockEncountersAlice[1],
+      encounterType: {
+        ...mockEncountersAlice[1].encounterType,
+        display: 'Custom Visit Note Type',
+      },
+      form: null,
+    };
+
+    const formBackedEncounter = mockEncountersAlice[0];
+
+    renderEncountersTable({
+      paginatedEncounters: [customVisitNoteEncounter, formBackedEncounter],
+      totalCount: 2,
+    });
+
+    const customVisitNoteRow = screen.getByRole('row', {
+      name: /03-Aug-2021, 12:47 AM Facility Visit Custom Visit Note Type -- User One Options/i,
+    });
+    await user.click(within(customVisitNoteRow).getByRole('button', { name: /expand current row/i }));
+    const expandedCustomVisitNoteRow = customVisitNoteRow.nextElementSibling as HTMLElement;
+    await user.click(within(expandedCustomVisitNoteRow).getByRole('button', { name: /edit this encounter/i }));
+
+    const formBackedEncounterRow = screen.getByRole('row', {
+      name: /18-Jan-2022, 04:25 PM Facility Visit Admission POC Consent Form -- Options/i,
+    });
+    await user.click(within(formBackedEncounterRow).getByRole('button', { name: /expand current row/i }));
+    const expandedFormBackedEncounterRow = formBackedEncounterRow.nextElementSibling as HTMLElement;
+    await user.click(within(expandedFormBackedEncounterRow).getByRole('button', { name: /edit this encounter/i }));
+
+    expect(mockLaunchWorkspace2).toHaveBeenCalledWith('visit-notes-form-workspace', {
+      encounter: expect.objectContaining({ encounterType: 'Custom Visit Note Type' }),
+      formContext: 'editing',
+      patientUuid: mockPatientAlice.uuid,
+    });
+    expect(mockLaunchWorkspace2).toHaveBeenCalledWith('patient-form-entry-workspace', {
+      form: expect.objectContaining({ display: 'POC Consent Form' }),
+      encounterUuid: formBackedEncounter.uuid,
+    });
   });
 });
 

--- a/packages/esm-patient-notes-app/src/config-schema.ts
+++ b/packages/esm-patient-notes-app/src/config-schema.ts
@@ -17,6 +17,15 @@ export const configSchema = {
     _default: '165095AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     _description: 'The concept UUID for storing sticky notes as observations',
   },
+  visitNoteEncounterTypes: {
+    _type: Type.Array,
+    _elements: {
+      _type: Type.String,
+    },
+    _default: ['Visit Note'],
+    _description:
+      'Encounter type names that should be treated as visit notes in visit note workflows (for example edit flow).',
+  },
   visitNoteConfig: notesConfigSchema,
 };
 
@@ -24,5 +33,6 @@ export interface ConfigObject {
   diagnosisConceptClass: string;
   isPrimaryDiagnosisRequired: boolean;
   stickyNoteConceptUuid: string;
+  visitNoteEncounterTypes: Array<string>;
   visitNoteConfig: VisitNoteConfigObject;
 }


### PR DESCRIPTION
## Requirements
- [x] I have filled in the PR template below
- [x] I have linked the related issue
- [x] My change is backward compatible via default config
- [x] I added/updated tests for this change

## Summary
This PR removes hardcoded visit note encounter type detection from the encounter edit flow and makes it configurable through app config.

Previously, visit note encounters were detected using:
`encounter.encounterType === 'Visit Note'`

Now detection is config-driven:
`visitNoteEncounterTypes.includes(encounter.encounterType)`

Implemented changes:
- Added `visitNoteEncounterTypes` config with default `['Visit Note']` in:
  - `packages/esm-patient-notes-app/src/config-schema.ts`
  - `packages/esm-patient-chart-app/src/config-schema.ts`
- Updated typings to include `visitNoteEncounterTypes: string[]`
- Replaced hardcoded visit note check in encounters table edit flow with config-driven logic
- Added focused regression test for config-driven workspace routing

## Screenshots
N/A (no visual UI changes; behavior/config update only)

## Related Issue
Fixes https://issues.openmrs.org/browse/O3-4677

## Other
### Backward compatibility
Preserved via default:
`visitNoteEncounterTypes: ['Visit Note']`

### Validation
- Added unit coverage for config-driven edit routing behavior in encounters table tests
- Manual verification recommended:
  - Visit notes still render correctly
  - Edit visit note flow still opens `visit-notes-form-workspace`
  - Non-visit-note encounters continue to open `patient-form-entry-workspace`
  - No regressions in retrospective data entry workflows