### PR TITLE
(fix) Improve keyboard access and add/edit titles in visit notes

### DIFF
--- a/e2e/specs/start-and-end-visit.spec.ts
+++ b/e2e/specs/start-and-end-visit.spec.ts
@@ -251,7 +251,7 @@ test('Verify visit context when starting / ending / deleting / restoring active 
   });
 
   await test.step('Then I should see the visit note form launch in the workspace', async () => {
-    await expect(page.getByText('Visit Note', { exact: true })).toBeVisible();
+    await expect(page.getByText('Add visit note', { exact: true })).toBeVisible();
   });
 
   await test.step('When I close the workspace', async () => {

--- a/e2e/specs/visit-note.spec.ts
+++ b/e2e/specs/visit-note.spec.ts
@@ -15,17 +15,20 @@ test('Add, edit, and delete a visit note', async ({ page, patient }) => {
   });
 
   await test.step('Then I should see the visit note form launch in the workspace', async () => {
-    await expect(page.getByText('Visit Note', { exact: true })).toBeVisible();
+    await expect(page.getByText('Add visit note', { exact: true })).toBeVisible();
   });
 
   await test.step('When I select `Asthma` as the primary diagnosis', async () => {
     await page.getByPlaceholder('Choose a primary diagnosis').fill('Asthma');
-    await page.getByRole('menuitem', { name: 'Asthma', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Asthma', exact: true })).toBeVisible();
+    await page.getByPlaceholder('Choose a primary diagnosis').press('ArrowDown');
+    await expect(page.getByRole('button', { name: 'Asthma', exact: true })).toBeFocused();
+    await page.keyboard.press('Enter');
   });
 
   await test.step('And I select `GI upset` as the secondary diagnosis', async () => {
     await page.getByPlaceholder('Choose a secondary diagnosis').fill('GI upset');
-    await page.getByRole('menuitem', { name: /gi upset/i }).click();
+    await page.getByRole('button', { name: /gi upset/i }).click();
   });
 
   await test.step('And I add a visit note', async () => {
@@ -86,6 +89,7 @@ test('Add, edit, and delete a visit note', async ({ page, patient }) => {
   });
 
   await test.step('Then the visit note form should open in edit mode with the existing note prefilled', async () => {
+    await expect(page.getByText('Edit visit note', { exact: true })).toBeVisible();
     await expect(page.getByPlaceholder('Write any notes here')).toHaveValue('This is a note');
   });
 

--- a/packages/esm-patient-notes-app/src/index.ts
+++ b/packages/esm-patient-notes-app/src/index.ts
@@ -30,7 +30,6 @@ export function startupApp() {
 export const notesOverview = getSyncLifecycle(notesOverviewExtension, options);
 export const visitNotesActionButton = getSyncLifecycle(visitNotesActionButtonExtension, options);
 
-// t('visitNoteWorkspaceTitle', 'Visit Note')
 export const visitNotesFormWorkspace = getAsyncLifecycle(() => import('./notes/visit-notes-form.workspace'), options);
 
 export const exportedVisitNotesFormWorkspace = getAsyncLifecycle(

--- a/packages/esm-patient-notes-app/src/notes/notes-overview.extension.tsx
+++ b/packages/esm-patient-notes-app/src/notes/notes-overview.extension.tsx
@@ -60,7 +60,7 @@ const NotesOverview: React.FC<NotesOverviewProps> = ({ patientUuid, patient, bas
         <Button
           kind="ghost"
           renderIcon={(props: ComponentProps<typeof AddIcon>) => <AddIcon size={16} {...props} />}
-          iconDescription={t('addVisitNote', 'Add a visit note')}
+          iconDescription={t('addVisitNote', 'Add visit note')}
           onClick={launchVisitNoteForm}
         >
           {t('add', 'Add')}

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -523,7 +523,10 @@ const VisitNotesForm: React.FC<VisitNotesFormProps> = ({
   const hasUserUnsavedChanges = Object.keys(dirtyFields).length > 0;
 
   return (
-    <Workspace2 title={t('visitNoteWorkspaceTitle', 'Visit note')} hasUnsavedChanges={hasUserUnsavedChanges}>
+    <Workspace2
+      title={isEditing ? t('editVisitNote', 'Edit visit note') : t('addVisitNote', 'Add visit note')}
+      hasUnsavedChanges={hasUserUnsavedChanges}
+    >
       <Form className={styles.form} onSubmit={handleSubmit(onSubmit, onError)}>
         <ExtensionSlot name="visit-context-header-slot" state={{ patientUuid }} />
 
@@ -535,7 +538,11 @@ const VisitNotesForm: React.FC<VisitNotesFormProps> = ({
 
         <div className={styles.formContainer}>
           <Stack gap={2}>
-            {isTablet ? <h2 className={styles.heading}>{t('addVisitNote', 'Add a visit note')}</h2> : null}
+            {isTablet ? (
+              <h2 className={styles.heading}>
+                {isEditing ? t('editVisitNote', 'Edit visit note') : t('addVisitNote', 'Add visit note')}
+              </h2>
+            ) : null}
             {isRetrospectiveDataEntryEnabled && (
               <Row className={styles.row}>
                 <Column sm={1}>
@@ -762,7 +769,7 @@ function DiagnosisSearch({
   setIsSearching,
 }: DiagnosisSearchProps) {
   const isTablet = useLayoutType() === 'tablet';
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const searchInputFocus = () => {
     inputRef.current.focus();
@@ -793,6 +800,15 @@ function DiagnosisSearch({
                 setIsSearching(true);
                 onChange(e);
                 handleSearch(name);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+                  const results = document.getElementById(`${name}-results`)?.querySelectorAll('button');
+                  if (results?.length) {
+                    event.preventDefault();
+                    results[event.key === 'ArrowDown' ? 0 : results.length - 1].focus();
+                  }
+                }
               }}
               value={value instanceof Date ? value.toISOString() : value}
               onBlur={onBlur}
@@ -825,15 +841,43 @@ function DiagnosesDisplay({
 
   if (!isSearching && searchResults?.length > 0) {
     return (
-      <ul className={styles.diagnosisList}>
+      <ul
+        id={`${fieldName}-results`}
+        className={styles.diagnosisList}
+        aria-label={t('diagnosisSearchResults', 'Diagnosis search results')}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            document.getElementById(fieldName)?.focus();
+          } else if (['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
+            const results = Array.from(event.currentTarget.querySelectorAll('button'));
+            const index = results.findIndex((result) => result === document.activeElement);
+            if (index < 0) {
+              return;
+            }
+            event.preventDefault();
+            const nextIndex =
+              event.key === 'Home'
+                ? 0
+                : event.key === 'End'
+                  ? results.length - 1
+                  : (index + (event.key === 'ArrowDown' ? 1 : -1) + results.length) % results.length;
+            results[nextIndex].focus();
+          }
+        }}
+      >
         {searchResults.filter(isDiagnosisNotSelected).map((diagnosis) => (
-          <li
-            className={styles.diagnosis}
-            key={diagnosis.uuid}
-            onClick={() => onAddDiagnosis(diagnosis, fieldName)}
-            role="menuitem"
-          >
-            {diagnosis.display}
+          <li className={styles.diagnosis} key={diagnosis.uuid}>
+            <button
+              type="button"
+              className={styles.diagnosisButton}
+              onClick={() => {
+                onAddDiagnosis(diagnosis, fieldName);
+                document.getElementById(fieldName)?.focus();
+              }}
+            >
+              {diagnosis.display}
+            </button>
           </li>
         ))}
       </ul>

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.component.tsx
@@ -831,6 +831,16 @@ function DiagnosesDisplay({
   t,
   value,
 }: DiagnosesDisplayProps) {
+  const resultsRef = useRef<HTMLUListElement | null>(null);
+  const setResultsRef = useCallback(
+    (node: HTMLUListElement | null) => {
+      if (!node && resultsRef.current?.contains(document.activeElement)) {
+        document.getElementById(fieldName)?.focus();
+      }
+      resultsRef.current = node;
+    },
+    [fieldName],
+  );
   if (!value) {
     return null;
   }
@@ -842,6 +852,7 @@ function DiagnosesDisplay({
   if (!isSearching && searchResults?.length > 0) {
     return (
       <ul
+        ref={setResultsRef}
         id={`${fieldName}-results`}
         className={styles.diagnosisList}
         aria-label={t('diagnosisSearchResults', 'Diagnosis search results')}

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -13,8 +13,23 @@
 }
 
 .diagnosis {
-  padding: layout.$spacing-04;
   border-top: 0.0625rem solid colors.$gray-20;
+}
+
+.diagnosisButton {
+  width: 100%;
+  padding: layout.$spacing-04;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid colors.$blue-60;
+    outline-offset: -2px;
+  }
 }
 
 .diagnosis:first-of-type {
@@ -196,7 +211,7 @@
     }
   }
 
-  .diagnosis {
+  .diagnosisButton {
     padding: layout.$spacing-05 layout.$spacing-04;
   }
 

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.scss
@@ -162,6 +162,10 @@
 
 .row {
   margin: layout.$spacing-03 0 layout.$spacing-08;
+
+  &:has(.diagnosisList) {
+    margin-bottom: layout.$spacing-05;
+  }
 }
 
 .skeleton {

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { vi, expect, test, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { screen, render } from '@testing-library/react';
+import { screen, render, waitFor } from '@testing-library/react';
 import {
   type Encounter,
   getDefaultsFromConfigSchema,
@@ -674,3 +674,28 @@ test('requires primary diagnosis when isPrimaryDiagnosisRequired is true', async
     ...ConfigMock,
   });
 });
+
+test.each(['primary', 'secondary'].flatMap((rank) => ['result', 'outside', 'body'].map((target) => [rank, target])))(
+  'allows continued typing after %s diagnosis results refresh when the user chooses %s',
+  async (rank, target) => {
+    mockFetchDiagnosisConceptsByName.mockImplementation((query) =>
+      query.endsWith('x') ? new Promise(() => {}) : Promise.resolve(diagnosisSearchResponse.results),
+    );
+    renderVisitNotesForm();
+    const user = userEvent.setup();
+    const input = screen.getByPlaceholderText(`Choose a ${rank} diagnosis`);
+    await user.type(input, 'Diabetes');
+    const result = await screen.findByRole('button', { name: 'Diabetes Mellitus' });
+    await user.type(input, 'x');
+    await user.keyboard('{ArrowDown}');
+    expect(result).toHaveFocus();
+    const outside = screen.getByRole('textbox', { name: /Write your notes/i });
+    if (target === 'outside') await user.click(outside);
+    if (target === 'body') await user.click(screen.getByText('Search for a primary diagnosis', { exact: true }));
+    await waitFor(() => expect(result).not.toBeInTheDocument());
+    expect(target === 'outside' ? outside : target === 'body' ? document.body : input).toHaveFocus();
+    await user.keyboard('yz');
+    expect(input).toHaveValue(target === 'result' ? 'Diabetesxyz' : 'Diabetesx');
+    expect(outside).toHaveValue(target === 'outside' ? 'yz' : '');
+  },
+);

--- a/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
+++ b/packages/esm-patient-notes-app/src/notes/visit-notes-form.test.tsx
@@ -15,6 +15,7 @@ import {
   showSnackbar,
   useConfig,
   useSession,
+  useLayoutType,
   useFeatureFlag,
   type Visit,
   type Workspace2DefinitionProps,
@@ -117,6 +118,7 @@ mockUseConfig.mockReturnValue({
 
 beforeEach(() => {
   mockedUseFeatureFlag.mockReturnValue(false);
+  vi.mocked(useLayoutType).mockReturnValue('small-desktop');
 });
 
 test('does not render the date picker when RDE is disabled', () => {
@@ -157,9 +159,9 @@ test('typing in the diagnosis search input triggers a search', async () => {
   await user.type(searchBox, 'Diabetes Mellitus');
 
   // Wait for the search results to appear
-  const targetSearchResult = await screen.findByRole('menuitem', { name: 'Diabetes Mellitus' });
+  const targetSearchResult = await screen.findByRole('button', { name: 'Diabetes Mellitus' });
   expect(targetSearchResult).toBeInTheDocument();
-  expect(screen.getByRole('menuitem', { name: 'Diabetes Mellitus, Type II' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Diabetes Mellitus, Type II' })).toBeInTheDocument();
 
   // clicking on a search result displays the selected diagnosis as a tag
   await user.click(targetSearchResult);
@@ -172,6 +174,54 @@ test('typing in the diagnosis search input triggers a search', async () => {
   await user.click(closeTagButton);
   // no selected diagnoses left
   expect(screen.getByText(/No diagnosis selected — Enter a diagnosis below/i)).toBeInTheDocument();
+});
+
+test.each(['primary', 'secondary'])('selects a %s diagnosis using only the keyboard', async (rank) => {
+  const user = userEvent.setup();
+  mockFetchDiagnosisConceptsByName.mockResolvedValue(diagnosisSearchResponse.results);
+  renderVisitNotesForm();
+
+  const search = screen.getByPlaceholderText(`Choose a ${rank} diagnosis`);
+  await user.type(search, 'Diabetes');
+  const first = await screen.findByRole('button', { name: 'Diabetes Mellitus' });
+  const second = screen.getByRole('button', { name: 'Diabetes Mellitus, Type II' });
+
+  await user.keyboard('{ArrowDown}');
+  expect(first).toHaveFocus();
+  await user.keyboard('{ArrowDown}');
+  expect(second).toHaveFocus();
+  await user.keyboard('{ArrowUp}');
+  expect(first).toHaveFocus();
+  await user.keyboard('{End}');
+  expect(second).toHaveFocus();
+  await user.keyboard('{Home}');
+  expect(first).toHaveFocus();
+  await user.keyboard('{Escape}');
+  expect(search).toHaveFocus();
+  expect(screen.getByText(/No diagnosis selected/)).toBeInTheDocument();
+
+  await user.keyboard('{ArrowUp}');
+  expect(second).toHaveFocus();
+  await user.keyboard('{Enter}');
+  expect(screen.getByTitle('Diabetes Mellitus, Type II')).toBeInTheDocument();
+  expect(search).toHaveFocus();
+  expect(search).toHaveValue('');
+
+  await user.type(search, 'Diabetes');
+  await screen.findByRole('button', { name: 'Diabetes Mellitus' });
+  expect(screen.queryByRole('button', { name: 'Diabetes Mellitus, Type II' })).not.toBeInTheDocument();
+  await user.keyboard('{ArrowDown}{Enter}');
+  expect(screen.getByTitle('Diabetes Mellitus')).toBeInTheDocument();
+});
+
+test.each(['small-desktop', 'tablet'] as const)('uses creation wording on %s', (layout) => {
+  vi.mocked(useLayoutType).mockReturnValue(layout);
+  renderVisitNotesForm();
+  expect(screen.getAllByText('Add visit note', { exact: true })).toHaveLength(layout === 'tablet' ? 2 : 1);
+  expect(screen.queryByText('Edit visit note')).not.toBeInTheDocument();
+  if (layout === 'tablet') {
+    expect(screen.getByRole('heading', { name: 'Add visit note', level: 2 })).toBeInTheDocument();
+  }
 });
 
 test('renders an error message when no matching diagnoses are found', async () => {
@@ -364,47 +414,54 @@ test('renders an error snackbar if there was a problem recording a condition', a
   });
 });
 
-test('initializes form with existing encounter data when in edit mode', () => {
-  mockedUseFeatureFlag.mockReturnValue(true);
+test.each(['small-desktop', 'tablet'] as const)(
+  'initializes the edit form with existing encounter data on %s',
+  (layout) => {
+    vi.mocked(useLayoutType).mockReturnValue(layout);
+    mockedUseFeatureFlag.mockReturnValue(true);
 
-  const mockEncounter = {
-    id: '123',
-    uuid: '123',
-    datetime: '20/03/2024',
-    rawDatetime: '2024-03-20T10:00:00.000Z',
-    obs: [
-      {
-        concept: { uuid: '162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
-        value: 'Existing clinical note',
-      },
-    ],
-    diagnoses: [
-      {
-        uuid: '456',
-        diagnosis: {
-          coded: { uuid: '789', display: 'Diabetes Mellitus' },
+    const mockEncounter = {
+      id: '123',
+      uuid: '123',
+      datetime: '20/03/2024',
+      rawDatetime: '2024-03-20T10:00:00.000Z',
+      obs: [
+        {
+          concept: { uuid: '162169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+          value: 'Existing clinical note',
         },
-        certainty: 'PROVISIONAL',
-        rank: 1,
-        display: 'Diabetes Mellitus',
-      },
-    ],
-  };
+      ],
+      diagnoses: [
+        {
+          uuid: '456',
+          diagnosis: {
+            coded: { uuid: '789', display: 'Diabetes Mellitus' },
+          },
+          certainty: 'PROVISIONAL',
+          rank: 1,
+          display: 'Diabetes Mellitus',
+        },
+      ],
+    };
 
-  renderVisitNotesForm({
-    formContext: 'editing',
-    encounter: mockEncounter as any as Encounter, // TODO: fix
-  });
+    renderVisitNotesForm({
+      formContext: 'editing',
+      encounter: mockEncounter as any as Encounter, // TODO: fix
+    });
 
-  // Verify date is pre-filled
-  expect(screen.getByLabelText(/visit date/i)).toHaveValue('20/03/2024');
+    expect(screen.getAllByText('Edit visit note')).toHaveLength(layout === 'tablet' ? 2 : 1);
+    expect(screen.queryByText('Add visit note')).not.toBeInTheDocument();
 
-  // Verify clinical note is pre-filled
-  expect(screen.getByRole('textbox', { name: /write your notes/i })).toHaveValue('Existing clinical note');
+    // Verify date is pre-filled
+    expect(screen.getByLabelText(/visit date/i)).toHaveValue('20/03/2024');
 
-  // Verify diagnosis is pre-filled
-  expect(screen.getByTitle('Diabetes Mellitus')).toBeInTheDocument();
-});
+    // Verify clinical note is pre-filled
+    expect(screen.getByRole('textbox', { name: /write your notes/i })).toHaveValue('Existing clinical note');
+
+    // Verify diagnosis is pre-filled
+    expect(screen.getByTitle('Diabetes Mellitus')).toBeInTheDocument();
+  },
+);
 
 test('updates existing visit note when in edit mode', async () => {
   const user = userEvent.setup();

--- a/packages/esm-patient-notes-app/translations/en.json
+++ b/packages/esm-patient-notes-app/translations/en.json
@@ -1,7 +1,7 @@
 {
   "add": "Add",
   "addImage": "Add image",
-  "addVisitNote": "Add a visit note",
+  "addVisitNote": "Add visit note",
   "clinicalNoteLabel": "Write your notes",
   "clinicalNotePlaceholder": "Write any notes here",
   "confirmDeleteStickyNote": "Confirm delete sticky note",
@@ -10,8 +10,10 @@
   "deleteStickyNote": "Delete sticky note",
   "deleting": "Deleting",
   "diagnoses": "Diagnoses",
+  "diagnosisSearchResults": "Diagnosis search results",
   "discard": "Discard",
   "editStickyNote": "Edit sticky note",
+  "editVisitNote": "Edit visit note",
   "emptyDiagnosisText": "No diagnosis selected — Enter a diagnosis below",
   "enterNotePlaceholder": "Enter your sticky note here...",
   "enterPrimaryDiagnoses": "Enter Primary diagnoses",
@@ -50,6 +52,5 @@
   "visitNoteNowVisible": "It is now visible on the Encounters page",
   "visitNotes": "Visit notes",
   "visitNoteSaved": "Visit note saved",
-  "visitNoteSaveError": "Error saving visit note",
-  "visitNoteWorkspaceTitle": "Visit Note"
+  "visitNoteSaveError": "Error saving visit note"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Diagnosis search results weren't keyboard accessible. We can now move through results with the arrow keys, select a diagnosis with Enter or Space, and return to the search input with Escape. Results have a visible focus outline, and focus returns to the search input after selection.

The workspace title and tablet heading now say “Add visit note” when creating a note and “Edit visit note” when editing one.

## Screenshots

We can now select diagnoses using the keyboard, with visible focus and focus returning to the search input after selection. The titles also make it clear whether we're adding a visit note or editing an existing one.

https://github.com/user-attachments/assets/9d2765a8-1cd6-47f9-92e1-f30c0cd07c5c

## Related Issue

These pre-existing issues came up while reviewing #3621.

## Other
