### PR TITLE
(fix) Render procedures form validation errors via Carbon invalid props

### DIFF
--- a/packages/esm-patient-procedures-app/src/components/concept-search-field/concept-search-field.component.tsx
+++ b/packages/esm-patient-procedures-app/src/components/concept-search-field/concept-search-field.component.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { useTranslation } from 'react-i18next';
+import classNames from 'classnames';
 import { InlineLoading, InlineNotification, Layer, Search, Tile } from '@carbon/react';
 import { ResponsiveWrapper } from '@openmrs/esm-framework';
 import type { ConceptReference } from '../../types';
@@ -20,34 +21,50 @@ export const ConceptSearchField = ({
   field,
   selectedConcept,
   onChange,
+  invalid,
+  invalidText,
 }: {
   label: string;
   placeholder: string;
   field: ReturnType<typeof useConceptSearchField>;
   selectedConcept: ConceptReference | null;
   onChange: (selectedConcept: ConceptReference | null) => void;
+  invalid?: boolean;
+  invalidText?: string;
 }) => {
   const { t } = useTranslation();
+  const invalidTextId = useId();
+  const showInvalidText = Boolean(invalid && invalidText);
 
   return (
     <>
       <ResponsiveWrapper>
-        <Search
-          labelText={label}
-          placeholder={placeholder}
-          onChange={(e) => {
-            field.setSearchTerm(e.target.value);
-            if (selectedConcept) {
+        <div className={classNames({ [styles.invalid]: invalid })}>
+          <Search
+            aria-describedby={showInvalidText ? invalidTextId : undefined}
+            aria-invalid={invalid || undefined}
+            labelText={label}
+            placeholder={placeholder}
+            onChange={(e) => {
+              field.setSearchTerm(e.target.value);
+              if (selectedConcept) {
+                onChange(null);
+              }
+            }}
+            onClear={() => {
+              field.clear();
               onChange(null);
-            }
-          }}
-          onClear={() => {
-            field.clear();
-            onChange(null);
-          }}
-          value={selectedConcept ? selectedConcept.display : field.searchTerm}
-        />
+            }}
+            value={selectedConcept ? selectedConcept.display : field.searchTerm}
+          />
+        </div>
       </ResponsiveWrapper>
+
+      {showInvalidText && (
+        <p className={styles.invalidText} id={invalidTextId}>
+          {invalidText}
+        </p>
+      )}
 
       {field.error ? (
         <InlineNotification

--- a/packages/esm-patient-procedures-app/src/components/concept-search-field/concept-search-field.scss
+++ b/packages/esm-patient-procedures-app/src/components/concept-search-field/concept-search-field.scss
@@ -37,3 +37,16 @@
   min-height: layout.$spacing-05;
   border: 1px solid $ui-03;
 }
+
+// Mirrors Carbon's invalid input outline, which Search doesn't support natively
+.invalid :global(.cds--search-input) {
+  outline: 2px solid $danger;
+  outline-offset: -2px;
+}
+
+// Mirrors Carbon's .cds--form-requirement
+.invalidText {
+  @include type.type-style('label-01');
+  color: $danger;
+  margin-top: layout.$spacing-02;
+}

--- a/packages/esm-patient-procedures-app/src/components/date-time-field/date-time-field.scss
+++ b/packages/esm-patient-procedures-app/src/components/date-time-field/date-time-field.scss
@@ -4,5 +4,6 @@
   display: grid;
   grid-template-columns: 2fr 1fr;
   gap: layout.$spacing-05;
-  align-items: end;
+  // Top-align so error text below one column doesn't drag the other column down
+  align-items: start;
 }

--- a/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures-form.scss
+++ b/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures-form.scss
@@ -75,9 +75,9 @@
 }
 
 .errorMessage {
-  @include type.type-style('label-02');
+  @include type.type-style('label-01');
   color: $danger;
-  margin-top: layout.$spacing-03;
+  margin-top: layout.$spacing-02;
 }
 
 .spinner {
@@ -95,14 +95,15 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: layout.$spacing-05;
-  align-items: end;
+  // Top-align so error text below one column doesn't drag the other column down
+  align-items: start;
 }
 
 .dateTimeFieldGroup {
   display: grid;
   grid-template-columns: 2fr 1fr;
   gap: layout.$spacing-05;
-  align-items: end;
+  align-items: start;
 }
 
 .submitButtons {

--- a/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures.form.component.tsx
+++ b/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures.form.component.tsx
@@ -201,10 +201,11 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
               selectedConcept={procedureConcept}
               onChange={(concept) => {
                 setProcedureConcept(concept);
-                setValue('procedureCoded', concept?.uuid ?? '');
+                setValue('procedureCoded', concept?.uuid ?? '', { shouldValidate: true });
               }}
+              invalid={Boolean(errors.procedureCoded)}
+              invalidText={errors.procedureCoded?.message}
             />
-            {errors.procedureCoded && <p className={styles.errorMessage}>{errors.procedureCoded.message}</p>}
           </FormGroup>
 
           <FormGroup legendText={<RequiredFieldLabel label={t('procedureType', 'Procedure type')} />}>
@@ -221,12 +222,13 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
                   itemToString={(item: ProcedureType) => item?.name ?? ''}
                   initialSelectedItem={procedureTypes.find((pt) => pt.uuid === getValues('procedureType')) ?? null}
                   onChange={({ selectedItem }: { selectedItem: ProcedureType | null }) =>
-                    setValue('procedureType', selectedItem?.uuid ?? '')
+                    setValue('procedureType', selectedItem?.uuid ?? '', { shouldValidate: true })
                   }
+                  invalid={Boolean(errors.procedureType)}
+                  invalidText={errors.procedureType?.message}
                 />
               </ResponsiveWrapper>
             )}
-            {errors.procedureType && <p className={styles.errorMessage}>{errors.procedureType.message}</p>}
           </FormGroup>
 
           <FormGroup legendText={<RequiredFieldLabel label={t('bodySite', 'Body site')} />}>
@@ -237,10 +239,11 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
               selectedConcept={bodySiteConcept}
               onChange={(concept) => {
                 setBodySiteConcept(concept);
-                setValue('bodySite', concept?.uuid ?? '');
+                setValue('bodySite', concept?.uuid ?? '', { shouldValidate: true });
               }}
+              invalid={Boolean(errors.bodySite)}
+              invalidText={errors.bodySite?.message}
             />
-            {errors.bodySite && <p className={styles.errorMessage}>{errors.bodySite.message}</p>}
           </FormGroup>
           <FormGroup legendText={t('isStartDateKnown', 'Is start date known?')}>
             <ContentSwitcher
@@ -296,6 +299,8 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
                     onChange={({ selectedItem }: { selectedItem: { id: string; label: string } | null }) =>
                       setEstimatedYear(selectedItem?.id ?? '')
                     }
+                    invalid={Boolean(errors.startDateTime)}
+                    invalidText={errors.startDateTime?.message}
                   />
                 </ResponsiveWrapper>
                 <ResponsiveWrapper>
@@ -312,7 +317,6 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
                   />
                 </ResponsiveWrapper>
               </div>
-              {errors.startDateTime && <p className={styles.errorMessage}>{errors.startDateTime.message}</p>}
             </FormGroup>
           )}
 
@@ -338,7 +342,7 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
               <Controller
                 name="duration"
                 control={control}
-                render={({ field: { onChange, value, ref, name } }) => (
+                render={({ field: { onChange, value, ref, name }, fieldState }) => (
                   <ResponsiveWrapper>
                     <NumberInput
                       id="duration"
@@ -349,6 +353,8 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
                       min={1}
                       hideSteppers
                       allowEmpty
+                      invalid={Boolean(fieldState.error)}
+                      invalidText={fieldState.error?.message}
                       value={value ?? ''}
                       onChange={(_event, { value: nextValue }: { value: number | string }) => {
                         if (nextValue == null || nextValue === '') {
@@ -365,7 +371,7 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
               <Controller
                 name="durationUnit"
                 control={control}
-                render={({ field }) => (
+                render={({ field, fieldState }) => (
                   <ResponsiveWrapper>
                     <ComboBox
                       id="durationUnit"
@@ -377,6 +383,8 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
                       onChange={({ selectedItem }: { selectedItem: ConceptReference | null }) =>
                         field.onChange(selectedItem?.uuid ?? null)
                       }
+                      invalid={Boolean(fieldState.error)}
+                      invalidText={fieldState.error?.message}
                     />
                   </ResponsiveWrapper>
                 )}
@@ -387,15 +395,13 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
                 </p>
               )}
             </div>
-            {errors.duration && <p className={styles.errorMessage}>{errors.duration.message}</p>}
-            {errors.durationUnit && <p className={styles.errorMessage}>{errors.durationUnit.message}</p>}
           </FormGroup>
 
           <FormGroup legendText={<RequiredFieldLabel label={t('status', 'Status')} />}>
             <Controller
               name="status"
               control={control}
-              render={({ field }) => (
+              render={({ field, fieldState }) => (
                 <ResponsiveWrapper>
                   <ComboBox
                     id="status"
@@ -408,6 +414,8 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
                     onChange={({ selectedItem }: { selectedItem: ConceptReference | null }) =>
                       field.onChange(selectedItem?.uuid ?? null)
                     }
+                    invalid={Boolean(fieldState.error)}
+                    invalidText={fieldState.error?.message}
                   />
                 </ResponsiveWrapper>
               )}
@@ -417,25 +425,25 @@ const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
                 {t('statusOptionsLoadFailed', 'Could not load status options. Please try again.')}
               </p>
             )}
-            {errors.status && <p className={styles.errorMessage}>{errors.status.message}</p>}
           </FormGroup>
 
           <FormGroup legendText={t('notes', 'Notes')}>
             <Controller
               name="notes"
               control={control}
-              render={({ field }) => (
+              render={({ field, fieldState }) => (
                 <ResponsiveWrapper>
                   <TextArea
                     {...field}
                     id="notes"
                     labelText=""
                     placeholder={t('enterNotes', 'Enter notes (optional)')}
+                    invalid={Boolean(fieldState.error)}
+                    invalidText={fieldState.error?.message}
                   />
                 </ResponsiveWrapper>
               )}
             />
-            {errors.notes && <p className={styles.errorMessage}>{errors.notes.message}</p>}
           </FormGroup>
         </Stack>
       </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The validation errors on the Record/Edit procedure form were rendered as custom `<p>` elements styled with the `label-02` type token. This made them noticeably larger than the error text the date picker renders natively, and the invalid inputs themselves showed no visual change.

This PR routes all field-level errors through Carbon's `invalid`/`invalidText` props instead, so every invalid field gets the red border, error icon, and 12px form-requirement error text, consistent with the date picker. The custom `ConceptSearchField` now accepts `invalid`/`invalidText` props and renders a matching red outline on its search input (Carbon's `Search` has no native invalid state), with `aria-invalid` and `aria-describedby` wiring so screen readers announce the error.

Two related fixes that surfaced while testing this:

- The date/time and duration/unit rows used `align-items: end`, so when error text appeared under one column it dragged the sibling column's inputs down. The grids are now top-aligned and the error text hangs below without shifting anything.
- Picking a procedure, procedure type, or body site did not clear a stale "required" error until the next submit, because those fields are set with bare `setValue()` calls. They now pass `shouldValidate: true`, matching the behavior of the Controller-driven fields.

The custom `.errorMessage` class is retained only for the status and duration unit options load-failure notices, downsized to `label-01` to match.

## Screenshots

### Before

<img width="2976" height="1766" alt="CleanShot 2026-06-03 at 21 59 52@2x" src="https://github.com/user-attachments/assets/ae56d0cb-0b70-4872-98ac-0436a3f27716" />

### After

<img width="2980" height="1764" alt="CleanShot 2026-06-03 at 21 59 35@2x" src="https://github.com/user-attachments/assets/d0ed74d7-a3d2-4cab-8f0f-d9d47aa30659" />

## Related Issue

## Other