### PR TITLE
(fix) Remove unnecessary padding from task list back button

### DIFF
--- a/packages/esm-patient-procedures-app/translations/en.json
+++ b/packages/esm-patient-procedures-app/translations/en.json
@@ -58,7 +58,6 @@
   "procedures": "Procedures",
   "procedures_lower": "procedures",
   "procedureSaved": "Procedure saved",
-  "proceduresOverview": "Procedures overview",
   "proceduresSummary": "Procedures summary",
   "procedureType": "Procedure type",
   "procedureTypeRequired": "Procedure type is required",

--- a/packages/esm-patient-task-list-app/src/workspace/task-list.scss
+++ b/packages/esm-patient-task-list-app/src/workspace/task-list.scss
@@ -15,8 +15,6 @@
 }
 
 .backButton {
-  padding: 0 layout.$spacing-05;
-
   button {
     display: flex;
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Removes an unnecessary  `padding` rule from the `.backButton` block in `task-list.scss`. 

## Screenshots

Before -
<img width="417" height="147" alt="Screenshot 2026-06-12 at 4 12 29 PM" src="https://github.com/user-attachments/assets/b609a8a1-b3a7-4196-af5d-ffbed798a396" />

After - 
<img width="417" height="147" alt="Screenshot 2026-06-12 at 4 11 23 PM" src="https://github.com/user-attachments/assets/b2fed340-4568-4d79-902c-92c2b7e9ff07" />


## Related Issue

<!-- https://issues.openmrs.org/browse/O3- -->

## Other

N/A