### PR TITLE
(feat) O3-5934: Map fhir person-attribute extensions to patient attributes in form-entry

### DIFF
--- a/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.spec.ts
+++ b/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.spec.ts
@@ -276,4 +276,74 @@ describe('Service: FormDataSourceService', () => {
       ]);
     });
   });
+
+  describe('person attributes mapping', () => {
+    const personAttributeUrl = 'http://fhir.openmrs.org/ext/person-attribute';
+
+    const personAttributeExtension = (attributeType?: string, value?: string): fhir.Extension => ({
+      url: personAttributeUrl,
+      extension: [
+        ...(attributeType === undefined ? [] : [{ url: `${personAttributeUrl}-type`, valueString: attributeType }]),
+        ...(value === undefined ? [] : [{ url: `${personAttributeUrl}-value`, valueString: value }]),
+      ],
+    });
+
+    const patientWithExtensions = (extension: Array<fhir.Extension>): fhir.Patient => ({
+      resourceType: 'Patient',
+      id: 'patient-uuid',
+      gender: 'female',
+      birthDate: '2000-01-01',
+      extension,
+    });
+
+    it('should map FHIR person-attribute extensions to person attributes', () => {
+      const service: FormDataSourceService = TestBed.inject(FormDataSourceService);
+      const patient = patientWithExtensions([
+        personAttributeExtension('Phone Number', '0716700900'),
+        personAttributeExtension('Email', 'test@example.com'),
+      ]);
+
+      const { attributes } = service.getPatientObject(patient);
+
+      expect(attributes).toEqual({
+        'Phone Number': '0716700900',
+        Email: 'test@example.com',
+      });
+      expect(attributes['Phone Number']).toBe('0716700900');
+    });
+
+    it('should ignore extensions that are not person attributes', () => {
+      const service: FormDataSourceService = TestBed.inject(FormDataSourceService);
+      const patient = patientWithExtensions([
+        { url: 'http://fhir.openmrs.org/ext/some-other-extension', valueString: 'ignored' },
+        personAttributeExtension('Phone Number', '0716700900'),
+      ]);
+
+      const { attributes } = service.getPatientObject(patient);
+
+      expect(attributes).toEqual({ 'Phone Number': '0716700900' });
+    });
+
+    it('should drop person attributes missing a type or a value', () => {
+      const service: FormDataSourceService = TestBed.inject(FormDataSourceService);
+      const patient = patientWithExtensions([
+        personAttributeExtension('Phone Number', undefined),
+        personAttributeExtension(undefined, 'orphan-value'),
+        personAttributeExtension('Email', 'test@example.com'),
+      ]);
+
+      const { attributes } = service.getPatientObject(patient);
+
+      expect(attributes).toEqual({ Email: 'test@example.com' });
+    });
+
+    it('should return an empty object when the patient has no extensions', () => {
+      const service: FormDataSourceService = TestBed.inject(FormDataSourceService);
+      const patient: fhir.Patient = { resourceType: 'Patient', id: 'patient-uuid' };
+
+      const { attributes } = service.getPatientObject(patient);
+
+      expect(attributes).toEqual({});
+    });
+  });
 });

--- a/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
@@ -39,6 +39,8 @@ function getConceptCode(concept: Concept, conceptSourceUuid: string): string | u
 
 @Injectable()
 export class FormDataSourceService {
+  private readonly personAttributeUrl = 'http://fhir.openmrs.org/ext/person-attribute';
+
   constructor(
     private providerResourceService: ProviderResourceService,
     private locationResourceService: LocationResourceService,
@@ -388,7 +390,7 @@ export class FormDataSourceService {
         return 'U';
     }
   }
-  public getPatientObject(patient): PatientModel {
+  public getPatientObject(patient: fhir.Patient): PatientModel {
     return {
       ...patient,
       patientUuid: patient.id,
@@ -397,7 +399,27 @@ export class FormDataSourceService {
       age: this.calculateAge(patient.birthDate),
       gendercreatconstant: patient.gender === 'female' ? 0.85 : patient.gender === 'male' ? 1 : undefined,
       identifiers: this.mapFHIRPatientIdentifiersToOpenMRSIdentifiers(patient),
+      attributes: this.mapFHIRPatientExtensionsToPersonAttributes(patient),
     };
+  }
+
+  private mapFHIRPatientExtensionsToPersonAttributes(patient: fhir.Patient): Record<string, string> {
+    const extensions = patient?.extension?.filter((ext) => ext.url?.startsWith(this.personAttributeUrl)) ?? [];
+
+    return extensions.reduce<Record<string, string>>((attributes, extension) => {
+      const attributeType = this.getNestedExtensionValue(extension, 'person-attribute-type');
+      const value = this.getNestedExtensionValue(extension, 'person-attribute-value');
+
+      if (attributeType && value) {
+        attributes[attributeType] = value;
+      }
+
+      return attributes;
+    }, {});
+  }
+
+  private getNestedExtensionValue(parent: fhir.Extension, name: string): string | undefined {
+    return parent.extension?.find((ext) => ext.url?.endsWith(name))?.valueString;
   }
 
   private calculateAge(birthday) {

--- a/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
+++ b/packages/esm-form-entry-app/src/app/form-data-source/form-data-source.service.ts
@@ -404,7 +404,7 @@ export class FormDataSourceService {
   }
 
   private mapFHIRPatientExtensionsToPersonAttributes(patient: fhir.Patient): Record<string, string> {
-    const extensions = patient?.extension?.filter((ext) => ext.url?.startsWith(this.personAttributeUrl)) ?? [];
+    const extensions = patient?.extension?.filter((ext) => ext.url === this.personAttributeUrl) ?? [];
 
     return extensions.reduce<Record<string, string>>((attributes, extension) => {
       const attributeType = this.getNestedExtensionValue(extension, 'person-attribute-type');
@@ -419,7 +419,7 @@ export class FormDataSourceService {
   }
 
   private getNestedExtensionValue(parent: fhir.Extension, name: string): string | undefined {
-    return parent.extension?.find((ext) => ext.url?.endsWith(name))?.valueString;
+    return parent.extension?.find((ext) => ext.url === `http://fhir.openmrs.org/ext/${name}`)?.valueString;
   }
 
   private calculateAge(birthday) {

--- a/packages/esm-form-entry-app/src/app/types/index.ts
+++ b/packages/esm-form-entry-app/src/app/types/index.ts
@@ -493,6 +493,7 @@ export interface PatientModel {
   age: number;
   gendercreatconstant?: number;
   identifiers: Array<Identifier>;
+  attributes: Record<string, string>;
   patientUuid: string;
   [key: string]: any;
 }

--- a/packages/esm-form-entry-app/tsconfig.json
+++ b/packages/esm-form-entry-app/tsconfig.json
@@ -16,7 +16,8 @@
     "types": [
       "node",
       "webpack-env",
-      "jasmine"
+      "jasmine",
+      "fhir"
     ],
     "lib": [
       "dom",

--- a/packages/esm-form-entry-app/tsconfig.spec.json
+++ b/packages/esm-form-entry-app/tsconfig.spec.json
@@ -4,7 +4,8 @@
     "outDir": "./out-tsc/spec",
     "types": [
       "jasmine",
-      "node"
+      "node",
+      "fhir"
     ],
     "paths": {
       "@openmrs/esm-framework": [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR exposes OpenMRS person attributes on the patient object available to O3 Form Engine expressions.

Previously, form logic could access only a limited set of patient properties, such as age and gender. Person attributes—including phone number, health facility, and marital status—were unavailable for conditional rendering, calculated values, and validation. With this change, form authors can reference person attributes alongside existing patient properties, for example

```json
{
    "hide": {
        "hideWhenExpression": "attributes['Telephone contact'] !== ''"
    }
}
```

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
 https://openmrs.atlassian.net/browse/O3-5934

## Other
<!-- Anything not covered above -->
