### PR TITLE
(fix) O3-5844: Allow recording vaccinations on a patient's birth date

### DIFF
--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
@@ -27,6 +27,7 @@ import { savePatientImmunization } from './immunizations.resource';
 import { FHIR_NEXT_DOSE_DATE_EXTENSION_URL } from './immunization-mapper';
 import { useImmunizations } from '../hooks/useImmunizations';
 import ImmunizationsForm from './immunizations-form.workspace';
+import { fireEvent } from '@testing-library/react';
 
 const mockCloseWorkspace = vi.fn();
 const mockSavePatientImmunization = savePatientImmunization as Mock;
@@ -593,6 +594,75 @@ describe('Immunizations Form', () => {
       'existing-uuid',
       expect.any(AbortController),
     );
+  });
+
+  it("should accept a vaccination date that matches the patient's birth date", async () => {
+    const user = userEvent.setup();
+    render(<ImmunizationsForm {...testProps} />);
+
+    mockSavePatientImmunization.mockResolvedValue({
+      status: 201,
+      ok: true,
+      data: { id: 'new-immunization-id' },
+    });
+
+    const vaccinationDateField = screen.getByRole('textbox', { name: /vaccination date/i });
+    fireEvent.change(vaccinationDateField, { target: { value: '04/04/1972' } }); // matches mockPatient.birthDate
+    fireEvent.blur(vaccinationDateField);
+
+    const vaccineField = screen.getByRole('combobox', { name: /Immunization/i });
+    await selectOption(vaccineField, 'Hepatitis B vaccination');
+    const doseField = screen.getByRole('spinbutton', { name: /Dose number within series/i });
+    await user.clear(doseField);
+    await user.type(doseField, '1');
+
+    expect(screen.queryByText(/Vaccination date cannot precede birth date/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Save/i }));
+
+    expect(mockSavePatientImmunization).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reject a vaccination date one day before the patient's birth date", async () => {
+    const user = userEvent.setup();
+    render(<ImmunizationsForm {...testProps} />);
+
+    const vaccinationDateField = screen.getByRole('textbox', { name: /vaccination date/i });
+    fireEvent.change(vaccinationDateField, { target: { value: '03/04/1972' } }); // one day before birth date
+    fireEvent.blur(vaccinationDateField);
+
+    const vaccineField = screen.getByRole('combobox', { name: /Immunization/i });
+    await selectOption(vaccineField, 'Hepatitis B vaccination');
+    const doseField = screen.getByRole('spinbutton', { name: /Dose number within series/i });
+    await user.clear(doseField);
+    await user.type(doseField, '1');
+
+    expect(screen.getByText(/Vaccination date cannot precede birth date/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Save/i }));
+
+    expect(mockSavePatientImmunization).not.toHaveBeenCalled();
+  });
+
+  it('should reject a vaccination date in the future', async () => {
+    const user = userEvent.setup();
+    render(<ImmunizationsForm {...testProps} />);
+
+    const vaccinationDateField = screen.getByRole('textbox', { name: /vaccination date/i });
+    fireEvent.change(vaccinationDateField, { target: { value: '01/01/2099' } });
+    fireEvent.blur(vaccinationDateField);
+
+    const vaccineField = screen.getByRole('combobox', { name: /Immunization/i });
+    await selectOption(vaccineField, 'Hepatitis B vaccination');
+    const doseField = screen.getByRole('spinbutton', { name: /Dose number within series/i });
+    await user.clear(doseField);
+    await user.type(doseField, '1');
+
+    expect(screen.getByText(/Vaccination date cannot be in the future/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Save/i }));
+
+    expect(mockSavePatientImmunization).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.test.tsx
@@ -6,10 +6,10 @@
  * matchers on form payloads that production code builds with `new Date()`.
  */
 import React from 'react';
-import { vi, describe, it, expect, test, beforeEach, type Mock } from 'vitest';
+import { vi, describe, it, expect, test, beforeEach, beforeAll, afterAll, type Mock } from 'vitest';
 import dayjs from 'dayjs';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import {
   getDefaultsFromConfigSchema,
   showSnackbar,
@@ -27,7 +27,6 @@ import { savePatientImmunization } from './immunizations.resource';
 import { FHIR_NEXT_DOSE_DATE_EXTENSION_URL } from './immunization-mapper';
 import { useImmunizations } from '../hooks/useImmunizations';
 import ImmunizationsForm from './immunizations-form.workspace';
-import { fireEvent } from '@testing-library/react';
 
 const mockCloseWorkspace = vi.fn();
 const mockSavePatientImmunization = savePatientImmunization as Mock;
@@ -596,73 +595,86 @@ describe('Immunizations Form', () => {
     );
   });
 
-  it("should accept a vaccination date that matches the patient's birth date", async () => {
-    const user = userEvent.setup();
-    render(<ImmunizationsForm {...testProps} />);
+  describe('Vaccination date boundaries', () => {
+    const originalTimezone = process.env.TZ;
 
-    mockSavePatientImmunization.mockResolvedValue({
-      status: 201,
-      ok: true,
-      data: { id: 'new-immunization-id' },
+    beforeAll(() => {
+      // The birth-date boundary bug only reproduces in timezones ahead of UTC
+      process.env.TZ = 'Africa/Nairobi';
     });
 
-    const vaccinationDateField = screen.getByRole('textbox', { name: /vaccination date/i });
-    fireEvent.change(vaccinationDateField, { target: { value: '04/04/1972' } }); // matches mockPatient.birthDate
-    fireEvent.blur(vaccinationDateField);
+    afterAll(() => {
+      process.env.TZ = originalTimezone;
+    });
 
-    const vaccineField = screen.getByRole('combobox', { name: /Immunization/i });
-    await selectOption(vaccineField, 'Hepatitis B vaccination');
-    const doseField = screen.getByRole('spinbutton', { name: /Dose number within series/i });
-    await user.clear(doseField);
-    await user.type(doseField, '1');
+    it("should accept a vaccination date that matches the patient's birth date", async () => {
+      const user = userEvent.setup();
+      render(<ImmunizationsForm {...testProps} />);
 
-    expect(screen.queryByText(/Vaccination date cannot precede birth date/i)).not.toBeInTheDocument();
+      mockSavePatientImmunization.mockResolvedValue({
+        status: 201,
+        ok: true,
+        data: { id: 'new-immunization-id' },
+      });
 
-    await user.click(screen.getByRole('button', { name: /Save/i }));
+      const vaccinationDateField = screen.getByRole('textbox', { name: /vaccination date/i });
+      fireEvent.change(vaccinationDateField, { target: { value: '1972-04-04' } }); // matches mockPatient.birthDate
+      fireEvent.blur(vaccinationDateField);
 
-    expect(mockSavePatientImmunization).toHaveBeenCalledTimes(1);
-  });
+      const vaccineField = screen.getByRole('combobox', { name: /Immunization/i });
+      await selectOption(vaccineField, 'Hepatitis B vaccination');
+      const doseField = screen.getByRole('spinbutton', { name: /Dose number within series/i });
+      await user.clear(doseField);
+      await user.type(doseField, '1');
 
-  it("should reject a vaccination date one day before the patient's birth date", async () => {
-    const user = userEvent.setup();
-    render(<ImmunizationsForm {...testProps} />);
+      expect(screen.queryByText(/Vaccination date cannot precede birth date/i)).not.toBeInTheDocument();
 
-    const vaccinationDateField = screen.getByRole('textbox', { name: /vaccination date/i });
-    fireEvent.change(vaccinationDateField, { target: { value: '03/04/1972' } }); // one day before birth date
-    fireEvent.blur(vaccinationDateField);
+      await user.click(screen.getByRole('button', { name: /Save/i }));
 
-    const vaccineField = screen.getByRole('combobox', { name: /Immunization/i });
-    await selectOption(vaccineField, 'Hepatitis B vaccination');
-    const doseField = screen.getByRole('spinbutton', { name: /Dose number within series/i });
-    await user.clear(doseField);
-    await user.type(doseField, '1');
+      expect(mockSavePatientImmunization).toHaveBeenCalledTimes(1);
+    });
 
-    expect(screen.getByText(/Vaccination date cannot precede birth date/i)).toBeInTheDocument();
+    it("should reject a vaccination date one day before the patient's birth date", async () => {
+      const user = userEvent.setup();
+      render(<ImmunizationsForm {...testProps} />);
 
-    await user.click(screen.getByRole('button', { name: /Save/i }));
+      const vaccinationDateField = screen.getByRole('textbox', { name: /vaccination date/i });
+      fireEvent.change(vaccinationDateField, { target: { value: '1972-04-03' } }); // one day before birth date
+      fireEvent.blur(vaccinationDateField);
 
-    expect(mockSavePatientImmunization).not.toHaveBeenCalled();
-  });
+      const vaccineField = screen.getByRole('combobox', { name: /Immunization/i });
+      await selectOption(vaccineField, 'Hepatitis B vaccination');
+      const doseField = screen.getByRole('spinbutton', { name: /Dose number within series/i });
+      await user.clear(doseField);
+      await user.type(doseField, '1');
 
-  it('should reject a vaccination date in the future', async () => {
-    const user = userEvent.setup();
-    render(<ImmunizationsForm {...testProps} />);
+      expect(screen.getByText(/Vaccination date cannot precede birth date/i)).toBeInTheDocument();
 
-    const vaccinationDateField = screen.getByRole('textbox', { name: /vaccination date/i });
-    fireEvent.change(vaccinationDateField, { target: { value: '01/01/2099' } });
-    fireEvent.blur(vaccinationDateField);
+      await user.click(screen.getByRole('button', { name: /Save/i }));
 
-    const vaccineField = screen.getByRole('combobox', { name: /Immunization/i });
-    await selectOption(vaccineField, 'Hepatitis B vaccination');
-    const doseField = screen.getByRole('spinbutton', { name: /Dose number within series/i });
-    await user.clear(doseField);
-    await user.type(doseField, '1');
+      expect(mockSavePatientImmunization).not.toHaveBeenCalled();
+    });
 
-    expect(screen.getByText(/Vaccination date cannot be in the future/i)).toBeInTheDocument();
+    it('should reject a vaccination date in the future', async () => {
+      const user = userEvent.setup();
+      render(<ImmunizationsForm {...testProps} />);
 
-    await user.click(screen.getByRole('button', { name: /Save/i }));
+      const vaccinationDateField = screen.getByRole('textbox', { name: /vaccination date/i });
+      fireEvent.change(vaccinationDateField, { target: { value: '2099-01-01' } });
+      fireEvent.blur(vaccinationDateField);
 
-    expect(mockSavePatientImmunization).not.toHaveBeenCalled();
+      const vaccineField = screen.getByRole('combobox', { name: /Immunization/i });
+      await selectOption(vaccineField, 'Hepatitis B vaccination');
+      const doseField = screen.getByRole('spinbutton', { name: /Dose number within series/i });
+      await user.clear(doseField);
+      await user.type(doseField, '1');
+
+      expect(screen.getByText(/Vaccination date cannot be in the future/i)).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /Save/i }));
+
+      expect(mockSavePatientImmunization).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -49,17 +49,9 @@ const ImmunizationsForm: React.FC<PatientWorkspace2DefinitionProps<{}, {}>> = ({
       vaccineUuid: z.string().min(1, t('vaccineRequired', 'Vaccine is required')),
       vaccinationDate: z
         .date()
-        .refine(
-          (date) => {
-            // Normalize both dates to start of day in local timezone
-            const inputDate = dayjs(date).startOf('day');
-            const birthDate = dayjs(patient.birthDate).startOf('day');
-            return inputDate.isSame(birthDate) || inputDate.isAfter(birthDate);
-          },
-          {
-            message: t('vaccinationDateCannotBeBeforeBirthDate', 'Vaccination date cannot precede birth date'),
-          },
-        )
+        .refine((date) => !patient.birthDate || !dayjs(date).isBefore(patient.birthDate, 'day'), {
+          message: t('vaccinationDateCannotBeBeforeBirthDate', 'Vaccination date cannot precede birth date'),
+        })
         .refine(
           (date) => {
             // Normalize both dates to start of day in local timezone

--- a/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
+++ b/packages/esm-patient-immunizations-app/src/immunizations/immunizations-form.workspace.tsx
@@ -49,9 +49,17 @@ const ImmunizationsForm: React.FC<PatientWorkspace2DefinitionProps<{}, {}>> = ({
       vaccineUuid: z.string().min(1, t('vaccineRequired', 'Vaccine is required')),
       vaccinationDate: z
         .date()
-        .min(new Date(patient.birthDate), {
-          message: t('vaccinationDateCannotBeBeforeBirthDate', 'Vaccination date cannot precede birth date'),
-        })
+        .refine(
+          (date) => {
+            // Normalize both dates to start of day in local timezone
+            const inputDate = dayjs(date).startOf('day');
+            const birthDate = dayjs(patient.birthDate).startOf('day');
+            return inputDate.isSame(birthDate) || inputDate.isAfter(birthDate);
+          },
+          {
+            message: t('vaccinationDateCannotBeBeforeBirthDate', 'Vaccination date cannot precede birth date'),
+          },
+        )
         .refine(
           (date) => {
             // Normalize both dates to start of day in local timezone


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
Vaccination date validation compared full `Date` timestamps instead of calendar days, so a vaccination recorded on the patient's actual birth date was rejected whenever local midnight preceded the backend's UTC birth date timestamp (e.g. any timezone ahead of UTC). This blocked recording routine birth-dose vaccines like BCG, Hepatitis B, and OPV-0.

Replaced the `.min()` timestamp comparison with a `.refine()` that normalizes both dates to start-of-day before comparing, mirroring the pattern already used for the future-date check.

## Screenshots
<img width="1366" height="768" alt="Screenshot (534)" src="https://github.com/user-attachments/assets/200229ec-9050-4783-ba98-ceeb523e73c0" />
<img width="1366" height="768" alt="Screenshot (535)" src="https://github.com/user-attachments/assets/ec9509dd-cad4-4c31-b678-077f0e929db2" />

## Related Issue
https://openmrs.atlassian.net/browse/O3-5844

## Other