### PR TITLE
(test) Add e2e coverage for creating a retrospective visit

### DIFF
--- a/e2e/specs/start-and-end-visit.spec.ts
+++ b/e2e/specs/start-and-end-visit.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import dayjs from 'dayjs';
 import { test } from '../core';
 import { ChartPage } from '../pages';
 import { ensureNoActiveVisits } from '../commands/visit-operations';
@@ -259,6 +260,71 @@ test('Verify visit context when starting / ending / deleting / restoring active 
     await expect(chartPage.page.getByText(/no active visit/i)).toBeVisible();
     await expect(chartPage.page.getByRole('button', { name: /cancel/i })).toBeVisible();
     await expect(chartPage.page.getByRole('button', { name: /start new visit/i })).toBeVisible();
+  });
+});
+
+test('Start a visit in the past', async ({ page, patient, api }) => {
+  await test.step('Ensure no active visits for the patient', async () => {
+    await ensureNoActiveVisits(api, patient.uuid);
+  });
+
+  const chartPage = new ChartPage(page);
+  const startDate = dayjs().subtract(2, 'day');
+  const endDate = dayjs().subtract(1, 'day');
+
+  await test.step('When I visit the chart summary page', async () => {
+    await chartPage.goTo(patient.uuid);
+  });
+
+  await test.step('And I click on the `Add visit` button in the actions overflow menu', async () => {
+    await chartPage.page.getByRole('button', { name: /actions/i }).click();
+    await chartPage.page.getByRole('menuitem', { name: /add visit/i }).click();
+  });
+
+  await test.step('When I select visit status: In the past', async () => {
+    const pastTab = chartPage.page.getByRole('tab', { name: /in the past/i });
+    await pastTab.click();
+    await expect(pastTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  await test.step('And the visit location should be resolved', async () => {
+    await waitForVisitLocationValue(chartPage.page);
+  });
+
+  await test.step('And I set the start date two days ago', async () => {
+    const startDateInput = chartPage.page.getByTestId('visitStartDateInput');
+    await startDateInput.getByRole('spinbutton', { name: /month/i }).fill(startDate.format('MM'));
+    await startDateInput.getByRole('spinbutton', { name: /day/i }).fill(startDate.format('DD'));
+    await startDateInput.getByRole('spinbutton', { name: /year/i }).fill(startDate.format('YYYY'));
+  });
+
+  await test.step('And I set the end date one day ago', async () => {
+    const endDateInput = chartPage.page.getByTestId('visitStopDateInput');
+    await endDateInput.getByRole('spinbutton', { name: /month/i }).fill(endDate.format('MM'));
+    await endDateInput.getByRole('spinbutton', { name: /day/i }).fill(endDate.format('DD'));
+    await endDateInput.getByRole('spinbutton', { name: /year/i }).fill(endDate.format('YYYY'));
+  });
+
+  await test.step('And I select the visit type: `OPD Visit`', async () => {
+    const opdVisitLabel = chartPage.page.locator('label').filter({ hasText: /^OPD Visit$/i });
+    await expect(opdVisitLabel).toBeVisible();
+    await opdVisitLabel.click();
+    await expect(chartPage.page.getByRole('radio', { name: /^OPD Visit$/i })).toBeChecked();
+  });
+
+  await test.step('And I click on the `Start Visit` button', async () => {
+    await chartPage.page
+      .locator('form')
+      .getByRole('button', { name: /start visit/i })
+      .click();
+  });
+
+  await test.step('Then I should see a success notification', async () => {
+    await expect(chartPage.page.getByText(/opd visit started successfully/i)).toBeVisible();
+  });
+
+  await test.step('And the patient should not have an active visit tag', async () => {
+    await expect(chartPage.page.getByLabel(/active visit/i)).toBeHidden();
   });
 });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The "Start and end a new visit" spec opens the "In the past" tab and asserts the start/end pickers appear, but never submits a retrospective visit (the date inputs were left as a `FIXME`). This adds a "Start a visit in the past" test that:

- backdates the start (2 days ago) and end (1 day ago) dates via the `OpenmrsDatePicker` day/month/year spinbuttons,
- starts an OPD visit, and
- asserts it is created as a completed visit: the success notification shows and no active-visit tag appears on the patient header.

The date pickers work fine through the segment spinbuttons; the earlier `FIXME` stemmed from targeting them as a textbox.

## Screenshots

## Related Issue

## Other
