### PR TITLE
(test) Route Laboratory worklist tab references through a typed locator

### DIFF
--- a/e2e/specs/lab-app-results.spec.ts
+++ b/e2e/specs/lab-app-results.spec.ts
@@ -20,9 +20,9 @@ test.describe('Adding laboratory results via the Laboratory app', () => {
     // with, or be a substring of, another patient's row and trip Playwright's strict mode.
     const patientSearchTerm = patient.person.display;
 
-    // Every tab reference in this spec goes through this locator, so each tab name is written once,
-    // as a `LaboratoryTab` literal. `getByRole` matches the accessible name as a substring, and none
-    // of the tab titles the Laboratory app registers is a substring of another, so each is unambiguous.
+    // Every tab reference in this spec goes through this locator, so all of them are typed by
+    // `LaboratoryTab`. `getByRole` matches the accessible name as a substring, and none of the tab
+    // titles the Laboratory app registers is a substring of another, so each literal is unambiguous.
     const worklistTab = (tabName: LaboratoryTab) => page.getByRole('tab', { name: tabName });
 
     // The Laboratory app renders every status tab's table into the DOM simultaneously, so all

--- a/e2e/specs/lab-app-results.spec.ts
+++ b/e2e/specs/lab-app-results.spec.ts
@@ -21,9 +21,11 @@ test.describe('Adding laboratory results via the Laboratory app', () => {
     const patientSearchTerm = patient.person.display;
 
     // The Laboratory app renders every status tab's table into the DOM simultaneously, so all
-    // interactions are scoped to the active tab's panel to avoid cross-tab matches. This filters the
-    // given tab's table to the seeded patient and returns the scoped panel locator.
+    // interactions are scoped to the active tab's panel to avoid cross-tab matches. This selects the
+    // given tab, filters its table to the seeded patient, and returns the scoped panel locator. The
+    // tab is located by the same `LaboratoryTab` literal as its panel, so both go through the union.
     const searchPatientInTab = async (tabName: LaboratoryTab): Promise<Locator> => {
+      await page.getByRole('tab', { name: tabName }).click();
       const panel = page.getByRole('tabpanel', { name: tabName });
       await panel.getByPlaceholder(/search this list/i).fill(patientSearchTerm);
       await expect(panel.getByRole('row').filter({ hasText: patientSearchTerm })).toBeVisible();
@@ -73,7 +75,6 @@ test.describe('Adding laboratory results via the Laboratory app', () => {
     });
 
     await test.step('When I switch to the `In progress` tab and expand my patient’s request', async () => {
-      await page.getByRole('tab', { name: /in progress/i }).click();
       inProgressPanel = await searchAndExpandInTab('In progress');
     });
 
@@ -95,7 +96,6 @@ test.describe('Adding laboratory results via the Laboratory app', () => {
     });
 
     await test.step('And the resulted request should move to the `Completed` tab', async () => {
-      await page.getByRole('tab', { name: /completed/i }).click();
       await searchPatientInTab('Completed');
     });
 

--- a/e2e/specs/lab-app-results.spec.ts
+++ b/e2e/specs/lab-app-results.spec.ts
@@ -20,12 +20,16 @@ test.describe('Adding laboratory results via the Laboratory app', () => {
     // with, or be a substring of, another patient's row and trip Playwright's strict mode.
     const patientSearchTerm = patient.person.display;
 
+    // Every tab reference in this spec goes through this locator, so each tab name is written once,
+    // as a `LaboratoryTab` literal. `getByRole` matches the accessible name as a substring, and none
+    // of the tab titles the Laboratory app registers is a substring of another, so each is unambiguous.
+    const worklistTab = (tabName: LaboratoryTab) => page.getByRole('tab', { name: tabName });
+
     // The Laboratory app renders every status tab's table into the DOM simultaneously, so all
     // interactions are scoped to the active tab's panel to avoid cross-tab matches. This selects the
-    // given tab, filters its table to the seeded patient, and returns the scoped panel locator. The
-    // tab is located by the same `LaboratoryTab` literal as its panel, so both go through the union.
+    // given tab, filters its table to the seeded patient, and returns the scoped panel locator.
     const searchPatientInTab = async (tabName: LaboratoryTab): Promise<Locator> => {
-      await page.getByRole('tab', { name: tabName }).click();
+      await worklistTab(tabName).click();
       const panel = page.getByRole('tabpanel', { name: tabName });
       await panel.getByPlaceholder(/search this list/i).fill(patientSearchTerm);
       await expect(panel.getByRole('row').filter({ hasText: patientSearchTerm })).toBeVisible();
@@ -48,7 +52,7 @@ test.describe('Adding laboratory results via the Laboratory app', () => {
 
     await test.step('When I navigate to the Laboratory app', async () => {
       await laboratoryPage.goTo();
-      await expect(page.getByRole('tab', { name: /tests ordered/i })).toBeVisible();
+      await expect(worklistTab('Tests ordered')).toBeVisible();
     });
 
     await test.step('And I search for my patient under the `Tests ordered` tab and expand their request', async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. <!-- N/A: test-only refactor, no UI -->
- [x] My work includes tests or is validated by existing tests.

## Summary

Small follow-up to #3582.

In `e2e/specs/lab-app-results.spec.ts` the Laboratory worklist tab names were written in two forms: as `LaboratoryTab` literals for the panel lookups, and as free-form regexes for the clicks and the page-loaded gate (`/tests ordered/i`, `/in progress/i`, `/completed/i`). The comment above the type says the union is there so a mistyped tab name is a compile error rather than a locator that silently never resolves, but every tab *locator* sat outside it, so an upstream rename needed two edits per tab and the type caught only one of them.

`getByRole`'s `name` option matches the accessible name as a substring, so a literal locates a tab just as well as the regex did. This adds one `worklistTab(tabName: LaboratoryTab)` locator and routes all four tab references through it: the helper's click, and the visibility gate in the first step. The two standalone click lines go away.

Nothing about what the spec asserts changes.

## Screenshots

N/A, test-only change.

## Related Issue

None of its own. Follow-up from reviewing #3582 (O3-5888).

## Other

What I verified rather than assumed:

- `getByRole`'s substring semantics come from Playwright's own type definitions: "By default, matching is case-insensitive and searches for a substring."
- None of the five titles the Laboratory app registers for `lab-panels-slot` (Tests ordered, In progress, Pending review tests, Completed, Declined tests) is a substring of another, checked pairwise against its `routes.json`, so each of the three literals this spec uses resolves to exactly one tab. That holds with `enableReviewingLabResultsBeforeApproval` on as well, which is what adds the fourth tab.
- `searchAndExpandInTab('Tests ordered')` now clicks a tab that is already selected. The Laboratory app renders a controlled `<Tabs selectedIndex={...} onChange={...}>`, and Carbon's `Tab` `onClick` only calls `setSelectedIndex(index)`, which through `useControllableState` resolves to `setSelectedTab(0)` with the index unchanged: no panel switch, no remount, no state churn.

One caveat worth stating plainly: nothing in this repo lints or type-checks `e2e/`. Every turbo `lint`/`typescript` task scopes its inputs to a package's `src/**`, the root workspace has no such script, and both git hooks reduce to those same tasks. So the union is enforced by an editor, not by CI, and the Playwright run is the only automation that touches this file. That is why the E2E job here is the real check, and I could not run it locally.
