### PR TITLE
(fix) O3-5822: Dedupe diagnoses in visit-level rollups

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/dedupe-diagnoses.test.ts
+++ b/packages/esm-patient-chart-app/src/visit/dedupe-diagnoses.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { type Diagnosis } from '@openmrs/esm-framework';
+import { dedupeDiagnoses } from './dedupe-diagnoses';
+
+const codedDiagnosis = (uuid: string, display: string, rank: number): Diagnosis =>
+  ({
+    uuid: `diagnosis-${uuid}-rank-${rank}`,
+    display,
+    diagnosis: { coded: { uuid, display } },
+    rank,
+  }) as Diagnosis;
+
+const nonCodedDiagnosis = (text: string, rank: number): Diagnosis =>
+  ({
+    uuid: `diagnosis-${text}-rank-${rank}`,
+    display: text,
+    diagnosis: { nonCoded: text },
+    rank,
+  }) as Diagnosis;
+
+describe('dedupeDiagnoses', () => {
+  it('collapses the same coded diagnosis recorded in multiple encounters into one entry', () => {
+    const diabetesFirstEncounter = codedDiagnosis('diabetes-uuid', 'Diabetes mellitus', 1);
+    const diabetesSecondEncounter = codedDiagnosis('diabetes-uuid', 'Diabetes mellitus', 1);
+
+    const result = dedupeDiagnoses([diabetesFirstEncounter, diabetesSecondEncounter]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].diagnosis.coded.uuid).toBe('diabetes-uuid');
+  });
+
+  it('keeps the primary occurrence when the same diagnosis is primary in one encounter and secondary in another', () => {
+    const secondary = codedDiagnosis('diabetes-uuid', 'Diabetes mellitus', 2);
+    const primary = codedDiagnosis('diabetes-uuid', 'Diabetes mellitus', 1);
+
+    const result = dedupeDiagnoses([secondary, primary]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].rank).toBe(1);
+  });
+
+  it('dedupes non-coded diagnoses by their text', () => {
+    const result = dedupeDiagnoses([
+      nonCodedDiagnosis('Persistent cough', 2),
+      nonCodedDiagnosis('Persistent cough', 2),
+      nonCodedDiagnosis('Fatigue', 2),
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((diagnosis) => diagnosis.diagnosis.nonCoded)).toEqual(['Persistent cough', 'Fatigue']);
+  });
+
+  it('does not merge distinct diagnoses and sorts them by rank', () => {
+    const hypertension = codedDiagnosis('hypertension-uuid', 'Hypertension', 2);
+    const diabetes = codedDiagnosis('diabetes-uuid', 'Diabetes mellitus', 1);
+    const cough = nonCodedDiagnosis('Persistent cough', 2);
+
+    const result = dedupeDiagnoses([hypertension, diabetes, cough]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].diagnosis.coded.uuid).toBe('diabetes-uuid');
+  });
+});

--- a/packages/esm-patient-chart-app/src/visit/dedupe-diagnoses.ts
+++ b/packages/esm-patient-chart-app/src/visit/dedupe-diagnoses.ts
@@ -1,0 +1,24 @@
+import { type Diagnosis } from '@openmrs/esm-framework';
+
+/**
+ * Sorts diagnoses by rank (primary first) and collapses repeats of the same diagnosis
+ * recorded across multiple encounters of a visit into a single entry, keeping the
+ * highest-ranked occurrence. Coded diagnoses are keyed by concept UUID and non-coded
+ * diagnoses by their text.
+ */
+export function dedupeDiagnoses(diagnoses: Array<Diagnosis>): Array<Diagnosis> {
+  const seen = new Set<string>();
+  return [...diagnoses]
+    .sort((a, b) => a.rank - b.rank)
+    .filter((diagnosis) => {
+      const key = diagnosis.diagnosis?.coded?.uuid ?? diagnosis.diagnosis?.nonCoded;
+      if (!key) {
+        return true;
+      }
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+}

--- a/packages/esm-patient-chart-app/src/visit/visit-history-table/visit-diagnoses-cell.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visit-history-table/visit-diagnoses-cell.component.tsx
@@ -1,5 +1,6 @@
 import { DiagnosisTags, type Visit } from '@openmrs/esm-framework';
 import React from 'react';
+import { dedupeDiagnoses } from '../dedupe-diagnoses';
 
 interface Props {
   visit: Visit;
@@ -7,10 +8,9 @@ interface Props {
 }
 
 const VisitDiagnosisCell: React.FC<Props> = ({ visit }) => {
-  const diagnoses = visit.encounters
-    .flatMap((encounter) => encounter.diagnoses)
-    .filter((diagnosis) => !diagnosis.voided)
-    .sort((a, b) => a.rank - b.rank);
+  const diagnoses = dedupeDiagnoses(
+    visit.encounters.flatMap((encounter) => encounter.diagnoses).filter((diagnosis) => !diagnosis.voided),
+  );
 
   return <DiagnosisTags diagnoses={diagnoses} />;
 };

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/past-visits-components/visit-summary.component.tsx
@@ -15,6 +15,7 @@ import {
 } from '@openmrs/esm-framework';
 import type { ChartConfig } from '../../../config-schema';
 import type { Note, Order, OrderItem } from '../visit.resource';
+import { dedupeDiagnoses } from '../../dedupe-diagnoses';
 import { encounterHasJsonSchemaForm } from './encounters-table/encounters-table.resource';
 import MedicationSummary from './medications-summary.component';
 import NotesSummary from './notes-summary.component';
@@ -84,13 +85,10 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({ visit, patientUuid }) => {
       }
     });
 
-    // Sort the diagnoses by rank, so that primary diagnoses come first
-    diagnoses.sort((a, b) => a.rank - b.rank);
-
     // Sort medications by dateActivated DESC (newest first) to align with backend ordering
     medications.sort((a, b) => new Date(b.order.dateActivated).getTime() - new Date(a.order.dateActivated).getTime());
 
-    return [diagnoses, notes, medications];
+    return [dedupeDiagnoses(diagnoses), notes, medications];
   }, [config.notesConceptUuids, visit?.encounters]);
 
   const encounterIds = useMemo(() => visit?.encounters?.map((e) => `Encounter/${e.uuid}`) ?? [], [visit?.encounters]);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

When the same diagnosis is recorded in multiple encounters of one visit (for example, two visit notes in the same visit both asserting Diabetes mellitus), the visit-level rollups repeat the tag once per encounter. Both the Diagnoses column in the visit history table and the expanded visit summary aggregate every encounter's diagnoses without deduplication before passing them to `DiagnosisTags`. Multi-encounter and multi-day visits are the worst case, since each progress note adds another copy of the same tag.

This adds a shared `dedupeDiagnoses` helper and applies it in both views. Coded diagnoses dedupe by concept UUID and non-coded diagnoses by exact text. The list is sorted by rank before deduplication, so a diagnosis that is primary in any encounter of the visit shows as primary.

This is a display-level change only. Encounter-level diagnosis records are unchanged, and per-encounter data still reflects every assertion as recorded.

## Screenshots

### Before

Duplicate "Diabetes mellitus" tags

<img width="2556" height="1340" alt="CleanShot 2026-07-21 at 17 05 44@2x" src="https://github.com/user-attachments/assets/a430c4c2-0207-4dbd-8ed0-604ac1e51eb4" />

### After

Only one top-level "Diabetes mellitus" tag

<img width="2532" height="1558" alt="CleanShot 2026-07-21 at 21 47 01@2x" src="https://github.com/user-attachments/assets/f74b591d-e710-4f8f-84c1-790cceb6ba06" />

## Related Issue

https://openmrs.atlassian.net/browse/O3-5822

## Other

The ticket flags deduplicating non-coded diagnoses by exact text as a proposed display rule rather than settled behavior. Happy to adjust if reviewers would rather keep non-coded entries separate.
