### PR TITLE
(test) Add form validation coverage for vitals, drug order, and visit forms

### DIFF
--- a/e2e/specs/drug-orders.spec.ts
+++ b/e2e/specs/drug-orders.spec.ts
@@ -366,4 +366,94 @@ test.describe('Drug Order Tests', () => {
       ).toBeVisible();
     });
   });
+
+  test('Block saving a drug order with missing required fields', async ({ page, patient }) => {
+    const orderBasket = page.locator('[data-extension-slot-name="order-basket-slot"]');
+    const medicationsPage = new MedicationsPage(page);
+
+    await test.step('When I visit the medications page', async () => {
+      await medicationsPage.goTo(patient.uuid);
+    });
+
+    await test.step('And I click the Add button on the medications details table to launch the order basket', async () => {
+      const launchOrderBasketButton = page
+        .getByRole('button', { name: /record active medications/i })
+        .or(page.getByRole('button', { name: 'Add', exact: true }))
+        .first();
+      await expect(launchOrderBasketButton).toBeVisible();
+      await launchOrderBasketButton.click();
+    });
+
+    await test.step('And I open the add-drug-order workspace in the order basket', async () => {
+      const addDrugOrderSearchbox = page.getByRole('searchbox', { name: /search for a drug or orderset/i });
+      const addToOrderBasketButton = page
+        .locator("[id='order-basket']")
+        .getByRole('button', { name: 'Add', exact: true })
+        .first();
+
+      // Some environments open the workspace directly after launching the order basket,
+      // while others require an additional "Add +" click.
+      await addToOrderBasketButton.click({ timeout: 5_000 }).catch(() => {});
+      await expect(addDrugOrderSearchbox).toBeVisible();
+    });
+
+    await test.step('And I search for "Aspirin" and add "Aspirin 325mg" to the basket', async () => {
+      await page.getByRole('searchbox', { name: /search for a drug or orderset/i }).fill('aspirin');
+      await page
+        .getByRole('listitem')
+        .filter({ hasText: /aspirin 325mg — 325mg — tablet/i })
+        .getByRole('button', { name: /add to basket/i })
+        .click();
+    });
+
+    await test.step('And I click on the incomplete drug order to open the order form', async () => {
+      const orderBasketLauncher = page.getByRole('button', { name: /^order basket$/i });
+      const incompleteAspirinBasketItem = orderBasket
+        .getByRole('listitem')
+        .filter({ hasText: /aspirin 325mg — 325mg — tablet/i });
+
+      await expect(incompleteAspirinBasketItem)
+        .toBeVisible({ timeout: 5_000 })
+        .catch(async () => {
+          await orderBasketLauncher.click();
+          await expect(incompleteAspirinBasketItem).toBeVisible();
+        });
+      await incompleteAspirinBasketItem.getByRole('status', { name: /incomplete/i }).click();
+      await expect(page.getByText(/order form/i)).toBeVisible();
+    });
+
+    await test.step('When I click on the "Save Order" button without filling in the required fields', async () => {
+      await page.getByRole('button', { name: /save order/i }).click();
+    });
+
+    await test.step('Then the save should be blocked with a validation error', async () => {
+      // Per-message assertions live in drug-order-form.test.tsx; here we only
+      // assert the journey outcome: save is blocked and an error is shown.
+      await expect(page.getByText(/dosage is required/i)).toBeVisible();
+    });
+
+    await test.step('And the order should remain in the Incomplete state in the order basket', async () => {
+      await expect(orderBasket.getByRole('status', { name: /incomplete/i })).toBeVisible();
+    });
+
+    await test.step('When I fill in the required fields', async () => {
+      await page.getByLabel(/^dose$/i, { exact: true }).fill('1');
+      await page.getByRole('combobox', { name: /route/i }).click();
+      await page.getByRole('option', { name: /oral/i }).click();
+      await page.getByRole('combobox', { name: /frequency/i }).click();
+      await page.getByRole('option', { name: /once daily/i }).click();
+      await page.getByLabel(/^quantity to dispense$/i).fill('3');
+      await page.getByLabel(/^prescription refills$/i).fill('1');
+      await page.getByRole('textbox', { name: 'Indication' }).fill('Headache');
+    });
+
+    await test.step('And when I click on the "Save Order" button', async () => {
+      await page.getByRole('button', { name: /save order/i }).click();
+    });
+
+    await test.step('Then the order status should be changed to "New"', async () => {
+      await expect(orderBasket.getByText(/incomplete/i)).toBeHidden();
+      await expect(orderBasket.getByText(/new/i)).toBeVisible();
+    });
+  });
 });

--- a/e2e/specs/start-and-end-visit.spec.ts
+++ b/e2e/specs/start-and-end-visit.spec.ts
@@ -79,7 +79,20 @@ test('Start and end a new visit', async ({ page, patient, api }) => {
     await waitForVisitLocationValue(chartPage.page);
   });
 
-  await test.step('And I select the visit type: `OPD Visit`', async () => {
+  await test.step('And when I click on the `Start Visit` button without selecting a visit type', async () => {
+    await chartPage.page
+      .locator('form')
+      .getByRole('button', { name: /start visit/i })
+      .click();
+  });
+
+  await test.step('Then I should see a `Missing visit type` validation error and no visit should start', async () => {
+    await expect(chartPage.page.getByText(/missing visit type/i)).toBeVisible();
+    await expect(chartPage.page.getByText(/please select a visit type/i)).toBeVisible();
+    await expect(chartPage.page.getByLabel(/active visit/i)).toBeHidden();
+  });
+
+  await test.step('When I select the visit type: `OPD Visit`', async () => {
     const opdVisitLabel = chartPage.page.locator('label').filter({ hasText: /^OPD Visit$/i });
     await expect(opdVisitLabel).toBeVisible();
     await opdVisitLabel.click();

--- a/e2e/specs/vitals.spec.ts
+++ b/e2e/specs/vitals.spec.ts
@@ -321,3 +321,99 @@ test('Add high and critically high range patient vitals', async ({ page, patient
     expect(afterContentLow).toBe('" ↑↑"');
   });
 });
+
+test('Show an error when saving vitals with no values entered', async ({ page, patient }) => {
+  const vitalsPage = new BiometricsAndVitalsPage(page);
+  const saveButton = vitalsPage.page.getByRole('button', { name: /save and close/i });
+
+  await test.step('When I visit the vitals and biometrics page', async () => {
+    await vitalsPage.goTo(patient.uuid);
+  });
+
+  await test.step('And I click the `Record vital signs` link to launch the form', async () => {
+    await vitalsPage.page.getByText(/record vital signs/i).click();
+  });
+
+  await test.step('Then I should see the `Record Vitals and Biometrics` form launch in the workspace', async () => {
+    await expect(vitalsPage.page.getByText(/record vitals and biometrics/i)).toBeVisible();
+  });
+
+  await test.step('And the `Save and close` button should be disabled while the form is pristine', async () => {
+    await expect(saveButton).toBeDisabled();
+  });
+
+  await test.step('When I type a note and then erase it', async () => {
+    await vitalsPage.page.getByPlaceholder(/type any additional notes here/i).fill('Test notes');
+    await vitalsPage.page.getByPlaceholder(/type any additional notes here/i).clear();
+  });
+
+  await test.step('And I click on the `Save and close` button', async () => {
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+  });
+
+  await test.step('Then I should see an error notification prompting me to fill at least one field', async () => {
+    await expect(vitalsPage.page.getByText(/please fill at least one field/i)).toBeVisible();
+  });
+
+  await test.step('And no vitals should be recorded for the patient', async () => {
+    await expect(vitalsPage.page.getByText(/vitals and biometrics saved/i)).toBeHidden();
+  });
+});
+
+test('Show an error when saving vitals with a value outside the allowed range', async ({ page, patient, api }) => {
+  const vitalsPage = new BiometricsAndVitalsPage(page);
+  let hiAbsolute: number;
+
+  await test.step('Given the oxygen saturation concept defines an absolute maximum below the value under test', async () => {
+    const oxygenSaturationConceptUuid = '5092AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    const res = await api.get(`concept/${oxygenSaturationConceptUuid}?v=custom:(hiAbsolute)`);
+    hiAbsolute = (await res.json()).hiAbsolute;
+    expect(
+      hiAbsolute,
+      `The oxygen saturation concept must define a hiAbsolute below 101 for this test to be valid; got ${hiAbsolute}. Check the concept dictionary in the e2e environment.`,
+    ).toBeLessThan(101);
+  });
+
+  await test.step('When I visit the vitals and biometrics page', async () => {
+    await vitalsPage.goTo(patient.uuid);
+  });
+
+  await test.step('And I click the `Record vital signs` link to launch the form', async () => {
+    await vitalsPage.page.getByText(/record vital signs/i).click();
+  });
+
+  await test.step('Then I should see the `Record Vitals and Biometrics` form launch in the workspace', async () => {
+    await expect(vitalsPage.page.getByText(/record vitals and biometrics/i)).toBeVisible();
+  });
+
+  await test.step('And the absolute ranges should have loaded into the form', async () => {
+    // The range check no-ops until the conceptreferencerange request resolves;
+    // the input's max attribute is populated from that same response.
+    await expect(vitalsPage.page.getByRole('spinbutton', { name: /oxygen saturation/i })).toHaveAttribute(
+      'max',
+      String(hiAbsolute),
+    );
+  });
+
+  await test.step('When I fill `101` as the oxygen saturation', async () => {
+    await vitalsPage.page.getByRole('spinbutton', { name: /oxygen saturation/i }).fill('101');
+  });
+
+  await test.step('And I click on the `Save and close` button', async () => {
+    await vitalsPage.page.getByRole('button', { name: /save and close/i }).click();
+  });
+
+  await test.step('Then I should see a field-level error indicating the allowed range', async () => {
+    await expect(vitalsPage.page.getByText(/value must be between/i)).toBeVisible();
+  });
+
+  await test.step('And I should see an error notification about invalid values', async () => {
+    await expect(vitalsPage.page.getByText(/error saving vitals and biometrics/i)).toBeVisible();
+    await expect(vitalsPage.page.getByText(/some of the values entered are invalid/i)).toBeVisible();
+  });
+
+  await test.step('And no vitals should be recorded for the patient', async () => {
+    await expect(vitalsPage.page.getByText(/vitals and biometrics saved/i)).toBeHidden();
+  });
+});

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.test.tsx
@@ -761,3 +761,43 @@ describe('DrugOrderForm - auto-calculation of dispense quantity', () => {
     expect((savedOrder.scheduledDate as Date).getDate()).toBe(futureStartDate.getDate());
   });
 });
+
+describe('DrugOrderForm - required field validation', () => {
+  beforeEach(() => {
+    mockOpenmrsDatePicker.mockImplementation(({ id, labelText }) => (
+      <>
+        <label htmlFor={id}>{labelText}</label>
+        <input id={id} type="text" />
+      </>
+    ));
+    mockUseMedicationOrders.mockReturnValue({
+      futureOrders: [],
+      activeOrders: [],
+      pastOrders: [],
+      error: null,
+      isLoading: false,
+      isValidating: false,
+    });
+    mockUseRequireOutpatientQuantity.mockReturnValue({
+      requireOutpatientQuantity: true,
+      error: null,
+      isLoading: false,
+    });
+  });
+
+  it('shows an error for each required field and does not save when submitting an empty order', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    renderDrugOrderForm(createNewOrderBasketItem(), onSave);
+
+    await user.click(screen.getByRole('button', { name: /save order/i }));
+
+    expect(await screen.findByText('Dosage is required')).toBeInTheDocument();
+    expect(screen.getByText('Route is required')).toBeInTheDocument();
+    expect(screen.getByText('Frequency is required')).toBeInTheDocument();
+    expect(screen.getByText('Indication is required')).toBeInTheDocument();
+    expect(screen.getByText('Quantity to dispense is required')).toBeInTheDocument();
+    expect(screen.getByText('Number of refills is required')).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Adds test coverage for form validation paths that previously had none, splitting assertions by level: exact per-message checks live in unit tests, while e2e tests assert the user journey.

- **Unit** (`drug-order-form.test.tsx`): submitting an empty drug order surfaces every required-field error (dosage, route, frequency, indication, quantity to dispense, refills) and does not save. Verified by mutation: temporarily relaxing the route schema makes the test fail on exactly "Route is required".
- **E2E, drug orders**: saving a drug order with missing required fields is blocked, the basket item stays Incomplete, and filling the fields produces a New order.
- **E2E, vitals (empty form)**: the save button is disabled while the form is pristine, and submitting a dirtied-then-cleared form shows the "Please fill at least one field" error.
- **E2E, vitals (out of range)**: saving SpO2 101 shows the field-level range error and the invalid-values notification. The test first verifies via API that the SpO2 concept defines `hiAbsolute` below 101, so a misconfigured environment fails fast with a clear message instead of a mystery failure. It also waits for the input's `max` attribute to be populated before saving, because the client-side range check silently no-ops until the `conceptreferencerange` request resolves (the test raced this under parallel load and the form saved 101 successfully).
- **E2E, visits**: starting a visit without selecting a visit type shows the "Missing visit type" error and no visit starts. This is folded into the existing start-and-end-visit journey rather than a standalone test, since the error strings themselves are already covered by `visit-form.test.tsx`; the e2e adds the recovery path (fix the error, then a real save succeeds).

## Screenshots

## Related Issue

## Other
