### PR TITLE
(test) O3-5888: Add e2e test coverage for entering lab results via the Laboratory app

### DIFF
--- a/e2e/commands/test-helpers.ts
+++ b/e2e/commands/test-helpers.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from '@playwright/test';
+import { ResultsViewerPage } from '../pages/results-viewer-page';
 
 export async function getAfterContent(element: Locator): Promise<string> {
   return await element.evaluate((el) => {
@@ -43,6 +44,23 @@ export async function expectCellInterpretation(
 
   expect(await getBackgroundColor(styledContent)).toBe(backgroundColor);
   expect(await getAfterContent(styledContent)).toBe(interpretation === 'normal' ? 'none' : `"${indicator}"`);
+}
+
+// Verifies a saved lab result for `conceptName` with `value` is visible in the patient's Results
+// Viewer under the "Individual tests" tab. Shared by the lab-orders and lab-app-results specs, which
+// both finish by confirming the entered result actually persisted and renders. The row is matched on
+// both the concept name and the value so a stale or empty row cannot satisfy it.
+export async function expectLabResultInResultsViewer(
+  page: Page,
+  patientUuid: string,
+  conceptName: string,
+  value: string,
+): Promise<void> {
+  const resultsViewerPage = new ResultsViewerPage(page);
+  await resultsViewerPage.goTo(patientUuid);
+  await page.getByRole('tab', { name: /individual tests/i }).click();
+  const row = page.getByRole('row').filter({ hasText: conceptName }).filter({ hasText: value }).first();
+  await expect(row).toBeVisible();
 }
 
 export async function calculateBirthdate(age: { years?: number; months?: number }): Promise<string> {

--- a/e2e/core/lab-fixtures.ts
+++ b/e2e/core/lab-fixtures.ts
@@ -1,0 +1,34 @@
+import { type Order } from '@openmrs/esm-patient-common-lib';
+import { createEncounter, deleteEncounter, deleteTestOrder, generateRandomTestOrder, getProvider } from '../commands';
+import { type Encounter } from '../commands/types';
+import { test as base } from './test';
+
+export interface ExistingLabOrderFixtures {
+  existingLabOrder: {
+    testOrder: Order;
+    encounter: Encounter;
+  };
+}
+
+// Seeds a lab order (Serum glucose) via the REST API with a null fulfillerStatus, so it starts
+// life under both the patient chart's Orders table and the Laboratory app's "Tests ordered" tab,
+// ready to be resulted. Shared by the lab-orders and lab-app-results specs so the seeding and
+// cleanup live in one place; the order and its encounter are torn down after each test.
+export const test = base.extend<ExistingLabOrderFixtures>({
+  existingLabOrder: async ({ api, patient, visit }, use) => {
+    const orderer = await getProvider(api);
+    const encounter = await createEncounter(api, patient.uuid, orderer.uuid, visit);
+    const testOrder = await generateRandomTestOrder(api, patient.uuid, encounter, orderer.uuid);
+
+    try {
+      await use({ testOrder, encounter });
+    } finally {
+      if (testOrder?.uuid) {
+        await deleteTestOrder(api, testOrder.uuid);
+      }
+      if (encounter?.uuid) {
+        await deleteEncounter(api, encounter.uuid);
+      }
+    }
+  },
+});

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -3,6 +3,7 @@ export * from './attachments-page';
 export * from './chart-page';
 export * from './conditions-page';
 export * from './immunizations-page';
+export * from './laboratory-page';
 export * from './mark-patient-deceased-page';
 export * from './medications-page';
 export * from './orders-page';

--- a/e2e/pages/laboratory-page.ts
+++ b/e2e/pages/laboratory-page.ts
@@ -1,0 +1,9 @@
+import { type Page } from '@playwright/test';
+
+export class LaboratoryPage {
+  constructor(readonly page: Page) {}
+
+  async goTo() {
+    await this.page.goto('/openmrs/spa/home/laboratory');
+  }
+}

--- a/e2e/specs/lab-app-results.spec.ts
+++ b/e2e/specs/lab-app-results.spec.ts
@@ -1,0 +1,106 @@
+import { expect, type Locator } from '@playwright/test';
+import { test } from '../core/lab-fixtures';
+import { expectLabResultInResultsViewer } from '../commands/test-helpers';
+import { LaboratoryPage } from '../pages';
+
+// Laboratory worklist tabs this spec navigates. Typed as a union rather than `string` so a mistyped
+// tab name is a compile error instead of a locator that silently never resolves.
+type LaboratoryTab = 'Tests ordered' | 'In progress' | 'Completed';
+
+test.describe('Adding laboratory results via the Laboratory app', () => {
+  test('Pick up a lab request and enter results from the Laboratory worklist', async ({
+    page,
+    patient,
+    existingLabOrder,
+  }) => {
+    const laboratoryPage = new LaboratoryPage(page);
+    const conceptName = existingLabOrder.testOrder.concept.display;
+    // The worklist groups requests by patient. Search on the full generated name (given + family) so
+    // the term is unique across the system-wide worklist; a given name alone (1-in-10k) can collide
+    // with, or be a substring of, another patient's row and trip Playwright's strict mode.
+    const patientSearchTerm = patient.person.display;
+
+    // The Laboratory app renders every status tab's table into the DOM simultaneously, so all
+    // interactions are scoped to the active tab's panel to avoid cross-tab matches. This filters the
+    // given tab's table to the seeded patient and returns the scoped panel locator.
+    const searchPatientInTab = async (tabName: LaboratoryTab): Promise<Locator> => {
+      const panel = page.getByRole('tabpanel', { name: tabName });
+      await panel.getByPlaceholder(/search this list/i).fill(patientSearchTerm);
+      await expect(panel.getByRole('row').filter({ hasText: patientSearchTerm })).toBeVisible();
+      return panel;
+    };
+
+    // As above, then expands the patient's row to reveal the per-order actions.
+    const searchAndExpandInTab = async (tabName: LaboratoryTab): Promise<Locator> => {
+      const panel = await searchPatientInTab(tabName);
+      await panel
+        .getByRole('row')
+        .filter({ hasText: patientSearchTerm })
+        .getByRole('button', { name: /expand current row/i })
+        .click();
+      return panel;
+    };
+
+    let testsOrderedPanel: Locator;
+    let inProgressPanel: Locator;
+
+    await test.step('When I navigate to the Laboratory app', async () => {
+      await laboratoryPage.goTo();
+      await expect(page.getByRole('tab', { name: /tests ordered/i })).toBeVisible();
+    });
+
+    await test.step('And I search for my patient under the `Tests ordered` tab and expand their request', async () => {
+      testsOrderedPanel = await searchAndExpandInTab('Tests ordered');
+    });
+
+    await test.step('Then I should see the ordered test in the expanded details', async () => {
+      await expect(testsOrderedPanel.getByText(conceptName, { exact: false })).toBeVisible();
+    });
+
+    await test.step('When I click the `Pick lab request` action', async () => {
+      await testsOrderedPanel.getByRole('button', { name: /^pick lab request$/i }).click();
+    });
+
+    await test.step('And I confirm the pick up in the modal', async () => {
+      await page
+        .getByRole('dialog')
+        .getByRole('button', { name: /pick up lab request/i })
+        .click();
+    });
+
+    await test.step('Then the request should be picked up successfully', async () => {
+      await expect(page.getByText(/successfully picked an order/i)).toBeVisible();
+    });
+
+    await test.step('When I switch to the `In progress` tab and expand my patient’s request', async () => {
+      await page.getByRole('tab', { name: /in progress/i }).click();
+      inProgressPanel = await searchAndExpandInTab('In progress');
+    });
+
+    await test.step('And I click the `Add lab results` action', async () => {
+      await inProgressPanel.getByRole('button', { name: /add lab results/i }).click();
+    });
+
+    await test.step('Then the lab results form should open', async () => {
+      await expect(page.getByRole('spinbutton', { name: conceptName })).toBeVisible();
+    });
+
+    await test.step('When I fill in the result and save', async () => {
+      await page.getByRole('spinbutton', { name: conceptName }).fill('55');
+      await page.getByRole('button', { name: 'Save and close' }).click();
+    });
+
+    await test.step('Then a confirmation message should indicate the result was saved', async () => {
+      await expect(page.getByText(/Lab results for .* have been successfully updated/i)).toBeVisible();
+    });
+
+    await test.step('And the resulted request should move to the `Completed` tab', async () => {
+      await page.getByRole('tab', { name: /completed/i }).click();
+      await searchPatientInTab('Completed');
+    });
+
+    await test.step('Then I should see the saved lab result in the Results Viewer', async () => {
+      await expectLabResultInResultsViewer(page, patient.uuid, conceptName, '55');
+    });
+  });
+});

--- a/e2e/specs/lab-orders.spec.ts
+++ b/e2e/specs/lab-orders.spec.ts
@@ -1,35 +1,7 @@
 import { expect } from '@playwright/test';
-import { type Order } from '@openmrs/esm-patient-common-lib';
-import { generateRandomTestOrder, deleteTestOrder, createEncounter, deleteEncounter, getProvider } from '../commands';
-import { type Encounter } from '../commands/types';
-import { test as base } from '../core';
-import { OrdersPage, ResultsViewerPage } from '../pages';
-
-interface ExistingLabOrderFixture {
-  existingLabOrder: {
-    testOrder: Order;
-    encounter: Encounter;
-  };
-}
-
-const test = base.extend<ExistingLabOrderFixture>({
-  existingLabOrder: async ({ api, patient, visit }, use) => {
-    const orderer = await getProvider(api);
-    const encounter = await createEncounter(api, patient.uuid, orderer.uuid, visit);
-    const testOrder = await generateRandomTestOrder(api, patient.uuid, encounter, orderer.uuid);
-
-    try {
-      await use({ testOrder, encounter });
-    } finally {
-      if (testOrder?.uuid) {
-        await deleteTestOrder(api, testOrder.uuid);
-      }
-      if (encounter?.uuid) {
-        await deleteEncounter(api, encounter.uuid);
-      }
-    }
-  },
-});
+import { test } from '../core/lab-fixtures';
+import { expectLabResultInResultsViewer } from '../commands/test-helpers';
+import { OrdersPage } from '../pages';
 
 test.describe('Running laboratory order tests sequentially', () => {
   test('Record a lab order', async ({ page, patient }) => {
@@ -119,11 +91,11 @@ test.describe('Modify and discontinue laboratory order tests sequentially', () =
 
     await test.step('Then I click on Add results action', async () => {
       await page.getByRole('menuitem', { name: 'Add results' }).click();
-      await expect(page.getByRole('spinbutton', { name: 'Serum glucose (>= 0 mg/dl)' })).toBeVisible();
+      await expect(page.getByRole('spinbutton', { name: conceptName })).toBeVisible();
     });
 
     await test.step('Then I fill in the lab result and click save', async () => {
-      await page.getByRole('spinbutton', { name: 'Serum glucose (>= 0 mg/dl)' }).fill('55');
+      await page.getByRole('spinbutton', { name: conceptName }).fill('55');
       await page.getByRole('button', { name: 'Save and close' }).click();
     });
 
@@ -131,18 +103,8 @@ test.describe('Modify and discontinue laboratory order tests sequentially', () =
       await expect(page.getByText(/Lab results for .* have been successfully updated/i)).toBeVisible();
     });
 
-    await test.step('When I navigate to the Results Viewer page', async () => {
-      const resultsViewerPage = new ResultsViewerPage(page);
-      await resultsViewerPage.goTo(patient.uuid);
-    });
-
-    await test.step('And I click on the Individual tests tab', async () => {
-      await page.getByRole('tab', { name: /individual tests/i }).click();
-    });
-
-    await test.step('Then I should see the saved lab result in the results viewer', async () => {
-      const row = page.getByRole('row').filter({ hasText: conceptName }).filter({ hasText: '55' }).first();
-      await expect(row).toBeVisible();
+    await test.step('Then I should see the saved lab result in the Results Viewer', async () => {
+      await expectLabResultInResultsViewer(page, patient.uuid, conceptName, '55');
     });
   });
 

--- a/e2e/support/github/run-e2e-docker-env.sh
+++ b/e2e/support/github/run-e2e-docker-env.sh
@@ -25,11 +25,15 @@ echo "Created packed app archives"
 echo "Creating dynamic spa-assemble-config.json..."
 # dynamically assemble our list of frontend modules, prepending the login app and
 # primary navigation apps; apps will all be in the /app directory of the Docker
-# container
+# container.
+# The Laboratory app (@openmrs/esm-laboratory-app) is not part of this monorepo, so
+# it is pulled from npm like the home and primary-navigation apps. It provides the
+# Laboratory worklist UI (Tests ordered / In progress / Completed tabs) exercised by
+# the lab-app-results e2e spec.
 jq -n \
   --arg apps "$apps" \
   --arg app_names "$(echo ${app_names[@]})" \
-  '{"@openmrs/esm-primary-navigation-app": "next", "@openmrs/esm-home-app": "next"} + (
+  '{"@openmrs/esm-primary-navigation-app": "next", "@openmrs/esm-home-app": "next", "@openmrs/esm-laboratory-app": "next"} + (
     ($apps | split("\n")) as $apps | ($app_names | split(" ") | map("/app/" + .)) as $app_files
     | [$apps, $app_files]
     | transpose


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. <!-- N/A: test-only change, no UI -->
- [x] My work includes tests or is validated by existing tests.

## Summary

The patient-chart e2e suite covered adding lab results via the **Orders app** ("Add results") but had no coverage for the **Laboratory app** worklist flow. This PR adds that coverage.

- New spec `e2e/specs/lab-app-results.spec.ts` driving the full lifecycle: seed a lab order via REST → **Pick lab request** from *Tests ordered* (→ `IN_PROGRESS`) → **Add lab results** from *In progress* → assert the order moves to *Completed* → verify the saved value in the Results Viewer.
- Enables `@openmrs/esm-laboratory-app` in the e2e docker frontend assembly (`e2e/support/github/run-e2e-docker-env.sh`) so the Laboratory app is present in CI.
- Hoists a shared lab-order fixture (`e2e/core/lab-fixtures.ts`) and a shared Results-Viewer assertion helper (`e2e/commands/test-helpers.ts`), consumed by both lab specs, removing prior duplication in `e2e/specs/lab-orders.spec.ts`.
- Adds a `LaboratoryPage` page object.

All 5 lab specs pass locally against a running O3 instance; the new spec is stable across repeated and concurrent runs.

## Screenshots

N/A — test-only change (no UI changes).

## Related Issue

https://openmrs.atlassian.net/browse/O3-5888

## Other

The Laboratory app is not part of this monorepo, so it is pulled from npm (`@openmrs/esm-laboratory-app: "next"`) alongside the existing home/primary-navigation apps in the e2e assemble step. Note `next` is a floating tag — a future upstream publish could affect this suite; happy to pin to a fixed version if reviewers prefer.