### PR TITLE
(fix) Patient chart shouldn't generate global CSS rules

### DIFF
--- a/packages/esm-patient-chart-app/src/root.scss
+++ b/packages/esm-patient-chart-app/src/root.scss
@@ -33,17 +33,13 @@
 
 // Overriding styles for RTL support
 html[dir='rtl'] {
-  :global(.cds--date-picker-input__wrapper) {
-    svg {
-      left: layout.$spacing-05;
-      right: unset;
-    }
-  }
-  :global(.cds--side-nav) {
-    right: 0;
-    :global(.active-left-nav-link) {
-      border-right: layout.$spacing-02 solid var(--brand-01);
-      border-left: unset;
+  .patientChartWrapper {
+    :global(.cds--side-nav) {
+      right: 0;
+      :global(.active-left-nav-link) {
+        border-right: layout.$spacing-02 solid var(--brand-01);
+        border-left: unset;
+      }
     }
   }
 

--- a/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.component.tsx
@@ -337,6 +337,25 @@ const OrderDetailsTable: React.FC<OrderDetailsProps> = ({
       onBeforeGetContentResolve.current = null;
       setIsPrinting(false);
     },
+    pageStyle: `
+      @page {
+        /* Remove browser default header (title) and footer (url) */
+        margin: 0;
+      }
+      @media print {
+        html,
+        body {
+          /* Tell browsers to print background colors */
+          -webkit-print-color-adjust: exact;
+          color-adjust: exact;
+          margin: 0 !important;
+          width: fit-content;
+          padding: 0 !important;
+          overflow: hidden;
+          page-break-inside: avoid;
+        }
+      }
+    `,
   });
 
   const orderTypesToDisplay = useMemo(

--- a/packages/esm-patient-orders-app/src/components/order-details-table.scss
+++ b/packages/esm-patient-orders-app/src/components/order-details-table.scss
@@ -133,17 +133,6 @@
   @extend .button;
 }
 
-@media print {
-  html,
-  body {
-    margin: 0 !important;
-    width: fit-content;
-    padding: 0 !important;
-    overflow: hidden;
-    page-break-inside: avoid;
-  }
-}
-
 .filterContainer {
   display: flex;
   align-items: center;

--- a/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.scss
+++ b/packages/esm-patient-tests-app/src/test-results/individual-results-table/individual-results-table.scss
@@ -3,7 +3,7 @@
 @use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
-p {
+.table p {
   @include type.type-style('body-compact-01');
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

In preparation for https://github.com/openmrs/openmrs-esm-core/pull/1869, we need to remove various CSS rules that were mistakenly targeting beyond the patient chart.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
