### PR TITLE
(fix) O3-5738: Prevent spurious unsaved-changes prompt when starting a visit

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visit-form/exported-visit-form.workspace.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/exported-visit-form.workspace.tsx
@@ -143,6 +143,7 @@ const ExportedVisitForm: React.FC<Workspace2DefinitionProps<ExportedVisitFormPro
   const { earliestAllowedStartDate, isLoading: isLoadingBirthdateCheck } =
     useEarliestAllowedVisitStartDate(patientUuid);
 
+  const [isVisitSaved, setIsVisitSaved] = useState(false);
   const [errorFetchingResources, setErrorFetchingResources] = useState<{
     blockSavingForm: boolean;
   } | null>(null);
@@ -359,6 +360,7 @@ const ExportedVisitForm: React.FC<Workspace2DefinitionProps<ExportedVisitFormPro
             // now that visit is created / updated, we run post-submit actions
             // to update visit attributes or any other OnVisitCreatedOrUpdated actions
             const visit = response.data;
+            setIsVisitSaved(true);
 
             // Use targeted SWR invalidation instead of global mutateVisit
             // This will invalidate visit history and encounter tables for this patient
@@ -401,6 +403,7 @@ const ExportedVisitForm: React.FC<Workspace2DefinitionProps<ExportedVisitFormPro
           payload.startDatetime,
         ).then(
           async (visit) => {
+            setIsVisitSaved(true);
             // Also invalidate visit history and encounter tables
             invalidateVisitAndEncounterData(globalMutate, patientUuid);
             invalidateCurrentVisit(globalMutate, patientUuid);
@@ -445,7 +448,7 @@ const ExportedVisitForm: React.FC<Workspace2DefinitionProps<ExportedVisitFormPro
   return (
     <Workspace2
       title={visitToEdit ? t('editVisit', 'Edit visit') : t('startVisitWorkspaceTitle', 'Start a visit')}
-      hasUnsavedChanges={isDirty}
+      hasUnsavedChanges={isDirty && !isVisitSaved}
     >
       <FormProvider {...methods}>
         <Form className={styles.form} onSubmit={handleSubmit(onSubmit)} data-openmrs-role="Start Visit Form">

--- a/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.test.tsx
@@ -14,6 +14,7 @@ import {
   useLocations,
   useVisit,
   useVisitTypes,
+  Workspace2,
   type Visit,
 } from '@openmrs/esm-framework';
 import { mockLocations, mockPastVisitWithEncounters, mockVisitTypes, mockVisitWithAttributes } from '__mocks__';
@@ -87,6 +88,7 @@ const mockUseDefaultVisitLocation = vi.fn().mockReturnValue(defaultVisitLocation
 
 const mockSaveVisit = vi.mocked(saveVisit);
 const mockUpdateVisit = vi.mocked(updateVisit);
+const mockWorkspace2 = vi.mocked(Workspace2);
 const mockUseConfig = vi.mocked(useConfig<ChartConfig>);
 const mockUseVisitAttributeType = vi.mocked(useVisitAttributeType);
 const mockUseVisit = vi.mocked(useVisit);
@@ -467,6 +469,34 @@ describe('Visit form', () => {
       kind: 'success',
       title: 'Visit started',
     });
+  });
+
+  it('reports no unsaved changes after a successful save, even while callbacks are still pending', async () => {
+    const user = userEvent.setup();
+
+    let resolveCallback: () => void;
+    const pendingCallback = new Promise<void>((resolve) => {
+      resolveCallback = resolve;
+    });
+    mockOnVisitCreatedOrUpdatedCallback.mockReturnValueOnce(pendingCallback);
+
+    renderVisitForm();
+
+    await user.click(screen.getByLabelText(/Outpatient visit/i));
+    const locationPicker = screen.getByRole('combobox', { name: /Select a location/i });
+    await user.click(locationPicker);
+    await user.click(screen.getByText('Inpatient Ward'));
+
+    await user.click(screen.getByRole('button', { name: /Start visit/i }));
+
+    await waitFor(() => expect(mockSaveVisit).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => {
+      const lastCall = mockWorkspace2.mock.lastCall?.[0];
+      expect(lastCall?.hasUnsavedChanges).toBe(false);
+    });
+
+    resolveCallback();
   });
 
   it('starts a new visit with attributes upon successful submission of the form', async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

When starting a visit with an extension field filled in (e.g. selecting an appointment to fulfill, or billing details), clicking **Start visit** could show the "Close workspace(s)" unsaved-changes confirmation modal even though the visit was being saved successfully.

This happens because of a race in the submit flow of `exported-visit-form.workspace.tsx`:

1. The visit `POST` succeeds, and the SWR invalidations (`invalidateVisitAndEncounterData` / `invalidateCurrentVisit`) kick off a revalidation of the active visit.
2. The submit handler then awaits the post-save extension callbacks (appointment `status-change` check-in, billing extra-visit info) before calling `closeWorkspace({ discardUnsavedChanges: true })`.
3. While those callbacks are in flight, the revalidated active visit causes `usePatientChartPatientAndVisit` to relaunch the patient chart workspace group with a new visit context. The framework treats this implicit relaunch as closing the open workspaces, finds the visit form still reporting `hasUnsavedChanges={isDirty}`, and prompts the user to discard changes that were already saved.

Whether the modal appears depends purely on whether the extension callback request finishes before or after the active-visit revalidation, which is why it reproduces intermittently on some servers (seen on test3) and not others (dev3) running the same code. Delaying the appointment `status-change` response by 4s reproduces it deterministically on both.

The fix makes the form stop reporting unsaved changes as soon as the visit create/update request resolves successfully (both the online and offline paths). From that moment the user's input is persisted, so whatever wins the race, the workspace-group relaunch finds nothing dirty and no prompt is shown.

Note: with this change, if a post-save extension callback fails (the form currently stays open with an error snackbar), closing the workspace afterwards no longer prompts. That seems correct, since the visit already exists and resubmitting the form would create a second visit.

Other Workspace2 forms that await secondary requests after a successful primary save while keeping `hasUnsavedChanges` bound to form dirtiness may have the same latent race and are worth auditing.

## Screenshots

Before -

https://github.com/user-attachments/assets/09364ff6-d92c-4e5b-97a8-50b73f61dcda


After - 

https://github.com/user-attachments/assets/6c4c9c93-4c2a-4a7f-bb16-09a5e52e4434


## Related Issue
https://openmrs.atlassian.net/browse/O3-5738

## Other

