### PR TITLE
(fix) O3-5801: Display location names for location observations

### DIFF
--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
@@ -25,6 +25,8 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
     if (
       obs.value !== null &&
       typeof obs.value === 'object' &&
+      'uuid' in obs.value &&
+      typeof obs.value.uuid === 'string' &&
       'display' in obs.value &&
       typeof obs.value.display === 'string'
     ) {
@@ -57,7 +59,7 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
               <span className={styles.parentConcept}>{obs.concept.display}</span>
               <span />
               {obs.groupMembers.map((member) => (
-                <React.Fragment key={index}>
+                <React.Fragment key={member.uuid}>
                   <span className={styles.childConcept}>{member.concept.display}</span>
                   <span>{getAnswer(member)}</span>
                 </React.Fragment>

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.component.tsx
@@ -21,6 +21,19 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
     }
   }
 
+  function getAnswer(obs: Obs): string {
+    if (
+      obs.value !== null &&
+      typeof obs.value === 'object' &&
+      'display' in obs.value &&
+      typeof obs.value.display === 'string'
+    ) {
+      return obs.value.display;
+    }
+
+    return getAnswerFromDisplay(obs.display);
+  }
+
   const filteredObservations = !!obsConceptUuidsToHide.length
     ? observations?.filter((obs) => {
         return !obsConceptUuidsToHide.includes(obs?.concept?.uuid);
@@ -46,7 +59,7 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
               {obs.groupMembers.map((member) => (
                 <React.Fragment key={index}>
                   <span className={styles.childConcept}>{member.concept.display}</span>
-                  <span>{getAnswerFromDisplay(member.display)}</span>
+                  <span>{getAnswer(member)}</span>
                 </React.Fragment>
               ))}
             </React.Fragment>
@@ -55,7 +68,7 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({ observati
           return (
             <React.Fragment key={index}>
               <span>{obs.concept.display}</span>
-              <span>{getAnswerFromDisplay(obs.display)}</span>
+              <span>{getAnswer(obs)}</span>
             </React.Fragment>
           );
         }

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { type Obs, useConfig } from '@openmrs/esm-framework';
+import EncounterObservations from './encounter-observations.component';
+
+const mockUseConfig = vi.mocked(useConfig);
+
+const makeObservation = (overrides: Partial<Obs> = {}): Obs =>
+  ({
+    uuid: 'obs-uuid',
+    display: 'Admission location: 123',
+    concept: {
+      uuid: 'location-concept-uuid',
+      display: 'Admission location',
+    },
+    value: {
+      uuid: 'location-uuid',
+      display: 'Inpatient Ward',
+    },
+    ...overrides,
+  }) as Obs;
+
+beforeEach(() => {
+  mockUseConfig.mockReturnValue({ obsConceptUuidsToHide: [] } as any);
+});
+describe('EncounterObservations', () => {
+  it('uses the display value for reference observations such as locations', () => {
+    render(<EncounterObservations observations={[makeObservation()]} />);
+
+    expect(screen.getByText('Admission location')).toBeInTheDocument();
+    expect(screen.getByText('Inpatient Ward')).toBeInTheDocument();
+    expect(screen.queryByText('123')).not.toBeInTheDocument();
+  });
+
+  it('keeps parsing the observation display for primitive values', () => {
+    render(<EncounterObservations observations={[makeObservation({ display: 'Temperature: 37.2', value: 37.2 })]} />);
+
+    expect(screen.getByText('37.2')).toBeInTheDocument();
+  });
+
+  it('uses the display value for reference-valued group members', () => {
+    const member = makeObservation();
+    const group = makeObservation({
+      display: 'Admission details',
+      concept: { uuid: 'group-concept-uuid', display: 'Admission details' },
+      value: null,
+      groupMembers: [member],
+    });
+
+    render(<EncounterObservations observations={[group]} />);
+
+    expect(screen.getByText('Admission details')).toBeInTheDocument();
+    expect(screen.getByText('Inpatient Ward')).toBeInTheDocument();
+  });
+});

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.test.tsx
@@ -25,6 +25,7 @@ const makeObservation = (overrides: Partial<Obs> = {}): Obs =>
 beforeEach(() => {
   mockUseConfig.mockReturnValue(getDefaultsFromConfigSchema(esmPatientChartSchema));
 });
+
 describe('EncounterObservations', () => {
   it('uses the display value for reference observations such as locations', () => {
     render(<EncounterObservations observations={[makeObservation()]} />);

--- a/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.test.tsx
+++ b/packages/esm-patient-chart-app/src/visit/visits-widget/encounter-observations/encounter-observations.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { type Obs, useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, type Obs, useConfig } from '@openmrs/esm-framework';
+import { type ChartConfig, esmPatientChartSchema } from '../../../config-schema';
 import EncounterObservations from './encounter-observations.component';
 
-const mockUseConfig = vi.mocked(useConfig);
+const mockUseConfig = vi.mocked(useConfig<ChartConfig>);
 
 const makeObservation = (overrides: Partial<Obs> = {}): Obs =>
   ({
@@ -22,7 +23,7 @@ const makeObservation = (overrides: Partial<Obs> = {}): Obs =>
   }) as Obs;
 
 beforeEach(() => {
-  mockUseConfig.mockReturnValue({ obsConceptUuidsToHide: [] } as any);
+  mockUseConfig.mockReturnValue(getDefaultsFromConfigSchema(esmPatientChartSchema));
 });
 describe('EncounterObservations', () => {
   it('uses the display value for reference observations such as locations', () => {
@@ -37,6 +38,19 @@ describe('EncounterObservations', () => {
     render(<EncounterObservations observations={[makeObservation({ display: 'Temperature: 37.2', value: 37.2 })]} />);
 
     expect(screen.getByText('37.2')).toBeInTheDocument();
+  });
+
+  it('keeps using the observation display for file values without a reference uuid', () => {
+    const fileValue = { display: 'raw file' } as unknown as Obs['value'];
+
+    render(
+      <EncounterObservations
+        observations={[makeObservation({ display: 'Attachment: discharge-summary.pdf', value: fileValue })]}
+      />,
+    );
+
+    expect(screen.getByText('discharge-summary.pdf')).toBeInTheDocument();
+    expect(screen.queryByText('raw file')).not.toBeInTheDocument();
   });
 
   it('uses the display value for reference-valued group members', () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a conventional commit label.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

Fixes [O3-5801](https://openmrs.atlassian.net/browse/O3-5801) by displaying the human-readable name for reference-valued observations such as locations.

Encounter observations previously derived the displayed answer from `obs.display`. For reference-valued observations, the actual readable resource name is available as `obs.value.display`, while `obs.display` may contain the referenced resource ID.

This change uses `obs.value.display` when the observation value is a reference resource with a UUID, while preserving the existing `obs.display` parsing for primitive values and file/image values that do not carry a resource UUID. The same handling is applied to grouped observation members.

Tests cover:
- reference-valued observations such as locations
- primitive observation values
- file values without a reference UUID, preserving the original filename
- reference-valued group members

## Screenshots

### Before
The Location observation shows the numeric resource ID (`9`) instead of the location name.

![Before — location observation displays numeric ID](https://raw.githubusercontent.com/pinankshah8-Aa/openmrs-esm-patient-chart/pr-assets/pr-assets/o3-5801-before.png)

### After
Using a fresh dev3 test patient, the Ward Admission form was completed with **Inpatient Ward**, then verified from **Visits → All encounters** with this branch loaded locally. The encounter now displays the human-readable location name.

![After — location observation displays Inpatient Ward](https://raw.githubusercontent.com/pinankshah8-Aa/openmrs-esm-patient-chart/pr-assets/pr-assets/o3-5801-after.png)

## Related Issue

https://openmrs.atlassian.net/browse/O3-5801

## Other

Local validation completed:
- patient-chart package tests: 192 passed, 1 skipped
- focused encounter-observation regression tests: 4 passed
- TypeScript: passed
- ESLint/Prettier pre-commit checks: passed
- repository pre-push `yarn verify`: passed
- manual end-to-end reproduction on dev3 with a fresh test patient: passed
- git diff --check: passed

[O3-5801]: https://openmrs.atlassian.net/browse/O3-5801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
