### PR TITLE
(chore) O3-5785: Upgrade dompurify from 3.4.1 to 3.4.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,13 @@ Please see the [Implementer Documentation](https://wiki.openmrs.org/pages/viewpa
 ## Deployment
 
 See [Creating a Distribution](https://openmrs.atlassian.net/wiki/x/xoIBCQ) for information about adding microfrontends to a distribution.
+
+## Dependency Overrides
+
+Some dependencies are temporarily pinned in `package.json` under the `resolutions` field to work around issues in upstream packages.
+
+### `dompurify`
+
+`dompurify` is pinned to `3.4.11` because `@carbon/charts@1.27.0` and `jspdf@4.2.1` have not yet updated their own dependency. This override should be removed once both upstream packages ship with `dompurify >=3.4.11` natively.
+
+Tracking issue: O3-5785.

--- a/README.md
+++ b/README.md
@@ -219,4 +219,4 @@ Some dependencies are temporarily pinned in `package.json` under the `resolution
 
 `dompurify` is pinned to `3.4.11` because `@carbon/charts@1.27.0` and `jspdf@4.2.1` have not yet updated their own dependency. This override should be removed once both upstream packages ship with `dompurify >=3.4.11` natively.
 
-Tracking issue: O3-5785.
+Tracking issue: [O3-5785](https://openmrs.atlassian.net/browse/O3-5785).

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "*.{css,scss,ts,tsx}": "prettier --write --list-different"
   },
   "resolutions": {
-    "sass": "^1.54.3"
+    "sass": "^1.54.3",
+    "dompurify": "^3.4.11"
   },
   "packageManager": "yarn@4.10.3"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10672,11 +10672,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "brace-expansion@npm:2.0.1"
+  version: 2.1.1
+  resolution: "brace-expansion@npm:2.1.1"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10/a61e7cd2e8a8505e9f0036b3b6108ba5e926b4b55089eeb5550cd04a471fe216c96d4fe7e4c7f995c728c554ae20ddfc4244cad10aef255e72b62930afd233d1
+  checksum: 10/4681c533dc4e6c77b3ad795b38683d297fd03c739a17bfb2a338529fa7dcf4540683a79dcd662905f4c5b0db7cfda18daafcd18dd1bbf7c3b076fe0c9c3487eb
   languageName: node
   linkType: hard
 
@@ -12720,15 +12720,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.6, dompurify@npm:^3.3.1":
-  version: 3.4.1
-  resolution: "dompurify@npm:3.4.1"
+"dompurify@npm:^3.4.11":
+  version: 3.4.11
+  resolution: "dompurify@npm:3.4.11"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10/dcaf945376eff2a61841b205501b163b2c8ae9afe7251e68276b561d9fcf943cefc67e2631fdeae080b52a8b37c96e6beb7e6ae80ad8a83692ff67965dd6b4db
+  checksum: 10/d0473e1a22ed9cc23d86ef426717bce866913d1a725512a9478985bd917b272e0faba5f1d6ad8b2e37f3f4219206c4385162d7c984cfedcd23396e1e6ae0bc5e
   languageName: node
   linkType: hard
 
@@ -18664,10 +18664,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.13.3":
-  version: 1.13.3
-  resolution: "object-inspect@npm:1.13.3"
-  checksum: 10/14cb973d8381c69e14d7f1c8c75044eb4caf04c6dabcf40ca5c2ce42dc2073ae0bb2a9939eeca142b0c05215afaa1cd5534adb7c8879c32cba2576e045ed8368
+"object-inspect@npm:^1.13.3, object-inspect@npm:^1.13.4":
+  version: 1.13.4
+  resolution: "object-inspect@npm:1.13.4"
+  checksum: 10/aa13b1190ad3e366f6c83ad8a16ed37a19ed57d267385aa4bfdccda833d7b90465c057ff6c55d035a6b2e52c1a2295582b294217a0a3a1ae7abdd6877ef781fb
   languageName: node
   linkType: hard
 
@@ -21618,6 +21618,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"side-channel-list@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-list@npm:1.0.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+  checksum: 10/3499671cd52adaee739eac1e14d07530b8e3530192741aeb05e7fe4ad1b51d1368ceea2cd3c21b0f62b05410a5c70a7c4d997ba4b143303ef73d0c65dfd1c252
+  languageName: node
+  linkType: hard
+
 "side-channel-map@npm:^1.0.1":
   version: 1.0.1
   resolution: "side-channel-map@npm:1.0.1"
@@ -21643,7 +21653,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4, side-channel@npm:^1.1.0":
+"side-channel@npm:^1.0.4":
+  version: 1.1.1
+  resolution: "side-channel@npm:1.1.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+    side-channel-list: "npm:^1.0.1"
+    side-channel-map: "npm:^1.0.1"
+    side-channel-weakmap: "npm:^1.0.2"
+  checksum: 10/5fa6393ff6ad25d8b4a38e9ba095481e498c8ebe5ab78481c1455146255a3d18ca37a6f936595cc671a6149134cdc295bbd2fa017620bdc73cbc7380634fa2fc
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.1.0":
   version: 1.1.0
   resolution: "side-channel@npm:1.1.0"
   dependencies:


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
Bumps `dompurify` (`3.4.1` → `^3.4.11`) via a scoped `resolutions` override to fix XSS-related advisories ([GHSA-cmwh-pvxp-8882](https://github.com/advisories/GHSA-cmwh-pvxp-8882), [GHSA-76mc-f452-cxcm](https://github.com/advisories/GHSA-76mc-f452-cxcm)). `dompurify` is pulled in by `@carbon/charts` (charts) and `jspdf` (PDF export), both of which are runtime-exposed. Override is documented in `README.md`; can be removed once upstream packages bump their own `dompurify` pin.

## Screenshots
<img width="1366" height="768" alt="Screenshot (476)" src="https://github.com/user-attachments/assets/e22fabf5-eada-45ff-bfb0-ea1a3bbfce58" />
<img width="1366" height="768" alt="Screenshot (477)" src="https://github.com/user-attachments/assets/e513424f-7725-4f52-a01e-0e58a110911d" />
<img width="1366" height="768" alt="Screenshot (481)" src="https://github.com/user-attachments/assets/416266b0-7d22-45cc-a4b7-5e51b71e0f11" />


## Related Issue
https://openmrs.atlassian.net/browse/O3-5785

## Other
`yarn why dompurify` confirms clean resolution to `3.4.11`. Build/tests pass for all affected apps except `esm-form-entry-app`'s build, which fails identically pre- and post-change (pre-existing, unrelated). Manual smoke tests (chart rendering, PDF export) all pass with no errors.