### PR TITLE
(fix) O3-5707: Relaunch patient chart workspace group when visit context changes

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.test.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.test.ts
@@ -1,0 +1,113 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { launchWorkspaceGroup2, usePatient, useVisit, type Visit } from '@openmrs/esm-framework';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
+import { mockFhirPatient } from '__mocks__';
+import { usePatientChartPatientAndVisit } from './patient-chart.resources';
+
+// TODO: remove once openmrs-esm-core ships launchWorkspaceGroup2 in the framework mock
+vi.mock('@openmrs/esm-framework', async () => {
+  const actual = (await vi.importActual('@openmrs/esm-framework')) as object;
+  return { ...actual, launchWorkspaceGroup2: vi.fn() };
+});
+
+vi.mock('@openmrs/esm-patient-common-lib', () => ({
+  usePatientChartStore: vi.fn(),
+}));
+
+const mockLaunchWorkspaceGroup = vi.mocked(launchWorkspaceGroup2);
+const mockUsePatient = vi.mocked(usePatient);
+const mockUseVisit = vi.mocked(useVisit);
+const mockUsePatientChartStore = vi.mocked(usePatientChartStore);
+
+const mutateVisitContext = vi.fn();
+const setPatient = vi.fn();
+const setVisitContext = vi.fn();
+
+const visitA = { uuid: 'visit-a', patient: { uuid: mockFhirPatient.id } } as Visit;
+const visitB = { uuid: 'visit-b', patient: { uuid: mockFhirPatient.id } } as Visit;
+
+describe('usePatientChartPatientAndVisit', () => {
+  beforeEach(() => {
+    mockLaunchWorkspaceGroup.mockResolvedValue(true);
+    mockUsePatient.mockReturnValue({
+      isLoading: false,
+      patient: mockFhirPatient,
+      patientUuid: mockFhirPatient.id,
+      error: null,
+    });
+    mockUsePatientChartStore.mockReturnValue({
+      patientUuid: mockFhirPatient.id,
+      patient: mockFhirPatient,
+      visitContext: null,
+      mutateVisitContext: null,
+      setPatient,
+      setVisitContext,
+    });
+  });
+
+  it('relaunches the patient-chart workspace group when the visit context changes', async () => {
+    let activeVisit = visitA;
+    mockUseVisit.mockImplementation(() => ({
+      activeVisit,
+      mutate: mutateVisitContext,
+      isValidating: false,
+      error: null,
+      currentVisit: null,
+      currentVisitIsRetrospective: false,
+      isLoading: false,
+    }));
+
+    const { rerender } = renderHook(() => usePatientChartPatientAndVisit(mockFhirPatient.id));
+
+    await waitFor(() => expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(1));
+    expect(mockLaunchWorkspaceGroup).toHaveBeenLastCalledWith(
+      'patient-chart',
+      expect.objectContaining({
+        patient: mockFhirPatient,
+        patientUuid: mockFhirPatient.id,
+        visitContext: visitA,
+        mutateVisitContext,
+      }),
+    );
+
+    activeVisit = visitB;
+    rerender();
+
+    await waitFor(() => expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(2));
+    expect(mockLaunchWorkspaceGroup).toHaveBeenLastCalledWith(
+      'patient-chart',
+      expect.objectContaining({
+        patient: mockFhirPatient,
+        patientUuid: mockFhirPatient.id,
+        visitContext: visitB,
+        mutateVisitContext,
+      }),
+    );
+  });
+
+  it('does not relaunch when the same visit UUID is returned with new object references', async () => {
+    let activeVisit: Visit = visitA;
+    mockUseVisit.mockImplementation(() => ({
+      activeVisit,
+      mutate: mutateVisitContext,
+      isValidating: false,
+      error: null,
+      currentVisit: null,
+      currentVisitIsRetrospective: false,
+      isLoading: false,
+    }));
+
+    const { rerender } = renderHook(() => usePatientChartPatientAndVisit(mockFhirPatient.id));
+
+    await waitFor(() => expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(1));
+
+    // Same UUID, new object reference — mimics SWR revalidation
+    activeVisit = { ...visitA, stopDatetime: '2026-05-26T00:00:00.000Z' } as Visit;
+    rerender();
+
+    // Wait for the effect to fire before asserting the launch count didn't increase
+    await waitFor(() => expect(setVisitContext).toHaveBeenCalledTimes(2));
+    expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
@@ -1,15 +1,16 @@
 import { useEffect, useMemo, useRef } from 'react';
 import useSWR from 'swr';
 import {
-  closeWorkspaceGroup2,
   launchWorkspaceGroup2,
   openmrsFetch,
   restBaseUrl,
+  showSnackbar,
   usePatient,
   useVisit,
   type Visit,
 } from '@openmrs/esm-framework';
 import { type PatientWorkspaceGroupProps, usePatientChartStore } from '@openmrs/esm-patient-common-lib';
+import { useTranslation } from 'react-i18next';
 
 const defaultVisitCustomRepresentation =
   'custom:(uuid,display,voided,indication,startDatetime,stopDatetime,' +
@@ -49,6 +50,7 @@ export function useVisitByUuid(visitUuid: string | null, representation: string 
  * @returns
  */
 export function usePatientChartPatientAndVisit(patientUuid: string) {
+  const { t } = useTranslation();
   const { isLoading: isLoadingPatient, patient } = usePatient(patientUuid);
   const {
     patientUuid: storePatientUuid,
@@ -58,7 +60,7 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
     setVisitContext,
   } = usePatientChartStore(patientUuid);
 
-  const isVisitContextValid = visitContext && visitContext.patient.uuid === patientUuid;
+  const isVisitContextValid = visitContext?.patient.uuid === patientUuid;
   const {
     visit: newVisitContext,
     mutate: newMutateVisitContext,
@@ -70,10 +72,11 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
     mutate: mutateActiveVisit,
   } = useVisit(isVisitContextValid ? null : patientUuid);
 
-  const isWorkspaceGroupLaunched = useRef(false);
   const launchedVisitContextUuid = useRef<string | null | undefined>(undefined);
+  const isWorkspaceGroupLaunchPending = useRef(false);
 
   useEffect(() => {
+    let cancelled = false;
     const initializeWorkspaceGroup = async () => {
       if (!isValidatingVisitContext && !isValidatingActiveVisit && patient) {
         let groupProps: PatientWorkspaceGroupProps = null;
@@ -105,17 +108,35 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
         const visitContextUuid = groupProps.visitContext?.uuid ?? null;
         const visitContextChanged = visitContextUuid !== launchedVisitContextUuid.current;
 
-        if (!isWorkspaceGroupLaunched.current || visitContextChanged) {
-          const launched = await launchWorkspaceGroup2('patient-chart', groupProps);
-          if (launched) {
-            isWorkspaceGroupLaunched.current = true;
-            launchedVisitContextUuid.current = visitContextUuid;
+        if (visitContextChanged && !isWorkspaceGroupLaunchPending.current) {
+          isWorkspaceGroupLaunchPending.current = true;
+          try {
+            const launched = await launchWorkspaceGroup2('patient-chart', groupProps);
+            if (cancelled) {
+              return;
+            }
+
+            if (launched) {
+              launchedVisitContextUuid.current = visitContextUuid;
+            }
+          } finally {
+            isWorkspaceGroupLaunchPending.current = false;
           }
         }
       }
     };
+    initializeWorkspaceGroup().catch((error) => {
+      showSnackbar({
+        title: t('errorLaunchingWorkspaceGroup', 'Error launching workspace group'),
+        subtitle: error.message,
+        kind: 'error',
+        isLowContrast: false,
+      })
+    });
 
-    initializeWorkspaceGroup();
+    return () => {
+      cancelled = true;
+    };
   }, [
     newVisitContext,
     isValidatingVisitContext,
@@ -125,8 +146,8 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
     isValidatingActiveVisit,
     storePatientUuid,
     mutateActiveVisit,
-    isWorkspaceGroupLaunched,
     patient,
+    t
   ]);
 
   useEffect(() => {

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import {
   launchWorkspaceGroup2,
@@ -10,7 +11,6 @@ import {
   type Visit,
 } from '@openmrs/esm-framework';
 import { type PatientWorkspaceGroupProps, usePatientChartStore } from '@openmrs/esm-patient-common-lib';
-import { useTranslation } from 'react-i18next';
 
 const defaultVisitCustomRepresentation =
   'custom:(uuid,display,voided,indication,startDatetime,stopDatetime,' +
@@ -77,6 +77,7 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
 
   useEffect(() => {
     let cancelled = false;
+
     const initializeWorkspaceGroup = async () => {
       if (!isValidatingVisitContext && !isValidatingActiveVisit && patient) {
         let groupProps: PatientWorkspaceGroupProps = null;
@@ -125,13 +126,14 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
         }
       }
     };
+
     initializeWorkspaceGroup().catch((error) => {
       showSnackbar({
         title: t('errorLaunchingWorkspaceGroup', 'Error launching workspace group'),
         subtitle: error.message,
         kind: 'error',
         isLowContrast: false,
-      })
+      });
     });
 
     return () => {
@@ -147,7 +149,7 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
     storePatientUuid,
     mutateActiveVisit,
     patient,
-    t
+    t,
   ]);
 
   useEffect(() => {

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
@@ -74,42 +74,48 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
   const launchedVisitContextUuid = useRef<string | null | undefined>(undefined);
 
   useEffect(() => {
-    if (!isValidatingVisitContext && !isValidatingActiveVisit && patient) {
-      let groupProps: PatientWorkspaceGroupProps = null;
-      if (activeVisit) {
-        groupProps = {
-          patientUuid: patient.id,
-          patient,
-          visitContext: activeVisit,
-          mutateVisitContext: mutateActiveVisit,
-        };
-      } else if (newVisitContext) {
-        groupProps = {
-          patientUuid: patient.id,
-          patient,
-          visitContext: newVisitContext,
-          mutateVisitContext: newMutateVisitContext,
-        };
-      } else {
-        groupProps = {
-          patientUuid: patient.id,
-          patient,
-          visitContext: null,
-          mutateVisitContext: null,
-        };
+    const initializeWorkspaceGroup = async () => {
+      if (!isValidatingVisitContext && !isValidatingActiveVisit && patient) {
+        let groupProps: PatientWorkspaceGroupProps = null;
+        if (activeVisit) {
+          groupProps = {
+            patientUuid: patient.id,
+            patient,
+            visitContext: activeVisit,
+            mutateVisitContext: mutateActiveVisit,
+          };
+        } else if (newVisitContext) {
+          groupProps = {
+            patientUuid: patient.id,
+            patient,
+            visitContext: newVisitContext,
+            mutateVisitContext: newMutateVisitContext,
+          };
+        } else {
+          groupProps = {
+            patientUuid: patient.id,
+            patient,
+            visitContext: null,
+            mutateVisitContext: null,
+          };
+        }
+
+        setVisitContext(groupProps.visitContext, groupProps.mutateVisitContext);
+
+        const visitContextUuid = groupProps.visitContext?.uuid ?? null;
+        const visitContextChanged = visitContextUuid !== launchedVisitContextUuid.current;
+
+        if (!isWorkspaceGroupLaunched.current || visitContextChanged) {
+          const launched = await launchWorkspaceGroup2('patient-chart', groupProps);
+          if (launched) {
+            isWorkspaceGroupLaunched.current = true;
+            launchedVisitContextUuid.current = visitContextUuid;
+          }
+        }
       }
+    };
 
-      setVisitContext(groupProps.visitContext, groupProps.mutateVisitContext);
-
-      const visitContextUuid = groupProps.visitContext?.uuid ?? null;
-      const visitContextChanged = visitContextUuid !== launchedVisitContextUuid.current;
-
-      if (!isWorkspaceGroupLaunched.current || visitContextChanged) {
-        launchWorkspaceGroup2('patient-chart', groupProps);
-        isWorkspaceGroupLaunched.current = true;
-        launchedVisitContextUuid.current = visitContextUuid;
-      }
-    }
+    initializeWorkspaceGroup();
   }, [
     newVisitContext,
     isValidatingVisitContext,

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
@@ -71,6 +71,7 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
   } = useVisit(isVisitContextValid ? null : patientUuid);
 
   const isWorkspaceGroupLaunched = useRef(false);
+  const launchedVisitContextUuid = useRef<string | null | undefined>(undefined);
 
   useEffect(() => {
     if (!isValidatingVisitContext && !isValidatingActiveVisit && patient) {
@@ -100,9 +101,13 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
 
       setVisitContext(groupProps.visitContext, groupProps.mutateVisitContext);
 
-      if (!isWorkspaceGroupLaunched.current) {
+      const visitContextUuid = groupProps.visitContext?.uuid ?? null;
+      const visitContextChanged = visitContextUuid !== launchedVisitContextUuid.current;
+
+      if (!isWorkspaceGroupLaunched.current || visitContextChanged) {
         launchWorkspaceGroup2('patient-chart', groupProps);
         isWorkspaceGroupLaunched.current = true;
+        launchedVisitContextUuid.current = visitContextUuid;
       }
     }
   }, [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue where the `patient-chart workspace` group kept stale `groupProps` after the visit context changed.

Previously, the workspace group was launched only once on mount using a boolean ref. If the visit context later changed — for example when a visit ended or a new one started — the patient chart store was updated but `launchWorkspaceGroup2` was never called again, causing workspaces opened from the patient chart to receive stale visit props.

This change tracks the UUID of the last successfully launched visit context and relaunches the workspace group whenever that UUID changes. The launch state is only recorded after `launchWorkspaceGroup2` returns true, so a user declining to close unsaved workspaces does not suppress future re-launch attempts.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
