### PR TITLE
(test) Add e2e coverage for deleting program enrollments and editing visit notes

### DIFF
--- a/e2e/specs/program-enrollment.spec.ts
+++ b/e2e/specs/program-enrollment.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from '../core';
 import { ProgramsPage } from '../pages';
 
-test('Add and edit a program enrollment', async ({ page, patient }) => {
+test('Add, edit, and delete a program enrollment', async ({ page, patient }) => {
   const programsPage = new ProgramsPage(page);
   const headerRow = programsPage.programsTable().locator('thead > tr');
   const dataRow = programsPage.programsTable().locator('tbody > tr');
@@ -116,5 +116,26 @@ test('Add and edit a program enrollment', async ({ page, patient }) => {
     await expect(dataRow).toContainText(/completed on 04-Jul-2023/i);
     await expect(dataRow).not.toContainText(/outpatient clinic/i);
     await expect(dataRow).toContainText(/community outreach/i);
+  });
+
+  await test.step('When I click the `Delete` button of the program', async () => {
+    await programsPage.overflowButton().click();
+    await page.getByRole('menuitem', { name: /delete/i }).click();
+  });
+
+  await test.step('Then I should see a confirmation modal', async () => {
+    await expect(page.getByText(/are you sure you want to delete this program enrollment\?/i)).toBeVisible();
+  });
+
+  await test.step('When I confirm the deletion', async () => {
+    await page.getByRole('button', { name: /confirm/i }).click();
+  });
+
+  await test.step('Then I should see a success notification', async () => {
+    await expect(page.getByText(/program enrollment deleted/i)).toBeVisible();
+  });
+
+  await test.step('And the program should no longer appear in the list', async () => {
+    await expect(page.getByRole('cell', { name: /hiv care and treatment/i })).toBeHidden();
   });
 });

--- a/e2e/specs/visit-note.spec.ts
+++ b/e2e/specs/visit-note.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from '../core';
 import { ChartPage, VisitsPage } from '../pages';
 
-test('Add and delete a visit note', async ({ page, patient }) => {
+test('Add, edit, and delete a visit note', async ({ page, patient }) => {
   const chartPage = new ChartPage(page);
   const visitsPage = new VisitsPage(page);
 
@@ -74,6 +74,43 @@ test('Add and delete a visit note', async ({ page, patient }) => {
 
   await test.step('Then I should see the newly added visit note', async () => {
     await expect(page.getByText(/this is a note/i)).toBeVisible();
+  });
+
+  await test.step('When I click the `All encounters` tab', async () => {
+    await page.getByRole('tab', { name: /all encounters/i }).click();
+  });
+
+  await test.step('And I open the overflow menu in the visit note row and select `Edit this encounter`', async () => {
+    await page
+      .getByRole('row')
+      .filter({ hasText: /visit note/i })
+      .getByRole('button', { name: /options/i })
+      .click();
+    await page.getByRole('menuitem', { name: /edit this encounter/i }).click();
+  });
+
+  await test.step('Then the visit note form should open in edit mode with the existing note prefilled', async () => {
+    await expect(page.getByPlaceholder('Write any notes here')).toHaveValue('This is a note');
+  });
+
+  await test.step('When I change the note text and click `Save and close`', async () => {
+    await page.getByPlaceholder('Write any notes here').fill('This is an edited note');
+    await page.getByRole('button', { name: /save and close/i }).click();
+  });
+
+  await test.step('Then I should see a success notification', async () => {
+    await expect(page.getByText(/visit note saved/i)).toBeVisible();
+  });
+
+  await test.step('When I reload the visits dashboard and open the `Notes` tab', async () => {
+    await visitsPage.goTo(patient.uuid);
+    await page.getByRole('button', { name: /expand current row/i }).click();
+    await page.getByRole('tab', { name: /notes/i }).click();
+  });
+
+  await test.step('Then I should see the edited note and not the original note', async () => {
+    await expect(page.getByText('This is an edited note')).toBeVisible();
+    await expect(page.getByText('This is a note', { exact: true })).toBeHidden();
   });
 
   await test.step('When I click the `All encounters` tab', async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Extends two existing patient-chart e2e specs to cover the CRUD operation each was missing, completing the round-trip:

- **program-enrollment**: previously covered add + edit; now also deletes the enrollment (overflow → Delete → confirm) and asserts the program no longer appears in the list.
- **visit-note**: previously covered add + delete; now also edits the note in place from the "All encounters" tab ("Edit this encounter"), then reloads the visits dashboard and verifies the updated note on the Notes tab.

## Screenshots

## Related Issue

## Other
