### PR TITLE
(chore) Resolve shell-quote security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "*.{css,scss,ts,tsx}": "prettier --write --list-different"
   },
   "resolutions": {
-    "sass": "^1.54.3"
+    "sass": "^1.54.3",
+    "shell-quote": ">=1.8.4"
   },
   "packageManager": "yarn@4.10.3"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21570,10 +21570,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.8.1":
-  version: 1.8.1
-  resolution: "shell-quote@npm:1.8.1"
-  checksum: 10/af19ab5a1ec30cb4b2f91fd6df49a7442d5c4825a2e269b3712eded10eedd7f9efeaab96d57829880733fc55bcdd8e9b1d8589b4befb06667c731d08145e274d
+"shell-quote@npm:>=1.8.4":
+  version: 1.9.0
+  resolution: "shell-quote@npm:1.9.0"
+  checksum: 10/c3bc91e74a469c4f96b6fd13b0c777fff16bcbda202692a4e5402d3d6b78fc6e02fe92fdf8dc0bddf992a9c6758e43207bfc5bdbefbf8a58190b1c885cbcc171
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Adds `"shell-quote": ">=1.8.4"` to the `resolutions` field in `package.json`, forcing all instances of `shell-quote` to resolve to a patched version.
- Yarn resolved to `1.9.0` (the latest). All three installed copies (root `node_modules`, `esm-form-entry-app`, and `build-angular` sub-install) are now at `1.9.0`.
- Only `package.json` and `yarn.lock` changed — no application code touched.

**Vulnerability:** [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) / CVE-2026-9277 (Critical, CVSS 9.2). `shell-quote`'s `quote()` did not escape newlines in object `.op` values, allowing shell command injection. Fixed in `1.8.4`.
## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1663" height="313" alt="image" src="https://github.com/user-attachments/assets/29677a7f-9c3d-4772-b9f5-76c790ab5cf0" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Note: Marked as chore because this is a maintenance update to patch a transitive dependency. The advisory primarily impacts backend/Node.js shell command usage and does not affect this frontend application's runtime behavior.
