### PR TITLE
(fix) O3-5799: E2E file upload tests fail due to ambiguous Playwright locator

### DIFF
--- a/e2e/specs/attachments.spec.ts
+++ b/e2e/specs/attachments.spec.ts
@@ -24,10 +24,7 @@ test('Add and remove an attachment', async ({ page, patient }) => {
   });
 
   await test.step('And I choose the attachment file to upload', async () => {
-    const fileChooserPromise = page.waitForEvent('filechooser');
-    await page.getByRole('button', { name: /drag and drop files here or click to upload/i }).click();
-    const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles(filePath);
+    await page.locator('input[type="file"]').setInputFiles(filePath);
   });
 
   await test.step('And I verify the image name field is pre-filled', async () => {
@@ -155,10 +152,7 @@ test('Upload and preview a PDF attachment', async ({ page, patient }) => {
   });
 
   await test.step('And I choose the PDF file to upload', async () => {
-    const fileChooserPromise = page.waitForEvent('filechooser');
-    await page.getByRole('button', { name: /drag and drop files here or click to upload/i }).click();
-    const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles(filePath);
+    await page.locator('input[type="file"]').setInputFiles(filePath);
   });
 
   await test.step('And I verify the file name field is pre-filled', async () => {

--- a/e2e/specs/visit-note.spec.ts
+++ b/e2e/specs/visit-note.spec.ts
@@ -37,11 +37,7 @@ test('Add, edit, and delete a visit note', async ({ page, patient }) => {
     await expect(page.getByText(/add attachment/i)).toBeVisible();
     await page.getByRole('tab', { name: /upload files/i }).click();
 
-    const fileChooserPromise = page.waitForEvent('filechooser');
-    await page.getByRole('button', { name: /drag and drop files here or click to upload/i }).click();
-    const fileChooser = await fileChooserPromise;
-
-    await fileChooser.setFiles('./e2e/support/upload/brainScan.jpeg');
+    await page.locator('input[type="file"]').setInputFiles('./e2e/support/upload/brainScan.jpeg');
     await page.getByLabel(/image name/i).fill('Cross-sectional brain scan');
     await page.getByRole('button', { name: /add attachment/i }).click();
     await expect(page.getByText(/cross-sectional brain scan/i)).toBeVisible();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the E2E tests problem , once merged .
Fixes flaky e2e file upload tests by replacing the ambiguous getByRole('button', { name: /drag and drop files here or click to upload/i }) locator with page.locator('input[type="file"]').setInputFiles(filePath). The previous locator resolved to both a <button> and an <input> element, causing Playwright's strict mode to fail.

Affected files:

e2e/specs/attachments.spec.ts
e2e/specs/visit-note.spec.ts

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-5799

## Other
### This PR will help to resolve the e2e tests failure for more pull requests like : https://github.com/openmrs/openmrs-esm-patient-chart/pull/3449 .