### PR TITLE
(fix) O3-5772: Task List: Add Task form action buttons overlap the form fields

### DIFF
--- a/packages/esm-patient-task-list-app/src/workspace/add-task-form.scss
+++ b/packages/esm-patient-task-list-app/src/workspace/add-task-form.scss
@@ -4,7 +4,8 @@
 
 .formContainer {
   padding: 0 layout.$spacing-05;
-  height: 100%;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .formSection {
@@ -20,6 +21,8 @@
 }
 
 .bottomButtons {
+  margin-top: auto;
+
   :global(.cds--btn) {
     width: 50%;
     max-width: unset;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR Fixes the Add Task form in the Task List workspace where the Discard / Add Task action buttons overlap the form fields instead of being pinned at the bottom.

## Screenshots
### Initial :
<img width="424" height="712" alt="initial" src="https://github.com/user-attachments/assets/224597a5-91f4-464c-b1b1-bd2a53c6fbfc" />

### After :
<img width="427" height="733" alt="After" src="https://github.com/user-attachments/assets/14f386a1-ae6d-40e8-b1b7-783a8592805a" />

## Related Issue
https://openmrs.atlassian.net/browse/O3-5772

## Other

Problem
In add-task-form.scss, .formContainer used height: 100%, which clamped the form's box to the workspace height while its content overflowed visibly. The ButtonSet rendered after .formContainer with no bottom-pinning, so it landed at the clamped box edge — in the middle of the overflowing content.

Solution
Followed the Workspace2 convention used by other workspace forms (e.g., Start Visit, Programs):

Removed height: 100% from .formContainer and replaced it with flex: 1; overflow-y: auto so the form content fills available space and scrolls internally.
Added margin-top: auto to .bottomButtons so the action buttons pin to the bottom of the flex column.
