### PR TITLE
(fix) O3-5798: Only hide the active visit tag when the past visit tag renders

### DIFF
--- a/packages/esm-patient-banner-app/src/banner-tags/past-visit-tag.extension.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/past-visit-tag.extension.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tag, Toggletip, ToggletipButton, ToggletipContent } from '@carbon/react';
-import { type Visit, formatDate, formatDatetime, parseDate, useFeatureFlag } from '@openmrs/esm-framework';
-import { usePatientChartStore, useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
+import { type Visit, formatDate, formatDatetime, parseDate } from '@openmrs/esm-framework';
+import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
+import { useIsInPastVisitContext } from '../hooks/useIsInPastVisitContext';
 import styles from './past-visit-tag.scss';
 
 interface PastVisitTagProps {
@@ -10,12 +11,10 @@ interface PastVisitTagProps {
 }
 
 function PastVisitTag({ patientUuid }: PastVisitTagProps) {
-  const { systemVisitEnabled } = useSystemVisitSetting();
-  const isRdeEnabled = useFeatureFlag('rde');
+  const isInPastVisitContext = useIsInPastVisitContext(patientUuid);
   const { visitContext } = usePatientChartStore(patientUuid);
-  const isPastVisit = Boolean(visitContext && visitContext.stopDatetime);
 
-  return systemVisitEnabled && isRdeEnabled && isPastVisit ? <PastVisitTagContent visitContext={visitContext} /> : null;
+  return isInPastVisitContext ? <PastVisitTagContent visitContext={visitContext} /> : null;
 }
 
 interface PastVisitTagContentProps {

--- a/packages/esm-patient-banner-app/src/banner-tags/past-visit-tag.scss
+++ b/packages/esm-patient-banner-app/src/banner-tags/past-visit-tag.scss
@@ -1,22 +1,12 @@
 @use '@carbon/layout';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
-.tooltipBox {
-  padding: layout.$spacing-02;
-}
-
 .tooltipSmallText {
   font-size: 80%;
 }
 
 .heading {
   margin-bottom: layout.$spacing-03;
-}
-
-.definitionToolTip {
-  & > button {
-    border-bottom: none;
-  }
 }
 
 // Compound selector (no type modifier is passed to the Carbon Tag) so this

--- a/packages/esm-patient-banner-app/src/banner-tags/visit-tag.extension.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/visit-tag.extension.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tag, Toggletip, ToggletipButton, ToggletipContent } from '@carbon/react';
 import { type Visit, formatDatetime, parseDate, useVisit } from '@openmrs/esm-framework';
-import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
+import { useIsInPastVisitContext } from '../hooks/useIsInPastVisitContext';
 import styles from './visit-tag.scss';
 
 interface VisitTagProps {
@@ -12,10 +12,11 @@ interface VisitTagProps {
 
 function VisitTag({ patientUuid, patient }: VisitTagProps) {
   const { activeVisit, isLoading } = useVisit(patientUuid);
-  const { visitContext } = usePatientChartStore(patientUuid);
   const isNotDeceased = !patient?.deceasedDateTime;
-  const isPastVisitContext = Boolean(visitContext && visitContext.stopDatetime);
-  return !isLoading && activeVisit && isNotDeceased && !isPastVisitContext ? (
+  // Hidden only when the past visit tag renders in its place, so the banner
+  // always shows exactly one visit tag while an active visit exists.
+  const isInPastVisitContext = useIsInPastVisitContext(patientUuid);
+  return !isLoading && activeVisit && isNotDeceased && !isInPastVisitContext ? (
     <ActiveVisitTag activeVisit={activeVisit} />
   ) : null;
 }

--- a/packages/esm-patient-banner-app/src/banner-tags/visit-tag.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner-tags/visit-tag.test.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { formatDatetime, parseDate, useVisit } from '@openmrs/esm-framework';
-import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
+import { formatDatetime, parseDate, useFeatureFlag, useVisit } from '@openmrs/esm-framework';
+import { usePatientChartStore, useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
 import { mockCurrentVisit } from '__mocks__';
 import { mockPatient } from 'tools';
 import VisitTag from './visit-tag.extension';
 
 const mockUseVisit = vi.mocked(useVisit);
+const mockUseFeatureFlag = vi.mocked(useFeatureFlag);
 const mockUsePatientChartStore = vi.mocked(usePatientChartStore);
+const mockUseSystemVisitSetting = vi.mocked(useSystemVisitSetting);
 
 vi.mock('@openmrs/esm-patient-common-lib', () => ({
   usePatientChartStore: vi.fn(),
+  useSystemVisitSetting: vi.fn(),
 }));
 
 describe('VisitBannerTag', () => {
@@ -24,6 +27,12 @@ describe('VisitBannerTag', () => {
       setPatient: vi.fn(),
       setVisitContext: vi.fn(),
     });
+    mockUseSystemVisitSetting.mockReturnValue({
+      systemVisitEnabled: true,
+      errorFetchingSystemVisitSetting: null,
+      isLoadingSystemVisitSetting: false,
+    });
+    mockUseFeatureFlag.mockReturnValue(true);
   });
 
   it('renders an active visit tag when an active visit is ongoing', () => {
@@ -95,5 +104,34 @@ describe('VisitBannerTag', () => {
     render(<VisitTag patientUuid={mockPatient.id} patient={patient} />);
 
     expect(screen.queryByRole('button', { name: /Active Visit/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the active visit tag when the visit in context is a past visit but the rde feature flag is off', () => {
+    // Without RDE, the past visit tag never renders, so the active visit tag must not
+    // hide either. A past visit can still land in the visit context without RDE, for
+    // example after editing a past visit's details from the visit history.
+    mockUseFeatureFlag.mockReturnValue(false);
+    mockUseVisit.mockReturnValue({
+      activeVisit: mockCurrentVisit,
+      currentVisit: mockCurrentVisit,
+      currentVisitIsRetrospective: false,
+      error: null,
+      isLoading: false,
+      isValidating: false,
+      mutate: vi.fn(),
+    });
+    mockUsePatientChartStore.mockReturnValue({
+      patientUuid: mockPatient.id,
+      patient: mockPatient,
+      visitContext: { ...mockCurrentVisit, stopDatetime: '2022-01-01T12:00:00.000+0000' },
+      mutateVisitContext: null,
+      setPatient: vi.fn(),
+      setVisitContext: vi.fn(),
+    });
+
+    const patient = { ...mockPatient, deceasedDateTime: null };
+    render(<VisitTag patientUuid={mockPatient.id} patient={patient} />);
+
+    expect(screen.getByRole('button', { name: /Active Visit/i })).toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-banner-app/src/hooks/useIsInPastVisitContext.ts
+++ b/packages/esm-patient-banner-app/src/hooks/useIsInPastVisitContext.ts
@@ -1,0 +1,18 @@
+import { useFeatureFlag } from '@openmrs/esm-framework';
+import { usePatientChartStore, useSystemVisitSetting } from '@openmrs/esm-patient-common-lib';
+
+/**
+ * Returns true when the patient chart's visit context is set to a past (ended) visit
+ * and retrospective data entry applies, i.e. system visits are enabled and the `rde`
+ * feature flag is turned on.
+ *
+ * The past visit tag renders exactly when this is true, and the active visit tag
+ * hides under the same condition. Sharing this predicate keeps the two in sync so
+ * the banner can never end up with neither tag while an active visit exists.
+ */
+export function useIsInPastVisitContext(patientUuid: string): boolean {
+  const { systemVisitEnabled } = useSystemVisitSetting();
+  const isRdeEnabled = useFeatureFlag('rde');
+  const { visitContext } = usePatientChartStore(patientUuid);
+  return Boolean(systemVisitEnabled && isRdeEnabled && visitContext?.stopDatetime);
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Follow-up to #3458, which added a "Past visit" tag to the patient banner and hid the "Active Visit" tag while a past visit is in context.

The two conditions could disagree: the active visit tag hid whenever the visit context held an ended visit, but the past visit tag that replaces it only renders when system visits are enabled and the `rde` feature flag is on. A past visit can land in the visit context without RDE, for example after editing a past visit's details from the visit history, which sets the edited visit as the visit context on save. In that state the banner showed no visit tag at all even though the patient has an active visit, and with RDE off the visit context switcher isn't available to recover with, so the tag stayed hidden until a full page reload.

This extracts the gating into a shared `useIsInPastVisitContext` hook used by both tags, so the active visit tag only hides when the past visit tag actually renders in its place. Also removes two unused style classes that were copied over from `visit-tag.scss`.

Verified live against the local RefApp distro: with RDE off, editing a past visit while an active visit is ongoing dropped the Active Visit tag from the banner on current `main`, and the tag stays in place with this change. Also covered by a new regression test.

## Screenshots

### Before

With RDE off, editing a past visit while an active visit is ongoing drops the Active Visit tag from the patient header.

https://github.com/user-attachments/assets/9b8f357a-d1c7-48e5-a4b5-0cf664939d69

### After

Active visit context is retained

https://github.com/user-attachments/assets/88a52dad-7ed9-4216-aee6-343a30d9e935

## Related Issue

https://openmrs.atlassian.net/browse/O3-5798

## Other
