### PR TITLE
(fix) Relaunch workspace group with latest visit when context changes mid-flight

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.test.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.test.ts
@@ -29,6 +29,7 @@ const visitB = { uuid: 'visit-b', patient: { uuid: mockFhirPatient.id } } as Vis
 
 describe('usePatientChartPatientAndVisit', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mockLaunchWorkspaceGroup.mockResolvedValue(true);
     mockUsePatient.mockReturnValue({
       isLoading: false,
@@ -109,5 +110,46 @@ describe('usePatientChartPatientAndVisit', () => {
     // Wait for the effect to fire before asserting the launch count didn't increase
     await waitFor(() => expect(setVisitContext).toHaveBeenCalledTimes(2));
     expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it('launches the latest visit context after a previous launch resolves', async () => {
+    let activeVisit = visitA;
+    let resolveFirstLaunch!: (value: boolean) => void;
+    const firstLaunch = new Promise<boolean>((resolve) => {
+      resolveFirstLaunch = resolve;
+    });
+
+    mockLaunchWorkspaceGroup.mockReturnValueOnce(firstLaunch).mockResolvedValue(true);
+    mockUseVisit.mockImplementation(() => ({
+      activeVisit,
+      mutate: mutateVisitContext,
+      isValidating: false,
+      error: null,
+      currentVisit: null,
+      currentVisitIsRetrospective: false,
+      isLoading: false,
+    }));
+
+    const { rerender } = renderHook(() => usePatientChartPatientAndVisit(mockFhirPatient.id));
+
+    await waitFor(() => expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(1));
+    expect(mockLaunchWorkspaceGroup).toHaveBeenLastCalledWith(
+      'patient-chart',
+      expect.objectContaining({ visitContext: visitA }),
+    );
+
+    activeVisit = visitB;
+    rerender();
+
+    await waitFor(() => expect(setVisitContext).toHaveBeenCalledTimes(2));
+    expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(1);
+
+    resolveFirstLaunch(true);
+
+    await waitFor(() => expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(2));
+    expect(mockLaunchWorkspaceGroup).toHaveBeenLastCalledWith(
+      'patient-chart',
+      expect.objectContaining({ visitContext: visitB }),
+    );
   });
 });

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.test.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.test.ts
@@ -26,6 +26,33 @@ const setVisitContext = vi.fn();
 
 const visitA = { uuid: 'visit-a', patient: { uuid: mockFhirPatient.id } } as Visit;
 const visitB = { uuid: 'visit-b', patient: { uuid: mockFhirPatient.id } } as Visit;
+const patientB = { ...mockFhirPatient, id: 'patient-b' };
+
+function mockNoActiveVisitForPatientSwitch() {
+  mockUsePatient.mockImplementation((patientUuid) => ({
+    isLoading: false,
+    patient: patientUuid === patientB.id ? patientB : mockFhirPatient,
+    patientUuid,
+    error: null,
+  }));
+  mockUseVisit.mockImplementation(() => ({
+    activeVisit: null,
+    mutate: mutateVisitContext,
+    isValidating: false,
+    error: null,
+    currentVisit: null,
+    currentVisitIsRetrospective: false,
+    isLoading: false,
+  }));
+  mockUsePatientChartStore.mockImplementation((patientUuid) => ({
+    patientUuid,
+    patient: patientUuid === patientB.id ? patientB : mockFhirPatient,
+    visitContext: null,
+    mutateVisitContext: null,
+    setPatient,
+    setVisitContext,
+  }));
+}
 
 describe('usePatientChartPatientAndVisit', () => {
   beforeEach(() => {
@@ -110,6 +137,62 @@ describe('usePatientChartPatientAndVisit', () => {
     // Wait for the effect to fire before asserting the launch count didn't increase
     await waitFor(() => expect(setVisitContext).toHaveBeenCalledTimes(2));
     expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it('relaunches when the patient changes and neither patient has an active visit', async () => {
+    mockNoActiveVisitForPatientSwitch();
+
+    const { rerender } = renderHook(({ patientUuid }) => usePatientChartPatientAndVisit(patientUuid), {
+      initialProps: { patientUuid: mockFhirPatient.id },
+    });
+
+    await waitFor(() => expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(1));
+    expect(mockLaunchWorkspaceGroup).toHaveBeenLastCalledWith(
+      'patient-chart',
+      expect.objectContaining({ patientUuid: mockFhirPatient.id, visitContext: null }),
+    );
+
+    rerender({ patientUuid: patientB.id });
+
+    await waitFor(() => expect(setVisitContext).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(2));
+    expect(mockLaunchWorkspaceGroup).toHaveBeenLastCalledWith(
+      'patient-chart',
+      expect.objectContaining({ patientUuid: patientB.id, visitContext: null }),
+    );
+  });
+
+  it('launches the latest patient after a previous launch resolves', async () => {
+    let patientUuid = mockFhirPatient.id;
+    let resolveFirstLaunch!: (value: boolean) => void;
+    const firstLaunch = new Promise<boolean>((resolve) => {
+      resolveFirstLaunch = resolve;
+    });
+
+    mockLaunchWorkspaceGroup.mockReturnValueOnce(firstLaunch).mockResolvedValue(true);
+    mockNoActiveVisitForPatientSwitch();
+
+    const { rerender } = renderHook(() => usePatientChartPatientAndVisit(patientUuid));
+
+    await waitFor(() => expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(1));
+    expect(mockLaunchWorkspaceGroup).toHaveBeenLastCalledWith(
+      'patient-chart',
+      expect.objectContaining({ patientUuid: mockFhirPatient.id, visitContext: null }),
+    );
+
+    patientUuid = patientB.id;
+    rerender();
+
+    await waitFor(() => expect(setVisitContext).toHaveBeenCalledTimes(2));
+    expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(1);
+
+    resolveFirstLaunch(true);
+
+    await waitFor(() => expect(mockLaunchWorkspaceGroup).toHaveBeenCalledTimes(2));
+    expect(mockLaunchWorkspaceGroup).toHaveBeenLastCalledWith(
+      'patient-chart',
+      expect.objectContaining({ patientUuid: patientB.id, visitContext: null }),
+    );
   });
 
   it('launches the latest visit context after a previous launch resolves', async () => {

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
@@ -24,6 +24,23 @@ const defaultVisitCustomRepresentation =
   'attributes:(uuid,display,attributeType:(name,datatypeClassname,uuid),value),' +
   'location:(uuid,name,display))';
 
+type WorkspaceGroupLaunchKey = {
+  patientUuid: string | null;
+  visitContextUuid: string | null;
+};
+
+// The workspace group is current only when it was launched for this patient and visit context.
+function getWorkspaceGroupLaunchKey(groupProps: PatientWorkspaceGroupProps | null): WorkspaceGroupLaunchKey {
+  return {
+    patientUuid: groupProps?.patientUuid ?? null,
+    visitContextUuid: groupProps?.visitContext?.uuid ?? null,
+  };
+}
+
+function workspaceGroupLaunchKeysEqual(a: WorkspaceGroupLaunchKey | null, b: WorkspaceGroupLaunchKey | null) {
+  return a?.patientUuid === b?.patientUuid && a?.visitContextUuid === b?.visitContextUuid;
+}
+
 export function useVisitByUuid(visitUuid: string | null, representation: string = defaultVisitCustomRepresentation) {
   const url = `${restBaseUrl}/visit/${visitUuid}?v=${representation}`;
   const { data, ...rest } = useSWR<{ data: Visit }>(visitUuid ? url : null, openmrsFetch);
@@ -72,9 +89,8 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
     mutate: mutateActiveVisit,
   } = useVisit(isVisitContextValid ? null : patientUuid);
 
-  // undefined = not yet launched; null = launched with no active visit
-  const launchedVisitContextUuid = useRef<string | null | undefined>(undefined);
-  const latestWorkspaceGroupProps = useRef<PatientWorkspaceGroupProps>(null);
+  const launchedWorkspaceGroupKey = useRef<WorkspaceGroupLaunchKey | null>(null);
+  const latestWorkspaceGroupProps = useRef<PatientWorkspaceGroupProps | null>(null);
   const isWorkspaceGroupLaunchPending = useRef(false);
   const isMounted = useRef(false);
 
@@ -96,11 +112,15 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
       let needsLaunch = true;
       while (needsLaunch) {
         const groupProps = latestWorkspaceGroupProps.current;
-        const visitContextUuid = groupProps?.visitContext?.uuid ?? null;
+        const launchKey = getWorkspaceGroupLaunchKey(groupProps);
 
-        if (visitContextUuid === launchedVisitContextUuid.current) {
+        if (workspaceGroupLaunchKeysEqual(launchKey, launchedWorkspaceGroupKey.current)) {
           needsLaunch = false;
           continue;
+        }
+
+        if (!isMounted.current) {
+          return;
         }
 
         const launched = await launchWorkspaceGroup2('patient-chart', groupProps);
@@ -109,15 +129,16 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
           return;
         }
 
+        // launchWorkspaceGroup2 returns false when the user keeps the current workspace group open.
         if (!launched) {
           needsLaunch = false;
           continue;
         }
 
-        launchedVisitContextUuid.current = visitContextUuid;
+        launchedWorkspaceGroupKey.current = launchKey;
 
-        const latestVisitContextUuid = latestWorkspaceGroupProps.current?.visitContext?.uuid ?? null;
-        if (latestVisitContextUuid === launchedVisitContextUuid.current) {
+        const latestLaunchKey = getWorkspaceGroupLaunchKey(latestWorkspaceGroupProps.current);
+        if (workspaceGroupLaunchKeysEqual(latestLaunchKey, launchedWorkspaceGroupKey.current)) {
           needsLaunch = false;
         }
       }

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
@@ -72,9 +72,18 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
     mutate: mutateActiveVisit,
   } = useVisit(isVisitContextValid ? null : patientUuid);
 
+  // undefined = not yet launched; null = launched with no active visit
   const launchedVisitContextUuid = useRef<string | null | undefined>(undefined);
   const latestWorkspaceGroupProps = useRef<PatientWorkspaceGroupProps>(null);
   const isWorkspaceGroupLaunchPending = useRef(false);
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   const launchLatestWorkspaceGroup = useCallback(async () => {
     if (isWorkspaceGroupLaunchPending.current) {
@@ -95,6 +104,10 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
         }
 
         const launched = await launchWorkspaceGroup2('patient-chart', groupProps);
+
+        if (!isMounted.current) {
+          return;
+        }
 
         if (!launched) {
           needsLaunch = false;

--- a/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
+++ b/packages/esm-patient-chart-app/src/patient-chart/patient-chart.resources.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import {
@@ -73,11 +73,47 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
   } = useVisit(isVisitContextValid ? null : patientUuid);
 
   const launchedVisitContextUuid = useRef<string | null | undefined>(undefined);
+  const latestWorkspaceGroupProps = useRef<PatientWorkspaceGroupProps>(null);
   const isWorkspaceGroupLaunchPending = useRef(false);
 
-  useEffect(() => {
-    let cancelled = false;
+  const launchLatestWorkspaceGroup = useCallback(async () => {
+    if (isWorkspaceGroupLaunchPending.current) {
+      return;
+    }
 
+    isWorkspaceGroupLaunchPending.current = true;
+
+    try {
+      let needsLaunch = true;
+      while (needsLaunch) {
+        const groupProps = latestWorkspaceGroupProps.current;
+        const visitContextUuid = groupProps?.visitContext?.uuid ?? null;
+
+        if (visitContextUuid === launchedVisitContextUuid.current) {
+          needsLaunch = false;
+          continue;
+        }
+
+        const launched = await launchWorkspaceGroup2('patient-chart', groupProps);
+
+        if (!launched) {
+          needsLaunch = false;
+          continue;
+        }
+
+        launchedVisitContextUuid.current = visitContextUuid;
+
+        const latestVisitContextUuid = latestWorkspaceGroupProps.current?.visitContext?.uuid ?? null;
+        if (latestVisitContextUuid === launchedVisitContextUuid.current) {
+          needsLaunch = false;
+        }
+      }
+    } finally {
+      isWorkspaceGroupLaunchPending.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
     const initializeWorkspaceGroup = async () => {
       if (!isValidatingVisitContext && !isValidatingActiveVisit && patient) {
         let groupProps: PatientWorkspaceGroupProps = null;
@@ -106,24 +142,8 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
 
         setVisitContext(groupProps.visitContext, groupProps.mutateVisitContext);
 
-        const visitContextUuid = groupProps.visitContext?.uuid ?? null;
-        const visitContextChanged = visitContextUuid !== launchedVisitContextUuid.current;
-
-        if (visitContextChanged && !isWorkspaceGroupLaunchPending.current) {
-          isWorkspaceGroupLaunchPending.current = true;
-          try {
-            const launched = await launchWorkspaceGroup2('patient-chart', groupProps);
-            if (cancelled) {
-              return;
-            }
-
-            if (launched) {
-              launchedVisitContextUuid.current = visitContextUuid;
-            }
-          } finally {
-            isWorkspaceGroupLaunchPending.current = false;
-          }
-        }
+        latestWorkspaceGroupProps.current = groupProps;
+        await launchLatestWorkspaceGroup();
       }
     };
 
@@ -136,9 +156,7 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
       });
     });
 
-    return () => {
-      cancelled = true;
-    };
+    return () => {};
   }, [
     newVisitContext,
     isValidatingVisitContext,
@@ -150,6 +168,7 @@ export function usePatientChartPatientAndVisit(patientUuid: string) {
     mutateActiveVisit,
     patient,
     t,
+    launchLatestWorkspaceGroup,
   ]);
 
   useEffect(() => {

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.workspace.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSWRConfig } from 'swr';
-import { launchWorkspaceGroup2, useVisit, type Visit } from '@openmrs/esm-framework';
+import { useVisit, type Visit } from '@openmrs/esm-framework';
 import {
   invalidateVisitByUuid,
   type PatientWorkspace2DefinitionProps,
@@ -41,13 +41,6 @@ const VisitForm: React.FC<PatientWorkspace2DefinitionProps<VisitFormProps, {}>> 
     const mutateSavedOrUpdatedVisit = () => invalidateVisitByUuid(globalMutate, visit.uuid);
     mutateActiveVisit();
     setVisitContext?.(visit, mutateSavedOrUpdatedVisit);
-
-    launchWorkspaceGroup2('patient-chart', {
-      patient,
-      patientUuid,
-      visitContext: visit,
-      mutateVisitContext: mutateSavedOrUpdatedVisit,
-    });
   };
   return (
     <ExportedVisitForm


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Builds on #3332. After that fix landed, a secondary issue remained: if the visit context changed *while* a workspace group launch was already in progress, the in-flight launch would complete with stale props and no relaunch would follow.

This PR replaces the inline async logic in `usePatientChartPatientAndVisit` with a `launchLatestWorkspaceGroup` callback that uses a while loop to re-read `latestWorkspaceGroupProps` after each resolved launch. If props changed while a launch was pending, the loop picks up the latest visit context and relaunches immediately — no separate effect run needed.

Also removes the redundant `launchWorkspaceGroup2` call from `VisitForm`. That call was a holdover from before the hook handled relaunching reactively; keeping it caused a double-launch on visit save.

## Screenshots

## Related Issue

https://openmrs.atlassian.net/browse/O3-5707

## Other

Adds a regression test that directly exercises the mid-flight race: holds the first launch via a controlled promise, changes the active visit while it's pending, resolves the first launch, and asserts the while loop picks up the latest visit and relaunches.