### PR TITLE
(fix) Clean build outputs before bundle size comparison

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -35,3 +35,4 @@ jobs:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           minimum-change-threshold: 10000 # 10 KB
           build-script: 'turbo run build --color --concurrency=5'
+          clean-script: 'clean:dist'

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "start": "openmrs develop --sources packages/esm-patient-chart-app/",
+    "clean:dist": "node tools/clean-dist.mjs",
     "lint": "eslint e2e --fix --max-warnings=0",
     "typescript": "tsc -p e2e",
     "ci:publish": "yarn workspaces foreach --all --topological --exclude @openmrs/esm-patient-chart npm publish --access public --tag latest",

--- a/tools/clean-dist.mjs
+++ b/tools/clean-dist.mjs
@@ -1,0 +1,11 @@
+import { readdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packagesDirectory = join(dirname(fileURLToPath(import.meta.url)), '..', 'packages');
+
+for (const packageEntry of readdirSync(packagesDirectory, { withFileTypes: true })) {
+  if (packageEntry.isDirectory()) {
+    rmSync(join(packagesDirectory, packageEntry.name, 'dist'), { force: true, recursive: true });
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a conventional commit label.
- [ ] My work is based on designs. Not applicable because this is a CI-only change.
- [x] My work includes tests or is validated by existing tests.

## Summary

The compressed-size action builds the PR and base revisions sequentially in the same workspace. When the base build is restored from the Turborepo cache, Rspack does not run and stale PR chunks remain in each package dist directory. This causes renamed chunks to be counted as removed instead of replaced and substantially inflates the reported bundle-size reduction.

This change uses the actions supported clean-script hook to delete package dist directories between measurements. The cleanup is implemented with Node standard-library APIs, is cross-platform, and remains scoped to generated dist directories.

## Screenshots

Not applicable.

## Related Issue

Follow-up to #3605.

## Other

Validation performed:

- Confirmed the cleanup removes package dist directories.
- Confirmed adjacent ignored state such as .turbo is preserved.
- Ran Node syntax validation, Prettier, and git diff checks.