### PR TITLE
(fix) O3-5841: Sort Vitals and Biometrics tables in the direction the header arrow indicates

### DIFF
--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
@@ -137,6 +137,18 @@ describe('Biometrics Overview', () => {
 
     // Initial state should be descending
     expect(getRowDates()).toEqual(expectedDescendingOrder);
+
+    const dateColumnHeader = () => screen.getByRole('columnheader', { name: /date and time/i });
+
+    // The first click sorts in ascending order, putting the oldest reading first
+    await user.click(sortRowsButton);
+    expect(dateColumnHeader()).toHaveAttribute('aria-sort', 'ascending');
+    expect(getRowDates()).toEqual(expectedAscendingOrder);
+
+    // The second click sorts in descending order, putting the newest reading first
+    await user.click(sortRowsButton);
+    expect(dateColumnHeader()).toHaveAttribute('aria-sort', 'descending');
+    expect(getRowDates()).toEqual(expectedDescendingOrder);
   });
 
   it('toggles between rendering either a tabular view or a chart view', async () => {

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
@@ -151,6 +151,93 @@ describe('Biometrics Overview', () => {
     expect(getRowDates()).toEqual(expectedDescendingOrder);
   });
 
+  it('sorts across the whole dataset even when the visible page holds a single row', async () => {
+    const user = userEvent.setup();
+
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(configSchema),
+      ...mockBiometricsConfig,
+    } as ConfigObject);
+
+    // The overview paginates five rows to a page, so a sixth reading leaves the
+    // second page holding a single row. Carbon's comparator is never invoked
+    // there, because `Array.prototype.sort` performs no comparisons on a
+    // single-element array.
+    mockUseVitalsAndBiometrics.mockReturnValue({
+      data: formattedBiometrics.slice(0, 6),
+    } as ReturnType<typeof useVitalsAndBiometrics>);
+
+    renderWithSwr(<BiometricsOverview {...testProps} />);
+
+    await waitForLoadingToFinish();
+    await screen.findByRole('table', { name: /biometrics/i });
+
+    const getRowDates = () =>
+      screen
+        .getAllByRole('row')
+        .slice(1) // Exclude the header row
+        .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
+        .filter(Boolean);
+
+    await user.click(screen.getByRole('button', { name: /next page/i }));
+    expect(getRowDates()).toEqual(['08 — Apr — 2021']);
+
+    const dateColumnHeader = () => screen.getByRole('columnheader', { name: /date and time/i });
+
+    await user.click(screen.getByRole('button', { name: /date and time/i }));
+
+    expect(dateColumnHeader()).toHaveAttribute('aria-sort', 'ascending');
+    expect(getRowDates()).toEqual(['12 — Aug — 2021']);
+  });
+
+  it('restores the unsorted order once the header cycles back to none', async () => {
+    const user = userEvent.setup();
+
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(configSchema),
+      ...mockBiometricsConfig,
+    } as ConfigObject);
+
+    mockUseVitalsAndBiometrics.mockReturnValue({
+      data: [
+        { id: '0', date: '2021-08-12T00:00:00.000Z', weight: 90 },
+        { id: '1', date: '2021-06-18T00:00:00.000Z', weight: 50 },
+        { id: '2', date: '2021-06-10T00:00:00.000Z', weight: 70 },
+      ],
+    } as ReturnType<typeof useVitalsAndBiometrics>);
+
+    renderWithSwr(<BiometricsOverview {...testProps} />);
+
+    await waitForLoadingToFinish();
+    await screen.findByRole('table', { name: /biometrics/i });
+
+    const getRowDates = () =>
+      screen
+        .getAllByRole('row')
+        .slice(1) // Exclude the header row
+        .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
+        .filter(Boolean);
+
+    const unsortedOrder = ['12 — Aug — 2021', '18 — Jun — 2021', '10 — Jun — 2021'];
+    expect(getRowDates()).toEqual(unsortedOrder);
+
+    const sortRowsButton = screen.getByRole('button', { name: /weight/i });
+    const weightColumnHeader = () => screen.getByRole('columnheader', { name: /weight/i });
+
+    await user.click(sortRowsButton);
+    expect(weightColumnHeader()).toHaveAttribute('aria-sort', 'ascending');
+    expect(getRowDates()).toEqual(['18 — Jun — 2021', '10 — Jun — 2021', '12 — Aug — 2021']);
+
+    await user.click(sortRowsButton);
+    expect(weightColumnHeader()).toHaveAttribute('aria-sort', 'descending');
+    expect(getRowDates()).toEqual(['12 — Aug — 2021', '10 — Jun — 2021', '18 — Jun — 2021']);
+
+    // The third click clears the sort, so the rows return to their original order
+    await user.click(sortRowsButton);
+    expect(weightColumnHeader()).toHaveAttribute('aria-sort', 'none');
+    expect(getRowDates()).toEqual(unsortedOrder);
+  });
+
   it('toggles between rendering either a tabular view or a chart view', async () => {
     const user = userEvent.setup();
 

--- a/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/biometrics-overview.test.tsx
@@ -41,6 +41,13 @@ mockUseConfig.mockReturnValue({
   ...mockBiometricsConfig,
 } as ConfigObject);
 
+const getRowDates = () =>
+  screen
+    .getAllByRole('row')
+    .slice(1) // Exclude the header row
+    .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
+    .filter(Boolean);
+
 describe('Biometrics Overview', () => {
   it('renders an empty state view if biometrics data is unavailable', async () => {
     mockUseVitalsAndBiometrics.mockReturnValue({
@@ -115,25 +122,19 @@ describe('Biometrics Overview', () => {
     const sortRowsButton = screen.getByRole('button', { name: /date and time/i });
 
     const expectedDescendingOrder = [
-      '12 — Aug — 2021, 12:00 AM',
-      '18 — Jun — 2021, 12:00 AM',
-      '10 — Jun — 2021, 12:00 AM',
-      '26 — May — 2021, 12:00 AM',
-      '10 — May — 2021, 12:00 AM',
+      '12 — Aug — 2021',
+      '18 — Jun — 2021',
+      '10 — Jun — 2021',
+      '26 — May — 2021',
+      '10 — May — 2021',
     ];
     const expectedAscendingOrder = [
-      '08 — Dec — 2020, 12:00 AM',
-      '08 — Dec — 2020, 12:00 AM',
-      '08 — Dec — 2020, 12:00 AM',
-      '08 — Dec — 2020, 12:00 AM',
-      '09 — Dec — 2020, 12:00 AM',
+      '08 — Dec — 2020',
+      '08 — Dec — 2020',
+      '08 — Dec — 2020',
+      '08 — Dec — 2020',
+      '09 — Dec — 2020',
     ];
-
-    const getRowDates = () =>
-      screen
-        .getAllByRole('row')
-        .slice(1) // Exclude header row
-        .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}, \d{1,2}:\d{2} (AM|PM)/)?.[0] || '');
 
     // Initial state should be descending
     expect(getRowDates()).toEqual(expectedDescendingOrder);
@@ -172,13 +173,6 @@ describe('Biometrics Overview', () => {
     await waitForLoadingToFinish();
     await screen.findByRole('table', { name: /biometrics/i });
 
-    const getRowDates = () =>
-      screen
-        .getAllByRole('row')
-        .slice(1) // Exclude the header row
-        .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
-        .filter(Boolean);
-
     await user.click(screen.getByRole('button', { name: /next page/i }));
     expect(getRowDates()).toEqual(['08 — Apr — 2021']);
 
@@ -210,13 +204,6 @@ describe('Biometrics Overview', () => {
 
     await waitForLoadingToFinish();
     await screen.findByRole('table', { name: /biometrics/i });
-
-    const getRowDates = () =>
-      screen
-        .getAllByRole('row')
-        .slice(1) // Exclude the header row
-        .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
-        .filter(Boolean);
 
     const unsortedOrder = ['12 — Aug — 2021', '18 — Jun — 2021', '10 — Jun — 2021'];
     expect(getRowDates()).toEqual(unsortedOrder);

--- a/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
@@ -27,6 +27,8 @@ interface PaginatedBiometricsProps {
   patientUuid: string;
 }
 
+const noopSortRow = () => 0;
+
 const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
   tableRows,
   pageSize,
@@ -45,25 +47,15 @@ const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
     sortDirection: 'NONE',
   });
 
-  const handleSorting = (
-    cellA: any,
-    cellB: any,
-    { key, sortDirection }: { key: string; sortDirection: DataTableSortState },
+  // Carbon only ever sorts the rows it was handed, which is a single page. We sort
+  // the full dataset ourselves instead, so the comparator stays inert and the sort
+  // state is read from the header's click handler, which Carbon calls exactly once
+  // per click with the state it is transitioning to.
+  const handleSortHeaderClick = (
+    _event: unknown,
+    { sortHeaderKey, sortDirection }: { sortHeaderKey: string; sortDirection: DataTableSortState },
   ) => {
-    // Carbon re-runs this comparator while deriving its own state, so keep the
-    // previous object when nothing changed. Returning a new one every time would
-    // re-render, produce a fresh `sortedData` reference, and re-enter this
-    // callback through Carbon's rows effect, looping indefinitely.
-    setSortParams((prevSortParams) => {
-      const nextKey = sortDirection === 'NONE' ? '' : key;
-
-      if (prevSortParams.key === nextKey && prevSortParams.sortDirection === sortDirection) {
-        return prevSortParams;
-      }
-
-      return { key: nextKey, sortDirection };
-    });
-    return 0;
+    setSortParams({ key: sortDirection === 'NONE' ? '' : sortHeaderKey, sortDirection });
   };
 
   const sortedData: Array<BiometricsTableRow> = useMemo(() => {
@@ -102,7 +94,7 @@ const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
         overflowMenuOnHover={!isTablet}
         rows={paginatedBiometrics}
         size={isTablet ? 'lg' : 'sm'}
-        sortRow={handleSorting}
+        sortRow={noopSortRow}
         useZebraStyles
       >
         {({ getHeaderProps, getTableProps, headers, rows }) => (
@@ -114,6 +106,7 @@ const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
                     <TableHeader
                       {...getHeaderProps({
                         header,
+                        onClick: handleSortHeaderClick,
                       })}
                     >
                       {header.header}

--- a/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DataTable,
@@ -9,10 +9,10 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-  type DataTableSortState,
 } from '@carbon/react';
 import { NumericObservation, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
+import { noopSortRow, useTableSorting } from '../common';
 import type { BiometricsTableHeader, BiometricsTableRow } from './types';
 import { VitalsAndBiometricsActionMenu } from '../components/action-menu/vitals-biometrics-action-menu.component';
 import styles from './paginated-biometrics.scss';
@@ -27,8 +27,6 @@ interface PaginatedBiometricsProps {
   patientUuid: string;
 }
 
-const noopSortRow = () => 0;
-
 const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
   tableRows,
   pageSize,
@@ -42,42 +40,7 @@ const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
 
   const { t } = useTranslation();
 
-  const [sortParams, setSortParams] = useState<{ key: string; sortDirection: 'ASC' | 'DESC' | 'NONE' }>({
-    key: '',
-    sortDirection: 'NONE',
-  });
-
-  // Carbon only ever sorts the rows it was handed, which is a single page. We sort
-  // the full dataset ourselves instead, so the comparator stays inert and the sort
-  // state is read from the header's click handler, which Carbon calls exactly once
-  // per click with the state it is transitioning to.
-  const handleSortHeaderClick = (
-    _event: unknown,
-    { sortHeaderKey, sortDirection }: { sortHeaderKey: string; sortDirection: DataTableSortState },
-  ) => {
-    setSortParams({ key: sortDirection === 'NONE' ? '' : sortHeaderKey, sortDirection });
-  };
-
-  const sortedData: Array<BiometricsTableRow> = useMemo(() => {
-    if (sortParams.sortDirection === 'NONE') {
-      return tableRows;
-    }
-
-    const header = tableHeaders.find((header) => header.key === sortParams.key);
-
-    if (!header) {
-      return tableRows;
-    }
-
-    // `sortFunc` compares in ascending order, so it maps directly onto the ASC
-    // sort direction and needs inverting for DESC.
-    const sortedRows = tableRows.slice().sort((rowA, rowB) => {
-      const sortingNum = header.sortFunc(rowA, rowB);
-      return sortParams.sortDirection === 'DESC' ? -sortingNum : sortingNum;
-    });
-
-    return sortedRows;
-  }, [tableRows, tableHeaders, sortParams]);
+  const { handleSortHeaderClick, sortedData } = useTableSorting<BiometricsTableRow>(tableRows, tableHeaders);
 
   const { results: paginatedBiometrics, goTo, currentPage } = usePagination(sortedData, pageSize);
 
@@ -103,12 +66,7 @@ const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
               <TableHead>
                 <TableRow>
                   {headers.map((header) => (
-                    <TableHeader
-                      {...getHeaderProps({
-                        header,
-                        onClick: handleSortHeaderClick,
-                      })}
-                    >
+                    <TableHeader {...getHeaderProps({ header, onClick: handleSortHeaderClick })} key={header.key}>
                       {header.header}
                     </TableHeader>
                   ))}

--- a/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
+++ b/packages/esm-patient-vitals-app/src/biometrics/paginated-biometrics.component.tsx
@@ -50,11 +50,19 @@ const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
     cellB: any,
     { key, sortDirection }: { key: string; sortDirection: DataTableSortState },
   ) => {
-    if (sortDirection === 'NONE') {
-      setSortParams({ key: '', sortDirection });
-    } else {
-      setSortParams({ key, sortDirection });
-    }
+    // Carbon re-runs this comparator while deriving its own state, so keep the
+    // previous object when nothing changed. Returning a new one every time would
+    // re-render, produce a fresh `sortedData` reference, and re-enter this
+    // callback through Carbon's rows effect, looping indefinitely.
+    setSortParams((prevSortParams) => {
+      const nextKey = sortDirection === 'NONE' ? '' : key;
+
+      if (prevSortParams.key === nextKey && prevSortParams.sortDirection === sortDirection) {
+        return prevSortParams;
+      }
+
+      return { key: nextKey, sortDirection };
+    });
     return 0;
   };
 
@@ -69,9 +77,11 @@ const PaginatedBiometrics: React.FC<PaginatedBiometricsProps> = ({
       return tableRows;
     }
 
+    // `sortFunc` compares in ascending order, so it maps directly onto the ASC
+    // sort direction and needs inverting for DESC.
     const sortedRows = tableRows.slice().sort((rowA, rowB) => {
       const sortingNum = header.sortFunc(rowA, rowB);
-      return sortParams.sortDirection === 'DESC' ? sortingNum : -sortingNum;
+      return sortParams.sortDirection === 'DESC' ? -sortingNum : sortingNum;
     });
 
     return sortedRows;

--- a/packages/esm-patient-vitals-app/src/common/index.ts
+++ b/packages/esm-patient-vitals-app/src/common/index.ts
@@ -17,3 +17,4 @@ export {
   interpretBloodPressure,
 } from './helpers';
 export type { ObservationInterpretation, PatientVitalsAndBiometrics } from './types';
+export { noopSortRow, useTableSorting } from './use-table-sorting';

--- a/packages/esm-patient-vitals-app/src/common/use-table-sorting.ts
+++ b/packages/esm-patient-vitals-app/src/common/use-table-sorting.ts
@@ -1,0 +1,65 @@
+import { useCallback, useMemo, useState } from 'react';
+import { type DataTableSortState } from '@carbon/react';
+
+interface SortableTableHeader<TableRow> {
+  key: string;
+  sortFunc: (rowA: TableRow, rowB: TableRow) => number;
+}
+
+/**
+ * Carbon only ever sorts the rows it was handed, which is a single page. Pass this
+ * as the table's `sortRow` to keep its comparator inert so that the hook can sort
+ * the full dataset instead.
+ */
+export const noopSortRow = () => 0;
+
+/**
+ * Sorts a paginated table's full dataset rather than just its visible page.
+ *
+ * The sort state is read from the header's click handler, which Carbon calls
+ * exactly once per click with the state it is transitioning to. `sortRow` is the
+ * wrong hook for that: Carbon re-runs it while deriving its own state, skips it
+ * when a header transitions to `NONE`, and never invokes it when the page holds a
+ * single row, because `Array.prototype.sort` performs no comparisons on a
+ * single-element array.
+ */
+export function useTableSorting<TableRow>(
+  tableRows: Array<TableRow>,
+  tableHeaders: Array<SortableTableHeader<TableRow>>,
+) {
+  const [sortParams, setSortParams] = useState<{ key: string; sortDirection: DataTableSortState }>({
+    key: '',
+    sortDirection: 'NONE',
+  });
+
+  const handleSortHeaderClick = useCallback(
+    (
+      _event: unknown,
+      { sortHeaderKey, sortDirection }: { sortHeaderKey: string; sortDirection: DataTableSortState },
+    ) => {
+      setSortParams({ key: sortDirection === 'NONE' ? '' : sortHeaderKey, sortDirection });
+    },
+    [],
+  );
+
+  const sortedData: Array<TableRow> = useMemo(() => {
+    if (sortParams.sortDirection === 'NONE') {
+      return tableRows;
+    }
+
+    const header = tableHeaders.find((header) => header.key === sortParams.key);
+
+    if (!header) {
+      return tableRows;
+    }
+
+    // `sortFunc` compares in ascending order, so it maps directly onto the ASC
+    // sort direction and needs inverting for DESC.
+    return tableRows.slice().sort((rowA, rowB) => {
+      const sortingNum = header.sortFunc(rowA, rowB);
+      return sortParams.sortDirection === 'DESC' ? -sortingNum : sortingNum;
+    });
+  }, [tableHeaders, tableRows, sortParams]);
+
+  return { handleSortHeaderClick, sortedData };
+}

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -54,11 +54,19 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
     _cellB: any,
     { key, sortDirection }: { key: string; sortDirection: DataTableSortState },
   ) => {
-    if (sortDirection === 'NONE') {
-      setSortParams({ key: '', sortDirection });
-    } else {
-      setSortParams({ key, sortDirection });
-    }
+    // Carbon re-runs this comparator while deriving its own state, so keep the
+    // previous object when nothing changed. Returning a new one every time would
+    // re-render, produce a fresh `sortedData` reference, and re-enter this
+    // callback through Carbon's rows effect, looping indefinitely.
+    setSortParams((prevSortParams) => {
+      const nextKey = sortDirection === 'NONE' ? '' : key;
+
+      if (prevSortParams.key === nextKey && prevSortParams.sortDirection === sortDirection) {
+        return prevSortParams;
+      }
+
+      return { key: nextKey, sortDirection };
+    });
     return 0;
   };
 
@@ -73,9 +81,11 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
       return tableRows;
     }
 
+    // `sortFunc` compares in ascending order, so it maps directly onto the ASC
+    // sort direction and needs inverting for DESC.
     const sortedRows = tableRows.slice().sort((rowA, rowB) => {
       const sortingNum = header.sortFunc(rowA, rowB);
-      return sortParams.sortDirection === 'DESC' ? sortingNum : -sortingNum;
+      return sortParams.sortDirection === 'DESC' ? -sortingNum : sortingNum;
     });
 
     return sortedRows;

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DataTable,
@@ -12,10 +12,10 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-  type DataTableSortState,
 } from '@carbon/react';
 import { NumericObservation, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
+import { noopSortRow, useTableSorting } from '../common';
 import type { VitalsTableHeader, VitalsTableRow } from './types';
 import { VitalsAndBiometricsActionMenu } from '../components/action-menu/vitals-biometrics-action-menu.component';
 import styles from './paginated-vitals.scss';
@@ -31,8 +31,6 @@ interface PaginatedVitalsProps {
   patient: fhir.Patient;
 }
 
-const noopSortRow = () => 0;
-
 const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
   isPrinting,
   pageSize,
@@ -46,42 +44,7 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
 
-  const [sortParams, setSortParams] = useState<{ key: string; sortDirection: 'ASC' | 'DESC' | 'NONE' }>({
-    key: '',
-    sortDirection: 'NONE',
-  });
-
-  // Carbon only ever sorts the rows it was handed, which is a single page. We sort
-  // the full dataset ourselves instead, so the comparator stays inert and the sort
-  // state is read from the header's click handler, which Carbon calls exactly once
-  // per click with the state it is transitioning to.
-  const handleSortHeaderClick = (
-    _event: unknown,
-    { sortHeaderKey, sortDirection }: { sortHeaderKey: string; sortDirection: DataTableSortState },
-  ) => {
-    setSortParams({ key: sortDirection === 'NONE' ? '' : sortHeaderKey, sortDirection });
-  };
-
-  const sortedData: Array<VitalsTableRow> = useMemo(() => {
-    if (sortParams.sortDirection === 'NONE') {
-      return tableRows;
-    }
-
-    const header = tableHeaders.find((header) => header.key === sortParams.key);
-
-    if (!header) {
-      return tableRows;
-    }
-
-    // `sortFunc` compares in ascending order, so it maps directly onto the ASC
-    // sort direction and needs inverting for DESC.
-    const sortedRows = tableRows.slice().sort((rowA, rowB) => {
-      const sortingNum = header.sortFunc(rowA, rowB);
-      return sortParams.sortDirection === 'DESC' ? -sortingNum : sortingNum;
-    });
-
-    return sortedRows;
-  }, [tableHeaders, tableRows, sortParams]);
+  const { handleSortHeaderClick, sortedData } = useTableSorting<VitalsTableRow>(tableRows, tableHeaders);
 
   const { results: paginatedVitals, goTo, currentPage } = usePagination(sortedData, pageSize);
 

--- a/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/paginated-vitals.component.tsx
@@ -31,6 +31,8 @@ interface PaginatedVitalsProps {
   patient: fhir.Patient;
 }
 
+const noopSortRow = () => 0;
+
 const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
   isPrinting,
   pageSize,
@@ -49,25 +51,15 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
     sortDirection: 'NONE',
   });
 
-  const handleSorting = (
-    _cellA: any,
-    _cellB: any,
-    { key, sortDirection }: { key: string; sortDirection: DataTableSortState },
+  // Carbon only ever sorts the rows it was handed, which is a single page. We sort
+  // the full dataset ourselves instead, so the comparator stays inert and the sort
+  // state is read from the header's click handler, which Carbon calls exactly once
+  // per click with the state it is transitioning to.
+  const handleSortHeaderClick = (
+    _event: unknown,
+    { sortHeaderKey, sortDirection }: { sortHeaderKey: string; sortDirection: DataTableSortState },
   ) => {
-    // Carbon re-runs this comparator while deriving its own state, so keep the
-    // previous object when nothing changed. Returning a new one every time would
-    // re-render, produce a fresh `sortedData` reference, and re-enter this
-    // callback through Carbon's rows effect, looping indefinitely.
-    setSortParams((prevSortParams) => {
-      const nextKey = sortDirection === 'NONE' ? '' : key;
-
-      if (prevSortParams.key === nextKey && prevSortParams.sortDirection === sortDirection) {
-        return prevSortParams;
-      }
-
-      return { key: nextKey, sortDirection };
-    });
-    return 0;
+    setSortParams({ key: sortDirection === 'NONE' ? '' : sortHeaderKey, sortDirection });
   };
 
   const sortedData: Array<VitalsTableRow> = useMemo(() => {
@@ -109,7 +101,7 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
         overflowMenuOnHover={!isTablet}
         rows={displayedRows}
         size={isTablet ? 'lg' : 'sm'}
-        sortRow={handleSorting}
+        sortRow={noopSortRow}
         useZebraStyles
       >
         {({ rows, headers, getTableProps, getHeaderProps, getExpandHeaderProps, getRowProps, getExpandedRowProps }) => (
@@ -119,7 +111,7 @@ const PaginatedVitals: React.FC<PaginatedVitalsProps> = ({
                 <TableRow>
                   {hasAnyNotes && <TableExpandHeader {...getExpandHeaderProps()} />}
                   {headers.map((header) => (
-                    <TableHeader {...getHeaderProps({ header })} key={header.key}>
+                    <TableHeader {...getHeaderProps({ header, onClick: handleSortHeaderClick })} key={header.key}>
                       {header.header}
                     </TableHeader>
                   ))}

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -111,6 +111,44 @@ describe('VitalsOverview', () => {
     expectedTableRows.map((row) => expect(screen.getByRole('row', { name: new RegExp(row, 'i') })).toBeInTheDocument());
   });
 
+  it('sorts the vitals table in the direction indicated by the column header', async () => {
+    const user = userEvent.setup();
+
+    mockUseVitalsAndBiometrics.mockReturnValue({
+      data: formattedVitals,
+    } as ReturnType<typeof useVitalsAndBiometrics>);
+
+    renderWithSwr(<VitalsOverview {...testProps} />);
+
+    await waitForLoadingToFinish();
+    expect(screen.getByRole('table', { name: /vitals/i })).toBeInTheDocument();
+
+    const getRowDates = () =>
+      screen
+        .getAllByRole('row')
+        .slice(1) // Exclude the header row
+        .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
+        .filter(Boolean);
+
+    const expectedDescendingOrder = ['19 — May — 2021', '10 — May — 2021', '07 — May — 2021', '08 — Apr — 2021'];
+    const expectedAscendingOrder = [...expectedDescendingOrder].reverse();
+
+    expect(getRowDates()).toEqual(expectedDescendingOrder);
+
+    const sortRowsButton = screen.getByRole('button', { name: /date and time/i });
+    const dateColumnHeader = () => screen.getByRole('columnheader', { name: /date and time/i });
+
+    // The first click sorts in ascending order, putting the oldest reading first
+    await user.click(sortRowsButton);
+    expect(dateColumnHeader()).toHaveAttribute('aria-sort', 'ascending');
+    expect(getRowDates()).toEqual(expectedAscendingOrder);
+
+    // The second click sorts in descending order, putting the newest reading first
+    await user.click(sortRowsButton);
+    expect(dateColumnHeader()).toHaveAttribute('aria-sort', 'descending');
+    expect(getRowDates()).toEqual(expectedDescendingOrder);
+  });
+
   it('expands a vitals row to show an associated note', async () => {
     const user = userEvent.setup();
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -149,6 +149,78 @@ describe('VitalsOverview', () => {
     expect(getRowDates()).toEqual(expectedDescendingOrder);
   });
 
+  it('sorts across the whole dataset even when the visible page holds a single row', async () => {
+    const user = userEvent.setup();
+
+    mockUseVitalsAndBiometrics.mockReturnValue({
+      data: formattedVitals,
+    } as ReturnType<typeof useVitalsAndBiometrics>);
+
+    // With one row per page Carbon's comparator is never invoked, because
+    // `Array.prototype.sort` performs no comparisons on a single-element array.
+    renderWithSwr(<VitalsOverview {...testProps} pageSize={1} />);
+
+    await waitForLoadingToFinish();
+
+    const getVisibleDate = () =>
+      screen
+        .getAllByRole('row')
+        .slice(1) // Exclude the header row
+        .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
+        .filter(Boolean);
+
+    expect(getVisibleDate()).toEqual(['19 — May — 2021']);
+
+    const dateColumnHeader = () => screen.getByRole('columnheader', { name: /date and time/i });
+
+    await user.click(screen.getByRole('button', { name: /date and time/i }));
+
+    expect(dateColumnHeader()).toHaveAttribute('aria-sort', 'ascending');
+    expect(getVisibleDate()).toEqual(['08 — Apr — 2021']);
+  });
+
+  it('restores the unsorted order once the header cycles back to none', async () => {
+    const user = userEvent.setup();
+
+    mockUseVitalsAndBiometrics.mockReturnValue({
+      data: [
+        { id: '0', date: '2021-05-19T04:26:51.000Z', pulse: 90 },
+        { id: '1', date: '2021-05-10T06:41:46.000Z', pulse: 60 },
+        { id: '2', date: '2021-05-07T09:04:51.000Z', pulse: 75 },
+      ],
+    } as ReturnType<typeof useVitalsAndBiometrics>);
+
+    renderWithSwr(<VitalsOverview {...testProps} />);
+
+    await waitForLoadingToFinish();
+
+    const getRowDates = () =>
+      screen
+        .getAllByRole('row')
+        .slice(1) // Exclude the header row
+        .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
+        .filter(Boolean);
+
+    const unsortedOrder = ['19 — May — 2021', '10 — May — 2021', '07 — May — 2021'];
+    expect(getRowDates()).toEqual(unsortedOrder);
+
+    const sortRowsButton = screen.getByRole('button', { name: /pulse/i });
+    const pulseColumnHeader = () => screen.getByRole('columnheader', { name: /pulse/i });
+
+    await user.click(sortRowsButton);
+    expect(pulseColumnHeader()).toHaveAttribute('aria-sort', 'ascending');
+    expect(getRowDates()).toEqual(['10 — May — 2021', '07 — May — 2021', '19 — May — 2021']);
+
+    await user.click(sortRowsButton);
+    expect(pulseColumnHeader()).toHaveAttribute('aria-sort', 'descending');
+    expect(getRowDates()).toEqual(['19 — May — 2021', '07 — May — 2021', '10 — May — 2021']);
+
+    // The third click clears the sort, so the rows return to their original order
+    await user.click(sortRowsButton);
+    expect(pulseColumnHeader()).toHaveAttribute('aria-sort', 'none');
+    expect(getRowDates()).toEqual(unsortedOrder);
+  });
+
   it('expands a vitals row to show an associated note', async () => {
     const user = userEvent.setup();
 

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../common', async () => {
 
 mockUseConfig.mockReturnValue({
   ...getDefaultsFromConfigSchema(configSchema),
-  mockVitalsConfig,
+  ...mockVitalsConfig,
 } as ConfigObject);
 
 const getRowDates = () =>

--- a/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals/vitals-overview.test.tsx
@@ -46,6 +46,13 @@ mockUseConfig.mockReturnValue({
   mockVitalsConfig,
 } as ConfigObject);
 
+const getRowDates = () =>
+  screen
+    .getAllByRole('row')
+    .slice(1) // Exclude the header row
+    .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
+    .filter(Boolean);
+
 describe('VitalsOverview', () => {
   it('renders an empty state view if vitals data is unavailable', async () => {
     mockUseVitalsAndBiometrics.mockReturnValue({
@@ -123,13 +130,6 @@ describe('VitalsOverview', () => {
     await waitForLoadingToFinish();
     expect(screen.getByRole('table', { name: /vitals/i })).toBeInTheDocument();
 
-    const getRowDates = () =>
-      screen
-        .getAllByRole('row')
-        .slice(1) // Exclude the header row
-        .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
-        .filter(Boolean);
-
     const expectedDescendingOrder = ['19 — May — 2021', '10 — May — 2021', '07 — May — 2021', '08 — Apr — 2021'];
     const expectedAscendingOrder = [...expectedDescendingOrder].reverse();
 
@@ -162,21 +162,14 @@ describe('VitalsOverview', () => {
 
     await waitForLoadingToFinish();
 
-    const getVisibleDate = () =>
-      screen
-        .getAllByRole('row')
-        .slice(1) // Exclude the header row
-        .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
-        .filter(Boolean);
-
-    expect(getVisibleDate()).toEqual(['19 — May — 2021']);
+    expect(getRowDates()).toEqual(['19 — May — 2021']);
 
     const dateColumnHeader = () => screen.getByRole('columnheader', { name: /date and time/i });
 
     await user.click(screen.getByRole('button', { name: /date and time/i }));
 
     expect(dateColumnHeader()).toHaveAttribute('aria-sort', 'ascending');
-    expect(getVisibleDate()).toEqual(['08 — Apr — 2021']);
+    expect(getRowDates()).toEqual(['08 — Apr — 2021']);
   });
 
   it('restores the unsorted order once the header cycles back to none', async () => {
@@ -193,13 +186,6 @@ describe('VitalsOverview', () => {
     renderWithSwr(<VitalsOverview {...testProps} />);
 
     await waitForLoadingToFinish();
-
-    const getRowDates = () =>
-      screen
-        .getAllByRole('row')
-        .slice(1) // Exclude the header row
-        .map((row) => row.textContent?.match(/\d{1,2} — \w{3} — \d{4}/)?.[0])
-        .filter(Boolean);
 
     const unsortedOrder = ['19 — May — 2021', '10 — May — 2021', '07 — May — 2021'];
     expect(getRowDates()).toEqual(unsortedOrder);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The Vitals and Biometrics tables sorted in the opposite direction to the one indicated by the column header arrow: an ascending (↑) arrow put the newest reading at the top, and a descending (↓) arrow put the oldest reading at the top.

Both `PaginatedVitals` and `PaginatedBiometrics` bypass Carbon's own row sorting and re-sort the full dataset themselves, so that sorting applies across pages rather than just the visible page. There were two bugs in that arrangement.

### 1. The sort direction was inverted

```js
return sortParams.sortDirection === 'DESC' ? sortingNum : -sortingNum;
```

Every `sortFunc` in `vitals-overview.component.tsx` and `biometrics-base.component.tsx` is an ascending comparator (`a - b`, i.e. negative when `a` sorts first). Carbon treats `ASC` the same way — its `defaultSortRow` returns `compare(cellA, cellB)` for `ASC` and `compare(cellB, cellA)` for `DESC` — and renders the header's `ArrowUp` icon rotated 180° only when the state is `DESC`. So `↑` = `ASC` = smallest/oldest first. The comparator therefore maps directly onto `ASC` and needs negating for `DESC`, which is the reverse of what the code did.

This aligns the rendered order with both the arrow and the header's `aria-sort` value, for every sortable column in these two tables rather than just `Date and time`.

### 2. The sort state was read from the wrong place

Both components recorded the sort state from inside `sortRow`, returning `0` so that Carbon would not reorder anything itself. `sortRow` is the wrong hook for that, for three reasons:

- **Carbon does not treat it as a pure comparator.** `getDerivedStateFromProps` calls `getSortedState` — and therefore `sortRow` — whenever `sortHeaderKey` is already set. Setting state from inside it closed a cycle: a new `sortParams` object → a new `sortedData` array → a new `rows` reference → Carbon's `useEffect([headers, rows])` → `getDerivedStateFromProps` → back into `sortRow`. Before the first click `sortHeaderKey` is `null`, so the cycle never started and the table looked fine, which is why this went unnoticed. Measured with a counter on `usePagination`, a single sort click produced 300+ renders, climbing until the heap was exhausted.
- **Carbon skips it when a header transitions to `NONE`.** The `sortDirection === 'NONE'` branch never fired, so the third click on a header left the rows sorted while `aria-sort` had already reset to `none`.
- **Carbon never invokes it when the page holds a single row**, because `Array.prototype.sort` performs no comparisons on a one-element array. On such a page, clicking a header moved `aria-sort` but left the rows untouched.

The sort state is now captured from the header's `onClick` callback, which Carbon calls exactly once per click with the state it is transitioning to:

```tsx
const handleSortHeaderClick = (
  _event: unknown,
  { sortHeaderKey, sortDirection }: { sortHeaderKey: string; sortDirection: DataTableSortState },
) => {
  setSortParams({ key: sortDirection === 'NONE' ? '' : sortHeaderKey, sortDirection });
};
```

`sortRow` is left as a pure `() => 0`. That covers all three sort states, fixes both of the gaps above, and removes the render loop at its source rather than damping it with a previous-state bailout.

Both tables carried their own copy of all of this — the sort state, the click handler and the block that re-sorts the full dataset were identical line for line, so any future change would have had to be made twice. They now share a `useTableSorting` hook in the package's `common` folder, which also exports the inert comparator as `noopSortRow`, and which types its sort direction with Carbon's `DataTableSortState` rather than restating `'ASC' | 'DESC' | 'NONE'` by hand.

## Screenshots

Patient `Grace Garcia`, Vitals & Biometrics dashboard, sorting on `Date and time`.

### Ascending (↑) arrow

**Before** — newest reading first:

<img width="900" alt="before-ascending" src="https://github.com/user-attachments/assets/125bdd88-952a-4e7e-8527-bc122714cf37" />

**After** — oldest reading first:

<img width="900" alt="after-ascending" src="https://github.com/user-attachments/assets/eaffa1ca-51f2-4d3e-8dc4-24b4f3217802" />

### Descending (↓) arrow

**Before** — oldest reading first:

<img width="900" alt="before-descending" src="https://github.com/user-attachments/assets/b3f322b2-5c78-4fd0-bcab-8698a143fa45" />

**After** — newest reading first:

<img width="900" alt="after-descending" src="https://github.com/user-attachments/assets/16e57e35-05f7-48aa-87de-8efe63f80880" />

## Related Issue

https://openmrs.atlassian.net/browse/O3-5841

## Other

`biometrics-overview.test.tsx` already declared the expected ascending and descending orders but never asserted them — the `sortRowsButton` and `expectedAscendingOrder` bindings were unused, which is why the inversion went unnoticed. Those assertions are now wired up and check `aria-sort` alongside the row order. An equivalent test was added for the Vitals table, which had no sorting coverage at all.

Each table also gets two further tests, covering the cases where Carbon never calls `sortRow`:

- **A single-row page still sorts the whole dataset.** Vitals renders with `pageSize={1}`; Biometrics paginates six readings five to a page and navigates to the second. In both, clicking `Date and time` swaps the visible row for the oldest reading.
- **The third click restores the unsorted order.** Sorting by `Pulse` / `Weight` through `ASC` → `DESC` → `NONE` and asserting the rows come back to their original order, with `aria-sort` at `none`.

All four fail against the previous `sortRow`-based implementation.

While in `paginated-biometrics.component.tsx`, the column headers now take an explicit `key={header.key}` rather than receiving it through the `getHeaderProps` spread, which React 19 warns about. `PaginatedVitals` already did this; the biometrics line predates the PR.

Two related things I left alone to keep this focused, both worth a follow-up:

- `tableHeaders` is rebuilt as a new array literal on every render in both `biometrics-base.component.tsx` and `vitals-overview.component.tsx`. It is a dependency of the `sortedData` memo and is passed straight to Carbon's `headers` prop, so each parent render currently costs an extra `DataTable` state sync. Memoising it would remove that churn; it is not required for the fix above.
- The same inverted direction mapping exists in `esm-generic-patient-widgets-app`'s `obs-table` and in `esm-patient-conditions-app`'s conditions sorting. In `obs-table` the date comparator is itself written backwards (`rowB - rowA`), so the two inversions cancel out for that one column while the other columns stay wrong.

