### PR TITLE
(fix) O3-5707: Workspace group launch state updated even on failed launch

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
@@ -101,8 +101,12 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
       setVisitContext(groupProps.visitContext, groupProps.mutateVisitContext);
 
       if (!isWorkspaceGroupLaunched.current) {
-        launchWorkspaceGroup2('patient-chart', groupProps);
-        isWorkspaceGroupLaunched.current = true;
+        (async () => {
+          const launchSucceeded = await launchWorkspaceGroup2('patient-chart', groupProps);
+          if (launchSucceeded) {
+            isWorkspaceGroupLaunched.current = true;
+          }
+        })();
       }
     }
   }, [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
I updated the launchWorkspaceGroup2 call to properly await inside a async function and ensure the system waits for the launch result before proceeding.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/issues?filter=-6&selectedIssue=O3-5707

## Other
<!-- Anything not covered above -->
