### PR TITLE
(fix): Preserve dosage drafts when switching medication dosage modes

### DIFF
--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.component.tsx
@@ -188,26 +188,11 @@ export function DrugOrderForm({
     formState: { isDirty, isSubmitting },
     getValues,
     handleSubmit,
+    resetField,
     setError,
     setValue,
     watch,
   } = drugOrderForm;
-
-  // reset the dosage information if set to free text dosage
-  const handleIsFreeTextDosageAfterChange = useCallback(
-    (newValue: MedicationOrderFormData['isFreeTextDosage']) => {
-      if (newValue) {
-        setValue('dosage', null, { shouldValidate: true });
-        setValue('unit', null, { shouldValidate: true });
-        setValue('route', null, { shouldValidate: true });
-        setValue('frequency', null, { shouldValidate: true });
-        setValue('patientInstructions', null, { shouldValidate: true });
-      } else {
-        setValue('freeTextDosage', null, { shouldValidate: true });
-      }
-    },
-    [setValue],
-  );
 
   const handleUnitAfterChange = useCallback(
     (newValue: MedicationOrderFormData['unit'], prevValue: MedicationOrderFormData['unit']) => {
@@ -346,11 +331,11 @@ export function DrugOrderForm({
       ...initialOrderBasketItem,
       drug: data.drug,
       isFreeTextDosage: data.isFreeTextDosage,
-      freeTextDosage: data.freeTextDosage,
-      dosage: data.dosage,
-      unit: data.unit,
-      route: data.route,
-      patientInstructions: data.patientInstructions,
+      freeTextDosage: data.isFreeTextDosage ? data.freeTextDosage : null,
+      dosage: data.isFreeTextDosage ? null : data.dosage,
+      unit: data.isFreeTextDosage ? null : data.unit,
+      route: data.isFreeTextDosage ? null : data.route,
+      patientInstructions: data.isFreeTextDosage ? null : data.patientInstructions,
       asNeeded: data.asNeeded,
       asNeededCondition: data.asNeededCondition,
       duration: data.duration,
@@ -369,6 +354,12 @@ export function DrugOrderForm({
     } as DrugOrderBasketItem;
 
     await onSave(newBasketItem);
+    resetField('patientInstructions', { defaultValue: '' });
+    resetField('freeTextDosage', { defaultValue: '' });
+    resetField('indication', { defaultValue: '' });
+    resetField('pillsDispensed', { defaultValue: null });
+    resetField('quantityUnits', { defaultValue: null });
+    resetField('numRefills', { defaultValue: null });
   };
 
   const handleFormSubmissionError = (errors: FieldErrors<MedicationOrderFormData>) => {
@@ -472,10 +463,10 @@ export function DrugOrderForm({
         {showStickyMedicationHeader && (
           <div className={styles.stickyMedicationInfo}>
             <MedicationInfoHeader
-              dosage={watchedDosage}
+              dosage={watchedIsFreeText ? null : watchedDosage}
               drug={drug}
-              routeValue={routeValue}
-              unitValue={watchedUnitValue}
+              routeValue={watchedIsFreeText ? '' : routeValue}
+              unitValue={watchedIsFreeText ? '' : watchedUnitValue}
             />
           </div>
         )}
@@ -506,10 +497,10 @@ export function DrugOrderForm({
             <h1 className={styles.orderFormHeading}>{t('orderForm', 'Order Form')}</h1>
             <div ref={medicationInfoHeaderRef}>
               <MedicationInfoHeader
-                dosage={watchedDosage}
+                dosage={watchedIsFreeText ? null : watchedDosage}
                 drug={drug}
-                routeValue={routeValue}
-                unitValue={watchedUnitValue}
+                routeValue={watchedIsFreeText ? '' : routeValue}
+                unitValue={watchedIsFreeText ? '' : watchedUnitValue}
               />
             </div>
             <section className={styles.formSection}>
@@ -526,7 +517,6 @@ export function DrugOrderForm({
                     id="freeTextDosageToggle"
                     aria-label={t('freeTextDosage', 'Free text dosage')}
                     labelText={t('freeTextDosage', 'Free text dosage')}
-                    handleAfterChange={handleIsFreeTextDosageAfterChange}
                   />
                 </Column>
               </Grid>

--- a/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.test.tsx
+++ b/packages/esm-patient-medications-app/src/add-drug-order/drug-order-form.test.tsx
@@ -84,12 +84,17 @@ function createNewOrderBasketItem(overrides?: Partial<DrugOrderBasketItem>): Dru
 }
 
 const completeMedicationOrderFields: Partial<DrugOrderBasketItem> = {
+  isFreeTextDosage: false,
+  scheduledDate: new Date(),
   dosage: 1,
   unit: { valueCoded: '1513AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', value: 'Tablet' },
   route: { valueCoded: '160240AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', value: 'Oral' },
   frequency: { valueCoded: 'once-daily-uuid', value: 'Once daily', frequencyPerDay: 1 },
   duration: 7,
   durationUnit: { valueCoded: '1072AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', value: 'Days' },
+  asNeeded: false,
+  asNeededCondition: '',
+  patientInstructions: '',
   indication: 'Pain',
   pillsDispensed: 7,
   quantityUnits: { valueCoded: '1513AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', value: 'Tablet' },
@@ -314,6 +319,70 @@ describe('DrugOrderForm - auto-calculation of dispense quantity', () => {
     const quantityInput = screen.getByRole('spinbutton', { name: /quantity to dispense/i });
     expect(quantityInput).not.toHaveValue();
     expect(screen.queryByText(/auto-calculated/i)).not.toBeInTheDocument();
+  });
+
+  it('preserves both dosage drafts when switching between dosage modes', async () => {
+    const user = userEvent.setup();
+    renderDrugOrderForm(createNewOrderBasketItem());
+
+    const doseInput = screen.getByRole('spinbutton', { name: /dose/i });
+    await user.clear(doseInput);
+    await user.type(doseInput, '1');
+
+    const patientInstructions = screen.getByPlaceholderText(/additional dosing instructions/i);
+    await user.type(patientInstructions, 'Take after eating');
+
+    const freeTextToggle = screen.getByRole('switch', { name: /free text dosage/i });
+    await user.click(freeTextToggle);
+
+    const freeTextDosage = screen.getByPlaceholderText(/^free text dosage$/i);
+    await user.type(freeTextDosage, 'Take one tablet when needed');
+
+    await user.click(freeTextToggle);
+    expect(screen.getByRole('spinbutton', { name: /dose/i })).toHaveValue(1);
+    expect(screen.getByPlaceholderText(/additional dosing instructions/i)).toHaveValue('Take after eating');
+
+    await user.click(freeTextToggle);
+    expect(screen.getByPlaceholderText(/^free text dosage$/i)).toHaveValue('Take one tablet when needed');
+  });
+
+  it('does not show simple dosage details while entering free-text dosage', async () => {
+    const user = userEvent.setup();
+    renderDrugOrderForm(createNewOrderBasketItem(completeMedicationOrderFields));
+
+    expect(screen.getAllByText(/1 tablet/i).length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole('switch', { name: /free text dosage/i }));
+
+    expect(screen.queryByText(/1 tablet/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/oral/i)).not.toBeInTheDocument();
+  });
+
+  it('clears submitted dosage, prescription, and dispensing drafts after save', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    renderDrugOrderForm(createNewOrderBasketItem(completeMedicationOrderFields), onSave);
+
+    await user.type(screen.getByPlaceholderText(/additional dosing instructions/i), 'Take after eating');
+    const indication = screen.getByPlaceholderText(/e\.g\. "Hypertension"/i);
+    await user.clear(indication);
+    await user.type(indication, 'Pain');
+
+    fireEvent.submit(screen.getByRole('form', { name: /add drug order/i }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave.mock.calls[0][0]).toMatchObject({
+      patientInstructions: 'Take after eating',
+      indication: 'Pain',
+      pillsDispensed: 7,
+      quantityUnits: expect.objectContaining({ value: 'Tablet' }),
+      numRefills: 0,
+    });
+    expect(screen.getByPlaceholderText(/additional dosing instructions/i)).toHaveValue('');
+    expect(screen.getByPlaceholderText(/e\.g\. "Hypertension"/i)).toHaveValue('');
+    expect(screen.getByRole('spinbutton', { name: /quantity to dispense/i })).not.toHaveValue();
+    expect(screen.getByRole('combobox', { name: /quantity unit/i })).toHaveValue('');
+    expect(screen.getByRole('spinbutton', { name: /prescription refills/i })).not.toHaveValue();
   });
 
   it('does not auto-calculate when quantity unit differs from dose unit', async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
 Description Preserve structured and free-text dosage drafts independently when toggling modes; hide inactive mode details; clear draft fields only after successful save. Adds regression tests for mode switching, draft preservation, display isolation, and post-save clearing
## Screenshots
The issue
https://github.com/user-attachments/assets/c1bd0ff1-1a3f-468d-82d8-10a37452f2e1
The fix
https://github.com/user-attachments/assets/ad708e44-0838-46f8-9c60-42f614d8b6d4

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->


