### PR TITLE
(fix) Recalculate revised medication quantities

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -225,6 +225,17 @@ export function DrugOrderForm({
     initialOrderBasketItem?.isQuantityManual ?? (isExistingOrder && initialOrderBasketItem?.pillsDispensed != null),
   );
 
+  const watchedFrequencyPerDay = useMemo(() => {
+    if (watchedFrequency?.frequencyPerDay != null) {
+      return watchedFrequency.frequencyPerDay;
+    }
+
+    return (
+      orderConfigObject?.orderFrequencies?.find(({ valueCoded }) => valueCoded === watchedFrequency?.valueCoded)
+        ?.frequencyPerDay ?? null
+    );
+  }, [orderConfigObject?.orderFrequencies, watchedFrequency?.frequencyPerDay, watchedFrequency?.valueCoded]);
+
   const calculatedQuantity = useMemo(() => {
     if (watchedIsFreeText || watchedAsNeeded) {
       return null;
@@ -232,8 +243,8 @@ export function DrugOrderForm({
     if (
       watchedDosage == null ||
       watchedDosage <= 0 ||
-      watchedFrequency?.frequencyPerDay == null ||
-      watchedFrequency.frequencyPerDay <= 0 ||
+      watchedFrequencyPerDay == null ||
+      watchedFrequencyPerDay <= 0 ||
       watchedDuration == null ||
       watchedDuration <= 0
     ) {
@@ -246,13 +257,13 @@ export function DrugOrderForm({
     if (durationDays == null) {
       return null;
     }
-    const result = Math.ceil(watchedDosage * watchedFrequency.frequencyPerDay * durationDays);
+    const result = Math.ceil(watchedDosage * watchedFrequencyPerDay * durationDays);
     return result > 0 && isFinite(result) ? result : null;
   }, [
     watchedIsFreeText,
     watchedAsNeeded,
     watchedDosage,
-    watchedFrequency?.frequencyPerDay,
+    watchedFrequencyPerDay,
     watchedDuration,
     watchedDurationUnit?.valueCoded,
     watchedUnit?.valueCoded,
@@ -277,7 +288,7 @@ export function DrugOrderForm({
     requireOutpatientQuantity,
     isManualOverride,
     calculatedQuantity,
-    watchedFrequency?.frequencyPerDay,
+    watchedFrequencyPerDay,
     watchedUnit,
     watchedQuantityUnits,
     getValues,
@@ -727,7 +738,8 @@ export function DrugOrderForm({
                     />
                     {requireOutpatientQuantity &&
                       (isManualOverride
-                        ? calculatedQuantity != null && (
+                        ? calculatedQuantity != null &&
+                          calculatedQuantity !== watchedPillsDispensed && (
                             <button type="button" className={styles.recalculateLink} onClick={handleRecalculate}>
                               {t('applyCalculatedQuantity', 'Apply calculated quantity ({{quantity}})', {
                                 quantity: calculatedQuantity,

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.test.tsx
@@ -559,13 +559,50 @@ describe('DrugOrderForm - auto-calculation of dispense quantity', () => {
 
     renderDrugOrderForm(item);
 
-    // Quantity is preserved from the existing order — the effect returns early for
-    // REVISE orders with null frequencyPerDay
+    // Quantity is preserved from the existing order until the clinician applies the
+    // calculated quantity.
     await waitFor(() => {
       expect(screen.getByRole('spinbutton', { name: /quantity to dispense/i })).toHaveValue(30);
     });
     expect(screen.queryByText(/auto-calculated/i)).not.toBeInTheDocument();
   });
+
+  it.each(['REVISE', 'RENEW'] as const)(
+    'uses order config frequencyPerDay to show recalculate link for %s orders',
+    async (action) => {
+      const user = userEvent.setup();
+      const item = createNewOrderBasketItem({
+        action,
+        pillsDispensed: 5,
+        frequency: {
+          valueCoded: 'once-daily-uuid',
+          value: 'Once daily',
+          frequencyPerDay: null,
+        },
+        dosage: 1,
+        unit: { valueCoded: '1513AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', value: 'Tablet' },
+        duration: 5,
+        durationUnit: { valueCoded: '1072AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', value: 'Days' },
+        quantityUnits: { valueCoded: '1513AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', value: 'Tablet' },
+      });
+
+      renderDrugOrderForm(item);
+
+      await waitFor(() => {
+        expect(screen.getByRole('spinbutton', { name: /quantity to dispense/i })).toHaveValue(5);
+      });
+      expect(screen.queryByText(/apply calculated quantity/i)).not.toBeInTheDocument();
+
+      const durationInput = screen.getByRole('spinbutton', { name: /duration/i });
+      await user.clear(durationInput);
+      await user.type(durationInput, '7');
+
+      await waitFor(() => {
+        expect(screen.getByRole('spinbutton', { name: /quantity to dispense/i })).toHaveValue(5);
+      });
+      expect(screen.getByText(/apply calculated quantity \(7\)/i)).toBeInTheDocument();
+    },
+  );
 
   it('shows recalculate link for REVISE orders after re-selecting frequency with frequencyPerDay', async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a conventional commit label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

When the outpatient-quantity setting is on, the drug order form auto-calculates "Quantity to dispense" from `dose × frequencyPerDay × duration`. This works for new orders, but silently broke for **revise** and **renew**: editing the dose or duration on an existing order recomputed nothing, and no recalculate link ever appeared.

The cause is how an order's frequency is reconstructed. `buildMedicationOrder` (`api/api.ts`) hardcodes `frequencyPerDay: null` because the value isn't on the order payload. OpenMRS core models `frequencyPerDay` on the `OrderFrequency` definition, and the REST layer serializes an order's frequency as a `REF` (uuid + display only), so the per-day multiplier is dropped. With it null, `calculatedQuantity` is always null on a revised order, so the form can't offer a recalculation until the clinician re-picks the frequency from the dropdown.

### What changed

- Resolve `frequencyPerDay` from the order config (`orderFrequencies`) by frequency UUID when the watched frequency doesn't carry it. That config is the same definition the backend treats as the source of truth. Freshly selected frequencies keep using their own value.
- Only show the "Apply calculated quantity" link when the calculated value differs from the current quantity, so an inherited (or deliberately set) quantity stays put on open and the link surfaces only when there's a real discrepancy to act on.

Manual overrides stay sticky and quantities are never auto-overwritten; recalculation remains an explicit, opt-in click.

## Screenshots

### Recalculation available when dosing inputs change for revise and renew flows

https://github.com/user-attachments/assets/50e6be9f-d9ad-4f79-90a7-9e2d651c9417

## Related Issue

## Other

 Follow-up to the auto-calculate dispense quantity feature (#3052).