### PR TITLE
(feat) O3-5798: Add past visit indicator to patient banner

### DIFF
--- a/packages/esm-patient-banner-app/src/banner-tags/past-visit-tag.extension.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/past-visit-tag.extension.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Tag, Toggletip, ToggletipButton, ToggletipContent } from '@carbon/react';
+import { type Visit, formatDate, formatDatetime, parseDate, useFeatureFlag } from '@openmrs/esm-framework';
+import { usePatientChartStore, useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
+import styles from './past-visit-tag.scss';
+
+interface PastVisitTagProps {
+  patientUuid: string;
+}
+
+function PastVisitTag({ patientUuid }: PastVisitTagProps) {
+  const { systemVisitEnabled } = useSystemVisitSetting();
+  const isRdeEnabled = useFeatureFlag('rde');
+  const { visitContext } = usePatientChartStore(patientUuid);
+  const isPastVisit = Boolean(visitContext && visitContext.stopDatetime);
+
+  return systemVisitEnabled && isRdeEnabled && isPastVisit ? <PastVisitTagContent visitContext={visitContext} /> : null;
+}
+
+interface PastVisitTagContentProps {
+  visitContext: Visit;
+}
+
+const PastVisitTagContent: React.FC<PastVisitTagContentProps> = ({ visitContext }) => {
+  const { t } = useTranslation();
+  const formattedVisitDate = formatDate(parseDate(visitContext.stopDatetime), { mode: 'standard', time: false });
+  const label = t('pastVisitWithDate', 'Past visit: {{date}}', { date: formattedVisitDate });
+
+  return (
+    <Toggletip align="bottom">
+      <ToggletipButton label={label}>
+        <Tag className={styles.pastVisitTag}>{label}</Tag>
+      </ToggletipButton>
+      <ToggletipContent>
+        <div role="tooltip">
+          <h6 className={styles.heading}>{visitContext?.visitType?.display}</h6>
+          <span>
+            <span className={styles.tooltipSmallText}>{t('started', 'Started')}: </span>
+            <span>{formatDatetime(parseDate(visitContext?.startDatetime), { mode: 'wide' })}</span>
+          </span>
+        </div>
+      </ToggletipContent>
+    </Toggletip>
+  );
+};
+
+export { PastVisitTagProps };
+export default PastVisitTag;

--- a/packages/esm-patient-banner-app/src/banner-tags/past-visit-tag.scss
+++ b/packages/esm-patient-banner-app/src/banner-tags/past-visit-tag.scss
@@ -1,0 +1,30 @@
+@use '@carbon/layout';
+@use '@openmrs/esm-styleguide/src/vars' as *;
+
+.tooltipBox {
+  padding: layout.$spacing-02;
+}
+
+.tooltipSmallText {
+  font-size: 80%;
+}
+
+.heading {
+  margin-bottom: layout.$spacing-03;
+}
+
+.definitionToolTip {
+  & > button {
+    border-bottom: none;
+  }
+}
+
+// Compound selector (no type modifier is passed to the Carbon Tag) so this
+// overrides Carbon's low-specificity base `.cds--tag` rule cleanly, without
+// fighting the much higher-specificity `:not()` chains on named type variants
+// (e.g. `.cds--tag--outline:not(...):not(...):not(...)`).
+.pastVisitTag:global(.cds--tag) {
+  background-color: $inverse-support-03;
+  border-color: $inverse-support-03;
+  color: $color-gray-100;
+}

--- a/packages/esm-patient-banner-app/src/banner-tags/past-visit-tag.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/past-visit-tag.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { formatDate, parseDate, useFeatureFlag } from '@openmrs/esm-framework';
+import { usePatientChartStore, useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
+import { mockVisit } from '__mocks__';
+import { mockPatient } from 'tools';
+import PastVisitTag from './past-visit-tag.extension';
+
+const mockUsePatientChartStore = vi.mocked(usePatientChartStore);
+const mockUseSystemVisitSetting = vi.mocked(useSystemVisitSetting);
+const mockUseFeatureFlag = vi.mocked(useFeatureFlag);
+
+vi.mock('@openmrs/esm-patient-common-lib', () => ({
+  usePatientChartStore: vi.fn(),
+  useSystemVisitSetting: vi.fn(),
+}));
+
+describe('PastVisitTag', () => {
+  beforeEach(() => {
+    mockUseSystemVisitSetting.mockReturnValue({
+      systemVisitEnabled: true,
+      errorFetchingSystemVisitSetting: null,
+      isLoadingSystemVisitSetting: false,
+    });
+    mockUseFeatureFlag.mockReturnValue(true);
+  });
+
+  it('renders a past visit tag with the visit date when the visit in context has ended', () => {
+    mockUsePatientChartStore.mockReturnValue({
+      patientUuid: mockPatient.id,
+      patient: mockPatient,
+      visitContext: mockVisit,
+      mutateVisitContext: null,
+      setPatient: vi.fn(),
+      setVisitContext: vi.fn(),
+    });
+
+    render(<PastVisitTag patientUuid={mockPatient.id} />);
+
+    const formattedVisitDate = formatDate(parseDate(mockVisit.stopDatetime), { mode: 'standard', time: false });
+
+    expect(
+      screen.getByRole('button', { name: new RegExp(`Past visit.*${formattedVisitDate}`, 'i') }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render the past visit tag when the visit in context is the active visit', () => {
+    mockUsePatientChartStore.mockReturnValue({
+      patientUuid: mockPatient.id,
+      patient: mockPatient,
+      visitContext: { ...mockVisit, stopDatetime: null },
+      mutateVisitContext: null,
+      setPatient: vi.fn(),
+      setVisitContext: vi.fn(),
+    });
+
+    render(<PastVisitTag patientUuid={mockPatient.id} />);
+
+    expect(screen.queryByRole('button', { name: /Past visit/i })).not.toBeInTheDocument();
+  });
+
+  it('should not render the past visit tag when the rde feature flag is disabled', () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+    mockUsePatientChartStore.mockReturnValue({
+      patientUuid: mockPatient.id,
+      patient: mockPatient,
+      visitContext: mockVisit,
+      mutateVisitContext: null,
+      setPatient: vi.fn(),
+      setVisitContext: vi.fn(),
+    });
+
+    render(<PastVisitTag patientUuid={mockPatient.id} />);
+
+    expect(screen.queryByRole('button', { name: /Past visit/i })).not.toBeInTheDocument();
+  });
+});

--- a/packages/esm-patient-banner-app/src/banner-tags/visit-tag.extension.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/visit-tag.extension.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tag, Toggletip, ToggletipButton, ToggletipContent } from '@carbon/react';
 import { type Visit, formatDatetime, parseDate, useVisit } from '@openmrs/esm-framework';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 import styles from './visit-tag.scss';
 
 interface VisitTagProps {
@@ -11,8 +12,12 @@ interface VisitTagProps {
 
 function VisitTag({ patientUuid, patient }: VisitTagProps) {
   const { activeVisit, isLoading } = useVisit(patientUuid);
+  const { visitContext } = usePatientChartStore(patientUuid);
   const isNotDeceased = !patient?.deceasedDateTime;
-  return !isLoading && activeVisit && isNotDeceased ? <ActiveVisitTag activeVisit={activeVisit} /> : null;
+  const isPastVisitContext = Boolean(visitContext && visitContext.stopDatetime);
+  return !isLoading && activeVisit && isNotDeceased && !isPastVisitContext ? (
+    <ActiveVisitTag activeVisit={activeVisit} />
+  ) : null;
 }
 
 interface ActiveVisitTagProps {

--- a/packages/esm-patient-banner-app/src/banner-tags/visit-tag.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/visit-tag.test.tsx
@@ -1,14 +1,31 @@
 import React from 'react';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { formatDatetime, parseDate, useVisit } from '@openmrs/esm-framework';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 import { mockCurrentVisit } from '__mocks__';
 import { mockPatient } from 'tools';
 import VisitTag from './visit-tag.extension';
 
 const mockUseVisit = vi.mocked(useVisit);
+const mockUsePatientChartStore = vi.mocked(usePatientChartStore);
+
+vi.mock('@openmrs/esm-patient-common-lib', () => ({
+  usePatientChartStore: vi.fn(),
+}));
 
 describe('VisitBannerTag', () => {
+  beforeEach(() => {
+    mockUsePatientChartStore.mockReturnValue({
+      patientUuid: mockPatient.id,
+      patient: mockPatient,
+      visitContext: null,
+      mutateVisitContext: null,
+      setPatient: vi.fn(),
+      setVisitContext: vi.fn(),
+    });
+  });
+
   it('renders an active visit tag when an active visit is ongoing', () => {
     mockUseVisit.mockReturnValue({
       activeVisit: mockCurrentVisit,
@@ -50,6 +67,31 @@ describe('VisitBannerTag', () => {
 
     const patient = { ...mockPatient, deceasedDateTime: '2002-04-04' };
 
+    render(<VisitTag patientUuid={mockPatient.id} patient={patient} />);
+
+    expect(screen.queryByRole('button', { name: /Active Visit/i })).not.toBeInTheDocument();
+  });
+
+  it('should not render the active visit tag when the visit in context is a past visit, even if an active visit exists', () => {
+    mockUseVisit.mockReturnValue({
+      activeVisit: mockCurrentVisit,
+      currentVisit: mockCurrentVisit,
+      currentVisitIsRetrospective: false,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    });
+    mockUsePatientChartStore.mockReturnValue({
+      patientUuid: mockPatient.id,
+      patient: mockPatient,
+      visitContext: { ...mockCurrentVisit, stopDatetime: '2022-01-01T12:00:00.000+0000' },
+      mutateVisitContext: null,
+      setPatient: vi.fn(),
+      setVisitContext: vi.fn(),
+    });
+
+    const patient = { ...mockPatient, deceasedDateTime: null };
     render(<VisitTag patientUuid={mockPatient.id} patient={patient} />);
 
     expect(screen.queryByRole('button', { name: /Active Visit/i })).not.toBeInTheDocument();

--- a/packages/esm-patient-banner-app/src/index.ts
+++ b/packages/esm-patient-banner-app/src/index.ts
@@ -9,6 +9,7 @@ import {
 import { configSchema } from './config-schema';
 import deceasedPatientTagComponent from './banner-tags/deceased-patient-tag.extension';
 import patientBannerComponent from './banner/patient-banner.component';
+import pastVisitTagComponent from './banner-tags/past-visit-tag.extension';
 import visitTagComponent from './banner-tags/visit-tag.extension';
 import { personAttributeTagsExtensionConfigSchema } from './banner-tags/person-attribute-tags.extension';
 
@@ -32,6 +33,8 @@ export function startupApp() {
 }
 
 export const visitTag = getSyncLifecycle(visitTagComponent, options);
+
+export const pastVisitTag = getSyncLifecycle(pastVisitTagComponent, options);
 
 export const deceasedPatientTag = getSyncLifecycle(deceasedPatientTagComponent, options);
 

--- a/packages/esm-patient-banner-app/src/routes.json
+++ b/packages/esm-patient-banner-app/src/routes.json
@@ -18,6 +18,13 @@
       "offline": true
     },
     {
+      "name": "past-visit-tag",
+      "slot": "patient-banner-tags-slot",
+      "component": "pastVisitTag",
+      "online": true,
+      "offline": true
+    },
+    {
       "name": "deceased-patient-tag",
       "slot": "patient-banner-tags-slot",
       "component": "deceasedPatientTag",

--- a/packages/esm-patient-banner-app/translations/en.json
+++ b/packages/esm-patient-banner-app/translations/en.json
@@ -9,6 +9,7 @@
   "deceased": "Deceased",
   "district": "District",
   "from_lower": "from",
+  "pastVisitWithDate": "Past visit: {{date}}",
   "postalCode": "Postal code",
   "started": "Started",
   "state": "State",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
When a user switches into a past visit context, the workspace panel correctly shows "Adding to: [past visit]", but the patient banner at the top still just says "Active Visit", nothing tells the user they're actually charting into an old, closed visit. This can cause real confusion during retrospective data entry, since it's easy to assume you're working in the current visit when you're not.

This PR adds a small tag to the patient banner that reads "Past visit: {date}" whenever this context is active. It uses the same visit-context data the workspace indicator already relies on, so the two stay in sync automatically.
The tag disappears once the user switches back to the active visit.

## Screenshots

BEFORE - the banner still says "Active Visit" even while charting into a past visit, with no way to tell you're not in the current visit:

<img width="1470" height="832" alt="before" src="https://github.com/user-attachments/assets/40f14a30-e5a0-4684-9ea5-61f4a4c535d3" />

https://github.com/user-attachments/assets/f35c77c1-a100-4c65-814f-7ad4adae5cc7

AFTER - the banner now shows a "Past visit" tag alongside "Active Visit", so it's always clear which visit you're actually entering data into:

<img width="1470" height="833" alt="after" src="https://github.com/user-attachments/assets/4586293a-2aaf-45f0-b456-b304b57defff" />

Short recording showing the tag appearing when switching into a past visit and disappearing when switching back:

https://github.com/user-attachments/assets/ea27902e-288b-4668-8e40-d82facbdbec3

## Related Issue
https://openmrs.atlassian.net/browse/O3-5798

## Other
N/A