### PR TITLE
(fix) O3-5722: Increase visit summary tab min-height to prevent content clipping

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.scss
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.scss
@@ -24,7 +24,7 @@
   padding: layout.$spacing-05;
 
   :global(.cds--tabs) {
-    min-height: 12rem;
+    min-height: 13rem;
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Increases the `min-height` of the `.cds--tabs` element in the visit summary widget from `12rem` to `13rem` to prevent tab content from being clipped.

## Screenshots

Before:
<img width="1920" height="1077" alt="Screenshot 2026-06-04 at 3 10 04 PM" src="https://github.com/user-attachments/assets/bb1576b0-67dc-4010-92bd-af17fa7c2267" />

After:
<img width="1920" height="1077" alt="Screenshot 2026-06-04 at 3 09 24 PM" src="https://github.com/user-attachments/assets/dac76f72-48f0-4b33-a6c1-6e63d4e22287" />


## Related Issue

https://issues.openmrs.org/browse/O3-5722

## Other
