### PR TITLE
(chore) O3-5782: Patch OWASP-reported transitive vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,26 @@
     "cross-spawn": "^7.0.6",
     "jpeg-js": "^0.4.4",
     "immutable": "^5.1.3",
-    "serialize-javascript": "^7.0.0"
+    "serialize-javascript": "^7.0.0",
+    "@sigstore/core": "^3.2.1",
+    "@tootallnate/once": "^2.0.1",
+    "brace-expansion@npm:^1.0.0": "^1.1.15",
+    "brace-expansion@npm:^2.0.0": "^2.1.1",
+    "brace-expansion@npm:^5.0.0": "^5.0.7",
+    "cookie@npm:^0.4.0": "^0.7.2",
+    "dompurify": "3.4.1",
+    "fast-uri": "^3.1.3",
+    "hono": "^4.12.27",
+    "http-proxy-middleware@npm:^2.0.0": "^2.0.10",
+    "lodash": "^4.18.1",
+    "micromatch": "^4.0.8",
+    "picomatch@npm:^2.0.0": "^2.3.2",
+    "qs": "^6.15.3",
+    "tar@npm:^7.0.0": "^7.5.19",
+    "tmp": "^0.2.7",
+    "undici": "^7.28.0",
+    "ws@npm:^8.0.0": "^8.21.0",
+    "xml2js": "^0.6.2"
   },
   "packageManager": "yarn@4.10.3"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7695,10 +7695,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sigstore/core@npm:^3.1.0, @sigstore/core@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@sigstore/core@npm:3.2.0"
-  checksum: 10/2425d20297d57a5f5a62f0e6c2f4280818015ea00b3defebdac63f13c7d01db988602c316c16e374ba091c3649dd9a22ae8c9ba3ac165f736b0503164c5da5f5
+"@sigstore/core@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@sigstore/core@npm:3.2.1"
+  checksum: 10/2f6c1ced55f8ed3f7fc705a668eb95db9471511dfb1f054927822bf97a051dd62228ecf6a9f1932d240c2c4ae69a3b5066550789e5ad8f4257839a4370e5a120
   languageName: node
   linkType: hard
 
@@ -8025,10 +8025,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tootallnate/once@npm:2":
-  version: 2.0.0
-  resolution: "@tootallnate/once@npm:2.0.0"
-  checksum: 10/ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+"@tootallnate/once@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@tootallnate/once@npm:2.0.1"
+  checksum: 10/487b59b5adb8458dc13394a5aae997bf9705c51fa1e2396c50cd967019d06b273faba3c4d9e7895a996b9e9b055f1c55e53d822e54b3e9c298bcb4f6967cd0d5
   languageName: node
   linkType: hard
 
@@ -12702,7 +12702,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.6, dompurify@npm:^3.3.1":
+"dompurify@npm:3.4.1":
   version: 3.4.1
   resolution: "dompurify@npm:3.4.1"
   dependencies:
@@ -14060,10 +14060,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.0.6
-  resolution: "fast-uri@npm:3.0.6"
-  checksum: 10/43c87cd03926b072a241590e49eca0e2dfe1d347ddffd4b15307613b42b8eacce00a315cf3c7374736b5f343f27e27ec88726260eb03a758336d507d6fbaba0a
+"fast-uri@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "fast-uri@npm:3.1.3"
+  checksum: 10/7969a50a327482035d5c8c93faf51b26d7a93ce62bc750c91b3df158550004b5fbb378c95c900fd71f4dded36b5a78d1c666fb8043bb1214efbaebd8518d873e
   languageName: node
   linkType: hard
 
@@ -15040,10 +15040,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.11.4":
-  version: 4.12.21
-  resolution: "hono@npm:4.12.21"
-  checksum: 10/e519bdc0a6d45dbc334c6582526d90484806bb3880aed84919229286321d1195c96e9737dfe481fd951d79abdad894e8cfe770b87d1d61b73da5e332fd307e52
+"hono@npm:^4.12.27":
+  version: 4.12.27
+  resolution: "hono@npm:4.12.27"
+  checksum: 10/f1bb52f3871093fae5b5bc40fb179ff2e6d43c6dab8d7065ef182d8ff6cdc1c41dc1124b07f2f02e0fe36ec1e39e72300ed3447f64391e39d71978616d4f5a07
   languageName: node
   linkType: hard
 
@@ -17108,14 +17108,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.17.11, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.18.1":
+"lodash@npm:^4.18.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
@@ -17787,17 +17780,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:4.0.5":
-  version: 4.0.5
-  resolution: "micromatch@npm:4.0.5"
-  dependencies:
-    braces: "npm:^3.0.2"
-    picomatch: "npm:^2.3.1"
-  checksum: 10/a749888789fc15cac0e03273844dbd749f9f8e8d64e70c564bcf06a033129554c789bb9e30d7566d7ff6596611a08e58ac12cf2a05f6e3c9c47c50c4c7e12fa2
-  languageName: node
-  linkType: hard
-
-"micromatch@npm:^4.0.2, micromatch@npm:^4.0.8":
+"micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -18633,6 +18616,13 @@ __metadata:
   version: 1.13.3
   resolution: "object-inspect@npm:1.13.3"
   checksum: 10/14cb973d8381c69e14d7f1c8c75044eb4caf04c6dabcf40ca5c2ce42dc2073ae0bb2a9939eeca142b0c05215afaa1cd5534adb7c8879c32cba2576e045ed8368
+  languageName: node
+  linkType: hard
+
+"object-inspect@npm:^1.13.4":
+  version: 1.13.4
+  resolution: "object-inspect@npm:1.13.4"
+  checksum: 10/aa13b1190ad3e366f6c83ad8a16ed37a19ed57d267385aa4bfdccda833d7b90465c057ff6c55d035a6b2e52c1a2295582b294217a0a3a1ae7abdd6877ef781fb
   languageName: node
   linkType: hard
 
@@ -19777,21 +19767,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.14.0, qs@npm:^6.14.1":
-  version: 6.15.2
-  resolution: "qs@npm:6.15.2"
+"qs@npm:^6.15.3":
+  version: 6.15.3
+  resolution: "qs@npm:6.15.3"
   dependencies:
-    side-channel: "npm:^1.1.0"
-  checksum: 10/7a934b2dba40654cf9878dab7c1e7ad56c6186265509727fbece67dadc38fd5d67715b61b6ef938e5a0475faeee701d18ec0a7ce420ad64367caad7f1bdb66e2
-  languageName: node
-  linkType: hard
-
-"qs@npm:~6.14.0":
-  version: 6.14.2
-  resolution: "qs@npm:6.14.2"
-  dependencies:
-    side-channel: "npm:^1.1.0"
-  checksum: 10/682933a85bb4b7bd0d66e13c0a40d9e612b5e4bcc2cb9238f711a9368cd22d91654097a74fff93551e58146db282c56ac094957dfdc60ce64ea72c3c9d7779ac
+    es-define-property: "npm:^1.0.1"
+    side-channel: "npm:^1.1.1"
+  checksum: 10/1cbb4b050872a19ba8a311445be29babb8f66ea5d6462b3c48c6efb2c95187cd286b69734cd4caea1878cca3b9d1f0e9b49335336be9e999a7d8d7cf137ba60d
   languageName: node
   linkType: hard
 
@@ -21518,6 +21500,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"side-channel-list@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-list@npm:1.0.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+  checksum: 10/3499671cd52adaee739eac1e14d07530b8e3530192741aeb05e7fe4ad1b51d1368ceea2cd3c21b0f62b05410a5c70a7c4d997ba4b143303ef73d0c65dfd1c252
+  languageName: node
+  linkType: hard
+
 "side-channel-map@npm:^1.0.1":
   version: 1.0.1
   resolution: "side-channel-map@npm:1.0.1"
@@ -21543,7 +21535,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4, side-channel@npm:^1.1.0":
+"side-channel@npm:^1.0.4":
   version: 1.1.0
   resolution: "side-channel@npm:1.1.0"
   dependencies:
@@ -21553,6 +21545,19 @@ __metadata:
     side-channel-map: "npm:^1.0.1"
     side-channel-weakmap: "npm:^1.0.2"
   checksum: 10/7d53b9db292c6262f326b6ff3bc1611db84ece36c2c7dc0e937954c13c73185b0406c56589e2bb8d071d6fee468e14c39fb5d203ee39be66b7b8174f179afaba
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "side-channel@npm:1.1.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+    side-channel-list: "npm:^1.0.1"
+    side-channel-map: "npm:^1.0.1"
+    side-channel-weakmap: "npm:^1.0.2"
+  checksum: 10/5fa6393ff6ad25d8b4a38e9ba095481e498c8ebe5ab78481c1455146255a3d18ca37a6f936595cc671a6149134cdc295bbd2fa017620bdc73cbc7380634fa2fc
   languageName: node
   linkType: hard
 
@@ -22521,10 +22526,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.2.1":
-  version: 0.2.6
-  resolution: "tmp@npm:0.2.6"
-  checksum: 10/4ba072821d65f6ec0ae680dd49261bcc66c96a5a463c80ca040747256238aaad68ad5db7aa8367dd1554d22aa77c2988bdb1c5556ecfc4df105f5b73206b7d9b
+"tmp@npm:^0.2.7":
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10/0a3bc90beb0c6275273c3475fb57e466eaab1c9c4a101d029ff62b18146ce136e7f75d09de34863d9f2c2a492751402508f9e028bc98eb34a1416195d4b15619
   languageName: node
   linkType: hard
 
@@ -22968,10 +22973,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.12.0, undici@npm:^7.21.0":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10/038d3568c72bb976e3cc389284f7f1cc64cd70d578300e4676a449fbcb624a35fe99ac127b5f3729f18b8246d6c090444ab61b1b67736bb88f52a3e913d76bf8
+"undici@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10/154423b280d623278a61decb437f8a7e581fb18b8c95556ef956b32a58cd668eadbb812d28e20678cb2dc545a566f35a3afc0962307ca801da30f4741117986d
   languageName: node
   linkType: hard
 
@@ -24257,13 +24262,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xml2js@npm:^0.4.5":
-  version: 0.4.23
-  resolution: "xml2js@npm:0.4.23"
+"xml2js@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "xml2js@npm:0.6.2"
   dependencies:
     sax: "npm:>=0.6.0"
     xmlbuilder: "npm:~11.0.0"
-  checksum: 10/52896ef39429f860f32471dd7bb2b89ef25b7e15528e3a4366de0bd5e55a251601565e7814763e70f9e75310c3afe649a42b8826442b74b41eff8a0ae333fccc
+  checksum: 10/df29de8eeedb762c367d87945c39bcf54db19a2c522607491c266ed6184b5a749e37ff29cfaed0ac149da9ba332ac3dcf8e5ff2bd0a206be3343eca95faa941d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Adds `resolutions` overrides for transitive dependencies flagged by the OWASP Dependency-Check scan. Each entry pins to the latest patched version within the existing consumer's major range; no consumer range is broken.


## Resolutions added (16 new entries)




| Package | Pinned | Primary advisory | CVE | Sev (CVSS v3) |
|---|---|---|---|---|
| `@sigstore/core` | `^3.2.1` | [GHSA-jfc7-64v2-mr8c](https://github.com/advisories/GHSA-jfc7-64v2-mr8c) — DSSE `payloadType` type-binding failure | [CVE-2026-48758](https://nvd.nist.gov/vuln/detail/CVE-2026-48758) | Medium |
| `@tootallnate/once` | `^2.0.1` | [GHSA-vpq2-c234-7xj6](https://github.com/advisories/GHSA-vpq2-c234-7xj6) — incorrect control-flow scoping with `AbortSignal` | [CVE-2026-3449](https://nvd.nist.gov/vuln/detail/CVE-2026-3449) | Low (3.3) |
| `brace-expansion@^1` | `^1.1.15` | [GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v) — zero-step sequence DoS (1.x < 1.1.13) | [CVE-2026-33750](https://nvd.nist.gov/vuln/detail/CVE-2026-33750) | Medium |
| `brace-expansion@^2` | `^2.1.1` | [GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v) — same advisory, 2.x branch (< 2.0.3) | [CVE-2026-33750](https://nvd.nist.gov/vuln/detail/CVE-2026-33750) | Medium |
| `brace-expansion@^5` | `^5.0.7` | [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) — large-numeric-range `max` bypass DoS (5.x < 5.0.6) | [CVE-2026-45149](https://nvd.nist.gov/vuln/detail/CVE-2026-45149) | Medium |
| `cookie` (`^0.4` → `^0.7.2`) | `^0.7.2` | [GHSA-pxg6-pf52-xh8x](https://github.com/advisories/GHSA-pxg6-pf52-xh8x) — out-of-bounds chars in name/path/domain (< 0.7.0) | [CVE-2024-47764](https://nvd.nist.gov/vuln/detail/CVE-2024-47764) | Low |
| `fast-uri` | `^3.1.3` | [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — host confusion via percent-encoded authority delimiters | [CVE-2026-6322](https://nvd.nist.gov/vuln/detail/CVE-2026-6322) | High |
|  |  | [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — path traversal via percent-encoded dot segments | [CVE-2026-6321](https://nvd.nist.gov/vuln/detail/CVE-2026-6321) | High |
| `hono` | `^4.12.27` | [GHSA-88fw-hqm2-52qc](https://github.com/advisories/GHSA-88fw-hqm2-52qc) — CORS middleware reflects any Origin with credentials | [CVE-2026-54290](https://nvd.nist.gov/vuln/detail/CVE-2026-54290) | High |
|  |  | [GHSA-rv63-4mwf-qqc2](https://github.com/advisories/GHSA-rv63-4mwf-qqc2) — Body Limit bypass on AWS Lambda | [CVE-2026-54288](https://nvd.nist.gov/vuln/detail/CVE-2026-54288) | Medium |
| `http-proxy-middleware@^2` | `^2.0.10` | [GHSA-gcq2-9pq2-cxqm](https://github.com/advisories/GHSA-gcq2-9pq2-cxqm) — multipart/form-data field injection via unescaped CRLF | [CVE-2026-55603](https://nvd.nist.gov/vuln/detail/CVE-2026-55603) | High |
|  |  | [GHSA-c7qv-q95q-8v27](https://github.com/advisories/GHSA-c7qv-q95q-8v27) — DoS (older advisory, < 2.0.7) | [CVE-2024-21536](https://nvd.nist.gov/vuln/detail/CVE-2024-21536) | High |
| `lodash` | `^4.18.1` | [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) — code injection via `_.template` (≤ 4.17.23; 4.18.x patched) | [CVE-2026-4800](https://nvd.nist.gov/vuln/detail/CVE-2026-4800) | High |
|  |  | [GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh) — prototype pollution via array-path bypass in `_.unset`/`_.set` | [CVE-2026-2950](https://nvd.nist.gov/vuln/detail/CVE-2026-2950) | Medium |
| `micromatch` | `^4.0.8` | [GHSA-952p-6rrq-rcjv](https://github.com/advisories/GHSA-952p-6rrq-rcjv) — ReDoS in `micromatch.braces`/`.parse` (< 4.0.8) | [CVE-2024-4067](https://nvd.nist.gov/vuln/detail/CVE-2024-4067) | Medium |
| `picomatch@^2` | `^2.3.2` | [GHSA-c2c7-rcm5-vvqj](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj) — ReDoS via extglob quantifiers (< 2.3.2) | [CVE-2026-33671](https://nvd.nist.gov/vuln/detail/CVE-2026-33671) | High |
|  |  | [GHSA-3v7f-55p6-f55p](https://github.com/advisories/GHSA-3v7f-55p6-f55p) — method injection in POSIX char classes (< 2.3.2) | [CVE-2026-33672](https://nvd.nist.gov/vuln/detail/CVE-2026-33672) | Medium |
| `qs` | `^6.15.3` | [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) — DoS via `qs.stringify` `TypeError` on null/undefined | [CVE-2026-8723](https://nvd.nist.gov/vuln/detail/CVE-2026-8723) | Medium |
|  |  | [GHSA-6rw7-vpxm-498p](https://github.com/advisories/GHSA-6rw7-vpxm-498p) — `arrayLimit` bracket-notation bypass DoS | [CVE-2025-15284](https://nvd.nist.gov/vuln/detail/CVE-2025-15284) | Medium |
| `tar@^7` | `^7.5.19` | [GHSA-vmf3-w455-68vh](https://github.com/advisories/GHSA-vmf3-w455-68vh) — PAX size override on intermediary GNU long-name headers (< 7.5.19) | [CVE-2026-53655](https://nvd.nist.gov/vuln/detail/CVE-2026-53655) | Medium |
|  |  | [GHSA-9ppj-qmqm-q256](https://github.com/advisories/GHSA-9ppj-qmqm-q256) — symlink path traversal via drive-relative linkpath | [CVE-2026-31802](https://nvd.nist.gov/vuln/detail/CVE-2026-31802) | High |
|  |  | [GHSA-qffp-2rhf-9h96](https://github.com/advisories/GHSA-qffp-2rhf-9h96) — hardlink path traversal via drive-relative linkpath | [CVE-2026-29786](https://nvd.nist.gov/vuln/detail/CVE-2026-29786) | High |
| `tmp` | `^0.2.7` | [GHSA-7c78-jf6q-g5cm](https://github.com/advisories/GHSA-7c78-jf6q-g5cm) — type-confusion bypass of `_assertPath`, path traversal (< 0.2.7) | [CVE-2026-49982](https://nvd.nist.gov/vuln/detail/CVE-2026-49982) | High |
|  |  | [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) — path traversal via unsanitized prefix/postfix | [CVE-2026-44705](https://nvd.nist.gov/vuln/detail/CVE-2026-44705) | High |
| `undici` | `^7.28.0` | [GHSA-vxpw-j846-p89q](https://github.com/advisories/GHSA-vxpw-j846-p89q) — WebSocket DoS via fragment-count bypass | [CVE-2026-12151](https://nvd.nist.gov/vuln/detail/CVE-2026-12151) | High |
|  |  | [GHSA-hm92-r4w5-c3mj](https://github.com/advisories/GHSA-hm92-r4w5-c3mj) — cross-origin routing via SOCKS5 proxy pool reuse | [CVE-2026-6734](https://nvd.nist.gov/vuln/detail/CVE-2026-6734) | High |
|  |  | [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g) — TLS certificate validation bypass via dropped requestTls | [CVE-2026-9697](https://nvd.nist.gov/vuln/detail/CVE-2026-9697) | High |
|  |  | [GHSA-p88m-4jfj-68fv](https://github.com/advisories/GHSA-p88m-4jfj-68fv) — HTTP header injection via Set-Cookie percent-decoding | [CVE-2026-9679](https://nvd.nist.gov/vuln/detail/CVE-2026-9679) | Medium |
| `ws@^8` | `^8.21.0` | [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) — memory-exhaustion DoS from tiny fragments | [CVE-2026-48779](https://nvd.nist.gov/vuln/detail/CVE-2026-48779) | High |
|  |  | [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) — uninitialized memory disclosure | [CVE-2026-45736](https://nvd.nist.gov/vuln/detail/CVE-2026-45736) | Medium |
|  |  | [GHSA-3h5v-q93c-6h6q](https://github.com/advisories/GHSA-3h5v-q93c-6h6q) — DoS from request with many HTTP headers (older; 7.5.x picks up `^7.5.11` transitively) | [CVE-2024-37890](https://nvd.nist.gov/vuln/detail/CVE-2024-37890) | High |
| `xml2js` | `^0.6.2` | [GHSA-776f-qx25-q3cc](https://github.com/advisories/GHSA-776f-qx25-q3cc) — prototype pollution (< 0.5.0) | [CVE-2023-0842](https://nvd.nist.gov/vuln/detail/CVE-2023-0842) | Medium |


Pulled from GitHub's advisory API on 2026-06-30.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-5782
## Other
<!-- Anything not covered above -->
### Deferred to follow-up PRs 

The following are intentionally **not** included here:

- **dompurify** is held at `3.4.1` (current) rather than bumped to `3.4.11`. `dompurify` is pulled by `@carbon/charts` and `jspdf`, both runtime XSS-sanitization paths — a bump must ship with an explicit XSS regression check, in a dedicated sub-PR.
- **Angular packages** (`@angular/core`, `@angular/common`, `@angular/compiler`) — isolated Angular upgrade PR (PR A) for `esm-form-entry-app`.
- **`vite`, `esbuild`, `picomatch@4.x`, `piscina`, `webpack`** — pinned to exact versions by `@angular-devkit/build-angular` / `@angular/build`; will be picked up by the Angular upgrade PR.
- **`@playwright/test`, `webpack-dev-server`, `vitest`** — direct dev-dep bumps (PR C).
- **`path-to-regexp@0.1.x`** (`express@4.22.1` locks `~0.1.12`), **`extend@1.x`** (`geopattern@1.2.3` locks `~1.2.1`), **`ajv@6.x`** (`@eslint/eslintrc@2.1.4` locks `^6.12.4`), **`yaml@1.x`** (`cosmiconfig@6` locks `^1.7.2`), **`launch-editor`** (already at latest 2.10.0), **`phin`** (jimp@0.16 locks `^2`), **`file-type@17.x`** (`@mole-inc/bin-wrapper@8` locks `^17`) — no in-range patched version available; will be evaluated for the suppression file PR (PR D) with rationale per entry.
- **`uuid`** — direct dep in `esm-form-entry-app` and `esm-patient-chart-app`; out of scope for transitive resolutions.
