### PR TITLE
(chore) Typecheck and lint the E2E suite in CI

### DIFF
--- a/e2e/declarations.d.ts
+++ b/e2e/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module '*.scss' {
+  const content: { [className: string]: string };
+  export default content;
+}

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*", "../playwright.config.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   ],
   "scripts": {
     "start": "openmrs develop --sources packages/esm-patient-chart-app/",
+    "lint": "eslint e2e --fix --max-warnings=0",
+    "typescript": "tsc -p e2e",
     "ci:publish": "yarn workspaces foreach --all --topological --exclude @openmrs/esm-patient-chart npm publish --access public --tag latest",
     "ci:prepublish": "yarn workspaces foreach --all --topological --exclude @openmrs/esm-patient-chart npm publish --access public --tag next",
     "ci:prepublish-patch": "yarn workspaces foreach --all --topological --exclude @openmrs/esm-patient-chart npm publish --access public --tag patch",

--- a/turbo.json
+++ b/turbo.json
@@ -65,6 +65,7 @@
     "//#typescript": {
       "inputs": [
         "e2e/**",
+        "packages/esm-patient-common-lib/package.json",
         "packages/esm-patient-common-lib/src/**",
         "playwright.config.ts",
         "tsconfig.json"

--- a/turbo.json
+++ b/turbo.json
@@ -49,10 +49,24 @@
         "$TURBO_ROOT$/eslint.config.mjs"
       ]
     },
+    "//#lint": {
+      "inputs": [
+        "e2e/**/*.{ts,tsx}",
+        "eslint.config.mjs"
+      ]
+    },
     "typescript": {
       "dependsOn": ["^typescript"],
       "inputs": [
         "src/**",
+        "tsconfig.json"
+      ]
+    },
+    "//#typescript": {
+      "inputs": [
+        "e2e/**",
+        "packages/esm-patient-common-lib/src/**",
+        "playwright.config.ts",
         "tsconfig.json"
       ]
     },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The e2e directory is currently excluded from every static check in CI. `yarn verify` runs `turbo run lint typescript test`, which only covers workspaces under `packages/`, and the E2E workflow transpiles the specs without typechecking. So a type error in a spec, fixture, command, or page object never fails a build.

This PR adds an `e2e/tsconfig.json` that extends the root config and covers everything under `e2e/` plus `playwright.config.ts`, and registers two root-level turbo tasks (`//#typescript` and `//#lint`) so `tsc -p e2e` and `eslint e2e` run as part of the existing verify pipeline on every PR. No workflow changes are needed since `turbo run lint typescript test` picks up the root tasks automatically.

The e2e program follows `@openmrs/esm-patient-common-lib` into its source through the package's `src/index.ts` main entry, so `e2e/declarations.d.ts` mirrors the per-package `*.scss` module declaration to keep those imports resolvable.

A few notes on validation:

- The new program covers all 53 TS files under `e2e/` plus `playwright.config.ts` (verified with `tsc --listFilesOnly`), and an injected type error in a spec fails the build.
- The e2e code is already clean, so both checks pass as-is. Same for `eslint e2e`, which the `e2e/**` override in `eslint.config.mjs` was already set up for but nothing ran in CI.
- `yarn verify` passes locally with the two root tasks in the graph.

## Screenshots

## Related Issue

## Other

Spun out of reviewing #3582, but independent of it.