### PR TITLE
(fix) Use assigned extensions from hook not store

### DIFF
--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
@@ -92,7 +92,9 @@ const ChartReview: React.FC<ChartReviewProps> = ({ patientUuid, patient, view, s
     .flatMap((e) => {
       if (e.config?.slotName) {
         if (e.config.slotName in extensionStore.slots) {
-          return getDashboardDefinition(e.meta, e.config, e.moduleName, e.name);
+          return getAssignedExtensions(e.config.slotName).map((e) =>
+            getDashboardDefinition(e.meta, e.config, e.moduleName, e.name),
+          );
         } else {
           registerExtensionSlot('@openmrs/esm-patient-chart-app', e.config.slotName);
           // Since we register the new extension slot, we need to force a re-render with the

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useMemo } from 'react';
 import { Navigate } from 'react-router-dom';
-import { type ConfigObject, useExtensionStore, registerExtensionSlot } from '@openmrs/esm-framework';
+import {
+  type ConfigObject,
+  useAssignedExtensions,
+  useExtensionStore,
+  registerExtensionSlot,
+} from '@openmrs/esm-framework';
 import { DashboardView, type DashboardConfig, type LayoutMode } from './dashboard-view.component';
 import { basePath } from '../../constants';
 
@@ -81,14 +86,13 @@ interface ChartReviewProps {
 
 const ChartReview: React.FC<ChartReviewProps> = ({ patientUuid, patient, view, setDashboardLayoutMode }) => {
   const extensionStore = useExtensionStore();
+  const assignedExtensions = useAssignedExtensions('patient-chart-dashboard-slot');
 
-  const dashboards = extensionStore.slots['patient-chart-dashboard-slot'].assignedExtensions
+  const dashboards = assignedExtensions
     .flatMap((e) => {
       if (e.config?.slotName) {
         if (e.config.slotName in extensionStore.slots) {
-          return extensionStore.slots[e.config.slotName].assignedExtensions.map((e) =>
-            getDashboardDefinition(e.meta, e.config, e.moduleName, e.name),
-          );
+          return getDashboardDefinition(e.meta, e.config, e.moduleName, e.name);
         } else {
           registerExtensionSlot('@openmrs/esm-patient-chart-app', e.config.slotName);
           // Since we register the new extension slot, we need to force a re-render with the

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.component.tsx
@@ -2,9 +2,10 @@ import React, { useEffect, useMemo } from 'react';
 import { Navigate } from 'react-router-dom';
 import {
   type ConfigObject,
+  getAssignedExtensions,
+  registerExtensionSlot,
   useAssignedExtensions,
   useExtensionStore,
-  registerExtensionSlot,
 } from '@openmrs/esm-framework';
 import { DashboardView, type DashboardConfig, type LayoutMode } from './dashboard-view.component';
 import { basePath } from '../../constants';

--- a/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.test.tsx
+++ b/packages/esm-patient-chart-app/src/patient-chart/chart-review/chart-review.test.tsx
@@ -5,14 +5,14 @@ import { screen, render } from '@testing-library/react';
 import {
   type AssignedExtension,
   type ExtensionSlotState,
+  useAssignedExtensions,
   useExtensionStore,
-  useExtensionSlotMeta,
 } from '@openmrs/esm-framework';
 import { mockPatient } from 'tools';
 import ChartReview from './chart-review.component';
 
+const mockUseAssignedExtensions = vi.mocked(useAssignedExtensions);
 const mockUseExtensionStore = vi.mocked(useExtensionStore);
-const mockUseExtensionSlotMeta = vi.mocked(useExtensionSlotMeta);
 
 vi.mock('react-router-dom', async () => ({
   ...((await vi.importActual('react-router-dom')) as object),
@@ -24,14 +24,6 @@ vi.mock('react-router-dom', async () => ({
     },
   }),
 }));
-
-function slotMetaFromStore(store, slotName) {
-  return Object.fromEntries(
-    store.slots[slotName].assignedExtensions.map((e) => {
-      return [e.name, e.meta];
-    }),
-  );
-}
 
 describe('ChartReview', () => {
   test('renders a grid-based layout', () => {
@@ -64,7 +56,7 @@ describe('ChartReview', () => {
     };
 
     mockUseExtensionStore.mockReturnValue(mockStore as unknown as ReturnType<typeof useExtensionStore>);
-    mockUseExtensionSlotMeta.mockImplementation((slotName) => slotMetaFromStore(mockStore, slotName));
+    mockUseAssignedExtensions.mockImplementation((slotName) => mockStore.slots[slotName]?.assignedExtensions ?? []);
 
     render(
       <BrowserRouter>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Switches to using `useAssignedExtensions()` instead of directly reading extension store state. Note that we do track the extension store for now because that's how we tell whether or not we need to define a slot for sub-menus.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
