### PR TITLE
(chore) Run OWASP dependency check on commits only

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -3,8 +3,6 @@ name: OWASP Dependency Check
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->


The OWASP dependency check currently runs on every pull request. In practice, it often fails because of vulnerabilities that already exist in the codebase rather than vulnerabilities introduced by the PR itself. This can mislead contributors into thinking their changes caused the failure.

Also, new vulnerabilities can appear at any time as the OWASP database is updated, even without any code changes.

This PR removes the OWASP check from the pull request workflow and keeps it running only on commits.

If a commit introduces a new vulnerable dependency, the check will still fail on that commit, notifying the merger before the changes are merged. The results will also remain available in the commit history, making it easy to track when a vulnerability was introduced.


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
