### PR TITLE
(fix) O3-5824: Keep dashboard grid widgets contained at narrow viewports

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.scss
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.scss
@@ -36,7 +36,7 @@
 // proper rendering when the workspace area is opened.
 @container dashboard (width <= 68.25rem) {
   .dashboard {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
@@ -48,6 +48,13 @@
   }
 }
 
+.extension {
+  // Grid items default to min-width: auto, which lets wide content (e.g. data
+  // tables) expand the item beyond its track and get clipped. min-width: 0
+  // keeps widgets contained so tables scroll within their own cards instead.
+  min-width: 0;
+}
+
 .extension:only-child {
   grid-column: 1 / -1;
 }
@@ -57,7 +64,7 @@
 }
 
 :global(.omrs-breakpoint-lt-desktop) .dashboard {
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 :global(.omrs-breakpoint-lt-tablet) .container {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

Dashboard widgets that are wider than the space available to them — like the vitals table — spill past the edge of the page and get cut off. There's no scrollbar, so the cut-off content (the SpO2 column, the table pagination, the Add button) is effectively hidden. This happens on tablets, on smaller desktop windows, and at any desktop size when an open workspace narrows the chart.

Two CSS Grid defaults cause it:

1. The single-column dashboard layout uses a plain `1fr` column, which can't shrink below its content's natural width. The two-column layout already avoids this with `minmax(0, 1fr)`.
2. The widgets are grid items, which default to `min-width: auto` and also refuse to shrink below their content.

This PR fixes both: the single-column layout now uses `minmax(0, 1fr)`, and widgets get `min-width: 0`. Fixing only the column is not enough — the widget itself still overflows (verified: the column shrank to 678px while the widget stayed at 831px). With both in place, widgets stay contained and Carbon's built-in table scrolling takes over, so wide tables scroll inside their own cards.

Tested at every width from 672px to 1920px, on both sides of each layout breakpoint, and with a workspace open: nothing is clipped, and the two-column layout on large screens is unchanged. Full measurements are in the ticket.

## Screenshots

### Before

<img width="1024" height="768" alt="before-1024" src="https://github.com/user-attachments/assets/b960274e-69b0-4154-8a4e-087019db61c6" />

### After

<img width="1024" height="768" alt="after-1024" src="https://github.com/user-attachments/assets/290106e9-07c4-460d-aab1-6d6ab1acdb9e" />

## Related Issue

https://openmrs.atlassian.net/browse/O3-5824

## Other
