### PR TITLE
 (feat) O3-5851: Paginate the visit summary Timeline

### DIFF
--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -136,6 +136,11 @@ export const esmPatientChartSchema = {
     _type: Type.ConceptUuid,
     _default: '159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
   },
+  visitTimelinePageSize: {
+    _type: Type.Number,
+    _default: 10,
+    _description: 'The number of encounters shown per page in the visit summary Timeline',
+  },
   visitTypeResourceUrl: {
     _type: Type.String,
     _default: '/etl-latest/etl/patient/',
@@ -210,6 +215,7 @@ export interface ChartConfig {
   showRecommendedVisitTypeTab: boolean;
   showServiceQueueFields: boolean; // used by extension from esm-service-queues-app
   showUpcomingAppointments: boolean; // used by extension from esm-appointments-app
+  visitTimelinePageSize: number;
   visitTypeResourceUrl: string;
   visitAttributeTypes: Array<{
     displayInThePatientBanner: boolean;

--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -1,4 +1,4 @@
-import { Type } from '@openmrs/esm-framework';
+import { Type, validator } from '@openmrs/esm-framework';
 
 export const esmPatientChartSchema = {
   defaultFacilityUrl: {
@@ -138,6 +138,9 @@ export const esmPatientChartSchema = {
   },
   visitTimelinePageSize: {
     _type: Type.Number,
+    _validators: [
+      validator((v: unknown) => typeof v === 'number' && Number.isInteger(v) && v >= 1, 'Must be a positive integer'),
+    ],
     _default: 10,
     _description: 'The number of encounters shown per page in the visit summary Timeline',
   },

--- a/packages/esm-patient-chart-app/src/config-schema.ts
+++ b/packages/esm-patient-chart-app/src/config-schema.ts
@@ -1,5 +1,8 @@
 import { Type, validator } from '@openmrs/esm-framework';
 
+// The Timeline falls back to this when the configured page size is unusable
+export const defaultVisitTimelinePageSize = 10;
+
 export const esmPatientChartSchema = {
   defaultFacilityUrl: {
     _type: Type.String,
@@ -141,7 +144,7 @@ export const esmPatientChartSchema = {
     _validators: [
       validator((v: unknown) => typeof v === 'number' && Number.isInteger(v) && v >= 1, 'Must be a positive integer'),
     ],
-    _default: 10,
+    _default: defaultVisitTimelinePageSize,
     _description: 'The number of encounters shown per page in the visit summary Timeline',
   },
   visitTypeResourceUrl: {

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.component.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentProps, useCallback, useMemo, useState } from 'react';
+import React, { type ComponentProps, useCallback, useEffect, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { useSWRConfig } from 'swr';
@@ -12,11 +12,12 @@ import {
   useConfig,
   useFeatureFlag,
   useLayoutType,
+  usePagination,
   userHasAccess,
   useSession,
   type Visit,
 } from '@openmrs/esm-framework';
-import { EmptyState, usePatientChartStore } from '@openmrs/esm-patient-common-lib';
+import { EmptyState, PatientChartPagination, usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 import { type ChartConfig } from '../../../../config-schema';
 import {
   canModifyEncounter,
@@ -80,6 +81,17 @@ function VisitTimeline({ onEditEncounter, patientUuid, visit }: VisitTimelinePro
     [canPrintEncounters, config, session?.user, visit?.encounters],
   );
 
+  const {
+    currentPage,
+    goTo,
+    results: paginatedTimelineEntries,
+  } = usePagination(timelineEntries, config.visitTimelinePageSize);
+
+  // goTo clamps to the last page, so deleting the final encounter of a page can't strand the user on an empty one
+  useEffect(() => {
+    goTo(currentPage);
+  }, [currentPage, goTo]);
+
   const toggleEncounter = useCallback((encounterUuid: string) => {
     setExpandedEncounters((previouslyExpanded) => {
       const expanded = new Set(previouslyExpanded);
@@ -116,7 +128,7 @@ function VisitTimeline({ onEditEncounter, patientUuid, visit }: VisitTimelinePro
         <span>{t('timeStarted', 'Time started')}</span>
       </p>
       <div className={styles.timelineEntries}>
-        {timelineEntries.map(
+        {paginatedTimelineEntries.map(
           ({
             canDeleteEncounter,
             canEditEncounter,
@@ -238,6 +250,13 @@ function VisitTimeline({ onEditEncounter, patientUuid, visit }: VisitTimelinePro
         )}
         <div className={styles.timelineLine} />
       </div>
+      <PatientChartPagination
+        currentItems={paginatedTimelineEntries.length}
+        onPageNumberChange={({ page }) => goTo(page)}
+        pageNumber={currentPage}
+        pageSize={config.visitTimelinePageSize}
+        totalItems={timelineEntries.length}
+      />
     </div>
   );
 }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.component.tsx
@@ -81,11 +81,10 @@ function VisitTimeline({ onEditEncounter, patientUuid, visit }: VisitTimelinePro
     [canPrintEncounters, config, session?.user, visit?.encounters],
   );
 
-  const {
-    currentPage,
-    goTo,
-    results: paginatedTimelineEntries,
-  } = usePagination(timelineEntries, config.visitTimelinePageSize);
+  // A failed config validator only logs, so a misconfigured page size still reaches us and must not break the widget
+  const pageSize = Math.max(1, Math.trunc(config.visitTimelinePageSize));
+
+  const { currentPage, goTo, results: paginatedTimelineEntries } = usePagination(timelineEntries, pageSize);
 
   // goTo clamps to the last page, so deleting the final encounter of a page can't strand the user on an empty one
   useEffect(() => {
@@ -254,7 +253,7 @@ function VisitTimeline({ onEditEncounter, patientUuid, visit }: VisitTimelinePro
         currentItems={paginatedTimelineEntries.length}
         onPageNumberChange={({ page }) => goTo(page)}
         pageNumber={currentPage}
-        pageSize={config.visitTimelinePageSize}
+        pageSize={pageSize}
         totalItems={timelineEntries.length}
       />
     </div>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.component.tsx
@@ -18,7 +18,7 @@ import {
   type Visit,
 } from '@openmrs/esm-framework';
 import { EmptyState, PatientChartPagination, usePatientChartStore } from '@openmrs/esm-patient-common-lib';
-import { type ChartConfig } from '../../../../config-schema';
+import { type ChartConfig, defaultVisitTimelinePageSize } from '../../../../config-schema';
 import {
   canModifyEncounter,
   confirmAndDeleteEncounter,
@@ -82,7 +82,9 @@ function VisitTimeline({ onEditEncounter, patientUuid, visit }: VisitTimelinePro
   );
 
   // A failed config validator only logs, so a misconfigured page size still reaches us and must not break the widget
-  const pageSize = Math.max(1, Math.trunc(config.visitTimelinePageSize));
+  const pageSize = Number.isFinite(config.visitTimelinePageSize)
+    ? Math.max(1, Math.trunc(config.visitTimelinePageSize))
+    : defaultVisitTimelinePageSize;
 
   const { currentPage, goTo, results: paginatedTimelineEntries } = usePagination(timelineEntries, pageSize);
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.test.tsx
@@ -15,7 +15,7 @@ import {
 import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 import { mockEncountersAlice, mockFhirPatient, mockPatientAlice, mockVisit } from '__mocks__';
 import { renderWithSwr } from 'tools';
-import { type ChartConfig, esmPatientChartSchema } from '../../../../config-schema';
+import { type ChartConfig, defaultVisitTimelinePageSize, esmPatientChartSchema } from '../../../../config-schema';
 import { jsonSchemaResourceName } from '../../../../constants';
 import { type MappedEncounter } from '../../past-visits-components/encounters-table/encounters-table.resource';
 import VisitTimeline from './visit-timeline.component';
@@ -300,8 +300,12 @@ describe('VisitTimeline', () => {
     [0, 1],
     [-5, 1],
     [2.5, 2],
+    ['not-a-number', defaultVisitTimelinePageSize],
   ])('renders a page of encounters when visitTimelinePageSize is %s', (visitTimelinePageSize, expectedPageSize) => {
-    mockUseConfig.mockReturnValue({ ...getDefaultsFromConfigSchema(esmPatientChartSchema), visitTimelinePageSize });
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(esmPatientChartSchema),
+      visitTimelinePageSize: visitTimelinePageSize as number,
+    });
 
     renderVisitTimeline(buildEncounters(25));
 

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.test.tsx
@@ -15,14 +15,14 @@ import {
 import { usePatientChartStore } from '@openmrs/esm-patient-common-lib';
 import { mockEncountersAlice, mockFhirPatient, mockPatientAlice, mockVisit } from '__mocks__';
 import { renderWithSwr } from 'tools';
-import { esmPatientChartSchema } from '../../../../config-schema';
+import { type ChartConfig, esmPatientChartSchema } from '../../../../config-schema';
 import { jsonSchemaResourceName } from '../../../../constants';
 import { type MappedEncounter } from '../../past-visits-components/encounters-table/encounters-table.resource';
 import VisitTimeline from './visit-timeline.component';
 
 const mockExtensionSlot = vi.mocked(ExtensionSlot);
 const mockLaunchWorkspace = vi.mocked(launchWorkspace2);
-const mockUseConfig = vi.mocked(useConfig);
+const mockUseConfig = vi.mocked(useConfig<ChartConfig>);
 const mockUseFeatureFlag = vi.mocked(useFeatureFlag);
 const mockUserHasAccess = vi.mocked(userHasAccess);
 const mockUsePatientChartStore = vi.mocked(usePatientChartStore);
@@ -51,6 +51,20 @@ const encounterWithJsonSchemaForm = {
     ],
   },
 } as Encounter;
+
+// Each encounter is a day older than the one before it, so the timeline renders them in index order
+function buildEncounters(count: number): Array<Encounter> {
+  return Array.from(
+    { length: count },
+    (_, index) =>
+      ({
+        ...admissionEncounter,
+        uuid: `encounter-${index}`,
+        encounterDatetime: new Date(Date.UTC(2024, 0, 1) - index * 24 * 60 * 60 * 1000).toISOString(),
+        encounterType: { ...admissionEncounter.encounterType, display: `Encounter ${index}` },
+      }) as Encounter,
+  );
+}
 
 function renderVisitTimeline(
   encounters: Array<Encounter> = mockEncountersAlice,
@@ -242,5 +256,42 @@ describe('VisitTimeline', () => {
     );
     // The observations panel is what the embedded form view replaces
     expect(screen.queryByText(/recorded via poc consent form/i)).not.toBeInTheDocument();
+  });
+
+  it('renders every encounter of a visit that fits on a single page, with the pager disabled', () => {
+    renderVisitTimeline(buildEncounters(10));
+
+    expect(screen.getAllByRole('button', { name: /expand encounter/i })).toHaveLength(10);
+    expect(screen.getByRole('button', { name: /next page/i })).toBeDisabled();
+  });
+
+  it('paginates a long visit, ten encounters to a page', async () => {
+    const user = userEvent.setup();
+    renderVisitTimeline(buildEncounters(25));
+
+    expect(screen.getAllByRole('button', { name: /expand encounter/i })).toHaveLength(10);
+    expect(screen.getByText('Encounter 0')).toBeInTheDocument();
+    expect(screen.queryByText('Encounter 10')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /next page/i }));
+
+    expect(screen.queryByText('Encounter 0')).not.toBeInTheDocument();
+    expect(screen.getByText('Encounter 10')).toBeInTheDocument();
+    expect(screen.getByText('Encounter 19')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /next page/i }));
+
+    // The last page holds the remaining five encounters
+    expect(screen.getAllByRole('button', { name: /expand encounter/i })).toHaveLength(5);
+    expect(screen.getByText('Encounter 24')).toBeInTheDocument();
+  });
+
+  it('takes the number of encounters shown per page from the visitTimelinePageSize config', () => {
+    mockUseConfig.mockReturnValue({ ...getDefaultsFromConfigSchema(esmPatientChartSchema), visitTimelinePageSize: 5 });
+
+    renderVisitTimeline(buildEncounters(25));
+
+    expect(screen.getAllByRole('button', { name: /expand encounter/i })).toHaveLength(5);
+    expect(screen.getByText(/5 \/ 25 items/i)).toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/single-visit-details/visit-timeline/visit-timeline.test.tsx
@@ -294,4 +294,18 @@ describe('VisitTimeline', () => {
     expect(screen.getAllByRole('button', { name: /expand encounter/i })).toHaveLength(5);
     expect(screen.getByText(/5 \/ 25 items/i)).toBeInTheDocument();
   });
+
+  // The config validator only logs, so these values still reach the component
+  it.each([
+    [0, 1],
+    [-5, 1],
+    [2.5, 2],
+  ])('renders a page of encounters when visitTimelinePageSize is %s', (visitTimelinePageSize, expectedPageSize) => {
+    mockUseConfig.mockReturnValue({ ...getDefaultsFromConfigSchema(esmPatientChartSchema), visitTimelinePageSize });
+
+    renderVisitTimeline(buildEncounters(25));
+
+    expect(screen.getAllByRole('button', { name: /expand encounter/i })).toHaveLength(expectedPageSize);
+    expect(screen.getByText(new RegExp(`${expectedPageSize} / 25 items`, 'i'))).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Follow-up on #3585. Retiring the Encounters tab leaves the Timeline as the only view of a visit's encounters, without the tab's 10-per-page cap, a long inpatient visit renders dozens of rows at once. Paginates it at 10 a page, configurable via `visitTimelinePageSize`.

The `goTo` effect: the Timeline deletes encounters in place and `usePagination` slices to an empty array rather than clamping when the list shrinks under the current page.

## Screenshots
<!-- Required if you are making UI changes. -->
### Before
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/5ce4de24-6ea4-4d60-a73d-ba20b15bd7bb" />

### After
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/5e9becc9-a418-4214-bb1c-3197b2552704" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
[O3-5851](https://openmrs.atlassian.net/browse/O3-5851)

## Other
<!-- Anything not covered above -->

[O3-5851]: https://openmrs.atlassian.net/browse/O3-5851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ