### PR TITLE
(fix) Match drug order form ComboBox heights to their paired number fields

### DIFF
--- a/e2e/specs/drug-orders.spec.ts
+++ b/e2e/specs/drug-orders.spec.ts
@@ -521,7 +521,7 @@ test.describe('Drug Order Tests', () => {
       await expect(page.getByText(/dose unit is required/i)).toBeVisible();
     });
 
-    await test.step('Then the Dose input stays top-aligned with the Dose unit field', async () => {
+    await test.step('Then the Dose and Dose unit fields stay top-aligned and equal height', async () => {
       // Regression test: the error label below the Dose unit field used to stretch the row
       // and push the centered Dose input down out of alignment. Both inputs should share the
       // same top edge regardless of the error label.
@@ -531,6 +531,11 @@ test.describe('Drug Order Tests', () => {
       expect(doseBox).not.toBeNull();
       expect(doseUnitBox).not.toBeNull();
       expect(Math.abs(doseBox.y - doseUnitBox.y)).toBeLessThanOrEqual(4);
+
+      // The size="sm" Dose unit ComboBox must match the size="sm" Dose field height; Carbon
+      // otherwise renders the list-box at its md height (~40px), leaving the pair mismatched.
+      // Assert parity rather than an absolute px value so this survives Carbon version changes.
+      expect(Math.abs(doseBox.height - doseUnitBox.height)).toBeLessThanOrEqual(2);
     });
   });
 });

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
@@ -34,6 +34,15 @@
     border: 0;
   }
 
+  // Carbon's `cds--list-box--sm` doesn't set --cds-layout-size-height, so size="sm"
+  // ComboBoxes render at md height (40px) and sit taller than their paired size="sm"
+  // NumberInputs (e.g. Dose vs Dose unit). Pin the token so Carbon's clamp resolves to the
+  // sm height and the paired fields match. Mirrors the styleguide's cds--search--lg fix;
+  // remove once @carbon/styles ships the sm list-box height.
+  :global(.cds--list-box--sm) {
+    --cds-layout-size-height: #{layout.$spacing-07};
+  }
+
   :global(.cds--number__control-btn) {
     border: 0;
   }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

In the drug order form, `size="sm"` ComboBoxes (Dose unit, Route, Frequency, Quantity unit, Duration unit) render ~8px taller than their paired `size="sm"` NumberInputs, so the Dose / Dose unit pair looks misaligned in height: the tops line up, but the ComboBox box extends lower.

Root cause: Carbon's `cds--list-box--sm` doesn't set `--cds-layout-size-height`, so the list-box falls back to Carbon's height clamp, which resolves to the md default (40px). The NumberInput uses an explicit `cds--number--sm` height (32px), so only it shrinks. Confirmed identical on a local backend and on dev3.

This pins the order form's sm list-boxes to the sm layout height so the clamp resolves to 32px and the paired fields match. It mirrors the workaround the styleguide already applies for `cds--search--lg`. This is a contained fix for the drug order form; the systemic fix (covering all `size="sm"` ComboBoxes app-wide) belongs in `esm-styleguide` and will follow.

## Screenshots

<img width="816" height="606" alt="CleanShot 2026-06-26 at 00 30 13@2x" src="https://github.com/user-attachments/assets/c43462fd-89e5-4c03-b03b-b70118db268c" />

## Related Issue

## Other

