### PR TITLE
(feat) O3-5726: Add lab test price tag on lab orders

### DIFF
--- a/packages/esm-patient-orders-app/src/components/test-order.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/test-order.component.tsx
@@ -23,6 +23,7 @@ import {
 import { useLabEncounter, useOrderConceptByUuid, useOrderConceptsByUuids } from '../lab-results/lab-results.resource';
 import { getConceptUuids, getEffectiveRanges, getInterpretationClass, interpretObservation } from '../utils';
 import styles from './test-order.scss';
+import OrderPriceDetailsComponent from './order-price-details.component';
 
 interface TestOrderProps {
   testOrder: Order;
@@ -133,6 +134,7 @@ const TestOrder: React.FC<TestOrderProps> = ({ testOrder, patientUuid: patientUu
 
   return (
     <div className={styles.testOrder}>
+      <OrderPriceDetailsComponent orderItemUuid={testOrder?.concept?.uuid} />
       <DataTable rows={testRows} headers={tableHeaders} size={isTablet ? 'lg' : 'sm'} useZebraStyles>
         {({ rows, headers, getHeaderProps, getRowProps, getTableProps, getTableContainerProps }) => (
           <TableContainer {...getTableContainerProps()}>
@@ -144,7 +146,7 @@ const TestOrder: React.FC<TestOrderProps> = ({ testOrder, patientUuid: patientUu
                     return (
                       <TableHeader
                         {...headerProps}
-                        className={classNames(headerProps.className, styles[`col-${header.key}`])}
+                        className={classNames(headerProps.className as string | undefined, styles[`col-${header.key}`])}
                       >
                         {header.header}
                       </TableHeader>

--- a/packages/esm-patient-orders-app/src/components/test-order.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/test-order.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithSwr } from 'tools';
 import { mockOrders, mockOrderPriceData } from '__mocks__';
@@ -12,26 +13,26 @@ import {
 import { useReferenceRanges, type Order } from '@openmrs/esm-patient-common-lib';
 import TestOrder from './test-order.component';
 
-const mockUseOrderPrice = jest.mocked(useOrderPrice);
-const mockUseLabEncounter = jest.mocked(useLabEncounter);
-const mockUseOrderConceptByUuid = jest.mocked(useOrderConceptByUuid);
-const mockUseOrderConceptsByUuids = jest.mocked(useOrderConceptsByUuids);
-const mockUseReferenceRanges = jest.mocked(useReferenceRanges);
+const mockUseOrderPrice = vi.mocked(useOrderPrice);
+const mockUseLabEncounter = vi.mocked(useLabEncounter);
+const mockUseOrderConceptByUuid = vi.mocked(useOrderConceptByUuid);
+const mockUseOrderConceptsByUuids = vi.mocked(useOrderConceptsByUuids);
+const mockUseReferenceRanges = vi.mocked(useReferenceRanges);
 
-jest.mock('../hooks/useOrderPrice', () => ({
-  useOrderPrice: jest.fn(),
+vi.mock('../hooks/useOrderPrice', () => ({
+  useOrderPrice: vi.fn(),
 }));
 
-jest.mock('../lab-results/lab-results.resource', () => ({
-  useLabEncounter: jest.fn(),
-  useOrderConceptByUuid: jest.fn(),
-  useOrderConceptsByUuids: jest.fn(),
+vi.mock('../lab-results/lab-results.resource', () => ({
+  useLabEncounter: vi.fn(),
+  useOrderConceptByUuid: vi.fn(),
+  useOrderConceptsByUuids: vi.fn(),
 }));
 
-jest.mock('@openmrs/esm-patient-common-lib', () => ({
-  ...jest.requireActual('@openmrs/esm-patient-common-lib'),
-  useReferenceRanges: jest.fn(),
-  ReferenceRangeDisplay: jest.fn(() => null),
+vi.mock('@openmrs/esm-patient-common-lib', async () => ({
+  ...(await vi.importActual('@openmrs/esm-patient-common-lib')),
+  useReferenceRanges: vi.fn(),
+  ReferenceRangeDisplay: vi.fn(() => null),
 }));
 
 const mockTestOrder = mockOrders[1] as unknown as Order;
@@ -64,14 +65,14 @@ const mockConcept: LabOrderConcept = {
 
 describe('TestOrder', () => {
   beforeEach(() => {
-    jest.resetAllMocks();
+    vi.resetAllMocks();
 
     mockUseOrderConceptByUuid.mockReturnValue({
       concept: mockConcept,
       isLoading: false,
       error: undefined,
       isValidating: false,
-      mutate: jest.fn(),
+      mutate: vi.fn(),
     });
 
     mockUseLabEncounter.mockReturnValue({
@@ -79,7 +80,7 @@ describe('TestOrder', () => {
       isLoading: false,
       error: undefined,
       isValidating: false,
-      mutate: jest.fn(),
+      mutate: vi.fn(),
     });
 
     mockUseOrderConceptsByUuids.mockReturnValue({
@@ -87,14 +88,14 @@ describe('TestOrder', () => {
       isLoading: false,
       error: undefined,
       isValidating: false,
-      mutate: jest.fn(),
+      mutate: vi.fn(),
     });
 
     mockUseReferenceRanges.mockReturnValue({
       ranges: new Map(),
       isLoading: false,
       error: undefined,
-      mutate: jest.fn(),
+      mutate: vi.fn(),
     });
   });
 

--- a/packages/esm-patient-orders-app/src/components/test-order.test.tsx
+++ b/packages/esm-patient-orders-app/src/components/test-order.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithSwr } from 'tools';
+import { mockOrders, mockOrderPriceData } from '__mocks__';
+import { useOrderPrice } from '../hooks/useOrderPrice';
+import {
+  useLabEncounter,
+  useOrderConceptByUuid,
+  useOrderConceptsByUuids,
+  type LabOrderConcept,
+} from '../lab-results/lab-results.resource';
+import { useReferenceRanges, type Order } from '@openmrs/esm-patient-common-lib';
+import TestOrder from './test-order.component';
+
+const mockUseOrderPrice = jest.mocked(useOrderPrice);
+const mockUseLabEncounter = jest.mocked(useLabEncounter);
+const mockUseOrderConceptByUuid = jest.mocked(useOrderConceptByUuid);
+const mockUseOrderConceptsByUuids = jest.mocked(useOrderConceptsByUuids);
+const mockUseReferenceRanges = jest.mocked(useReferenceRanges);
+
+jest.mock('../hooks/useOrderPrice', () => ({
+  useOrderPrice: jest.fn(),
+}));
+
+jest.mock('../lab-results/lab-results.resource', () => ({
+  useLabEncounter: jest.fn(),
+  useOrderConceptByUuid: jest.fn(),
+  useOrderConceptsByUuids: jest.fn(),
+}));
+
+jest.mock('@openmrs/esm-patient-common-lib', () => ({
+  ...jest.requireActual('@openmrs/esm-patient-common-lib'),
+  useReferenceRanges: jest.fn(),
+  ReferenceRangeDisplay: jest.fn(() => null),
+}));
+
+const mockTestOrder = mockOrders[1] as unknown as Order;
+
+const mockConcept: LabOrderConcept = {
+  uuid: mockOrders[1].concept.uuid,
+  display: mockOrders[1].concept.display,
+  datatype: {
+    uuid: 'datatype-uuid',
+    display: 'Numeric',
+    name: 'Numeric',
+    description: 'Numeric datatype',
+    hl7Abbreviation: 'NM',
+    retired: false,
+    resourceVersion: '1.0',
+  },
+  set: false,
+  version: '1.0',
+  retired: false,
+  descriptions: [],
+  setMembers: [],
+  hiNormal: undefined,
+  hiAbsolute: undefined,
+  hiCritical: undefined,
+  lowNormal: undefined,
+  lowAbsolute: undefined,
+  lowCritical: undefined,
+  units: undefined,
+};
+
+describe('TestOrder', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mockUseOrderConceptByUuid.mockReturnValue({
+      concept: mockConcept,
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+      mutate: jest.fn(),
+    });
+
+    mockUseLabEncounter.mockReturnValue({
+      encounter: undefined,
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+      mutate: jest.fn(),
+    });
+
+    mockUseOrderConceptsByUuids.mockReturnValue({
+      concepts: [],
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+      mutate: jest.fn(),
+    });
+
+    mockUseReferenceRanges.mockReturnValue({
+      ranges: new Map(),
+      isLoading: false,
+      error: undefined,
+      mutate: jest.fn(),
+    });
+  });
+
+  it('renders the price tag when price data is available', () => {
+    mockUseOrderPrice.mockReturnValue({
+      data: mockOrderPriceData,
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithSwr(<TestOrder testOrder={mockTestOrder} />);
+
+    expect(screen.getByText('Price:')).toBeInTheDocument();
+    expect(screen.getByText('$99.99')).toBeInTheDocument();
+  });
+
+  it('renders nothing for price when price data is unavailable', () => {
+    mockUseOrderPrice.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithSwr(<TestOrder testOrder={mockTestOrder} />);
+
+    expect(screen.queryByText('Price:')).not.toBeInTheDocument();
+  });
+
+  it('renders a loading skeleton while price data is loading', () => {
+    mockUseOrderPrice.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: undefined,
+    });
+
+    renderWithSwr(<TestOrder testOrder={mockTestOrder} />);
+
+    expect(screen.getByRole('paragraph')).toBeInTheDocument();
+  });
+
+  it('renders the price disclaimer tooltip', () => {
+    mockUseOrderPrice.mockReturnValue({
+      data: mockOrderPriceData,
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithSwr(<TestOrder testOrder={mockTestOrder} />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByLabelText(/This price is indicative/)).toBeInTheDocument();
+  });
+});

--- a/packages/esm-patient-orders-app/tsconfig.json
+++ b/packages/esm-patient-orders-app/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*", "../../tools/setup-tests.ts"],
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src/**/*", "../../tools/setup-tests.ts"]
 }

--- a/packages/esm-patient-orders-app/tsconfig.json
+++ b/packages/esm-patient-orders-app/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "ignoreDeprecations": "6.0"
-  },
-  "include": ["src/**/*", "../../tools/setup-tests.ts"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+  "include": ["src/**/*", "../../tools/setup-tests.ts"]
 }

--- a/packages/esm-patient-orders-app/tsconfig.json
+++ b/packages/esm-patient-orders-app/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "ignoreDeprecations": "6.0"
   },
-  "include": ["src/**/*", "../../tools/setup-tests.ts"]
+  "include": ["src/**/*", "../../tools/setup-tests.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
Previously, providers had no way to see the price of a lab test when placing an order, leading to unexpected patient bills. This PR wires the existing `OrderPriceDetailsComponent` and `useOrderPrice` hook into `test-order.component.tsx`, displaying the preconfigured price to the provider at the point of ordering. The price only shows when the `billing` and `fhirproxy` backend modules are installed and a price is configured for the test.

## Screenshots
N/A

## Related Issue
https://openmrs.atlassian.net/browse/O3-5726

## Other
`OrderPriceDetailsComponent` and `useOrderPrice` were already in the codebase but unused — this PR completes their...