### PR TITLE
(feat) O3-5907: Render medication side effects extension slot on the drug order form

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -512,7 +512,7 @@ export function DrugOrderForm({
                 unitValue={watchedUnitValue}
               />
             </div>
-            {drug?.uuid && <ExtensionSlot name="order-form-side-effects-slot" state={{ drugUuid: drug.uuid }} />}
+            {drug?.uuid && <ExtensionSlot name="drug-order-form-side-effects-slot" state={{ drugUuid: drug.uuid }} />}
             <section className={styles.formSection}>
               <Grid className={styles.gridRow}>
                 <Column lg={12} md={6} sm={4}>

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -512,6 +512,7 @@ export function DrugOrderForm({
                 unitValue={watchedUnitValue}
               />
             </div>
+            {drug?.uuid && <ExtensionSlot name="order-form-side-effects-slot" state={{ drugUuid: drug.uuid }} />}
             <section className={styles.formSection}>
               <Grid className={styles.gridRow}>
                 <Column lg={12} md={6} sm={4}>

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.scss
@@ -49,7 +49,7 @@
 
   counter-reset: section;
 
-  h3 {
+  .sectionHeader {
     counter-increment: section;
 
     &::before {

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { getDefaultsFromConfigSchema, OpenmrsDatePicker, useConfig, useSession } from '@openmrs/esm-framework';
+import { ExtensionSlot, getDefaultsFromConfigSchema, OpenmrsDatePicker, useConfig, useSession } from '@openmrs/esm-framework';
 import { type DrugOrderBasketItem } from '@openmrs/esm-patient-common-lib';
 import { mockPatient } from 'tools';
 import { mockDrugSearchResultApiData, mockSessionDataResponse } from '__mocks__';
@@ -13,6 +13,7 @@ import DrugOrderForm, { getOrderStartDateForSubmission } from './drug-order-form
 const mockUseConfig = vi.mocked(useConfig<ConfigObject>);
 const mockUseSession = vi.mocked(useSession);
 const mockOpenmrsDatePicker = vi.mocked(OpenmrsDatePicker);
+const mockExtensionSlot = vi.mocked(ExtensionSlot);
 const mockUseMedicationOrders = vi.fn().mockReturnValue({
   futureOrders: [],
   activeOrders: [],
@@ -205,6 +206,18 @@ describe('DrugOrderForm - auto-calculation of dispense quantity', () => {
       expect(quantityInput).toHaveValue(14);
     });
     expect(screen.getByText(/auto-calculated/i)).toBeInTheDocument();
+  });
+
+  it('mounts the side effects extension slot with the selected drug uuid', () => {
+    mockExtensionSlot.mockClear();
+    const item = createNewOrderBasketItem();
+    renderDrugOrderForm(item);
+
+    const slotCall = mockExtensionSlot.mock.calls.find(
+      (call) => call[0].name === 'drug-order-form-side-effects-slot',
+    );
+    expect(slotCall).toBeTruthy();
+    expect(slotCall?.[0].state).toEqual({ drugUuid: item.drug.uuid });
   });
 
   it('auto-calculates with weekly duration units', async () => {

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.test.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { ExtensionSlot, getDefaultsFromConfigSchema, OpenmrsDatePicker, useConfig, useSession } from '@openmrs/esm-framework';
+import {
+  ExtensionSlot,
+  getDefaultsFromConfigSchema,
+  OpenmrsDatePicker,
+  useConfig,
+  useSession,
+} from '@openmrs/esm-framework';
 import { type DrugOrderBasketItem } from '@openmrs/esm-patient-common-lib';
 import { mockPatient } from 'tools';
 import { mockDrugSearchResultApiData, mockSessionDataResponse } from '__mocks__';
@@ -213,9 +219,7 @@ describe('DrugOrderForm - auto-calculation of dispense quantity', () => {
     const item = createNewOrderBasketItem();
     renderDrugOrderForm(item);
 
-    const slotCall = mockExtensionSlot.mock.calls.find(
-      (call) => call[0].name === 'drug-order-form-side-effects-slot',
-    );
+    const slotCall = mockExtensionSlot.mock.calls.find((call) => call[0].name === 'drug-order-form-side-effects-slot');
     expect(slotCall).toBeTruthy();
     expect(slotCall?.[0].state).toEqual({ drugUuid: item.drug.uuid });
   });


### PR DESCRIPTION
## Requirements

  - [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
 - [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
 - [x] My work includes tests or is validated by existing tests.

## Summary

 Adds a single `drug-order-form-side-effects-slot` extension slot to the drug order form, mounted with the selected drug's uuid when one is set. The host only declares the slot - all rendering lives in the `openmrs-esm-medication-side-effects` microfrontend, which plugs its panel in.

## Screenshots

<img width="445" height="896" alt="image" src="https://github.com/user-attachments/assets/4964007f-3fdf-45f8-9d39-c24ff92ce2e6" />

## Related Issue

  https://openmrs.atlassian.net/browse/O3-5907

## Other

  Related PRs:
  * https://github.com/openmrs/openmrs-esm-medication-side-effects/pull/1
  * https://github.com/openmrs/openmrs-esm-dispensing-app/pull/889
  * https://github.com/openmrs/openmrs-module-medicationsideeffects/pull/1
  * https://github.com/mekomsolutions/openmrs-module-initializer/pull/333
  * https://github.com/openmrs/openmrs-content-referenceapplication-demo/pull/85
