### PR TITLE
(chore) Include ngx-formentry in the OpenMRS dependency auto-update

### DIFF
--- a/tools/update-openmrs-deps.mjs
+++ b/tools/update-openmrs-deps.mjs
@@ -2,7 +2,7 @@ import { execSync } from 'node:child_process';
 
 try {
   // NB for other places use '@openmrs/*@next'; here we want to ignore patient-common-lib
-  execSync(`yarn up --fixed '@openmrs/esm-framework@next' '@openmrs/esm-form-engine-lib@next' 'openmrs@next'`, {
+  execSync(`yarn up --fixed '@openmrs/esm-framework@next' '@openmrs/esm-form-engine-lib@next' '@openmrs/ngx-formentry@next' 'openmrs@next'`, {
     stdio: ['ignore', 'inherit', 'inherit'],
     windowsHide: true,
   });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

Amends the OpenMRS dependency auto-update workflow to include the Angular form engine (`@openmrs/ngx-formentry`) so that downstream consumers of the library continue get quick access to the latest pre-releases, despite it not being utilised in the refapp out of the box. 

As a result the `esm-form-entry-app` lockfile resolution for the Angular form engine froze at `20.0.1-pre.525` while the engine kept moving; the current `next` is `20.0.1-pre.564`, carrying the ICD-11 diagnosis code display (openmrs/openmrs-ngx-formentry#176), the schema-configurable endpoint data source (openmrs/openmrs-ngx-formentry#178), and the remote-select centering fixes (openmrs/openmrs-ngx-formentry#179).

This adds the package to the updater's `yarn up` list, so the existing automation opens the catch-up bump on its next run and keeps the Angular engine current alongside its React peer. Notably, the ICD-11 datasource work merged in #3479 only becomes active once the engine bump lands, and #3485 adds the translation strings the new engine version renders.

## Screenshots

## Related Issue

## Other
