### PR TITLE
(fix) O3-5825: Make patient banner layout respond to banner resizes

### DIFF
--- a/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.component.tsx
@@ -17,24 +17,23 @@ interface PatientBannerProps {
 }
 
 const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hideActionsOverflow }) => {
-  const patientBannerRef = useRef(null);
-  const [isTabletViewport, setIsTabletViewport] = useState(false);
+  const patientBannerRef = useRef<HTMLElement>(null);
+  const [bannerWidth, setBannerWidth] = useState<number | null>(null);
   const [showContactDetails, setShowContactDetails] = useState(false);
 
   useEffect(() => {
-    const currentRef = patientBannerRef.current;
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
-        setIsTabletViewport(entry.contentRect.width < 1023);
+        setBannerWidth(entry.contentRect.width);
       }
     });
-    resizeObserver.observe(patientBannerRef.current);
-    return () => {
-      if (currentRef) {
-        resizeObserver.unobserve(currentRef);
-      }
-    };
-  }, [patientBannerRef, setIsTabletViewport]);
+    if (patientBannerRef.current) {
+      resizeObserver.observe(patientBannerRef.current);
+    }
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  const isTabletViewport = bannerWidth !== null && bannerWidth < 1023;
 
   const patientName = patient ? getPatientName(patient) : '';
 
@@ -44,7 +43,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
 
   const isDeceased = Boolean(patient?.deceasedDateTime);
   const maxDesktopWorkspaceWidthInPx = 520;
-  const showDetailsButtonBelowHeader = patientBannerRef.current?.scrollWidth <= maxDesktopWorkspaceWidthInPx;
+  const showDetailsButtonBelowHeader = bannerWidth !== null && bannerWidth <= maxDesktopWorkspaceWidthInPx;
 
   return (
     <header
@@ -61,7 +60,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
           <PatientPhoto patientUuid={patientUuid} patientName={patientName} />
         </div>
         <PatientBannerPatientInfo patient={patient} renderedFrom="patient-chart" />
-        <div className={styles.buttonCol}>
+        <div className={styles.buttonCol} data-testid="patient-banner-button-col">
           <div className={styles.buttonRow}>
             {!hideActionsOverflow ? (
               <PatientBannerActionsMenu

--- a/packages/esm-patient-banner-app/src/banner/patient-banner.test.tsx
+++ b/packages/esm-patient-banner-app/src/banner/patient-banner.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, within } from '@testing-library/react';
+import { mockPatient } from 'tools';
+import PatientBanner from './patient-banner.component';
+
+const toggleButtonText = 'Patient Banner Toggle Contact Details Button';
+
+let resizeCallback: ResizeObserverCallback;
+
+class ControllableResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeCallback = callback;
+  }
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+function resizeBannerTo(width: number) {
+  act(() => {
+    resizeCallback([{ contentRect: { width } } as ResizeObserverEntry], {} as ResizeObserver);
+  });
+}
+
+function getButtonCol() {
+  return screen.getByTestId('patient-banner-button-col');
+}
+
+describe('PatientBanner', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', ControllableResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the toggle contact details button in the header row at typical widths', () => {
+    render(<PatientBanner patient={mockPatient} patientUuid={mockPatient.id} />);
+    resizeBannerTo(800);
+
+    expect(within(getButtonCol()).getByText(toggleButtonText)).toBeInTheDocument();
+  });
+
+  it('moves the toggle contact details button below the header when the banner is 520px or narrower', () => {
+    render(<PatientBanner patient={mockPatient} patientUuid={mockPatient.id} />);
+    resizeBannerTo(800);
+    resizeBannerTo(500);
+
+    expect(within(getButtonCol()).queryByText(toggleButtonText)).not.toBeInTheDocument();
+    expect(screen.getByText(toggleButtonText)).toBeInTheDocument();
+  });
+
+  it('moves the toggle contact details button back into the header row when the banner widens again', () => {
+    render(<PatientBanner patient={mockPatient} patientUuid={mockPatient.id} />);
+    resizeBannerTo(500);
+    resizeBannerTo(800);
+
+    expect(within(getButtonCol()).getByText(toggleButtonText)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The patient banner moves its "Show more" (toggle contact details) button below the header when the banner is 520px or narrower — for example, when a workspace squeezes the chart. But that check read the DOM ref during render, and the banner's ResizeObserver only stored a coarse "narrower than 1023px" boolean. So a resize that didn't flip the boolean (say, 900px down to 500px) never re-rendered the banner, and the button stayed in the wrong position until something unrelated triggered a render.

The fix stores the observed banner width in state and derives both layout decisions from it, so every resize re-evaluates the layout. Initial-render behavior is unchanged.

Includes tests that drive a mocked ResizeObserver across the 520px threshold and assert the button's position (a `data-testid` was added to the header button column for this). The resize-only scenario was also verified in a real browser: narrowing 900px → 500px without any interaction now moves the button immediately, and widening moves it back.

## Screenshots

### Before

Button position does not respond automatically to resizes

https://github.com/user-attachments/assets/e8bee889-46f2-48f5-afc3-60fc063bb298

### After

Button position adapts to the banner size automatically 


https://github.com/user-attachments/assets/650da091-a3ff-4728-bb92-3810e5bafc8c

## Related Issue

https://openmrs.atlassian.net/browse/O3-5825

## Other
