### PR TITLE
(feat) O3-5815: Return ICD-11 codes for diagnoses in the form-entry datasources

### DIFF
--- a/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed, fakeAsync, inject, tick } from '@angular/core/testing';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 
 import { FormDataSourceService } from './form-data-source.service';
+import { ConceptResourceService } from '../openmrs-api/concept-resource.service';
 import { ProviderResourceService } from '../openmrs-api/provider-resource.service';
 import { FakeProviderResourceService } from '../openmrs-api/provider-resource.service.mock';
 import { LocationResourceService } from '../openmrs-api/location-resource.service';
@@ -168,4 +169,111 @@ describe('Service: FormDataSourceService', () => {
     tick(100);
     expect(resultData).toBeTruthy();
   }));
+
+  describe('diagnosis concept codes', () => {
+    const diagnosisClassUuid = '8d4918b0-c2cc-11de-8d13-0010c6dffd0f';
+    const icd11SourceUuid = '43aaca5f-d623-43fd-993b-673b5d927cdd';
+    const sameAsMapTypeUuid = '35543629-7d8c-11e1-909d-c80aa9edcf4e';
+
+    const choleraConcept = {
+      uuid: 'cholera-uuid',
+      name: { display: 'Cholera' },
+      conceptClass: { uuid: diagnosisClassUuid },
+      mappings: [
+        {
+          conceptMapType: { uuid: 'narrower-than-uuid', display: 'NARROWER-THAN' },
+          conceptReferenceTerm: { code: '1A0Z', conceptSource: { uuid: icd11SourceUuid } },
+        },
+        {
+          conceptMapType: { uuid: sameAsMapTypeUuid, display: 'SAME-AS' },
+          conceptReferenceTerm: { code: '1A00', conceptSource: { uuid: icd11SourceUuid } },
+        },
+        {
+          conceptMapType: { uuid: sameAsMapTypeUuid, display: 'SAME-AS' },
+          conceptReferenceTerm: { code: 'A00', conceptSource: { uuid: 'icd10-source-uuid' } },
+        },
+      ],
+    };
+
+    const unmappedConcept = {
+      uuid: 'unmapped-uuid',
+      name: { display: 'Typhoid arthritis' },
+      conceptClass: { uuid: diagnosisClassUuid },
+      mappings: [],
+    };
+
+    it('should include the code from the configured concept source, preferring SAME-AS mappings', (done) => {
+      const service: FormDataSourceService = TestBed.inject(FormDataSourceService);
+      const conceptResourceService = TestBed.inject(ConceptResourceService);
+      const searchSpy = spyOn(conceptResourceService, 'searchConcept').and.returnValue(of([choleraConcept]));
+
+      service.findDiagnoses('chol', { conceptSourceUuid: icd11SourceUuid }).subscribe((results) => {
+        expect(searchSpy).toHaveBeenCalledWith('chol', false, jasmine.stringContaining('mappings'));
+        expect(results).toEqual([{ value: 'cholera-uuid', label: 'Cholera', code: '1A00' }]);
+        done();
+      });
+    });
+
+    it('should fall back to the first mapping to the source when none is SAME-AS', (done) => {
+      const service: FormDataSourceService = TestBed.inject(FormDataSourceService);
+      const conceptResourceService = TestBed.inject(ConceptResourceService);
+      const narrowerOnly = {
+        ...choleraConcept,
+        mappings: [choleraConcept.mappings[0]],
+      };
+      spyOn(conceptResourceService, 'searchConcept').and.returnValue(of([narrowerOnly]));
+
+      service.findDiagnoses('chol', { conceptSourceUuid: icd11SourceUuid }).subscribe((results) => {
+        expect(results[0].code).toBe('1A0Z');
+        done();
+      });
+    });
+
+    it('should omit the code for concepts without a mapping to the source', (done) => {
+      const service: FormDataSourceService = TestBed.inject(FormDataSourceService);
+      const conceptResourceService = TestBed.inject(ConceptResourceService);
+      spyOn(conceptResourceService, 'searchConcept').and.returnValue(of([unmappedConcept]));
+
+      service.findDiagnoses('typh', { conceptSourceUuid: icd11SourceUuid }).subscribe((results) => {
+        expect(results).toEqual([{ value: 'unmapped-uuid', label: 'Typhoid arthritis' }]);
+        done();
+      });
+    });
+
+    it('should not request mappings or emit codes when no concept source is configured', (done) => {
+      const service: FormDataSourceService = TestBed.inject(FormDataSourceService);
+      const conceptResourceService = TestBed.inject(ConceptResourceService);
+      const searchSpy = spyOn(conceptResourceService, 'searchConcept').and.returnValue(of([choleraConcept]));
+
+      service.findDiagnoses('chol').subscribe((results) => {
+        expect(searchSpy).toHaveBeenCalledWith('chol', false, null);
+        expect(results).toEqual([{ value: 'cholera-uuid', label: 'Cholera' }]);
+        done();
+      });
+    });
+
+    it('should resolve a selected value with its code from the configured source', (done) => {
+      const service: FormDataSourceService = TestBed.inject(FormDataSourceService);
+      const conceptResourceService = TestBed.inject(ConceptResourceService);
+      const getSpy = spyOn(conceptResourceService, 'getConceptByUuid').and.returnValue(of(choleraConcept));
+
+      service.resolveConcept('cholera-uuid', { conceptSourceUuid: icd11SourceUuid }).subscribe((result) => {
+        expect(getSpy).toHaveBeenCalledWith('cholera-uuid', false, jasmine.stringContaining('mappings'));
+        expect(result).toEqual({ value: 'cholera-uuid', label: 'Cholera', code: '1A00' });
+        done();
+      });
+    });
+
+    it('should stay safe when mapConcept is used as an unbound Array.map callback', () => {
+      const service: FormDataSourceService = TestBed.inject(FormDataSourceService);
+      // The cast mirrors the service's own untyped `.map(this.mapConcept)` call
+      // sites; at runtime the callback still receives (value, index, array) and
+      // no `this` context.
+      const mapped = [choleraConcept, unmappedConcept].map(service.mapConcept as (concept: any) => any);
+      expect(mapped).toEqual([
+        { value: 'cholera-uuid', label: 'Cholera' },
+        { value: 'unmapped-uuid', label: 'Typhoid arthritis' },
+      ]);
+    });
+  });
 });

--- a/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
@@ -11,6 +11,7 @@ import { ConceptResourceService } from '../openmrs-api/concept-resource.service'
 import { LocalStorageService } from '../local-storage/local-storage.service';
 import type {
   Concept,
+  ConceptMapping,
   FormSchema,
   Identifier,
   Location,
@@ -19,6 +20,22 @@ import type {
   Provider,
   Questions,
 } from '../types';
+
+const conceptWithMappingsRep =
+  'custom:(uuid,name,conceptClass,mappings:(conceptMapType:(uuid,display),conceptReferenceTerm:(code,conceptSource:(uuid))))';
+const sameAsConceptMapTypeUuid = '35543629-7d8c-11e1-909d-c80aa9edcf4e';
+
+function getConceptCode(concept: Concept, conceptSourceUuid: string): string | undefined {
+  const mappingsToSource: Array<ConceptMapping> =
+    concept.mappings?.filter((mapping) => mapping.conceptReferenceTerm?.conceptSource?.uuid === conceptSourceUuid) ??
+    [];
+  const sameAsMapping = mappingsToSource.find(
+    (mapping) =>
+      mapping.conceptMapType?.uuid === sameAsConceptMapTypeUuid ||
+      mapping.conceptMapType?.display?.toUpperCase() === 'SAME-AS',
+  );
+  return (sameAsMapping ?? mappingsToSource[0])?.conceptReferenceTerm?.code;
+}
 
 @Injectable()
 export class FormDataSourceService {
@@ -260,8 +277,11 @@ export class FormDataSourceService {
     );
   }
 
-  public resolveConcept(uuid: string) {
-    return this.conceptResourceService.getConceptByUuid(uuid).pipe(map(this.mapConcept));
+  public resolveConcept(uuid: string, dataSourceOptions?: Record<string, unknown>) {
+    const conceptSourceUuid = this.getConceptSourceUuid(dataSourceOptions);
+    return this.conceptResourceService
+      .getConceptByUuid(uuid, false, conceptSourceUuid ? conceptWithMappingsRep : undefined)
+      .pipe(map((concept) => this.mapConcept(concept as Concept, conceptSourceUuid)));
   }
 
   public getConceptAnswers(uuid: string) {
@@ -307,27 +327,42 @@ export class FormDataSourceService {
         ),
       );
   }
-  public findDiagnoses(searchText) {
+  public findDiagnoses(searchText: string, dataSourceOptions?: Record<string, unknown>) {
     const allowedConceptClasses = ['8d4918b0-c2cc-11de-8d13-0010c6dffd0f'];
+    const conceptSourceUuid = this.getConceptSourceUuid(dataSourceOptions);
 
     return this.conceptResourceService
-      .searchConcept(searchText)
+      .searchConcept(searchText, false, conceptSourceUuid ? conceptWithMappingsRep : null)
       .pipe(
         map((concepts) =>
           concepts
             .filter((concept) => concept.conceptClass && allowedConceptClasses.includes(concept.conceptClass.uuid))
-            .map(this.mapConcept),
+            .map((concept) => this.mapConcept(concept, conceptSourceUuid)),
         ),
       );
   }
 
-  public mapConcept(concept?: Concept) {
-    return (
-      concept && {
-        value: concept.uuid,
-        label: concept.name.display,
-      }
-    );
+  public mapConcept(concept?: Concept, conceptSourceUuid?: string) {
+    if (!concept) {
+      return concept;
+    }
+    // mapConcept is also used as an unbound Array.map callback, which passes
+    // the element index as the second argument and no `this` context. Only
+    // dereference the code lookup for an explicitly provided source string.
+    const code =
+      typeof conceptSourceUuid === 'string' && conceptSourceUuid
+        ? getConceptCode(concept, conceptSourceUuid)
+        : undefined;
+    return {
+      value: concept.uuid,
+      label: concept.name.display,
+      ...(code ? { code } : {}),
+    };
+  }
+
+  private getConceptSourceUuid(dataSourceOptions?: Record<string, unknown>): string | undefined {
+    const conceptSourceUuid = dataSourceOptions?.conceptSourceUuid;
+    return typeof conceptSourceUuid === 'string' && conceptSourceUuid ? conceptSourceUuid : undefined;
   }
 
   public getCachedProviderSearchResults() {

--- a/packages/esm-form-entry-app/src/app/types/index.ts
+++ b/packages/esm-form-entry-app/src/app/types/index.ts
@@ -261,6 +261,20 @@ export interface Concept {
   answers: Array<Concept>;
   setMembers: Array<Concept>;
   display: string;
+  mappings?: Array<ConceptMapping>;
+}
+
+export interface ConceptMapping {
+  conceptMapType?: {
+    uuid?: string;
+    display?: string;
+  };
+  conceptReferenceTerm?: {
+    code?: string;
+    conceptSource?: {
+      uuid?: string;
+    };
+  };
 }
 
 export interface Visit {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The Angular form engine passes a diagnosis question's schema-level datasource config (`datasource.config`, including `conceptSourceUuid`) to `searchOptions` and `resolveSelectedValue`. The `diagnoses` datasource previously ignored it, so no terminology code could be shown next to a diagnosis.

With this change, `findDiagnoses` and `resolveConcept` accept the optional options argument. When it names a `conceptSourceUuid`, the concept search and the selected-value lookup request `conceptMappings` and emit a `code` field on the option, which the form engine renders as `{ICD11CODE} {Name}` per the KNHTS convention. The code comes from the concept's mapping to the configured source, preferring SAME-AS mappings. Concepts without a mapping, and questions without the config, behave exactly as before; other datasources sharing `mapConcept`/`resolveConcept` are unchanged.

## Screenshots

https://github.com/user-attachments/assets/a4aa8983-73b8-49f1-aec7-982b20556a24

## Related Issue

https://openmrs.atlassian.net/browse/O3-5815

## Other

Companion to openmrs/openmrs-ngx-formentry#176, which renders the `code` field in the diagnosis picker.
