### PR TITLE
(feat) O3-5713: Add severity-based styling for allergens 

### DIFF
--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.component.tsx
@@ -13,9 +13,10 @@ import {
   TableHeader,
   TableRow,
 } from '@carbon/react';
-import { AddIcon, formatDate, launchWorkspace2, parseDate, useLayoutType } from '@openmrs/esm-framework';
+import { AddIcon, formatDate, launchWorkspace2, parseDate, useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { CardHeader, EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { patientAllergiesFormWorkspace } from '../constants';
+import { type AllergiesConfigObject } from '../config-schema';
 import { useAllergies } from './allergy-intolerance.resource';
 import { AllergiesActionMenu } from './allergies-action-menu.component';
 import styles from './allergies-detailed-summary.scss';
@@ -28,6 +29,7 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
   const { t } = useTranslation();
   const layout = useLayoutType();
   const { allergies, error, isLoading, isValidating } = useAllergies(patient.id);
+  const { severityStyleMap, enableSeverityBackgroundColoring } = useConfig<AllergiesConfigObject>();
   const isTablet = layout === 'tablet';
   const isDesktop = layout === 'small-desktop' || layout === 'large-desktop';
   const displayText = t('allergyIntolerances', 'allergy intolerances');
@@ -48,16 +50,51 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
     },
   ];
 
+  const getReactionSeverityClassName = useCallback(
+    (severity?: string) => {
+      const normalizedSeverity = severity?.toLowerCase();
+      const styleLevel = normalizedSeverity ? severityStyleMap?.[normalizedSeverity] : undefined;
+
+      if (styleLevel === 'high') {
+        return styles.allergySeverityHigh;
+      }
+
+      if (styleLevel === 'moderate') {
+        return styles.allergySeverityModerate;
+      }
+
+      if (styleLevel === 'low') {
+        return styles.allergySeverityLow;
+      }
+
+      return undefined;
+    },
+    [severityStyleMap],
+  );
+
   const tableRows = useMemo(
     () =>
       allergies?.map((allergy) => ({
         ...allergy,
+        display: (
+          <div
+            className={[
+              styles.cell,
+              getReactionSeverityClassName(allergy.reactionSeverity),
+              enableSeverityBackgroundColoring ? styles.withSeverityBackground : undefined,
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            {allergy.display ?? '--'}
+          </div>
+        ),
         lastUpdated: allergy.lastUpdated ? formatDate(parseDate(allergy.lastUpdated), { time: false }) : '--',
         note: allergy?.note ?? '--',
         reaction: allergy.reactionManifestations?.sort((a, b) => a.localeCompare(b))?.join(', ') ?? '--',
         reactionSeverity: t(allergy.reactionSeverity) ?? '--',
       })),
-    [allergies, t],
+    [allergies, enableSeverityBackgroundColoring, getReactionSeverityClassName, t],
   );
 
   if (isLoading) {
@@ -105,7 +142,12 @@ const AllergiesDetailedSummary: React.FC<AllergiesDetailedSummaryProps> = ({ pat
                   {rows.map((row) => (
                     <TableRow key={row.id}>
                       {row.cells.map((cell) => (
-                        <TableCell key={cell.id}>{cell.value?.content ?? cell.value}</TableCell>
+                        <TableCell
+                          key={cell.id}
+                          className={cell.info.header === 'display' ? styles.allergenCell : undefined}
+                        >
+                          {cell.value?.content ?? cell.value}
+                        </TableCell>
                       ))}
                       <TableCell className="cds--table-column-menu">
                         <AllergiesActionMenu

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.scss
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.scss
@@ -1,4 +1,6 @@
 @use '@carbon/type';
+@use '@carbon/layout';
+@use '@carbon/colors';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
 .widgetCard {
@@ -14,6 +16,35 @@
 
 .allergySeverityHigh {
   font-weight: 800;
+}
+
+.cell {
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding-top: 0.4375rem;
+  padding-bottom: 0.375rem;
+  padding-left: layout.$spacing-05;
+  padding-right: layout.$spacing-05;
+}
+
+.allergenCell {
+  padding: 0 !important;
+}
+
+.withSeverityBackground.allergySeverityHigh {
+  background-color: colors.$red-20 !important;
+  border-top: 1px solid colors.$red-20-hover !important;
+}
+
+.withSeverityBackground.allergySeverityModerate {
+  background-color: colors.$orange-20 !important;
+  border-top: 1px solid colors.$orange-20-hover !important;
+}
+
+.withSeverityBackground.allergySeverityLow {
+  background-color: colors.$yellow-10 !important;
+  border-top: 1px solid colors.$yellow-10-hover !important;
 }
 
 .tableHeader {

--- a/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
+++ b/packages/esm-patient-allergies-app/src/allergies/allergies-detailed-summary.test.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
-import { vi, describe, it, expect, type Mock } from 'vitest';
+import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
 import { screen } from '@testing-library/react';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, openmrsFetch, useConfig } from '@openmrs/esm-framework';
 import { ErrorState } from '@openmrs/esm-patient-common-lib';
 import { mockFhirAllergyIntoleranceResponse } from '__mocks__';
 import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
+import { type AllergiesConfigObject, configSchema } from '../config-schema';
 import AllergiesDetailedSummary from './allergies-detailed-summary.component';
+import styles from './allergies-detailed-summary.scss';
 
 const mockOpenmrsFetch = openmrsFetch as Mock;
+const mockUseConfig = vi.mocked(useConfig<AllergiesConfigObject>);
 mockOpenmrsFetch.mockImplementation(vi.fn());
 
 describe('AllergiesDetailedSummary', () => {
+  beforeEach(() => {
+    mockUseConfig.mockReturnValue(getDefaultsFromConfigSchema(configSchema));
+  });
+
   it('renders an empty state view if allergy data is unavailable', async () => {
     mockOpenmrsFetch.mockReturnValueOnce({ data: { entry: [] } });
     renderWithSwr(<AllergiesDetailedSummary patient={mockPatient} />);
@@ -72,5 +79,67 @@ describe('AllergiesDetailedSummary', () => {
 
     const expectedNonCodedAllergy = /non-coded allergen severe non-coded allergic reaction non coded allergic note/i;
     expect(screen.getByRole('row', { name: new RegExp(expectedNonCodedAllergy) })).toBeInTheDocument();
+  });
+
+  it('uses configured severity-style mapping for allergen styling', async () => {
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(configSchema),
+      severityStyleMap: {
+        severe: 'low',
+        moderate: 'moderate',
+        mild: 'high',
+      },
+    });
+    mockOpenmrsFetch.mockReturnValueOnce({ data: mockFhirAllergyIntoleranceResponse });
+    renderWithSwr(<AllergiesDetailedSummary patient={mockPatient} />);
+    await waitForLoadingToFinish();
+
+    const severeAllergen = screen.getByText(/penicillins/i);
+    expect(severeAllergen).toHaveClass(styles.allergySeverityLow);
+  });
+
+  it('uses default severity-style mapping when config is not overridden', async () => {
+    mockOpenmrsFetch.mockReturnValueOnce({ data: mockFhirAllergyIntoleranceResponse });
+    renderWithSwr(<AllergiesDetailedSummary patient={mockPatient} />);
+    await waitForLoadingToFinish();
+
+    const severeAllergen = screen.getByText(/penicillins/i);
+    expect(severeAllergen).toHaveClass(styles.allergySeverityHigh);
+  });
+
+  it('does not apply severity class for unknown severities', async () => {
+    const customResponse = structuredClone(mockFhirAllergyIntoleranceResponse);
+    customResponse.entry[2].resource.reaction[0].severity = 'unknown';
+
+    mockOpenmrsFetch.mockReturnValueOnce({ data: customResponse });
+    renderWithSwr(<AllergiesDetailedSummary patient={mockPatient} />);
+    await waitForLoadingToFinish();
+
+    const unknownSeverityAllergen = screen.getByText(/penicillins/i);
+    expect(unknownSeverityAllergen).not.toHaveClass(styles.allergySeverityHigh);
+    expect(unknownSeverityAllergen).not.toHaveClass(styles.allergySeverityModerate);
+    expect(unknownSeverityAllergen).not.toHaveClass(styles.allergySeverityLow);
+  });
+
+  it('does not apply background severity class by default', async () => {
+    mockOpenmrsFetch.mockReturnValueOnce({ data: mockFhirAllergyIntoleranceResponse });
+    renderWithSwr(<AllergiesDetailedSummary patient={mockPatient} />);
+    await waitForLoadingToFinish();
+
+    const severeAllergen = screen.getByText(/penicillins/i);
+    expect(severeAllergen).not.toHaveClass(styles.withSeverityBackground);
+  });
+
+  it('applies background severity class when enabled via config', async () => {
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(configSchema),
+      enableSeverityBackgroundColoring: true,
+    });
+    mockOpenmrsFetch.mockReturnValueOnce({ data: mockFhirAllergyIntoleranceResponse });
+    renderWithSwr(<AllergiesDetailedSummary patient={mockPatient} />);
+    await waitForLoadingToFinish();
+
+    const severeAllergen = screen.getByText(/penicillins/i);
+    expect(severeAllergen).toHaveClass(styles.withSeverityBackground);
   });
 });

--- a/packages/esm-patient-allergies-app/src/config-schema.ts
+++ b/packages/esm-patient-allergies-app/src/config-schema.ts
@@ -11,6 +11,8 @@ export interface AllergiesConfigObject {
     allergyReactionUuid: string;
     otherConceptUuid: string;
   };
+  severityStyleMap: Record<string, 'high' | 'moderate' | 'low'>;
+  enableSeverityBackgroundColoring: boolean;
 }
 
 export const configSchema = {
@@ -47,5 +49,17 @@ export const configSchema = {
       _type: Type.ConceptUuid,
       _default: '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     },
+  },
+  severityStyleMap: {
+    _type: Type.Object,
+    _default: {
+      severe: 'high',
+      moderate: 'moderate',
+      mild: 'low',
+    },
+  },
+  enableSeverityBackgroundColoring: {
+    _type: Type.Boolean,
+    _default: false,
   },
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
Enhance the Allergies detailed summary table (esm-patient-allergies-app) so allergen names in the Allergen column are styled by reaction severity. Severity labels and visual treatment must be configurable per implementation, with optional full-cell background highlighting.

## Screenshots
<img width="768" height="228" alt="Screenshot from 2026-05-28 19-05-26" src="https://github.com/user-attachments/assets/77d094c0-1cbd-44a6-8b5e-86be25c6a2f9" />


## Related Issue
https://openmrs.atlassian.net/browse/O3-5713
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
