### PR TITLE
(feat) O3-5746: Support conditional order reasons via hide expression

### DIFF
--- a/packages/esm-patient-tests-app/src/config-schema.ts
+++ b/packages/esm-patient-tests-app/src/config-schema.ts
@@ -35,7 +35,8 @@ export const configSchema = {
   },
   orderTypeUuid: {
     _type: Type.UUID,
-    _description: "UUID identifying this extension's order type for order basket panel filtering. Must match orders.labOrderTypeUuid if that value is overridden.",
+    _description:
+      "UUID identifying this extension's order type for order basket panel filtering. Must match orders.labOrderTypeUuid if that value is overridden.",
     _default: '52a447d3-a64a-11e3-9aeb-50e549534c5e',
   },
   orders: {
@@ -107,9 +108,9 @@ export const configSchema = {
         _type: Type.Array,
         _elements: {
           _type: Type.ConceptUuid,
-          _description: 'Array of coded concepts that represent reasons for ordering a lab test',
         },
-        _description: 'Coded Lab test order reason options',
+        _description:
+          'Coded Lab test order reason options. Each entry may be a plain concept UUID string, or an object with `conceptUuid` (string) and an optional `hideWhenExpression`.',
         _default: [],
       },
     },
@@ -128,9 +129,16 @@ export interface LabTestReason {
   label?: string;
 }
 
+export interface OrderReasonReferenceConfig {
+  conceptUuid: string;
+  hideWhenExpression?: string;
+}
+
+export type OrderReasonReference = string | OrderReasonReferenceConfig;
+
 export interface OrderReason {
   labTestUuid: string;
-  orderReasons: Array<string>;
+  orderReasons: Array<OrderReasonReference>;
   required: boolean;
 }
 

--- a/packages/esm-patient-tests-app/src/config-schema.ts
+++ b/packages/esm-patient-tests-app/src/config-schema.ts
@@ -1,4 +1,4 @@
-import { Type } from '@openmrs/esm-framework';
+import { Type, validator } from '@openmrs/esm-framework';
 
 export const configSchema = {
   resultsViewerConcepts: {
@@ -107,7 +107,13 @@ export const configSchema = {
       orderReasons: {
         _type: Type.Array,
         _elements: {
-          _type: Type.ConceptUuid,
+          _validators: [
+            validator(
+              (v) =>
+                typeof v === 'string' || (typeof v === 'object' && v !== null && typeof v.conceptUuid === 'string'),
+              'must be a concept UUID string or an object with a `conceptUuid` string',
+            ),
+          ],
         },
         _description:
           'Coded Lab test order reason options. Each entry may be a plain concept UUID string, or an object with `conceptUuid` (string) and an optional `hideWhenExpression`.',

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.test.tsx
@@ -178,6 +178,42 @@ describe('LabOrderForm', () => {
     await screen.findByText(/order reason is required/i);
   });
 
+  it('allows saving when required:true but every reason is hidden by expression', async () => {
+    const user = userEvent.setup();
+    const mockSetOrders = vi.fn();
+    mockUseOrderBasket.mockReturnValue({ orders: [], setOrders: mockSetOrders, clearOrders: vi.fn() });
+    const actual = await vi.importActual<typeof Api>('../api');
+    mockUseOrderReasons.mockImplementation(actual.useOrderReasons);
+
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(configSchema),
+      showReferenceNumberField: true,
+      labTestsWithOrderReasons: [
+        {
+          labTestUuid: testType.conceptUuid,
+          required: true,
+          orderReasons: [{ conceptUuid: 'reason-uuid-1', hideWhenExpression: 'true' }],
+        },
+      ],
+    });
+
+    // conceptreferences is never reached because the visible list is empty
+    mockOpenmrsFetch.mockResolvedValue({ data: {} } as any);
+
+    renderLabOrderForm();
+
+    // No combobox — all reasons are hidden
+    await waitFor(() => {
+      expect(screen.queryByRole('combobox', { name: /order reason/i })).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /save order/i }));
+
+    // Form submits; no "Order reason is required" blocking error
+    await waitFor(() => expect(mockSetOrders).toHaveBeenCalled());
+    expect(screen.queryByText(/order reason is required/i)).not.toBeInTheDocument();
+  });
+
   it('hides the order reason field when only one reason exists but is hidden by expression', async () => {
     const actual = await vi.importActual<typeof Api>('../api');
     mockUseOrderReasons.mockImplementation(actual.useOrderReasons);

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.test.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.test.tsx
@@ -1,0 +1,331 @@
+import React from 'react';
+import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
+import type * as EsmExpressionEvaluator from '@openmrs/esm-expression-evaluator';
+import type * as Api from '../api';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
+import { getDefaultsFromConfigSchema, openmrsFetch, useConfig, useLayoutType } from '@openmrs/esm-framework';
+import { useOrderBasket, useOrderType, useMutatePatientOrders } from '@openmrs/esm-patient-common-lib';
+import { mockFhirPatient } from '__mocks__';
+import { configSchema, type ConfigObject } from '../../config-schema';
+import { useOrderReasons } from '../api';
+import { LabOrderForm } from './test-order-form.component';
+
+vi.mock('@openmrs/esm-framework', async () => {
+  const { evaluateAsBooleanAsync } = await vi.importActual<typeof EsmExpressionEvaluator>(
+    '@openmrs/esm-expression-evaluator',
+  );
+  return {
+    ...(await vi.importActual('@openmrs/esm-framework')),
+    evaluateAsBooleanAsync,
+    openmrsFetch: vi.fn(),
+  };
+});
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual<typeof Api>('../api');
+  return {
+    ...actual,
+    prepTestOrderPostData: vi.fn(),
+    useOrderReasons: vi.fn(actual.useOrderReasons),
+  };
+});
+
+vi.mock('@openmrs/esm-patient-common-lib', async () => ({
+  ...(await vi.importActual('@openmrs/esm-patient-common-lib')),
+  useOrderBasket: vi.fn(),
+  useOrderType: vi.fn(),
+  useMutatePatientOrders: vi.fn(),
+}));
+
+const mockOpenmrsFetch = vi.mocked(openmrsFetch);
+const mockUseConfig = vi.mocked(useConfig<ConfigObject>);
+const mockUseLayoutType = vi.mocked(useLayoutType);
+const mockUseOrderReasons = vi.mocked(useOrderReasons);
+const mockUseOrderBasket = useOrderBasket as Mock;
+const mockUseOrderType = useOrderType as Mock;
+const mockUseMutatePatientOrders = useMutatePatientOrders as Mock;
+
+const HIV_VIRAL_LOAD_UUID = '856AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+const testType = { conceptUuid: 'test-concept-uuid', label: 'CD4 COUNT' };
+
+const defaultProps = {
+  closeWorkspace: vi.fn(),
+  initialOrder: {
+    action: 'NEW' as const,
+    urgency: 'ROUTINE' as const,
+    display: 'CD4 COUNT',
+    testType,
+    visit: null,
+  },
+  onCancel: vi.fn(),
+  orderTypeUuid: 'test-order-type-uuid',
+  orderableConceptSets: [],
+  setHasUnsavedChanges: vi.fn(),
+  patient: mockFhirPatient,
+};
+
+function renderLabOrderForm(props = {}) {
+  return render(<LabOrderForm {...defaultProps} {...props} />);
+}
+
+describe('LabOrderForm', () => {
+  beforeEach(() => {
+    mockUseLayoutType.mockReturnValue('small-desktop');
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(configSchema),
+      showReferenceNumberField: true,
+      labTestsWithOrderReasons: [
+        {
+          labTestUuid: testType.conceptUuid,
+          required: false,
+          orderReasons: [],
+        },
+      ],
+    });
+    mockUseOrderBasket.mockReturnValue({ orders: [], setOrders: vi.fn(), clearOrders: vi.fn() });
+    mockUseOrderType.mockReturnValue({ orderType: { display: 'Test order' } });
+    mockUseMutatePatientOrders.mockReturnValue({ mutate: vi.fn() });
+    mockUseOrderReasons.mockReturnValue({ orderReasons: [], isLoading: false });
+  });
+
+  it('does not show the order reason field when all reasons are hidden by expression', () => {
+    mockUseOrderReasons.mockReturnValue({ orderReasons: [], isLoading: false });
+
+    renderLabOrderForm();
+
+    expect(screen.queryByRole('combobox', { name: /order reason/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the order reason field when reasons are visible', () => {
+    mockUseOrderReasons.mockReturnValue({
+      orderReasons: [
+        { uuid: 'reason-uuid-1', display: 'Routine screening' },
+        { uuid: 'reason-uuid-2', display: 'Follow-up' },
+      ],
+      isLoading: false,
+    });
+
+    renderLabOrderForm();
+
+    expect(screen.getByRole('combobox', { name: /order reason/i })).toBeInTheDocument();
+  });
+
+  it('shows both visible order reasons in the dropdown', async () => {
+    const user = userEvent.setup();
+    mockUseOrderReasons.mockReturnValue({
+      orderReasons: [
+        { uuid: 'reason-uuid-1', display: 'Routine screening' },
+        { uuid: 'reason-uuid-2', display: 'Follow-up' },
+      ],
+      isLoading: false,
+    });
+
+    renderLabOrderForm();
+
+    const combobox = screen.getByRole('combobox', { name: /order reason/i });
+    await user.click(combobox);
+
+    expect(screen.getByText('Routine screening')).toBeInTheDocument();
+    expect(screen.getByText('Follow-up')).toBeInTheDocument();
+  });
+
+  it('submits the selected order reason', async () => {
+    const user = userEvent.setup();
+    const mockSetOrders = vi.fn();
+    mockUseOrderBasket.mockReturnValue({ orders: [], setOrders: mockSetOrders, clearOrders: vi.fn() });
+    mockUseOrderReasons.mockReturnValue({
+      orderReasons: [{ uuid: 'reason-uuid-1', display: 'Routine screening' }],
+      isLoading: false,
+    });
+
+    renderLabOrderForm();
+
+    const combobox = screen.getByRole('combobox', { name: /order reason/i });
+    await user.click(combobox);
+    await user.click(screen.getByText('Routine screening'));
+
+    await user.click(screen.getByRole('button', { name: /save order/i }));
+
+    await waitFor(() =>
+      expect(mockSetOrders).toHaveBeenCalledWith([expect.objectContaining({ orderReason: 'reason-uuid-1' })]),
+    );
+  });
+
+  it('shows validation error when order reason is required but not selected', async () => {
+    const user = userEvent.setup();
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(configSchema),
+      showReferenceNumberField: true,
+      labTestsWithOrderReasons: [
+        {
+          labTestUuid: testType.conceptUuid,
+          required: true,
+          orderReasons: [],
+        },
+      ],
+    });
+    mockUseOrderReasons.mockReturnValue({
+      orderReasons: [{ uuid: 'reason-uuid-1', display: 'Routine screening' }],
+      isLoading: false,
+    });
+
+    renderLabOrderForm();
+
+    await user.click(screen.getByRole('button', { name: /save order/i }));
+
+    await screen.findByText(/order reason is required/i);
+  });
+
+  it('hides the order reason field when only one reason exists but is hidden by expression', async () => {
+    const actual = await vi.importActual<typeof Api>('../api');
+    mockUseOrderReasons.mockImplementation(actual.useOrderReasons);
+
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(configSchema),
+      showReferenceNumberField: true,
+      labTestsWithOrderReasons: [
+        {
+          labTestUuid: testType.conceptUuid,
+          required: false,
+          orderReasons: [{ conceptUuid: 'reason-uuid-1', hideWhenExpression: "patient.gender === 'male'" }],
+        },
+      ],
+    });
+
+    mockOpenmrsFetch.mockResolvedValue({ data: {} } as any);
+
+    renderLabOrderForm();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('combobox', { name: /order reason/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('order reasons with patient-conditional hideWhenExpression', () => {
+    const conceptsMap: Record<string, { uuid: string; display: string }> = {
+      '1259AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA': { uuid: '1259AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Reason A' },
+      '163718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA': {
+        uuid: '163718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        display: 'Female-only reason 1',
+      },
+      'f87f344a-62de-45ac-9cc0-b5bed81c289e': {
+        uuid: 'f87f344a-62de-45ac-9cc0-b5bed81c289e',
+        display: 'Female-only reason 2',
+      },
+      'bb9780b3-4f44-42fd-9e94-3958d36d106f': { uuid: 'bb9780b3-4f44-42fd-9e94-3958d36d106f', display: 'Reason D' },
+      '167391AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA': { uuid: '167391AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Reason E' },
+      'e299c5c6-5dc7-4977-9b9a-516252d4d582': { uuid: 'e299c5c6-5dc7-4977-9b9a-516252d4d582', display: 'Reason F' },
+    };
+
+    const femalePatient: fhir.Patient = { resourceType: 'Patient', id: 'female-patient-uuid', gender: 'female' };
+    const malePatient: fhir.Patient = { resourceType: 'Patient', id: 'male-patient-uuid', gender: 'male' };
+
+    const hivViralLoadTestType = { conceptUuid: HIV_VIRAL_LOAD_UUID, label: 'HIV VIRAL LOAD' };
+
+    const hivInitialOrder = {
+      action: 'NEW' as const,
+      urgency: 'ROUTINE' as const,
+      display: 'HIV VIRAL LOAD',
+      testType: hivViralLoadTestType,
+      visit: null,
+    };
+
+    beforeEach(async () => {
+      const actual = await vi.importActual<typeof Api>('../api');
+      mockUseOrderReasons.mockImplementation(actual.useOrderReasons);
+
+      mockUseConfig.mockReturnValue({
+        ...getDefaultsFromConfigSchema(configSchema),
+        showReferenceNumberField: true,
+        labTestsWithOrderReasons: [
+          {
+            labTestUuid: HIV_VIRAL_LOAD_UUID,
+            required: true,
+            orderReasons: [
+              '1259AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              { conceptUuid: '163718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', hideWhenExpression: "patient.gender === 'male'" },
+              { conceptUuid: 'f87f344a-62de-45ac-9cc0-b5bed81c289e', hideWhenExpression: "patient.gender === 'male'" },
+              'bb9780b3-4f44-42fd-9e94-3958d36d106f',
+              '167391AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              'e299c5c6-5dc7-4977-9b9a-516252d4d582',
+            ],
+          },
+        ],
+      });
+
+      mockOpenmrsFetch.mockImplementation(async (url: string, options?: any) => {
+        if (url.includes('conceptreferences')) {
+          const refs: string[] = options?.body?.references ?? [];
+          const data = Object.fromEntries(
+            refs.filter((uuid) => conceptsMap[uuid]).map((uuid) => [uuid, conceptsMap[uuid]]),
+          );
+          return { data } as any;
+        }
+        return { data: {} } as any;
+      });
+    });
+
+    it('shows all 6 reasons for a female patient', async () => {
+      const user = userEvent.setup();
+
+      render(<LabOrderForm {...defaultProps} initialOrder={hivInitialOrder} patient={femalePatient} />);
+
+      await screen.findByRole('combobox', { name: /order reason/i });
+
+      await user.click(screen.getByRole('combobox', { name: /order reason/i }));
+
+      Object.values(conceptsMap).forEach(({ display }) => expect(screen.getByText(display)).toBeInTheDocument());
+    });
+
+    it('shows only 4 reasons for a male patient (gender-hidden concepts excluded)', async () => {
+      const user = userEvent.setup();
+
+      render(<LabOrderForm {...defaultProps} initialOrder={hivInitialOrder} patient={malePatient} />);
+
+      await screen.findByRole('combobox', { name: /order reason/i });
+
+      await user.click(screen.getByRole('combobox', { name: /order reason/i }));
+
+      expect(screen.getByText('Reason A')).toBeInTheDocument();
+      expect(screen.getByText('Reason D')).toBeInTheDocument();
+      expect(screen.getByText('Reason E')).toBeInTheDocument();
+      expect(screen.getByText('Reason F')).toBeInTheDocument();
+      expect(screen.queryByText('Female-only reason 1')).not.toBeInTheDocument();
+      expect(screen.queryByText('Female-only reason 2')).not.toBeInTheDocument();
+    });
+
+    it('allows selecting one of the 4 male-visible reasons and saving', async () => {
+      const user = userEvent.setup();
+      const mockSetOrders = vi.fn();
+      mockUseOrderBasket.mockReturnValue({ orders: [], setOrders: mockSetOrders, clearOrders: vi.fn() });
+
+      render(<LabOrderForm {...defaultProps} initialOrder={hivInitialOrder} patient={malePatient} />);
+
+      await screen.findByRole('combobox', { name: /order reason/i });
+
+      await user.click(screen.getByRole('combobox', { name: /order reason/i }));
+      await user.click(screen.getByText('Reason D'));
+      await user.click(screen.getByRole('button', { name: /save order/i }));
+
+      await waitFor(() =>
+        expect(mockSetOrders).toHaveBeenCalledWith([
+          expect.objectContaining({ orderReason: 'bb9780b3-4f44-42fd-9e94-3958d36d106f' }),
+        ]),
+      );
+    });
+
+    it('shows required validation error when no reason is selected for HIV Viral Load', async () => {
+      const user = userEvent.setup();
+
+      render(<LabOrderForm {...defaultProps} initialOrder={hivInitialOrder} patient={malePatient} />);
+
+      await screen.findByRole('combobox', { name: /order reason/i });
+
+      await user.click(screen.getByRole('button', { name: /save order/i }));
+
+      await screen.findByText(/order reason is required/i);
+    });
+  });
+});

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
@@ -137,7 +137,7 @@ export function LabOrderForm({
     (config.labTestsWithOrderReasons?.find((c) => c.labTestUuid === defaultValues?.testType?.conceptUuid) || {})
       .orderReasons || [];
 
-  const { orderReasons } = useOrderReasons(orderReasonUuids);
+  const { orderReasons } = useOrderReasons(orderReasonUuids, patient);
 
   const filterItemsByName = useCallback((menu) => {
     const inputValue = menu?.inputValue?.toLowerCase();

--- a/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
+++ b/packages/esm-patient-tests-app/src/test-orders/add-test-order/test-order-form.component.tsx
@@ -84,6 +84,12 @@ export function LabOrderForm({
     [config.labTestsWithOrderReasons, initialOrder?.testType?.conceptUuid],
   );
 
+  const orderReasonUuids =
+    (config.labTestsWithOrderReasons?.find((c) => c.labTestUuid === initialOrder?.testType?.conceptUuid) || {})
+      .orderReasons || [];
+
+  const { orderReasons } = useOrderReasons(orderReasonUuids, patient);
+
   const labOrderFormSchema = useMemo(
     () =>
       z
@@ -100,20 +106,21 @@ export function LabOrderForm({
               invalid_type_error: t('testTypeRequired', 'Test type is required'),
             },
           ),
-          orderReason: orderReasonRequired
-            ? z
-                .string({
-                  required_error: t('orderReasonRequired', 'Order reason is required'),
-                })
-                .refine((value) => !!value, t('orderReasonRequired', 'Order reason is required'))
-            : z.string().optional(),
+          orderReason:
+            orderReasonRequired && orderReasons.length > 0
+              ? z
+                  .string({
+                    required_error: t('orderReasonRequired', 'Order reason is required'),
+                  })
+                  .refine((value) => !!value, t('orderReasonRequired', 'Order reason is required'))
+              : z.string().optional(),
           scheduledDate: z.date({}).nullish(),
         })
         .refine((data) => data.urgency !== 'ON_SCHEDULED_DATE' || Boolean(data.scheduledDate), {
           message: t('scheduledDateRequired', 'Scheduled date is required'),
           path: ['scheduledDate'],
         }),
-    [orderReasonRequired, t],
+    [orderReasonRequired, orderReasons.length, t],
   );
 
   const {
@@ -132,12 +139,6 @@ export function LabOrderForm({
   });
 
   const isScheduledDateRequired = watch('urgency') === 'ON_SCHEDULED_DATE';
-
-  const orderReasonUuids =
-    (config.labTestsWithOrderReasons?.find((c) => c.labTestUuid === defaultValues?.testType?.conceptUuid) || {})
-      .orderReasons || [];
-
-  const { orderReasons } = useOrderReasons(orderReasonUuids, patient);
 
   const filterItemsByName = useCallback((menu) => {
     const inputValue = menu?.inputValue?.toLowerCase();

--- a/packages/esm-patient-tests-app/src/test-orders/api.ts
+++ b/packages/esm-patient-tests-app/src/test-orders/api.ts
@@ -73,11 +73,19 @@ async function getVisibleConceptUuids(conceptUuids: Array<OrderReasonReference>,
       }
 
       if (concept.hideWhenExpression) {
-        const evaluatedExpression = await evaluateAsBooleanAsync(concept.hideWhenExpression, {
-          patient: patient,
-          openmrsFetch,
-        });
-        return evaluatedExpression ? null : concept.conceptUuid;
+        try {
+          const evaluatedExpression = await evaluateAsBooleanAsync(concept.hideWhenExpression, {
+            patient: patient,
+            openmrsFetch,
+          });
+          return evaluatedExpression ? null : concept.conceptUuid;
+        } catch (err) {
+          console.error(
+            `Failed to evaluate hideWhenExpression "${concept.hideWhenExpression}" for concept ${concept.conceptUuid}; showing reason anyway.`,
+            err,
+          );
+          return concept.conceptUuid;
+        }
       }
 
       return concept.conceptUuid;

--- a/packages/esm-patient-tests-app/src/test-orders/api.ts
+++ b/packages/esm-patient-tests-app/src/test-orders/api.ts
@@ -10,6 +10,7 @@ import {
   type TestOrderPost,
 } from '@openmrs/esm-patient-common-lib';
 import {
+  evaluateAsBooleanAsync,
   type FetchResponse,
   openmrsFetch,
   restBaseUrl,
@@ -17,7 +18,7 @@ import {
   toOmrsIsoString,
   useConfig,
 } from '@openmrs/esm-framework';
-import { type ConfigObject } from '../config-schema';
+import { type ConfigObject, type OrderReasonReference } from '../config-schema';
 
 /**
  * SWR-based data fetcher for patient orders.
@@ -64,17 +65,45 @@ export function usePatientLabOrders(patientUuid: string, status: 'ACTIVE' | 'any
 
 const conceptRepresentation = 'custom:(uuid,display)';
 
-export function useOrderReasons(conceptUuids: Array<string>) {
+async function getVisibleConceptUuids(conceptUuids: Array<OrderReasonReference>, patient: fhir.Patient) {
+  const visibleConceptUuids = await Promise.allSettled(
+    conceptUuids.map(async (concept) => {
+      if (typeof concept === 'string') {
+        return concept;
+      }
+
+      if (concept.hideWhenExpression) {
+        const evaluatedExpression = await evaluateAsBooleanAsync(concept.hideWhenExpression, {
+          patient: patient,
+          openmrsFetch,
+        });
+        return evaluatedExpression ? null : concept.conceptUuid;
+      }
+
+      return concept.conceptUuid;
+    }),
+  );
+
+  return visibleConceptUuids
+    .filter(
+      (result): result is PromiseFulfilledResult<string> => result.status === 'fulfilled' && result.value !== null,
+    )
+    .map((result) => result.value);
+}
+
+export function useOrderReasons(conceptUuids: Array<OrderReasonReference>, patient: fhir.Patient) {
   const { data, error, isLoading } = useSWRImmutable<FetchResponse<ConceptReferenceResponse>, Error>(
     conceptUuids && conceptUuids.length > 0
-      ? [`${restBaseUrl}/conceptreferences?v=${conceptRepresentation}`, conceptUuids]
+      ? [`${restBaseUrl}/conceptreferences?v=${conceptRepresentation}`, conceptUuids, patient.id]
       : null,
-    ([url, refs]) =>
-      openmrsFetch<ConceptReferenceResponse>(url, {
+    async ([url]) => {
+      const refs = await getVisibleConceptUuids(conceptUuids, patient);
+      return openmrsFetch<ConceptReferenceResponse>(url, {
         headers: { 'Content-Type': 'application/json' },
         body: { references: refs },
         method: 'POST',
-      }),
+      });
+    },
   );
 
   const orderReasons = Object.values(data?.data ?? {}).map((value) => ({


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR extends `orderReasons` config to accept either a plain concept UUID string or an object `{ conceptUuid, hideWhenExpression }`, allowing individual order reason options to be conditionally hidden per patient context.
## Screenshots
https://github.com/user-attachments/assets/9bb78b0d-472f-46ee-b61b-ed8d0c41e8a3
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
