### PR TITLE
(fix) O3-5790: Upgrade undici to 7.28.0 via jsdom resolution

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -23038,9 +23038,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.12.0, undici@npm:^7.21.0":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10/038d3568c72bb976e3cc389284f7f1cc64cd70d578300e4676a449fbcb624a35fe99ac127b5f3729f18b8246d6c090444ab61b1b67736bb88f52a3e913d76bf8
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10/154423b280d623278a61decb437f8a7e581fb18b8c95556ef956b32a58cd668eadbb812d28e20678cb2dc545a566f35a3afc0962307ca801da30f4741117986d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] My work includes tests or is validated by existing tests.
- [x] My work conforms to the OpenMRS 3.0 Styleguide and design documentation.
- [x] This PR has a title that briefly describes the work done including the ticket number.

## Summary

Bumped `undici` from `7.25.0` to `7.28.0` in `yarn.lock` to resolve known vulnerabilities pulled in via `jsdom`/`cheerio`. No `package.json` changes needed — both already allow `>=7.28.0`; the old version was just frozen in the lockfile. Confirmed `cheerio` is not a direct dependency.

## Screenshots

N/A

## Related Issue

https://openmrs.atlassian.net/browse/O3-5790

## Other

Only `yarn.lock` changed. No resolutions override used.