### PR TITLE
(fix) O3-5957: Correct MUAC color code age boundaries

### DIFF
--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.test.ts
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.test.ts
@@ -2,27 +2,35 @@ import { describe, it, expect } from 'vitest';
 import { getMuacColorCode } from './vitals-biometrics-form.utils';
 
 describe('getMuacColorCode', () => {
-  it('sets a color code for a healthy 5-year-old (age boundary)', () => {
+  it('classifies a 5-year-old with MUAC 13.0cm as SAM (red), per the 5-<10y bracket', () => {
     let result = '';
-    getMuacColorCode(5, 13, (color) => {
+    getMuacColorCode(5, 13.0, (color) => {
       result = color;
     });
-    expect(result).toBe('green');
+    expect(result).toBe('red');
   });
 
   it('sets a color code for a 10-year-old (age boundary)', () => {
     let result = '';
-    getMuacColorCode(10, 20, (color) => {
+    getMuacColorCode(10, 17.0, (color) => {
       result = color;
     });
-    expect(result).toBe('green');
+    expect(result).toBe('yellow');
   });
 
-  it('sets a color code for an 18-year-old (age boundary)', () => {
+  it('sets a color code for a 15-year-old (age boundary)', () => {
     let result = '';
-    getMuacColorCode(18, 20, (color) => {
+    getMuacColorCode(15, 20.0, (color) => {
       result = color;
     });
-    expect(result).toBe('green');
+    expect(result).toBe('yellow');
+  });
+
+  it('sets a color code for an 18-year-old (age boundary), classified with adults', () => {
+    let result = '';
+    getMuacColorCode(18, 20.0, (color) => {
+      result = color;
+    });
+    expect(result).toBe('yellow');
   });
 });

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.test.ts
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { getMuacColorCode } from './vitals-biometrics-form.utils';
+
+describe('getMuacColorCode', () => {
+  it('sets a color code for a healthy 5-year-old (age boundary)', () => {
+    let result = '';
+    getMuacColorCode(5, 13, (color) => {
+      result = color;
+    });
+    expect(result).toBe('green');
+  });
+
+  it('sets a color code for a 10-year-old (age boundary)', () => {
+    let result = '';
+    getMuacColorCode(10, 20, (color) => {
+      result = color;
+    });
+    expect(result).toBe('green');
+  });
+
+  it('sets a color code for an 18-year-old (age boundary)', () => {
+    let result = '';
+    getMuacColorCode(18, 20, (color) => {
+      result = color;
+    });
+    expect(result).toBe('green');
+  });
+});

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
@@ -54,44 +54,44 @@ export function extractNumbers(str: string) {
 
 export function getMuacColorCode(age: number, muac: number, setColorCode: (color) => void) {
   switch (true) {
-    // children 5 years and below with a muac equal to 14
+    // children 5 years and below (0-5 inclusive)
     case age <= 5 && muac <= 11.5 && muac > 0:
       setColorCode('red');
       break;
-    case age < 5 && muac > 11.5 && muac < 12.5:
+    case age <= 5 && muac > 11.5 && muac < 12.5:
       setColorCode('yellow');
       break;
-    case age < 5 && muac > 12.5:
+    case age <= 5 && muac >= 12.5:
       setColorCode('green');
       break;
-    // above 5 but less than 10
-    case age > 5 && age < 10 && muac <= 13.5 && muac > 0:
+    // above 5, up to and including 10
+    case age > 5 && age <= 10 && muac <= 13.5 && muac > 0:
       setColorCode('red');
       break;
-    case age > 5 && age < 10 && muac > 13.5 && muac < 14.5:
+    case age > 5 && age <= 10 && muac > 13.5 && muac < 14.5:
       setColorCode('yellow');
       break;
-    case age > 5 && age < 10 && muac > 14.5:
+    case age > 5 && age <= 10 && muac >= 14.5:
       setColorCode('green');
       break;
-    //above 10 but less than 18
-    case age > 10 && age < 18 && muac <= 16.5 && muac > 0:
+    // above 10, up to and including 18
+    case age > 10 && age <= 18 && muac <= 16.5 && muac > 0:
       setColorCode('red');
       break;
-    case age > 10 && age < 18 && muac > 16.5 && muac < 19.0:
+    case age > 10 && age <= 18 && muac > 16.5 && muac < 19.0:
       setColorCode('yellow');
       break;
-    case age > 10 && age < 18 && muac > 19.0:
+    case age > 10 && age <= 18 && muac >= 19.0:
       setColorCode('green');
       break;
     // above 18
     case age > 18 && muac <= 19.5 && muac > 0:
       setColorCode('red');
       break;
-    case age > 18 && muac > 19.0 && muac < 22.0:
+    case age > 18 && muac > 19.5 && muac < 22.0:
       setColorCode('yellow');
       break;
-    case age > 18 && muac > 22.0:
+    case age > 18 && muac >= 22.0:
       setColorCode('green');
       break;
   }

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/vitals-biometrics-form.utils.ts
@@ -53,45 +53,61 @@ export function extractNumbers(str: string) {
 }
 
 export function getMuacColorCode(age: number, muac: number, setColorCode: (color) => void) {
+  // Age brackets and MUAC cut-offs follow the Uganda Ministry of Health IMAM Guidelines
+  // (Jan 2016), Table 2: Summary of Classification of Acute Malnutrition.
+  // https://platform.who.int/docs/default-source/mca-documents/policy-documents/guideline/UGA-CH-38-03-GUIDELINE-2016-eng-IMAM-Guidelines-for-Uganda-Jan-2016.pdf
+  // `age` is the whole number of years extracted from the patient's birth date, so the
+  // lower bound of each bracket is inclusive (e.g. a patient turning exactly 5 falls
+  // into the "5 to <10 years" bracket per the guideline, not the "6-59 months" bracket).
   switch (true) {
-    // children 5 years and below (0-5 inclusive)
-    case age <= 5 && muac <= 11.5 && muac > 0:
+    // 6-59 months (approximated here as under 5 whole years)
+    case age < 5 && muac <= 11.5 && muac > 0:
       setColorCode('red');
       break;
-    case age <= 5 && muac > 11.5 && muac < 12.5:
+    case age < 5 && muac > 11.5 && muac < 12.5:
       setColorCode('yellow');
       break;
-    case age <= 5 && muac >= 12.5:
+    case age < 5 && muac >= 12.5:
       setColorCode('green');
       break;
-    // above 5, up to and including 10
-    case age > 5 && age <= 10 && muac <= 13.5 && muac > 0:
+    // 5 to <10 years
+    case age >= 5 && age < 10 && muac <= 13.5 && muac > 0:
       setColorCode('red');
       break;
-    case age > 5 && age <= 10 && muac > 13.5 && muac < 14.5:
+    case age >= 5 && age < 10 && muac > 13.5 && muac < 14.5:
       setColorCode('yellow');
       break;
-    case age > 5 && age <= 10 && muac >= 14.5:
+    case age >= 5 && age < 10 && muac >= 14.5:
       setColorCode('green');
       break;
-    // above 10, up to and including 18
-    case age > 10 && age <= 18 && muac <= 16.5 && muac > 0:
+    // 10 to <15 years
+    case age >= 10 && age < 15 && muac <= 16.0 && muac > 0:
       setColorCode('red');
       break;
-    case age > 10 && age <= 18 && muac > 16.5 && muac < 19.0:
+    case age >= 10 && age < 15 && muac > 16.0 && muac < 18.5:
       setColorCode('yellow');
       break;
-    case age > 10 && age <= 18 && muac >= 19.0:
+    case age >= 10 && age < 15 && muac >= 18.5:
       setColorCode('green');
       break;
-    // above 18
-    case age > 18 && muac <= 19.5 && muac > 0:
+    // 15 to <18 years
+    case age >= 15 && age < 18 && muac <= 18.5 && muac > 0:
       setColorCode('red');
       break;
-    case age > 18 && muac > 19.5 && muac < 22.0:
+    case age >= 15 && age < 18 && muac > 18.5 && muac < 21.0:
       setColorCode('yellow');
       break;
-    case age > 18 && muac >= 22.0:
+    case age >= 15 && age < 18 && muac >= 21.0:
+      setColorCode('green');
+      break;
+    // 18 years and above (adults)
+    case age >= 18 && muac <= 19.0 && muac > 0:
+      setColorCode('red');
+      break;
+    case age >= 18 && muac > 19.0 && muac < 22.0:
+      setColorCode('yellow');
+      break;
+    case age >= 18 && muac >= 22.0:
       setColorCode('green');
       break;
   }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

`getMuacColorCode` (in `vitals-biometrics-form.utils.ts`) had inconsistent age-bracket boundary conditions. Patients aged exactly 10 or 18 got no color code set at all, for any MUAC value, because adjacent brackets both excluded the boundary age.

**Update after review:** the initial fix only closed the gap without checking which side of each boundary was correct. Per [@denniskigen's review](#), age brackets and MUAC cut-offs now follow the Uganda Ministry of Health IMAM Guidelines (Jan 2016), Table 2: Summary of Classification of Acute Malnutrition (https://platform.who.int/docs/default-source/mca-documents/policy-documents/guideline/UGA-CH-38-03-GUIDELINE-2016-eng-IMAM-Guidelines-for-Uganda-Jan-2016.pdf).

Since `age` is the whole number of years extracted from the patient's birth date, each bracket's **lower bound is inclusive** (e.g. a patient turning exactly 5 falls into the "5 to <10 years" bracket, not "6-59 months"). The brackets are now:

| Age | SAM (red) | MAM (yellow) | Healthy (green) |
|---|---|---|---|
| under 5y | ≤11.5cm | 11.5–<12.5cm | ≥12.5cm |
| 5 to <10y | ≤13.5cm | 13.5–<14.5cm | ≥14.5cm |
| 10 to <15y | ≤16.0cm | 16.0–<18.5cm | ≥18.5cm |
| 15 to <18y | ≤18.5cm | 18.5–<21.0cm | ≥21.0cm |
| 18y+ (adults) | ≤19.0cm | 19.0–<22.0cm | ≥22.0cm |

This also splits the old combined "10 to <18" bracket into the two separate brackets (10-<15 and 15-<18) that the guideline actually specifies, and corrects their MUAC thresholds (previously both used 16.5/19.0, which matched neither bracket).

Verified against the reviewer's own example: a 5-year-old with MUAC 13.0cm now correctly classifies as red/SAM (previously green under the first pass, and previously no color at all before any fix).

Before any fix, 3/3 boundary-age tests fail:
getMuacColorCode (3)
× sets a color code for a healthy 5-year-old (age boundary)
× sets a color code for a 10-year-old (age boundary)
× sets a color code for an 18-year-old (age boundary)

After the guideline-aligned fix, all tests pass, including a new test for the 15-year-old boundary and the reviewer's 5y/13.0cm example:
getMuacColorCode (4)
✓ classifies a 5-year-old with MUAC 13.0cm as SAM (red), per the 5-<10y bracket
✓ sets a color code for a 10-year-old (age boundary)
✓ sets a color code for a 15-year-old (age boundary)
✓ sets a color code for an 18-year-old (age boundary), classified with adults

Full esm-patient-vitals-app test suite also passes.

## Screenshots

N/A  this is a pure logic fix in a utility function, not directly rendered UI. The `useMuacColors` config flag is off by default, so behavior is covered by unit tests rather than a visual screenshot.

## Related Issue

https://issues.openmrs.org/browse/O3-5957

## Other

Found via direct code review of the vitals/biometrics module. Boundary-age direction and bracket split corrected per review feedback, using the Uganda MoH IMAM Guidelines as the source of truth.